### PR TITLE
fix: suppress stack trace exposure in worker status page

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -107,7 +107,7 @@ async def _send_heartbeat() -> None:
             logger.debug("Heartbeat sent to %s", UI_URL)
     except Exception as exc:
         _ui_connected = False
-        _last_error = str(exc)
+        _last_error = "connection failed"
         logger.warning("Heartbeat failed: %s", exc)
 
 


### PR DESCRIPTION
## Summary

Fixes [CodeQL alert #2](https://github.com/GeiserX/CashPilot/security/code-scanning/2) — CWE-209/CWE-497 stack trace information exposure.

The raw exception message from failed heartbeats (`str(exc)`) was stored in `_last_error` and rendered directly in the worker HTML status page. This could leak internal implementation details (file paths, hostnames, connection strings) to anyone viewing the worker status page.

## Change

Replace `_last_error = str(exc)` with `_last_error = "connection failed"`. Full exception details remain in server logs via `logger.warning()`.

## Test plan

- [ ] CI passes (ruff, tests, CodeQL)
- [ ] CodeQL alert #2 resolves after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status page now displays a standardized "connection failed" message when heartbeat transmission fails, providing clearer error reporting to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->