### PR TITLE
fix: use UTC import instead of datetime.UTC attribute

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -227,7 +227,7 @@ async def upsert_earnings(
     date: str | None = None,
 ) -> None:
     """Insert or update an earnings record for a platform + date."""
-    date = date or datetime.now(datetime.UTC).strftime("%Y-%m-%d")
+    date = date or datetime.now(UTC).strftime("%Y-%m-%d")
     db = await _get_db()
     try:
         await db.execute(
@@ -305,9 +305,9 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
     """Return aggregated earnings stats for the dashboard."""
     db = await _get_db()
     try:
-        today = datetime.now(datetime.UTC).strftime("%Y-%m-%d")
-        yesterday = (datetime.now(datetime.UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
-        first_of_month = datetime.now(datetime.UTC).replace(day=1).strftime("%Y-%m-%d")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        yesterday = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
+        first_of_month = datetime.now(UTC).replace(day=1).strftime("%Y-%m-%d")
 
         # Total: sum of latest balance per platform (USD only for now)
         cursor = await db.execute(
@@ -377,7 +377,7 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
         month_earned = max(0.0, row["earned"])
 
         # Yesterday's delta for percentage change
-        day_before = (datetime.now(datetime.UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
+        day_before = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
         cursor = await db.execute(
             """
             SELECT COALESCE(SUM(y.balance - COALESCE(dy.balance, 0)), 0) as earned
@@ -472,7 +472,7 @@ async def get_daily_earnings(days: int = 7) -> list[dict[str, Any]]:
             balance_by_date[row["date"]] = row["total_balance"]
 
         # Generate result for exactly `days` days
-        now = datetime.now(datetime.UTC)
+        now = datetime.now(UTC)
         result = []
         for i in range(days - 1, -1, -1):
             d = now - timedelta(days=i)

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -204,10 +204,10 @@ async def _check_stale_workers() -> None:
     """Mark workers as offline if they haven't sent a heartbeat recently."""
     try:
         workers = await database.list_workers()
-        cutoff = datetime.now(datetime.UTC) - timedelta(seconds=STALE_WORKER_SECONDS)
+        cutoff = datetime.now(UTC) - timedelta(seconds=STALE_WORKER_SECONDS)
         for w in workers:
             if w["status"] == "online" and w.get("last_heartbeat"):
-                last = datetime.fromisoformat(w["last_heartbeat"]).replace(tzinfo=datetime.UTC)
+                last = datetime.fromisoformat(w["last_heartbeat"]).replace(tzinfo=UTC)
                 if last < cutoff:
                     await database.set_worker_status(w["id"], "offline")
                     logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], w["last_heartbeat"])


### PR DESCRIPTION
## Summary
- `from datetime import datetime` makes `datetime` the class, not the module
- `datetime.UTC` only exists on the module level, causing `AttributeError: type object 'datetime.datetime' has no attribute 'UTC'` at runtime
- Fixed by importing `UTC` directly: `from datetime import UTC, datetime, timedelta`

Discovered during v0.2.71 production deployment — collection runs were failing with this error.

## Files changed
- `app/database.py` — 6 occurrences
- `app/main.py` — 2 occurrences

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/test_auth.py` — 15/15 passing
- [x] `python3 -c "from datetime import UTC, datetime; datetime.now(UTC)"` works