### PR TITLE
Update proxyrack.yml to match min. payout.

### DIFF
--- a/services/bandwidth/proxyrack.yml
+++ b/services/bandwidth/proxyrack.yml
@@ -49,7 +49,7 @@ requirements:
 
 payment:
   methods: [paypal, crypto]
-  minimum_payout: "$5"
+  minimum_payout: "$20"
   currency: USD
   frequency: "On request"
 
@@ -63,7 +63,7 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://peer.proxyrack.com/dashboard"
-  min_amount: 5.0
+  min_amount: 20.0
   currency: USD
 
 platforms: [docker, windows, macos, linux]


### PR DESCRIPTION
Changed min. payout from 5 to 20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bandwidth service minimum payout threshold to $20 USD.
  * Updated cashout minimum requirement to $20 USD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->