### PR TITLE
feat: add option to clear service credentials

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -547,6 +547,19 @@ async def set_config_bulk(data: dict[str, str]) -> None:
         await db.close()
 
 
+async def delete_config_keys(keys: list[str]) -> None:
+    """Delete one or more config entries by key."""
+    if not keys:
+        return
+    db = await _get_db()
+    try:
+        placeholders = ",".join("?" for _ in keys)
+        await db.execute(f"DELETE FROM config WHERE key IN ({placeholders})", keys)
+        await db.commit()
+    finally:
+        await db.close()
+
+
 # --- Deployments ---
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1466,6 +1466,31 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
     return {"status": "saved"}
 
 
+@app.delete("/api/config/{slug}")
+async def api_clear_service_config(request: Request, slug: str) -> dict[str, str]:
+    """Remove all stored credentials (and signup bonus) for a service."""
+    _require_owner(request)
+    from app.collectors import _COLLECTOR_ARGS
+
+    arg_keys = _COLLECTOR_ARGS.get(slug)
+    if not arg_keys:
+        raise HTTPException(status_code=404, detail="Unknown service")
+
+    config_keys = [f"{slug}_{a.lstrip('?')}" for a in arg_keys]
+    config_keys.append(f"{slug}_signup_bonus")
+    await database.delete_config_keys(config_keys)
+
+    # Remove the auto-created "external" deployment record if present
+    svc = catalog.get_service(slug)
+    if svc:
+        docker_conf = svc.get("docker", {})
+        if not (docker_conf and docker_conf.get("image")):
+            await database.remove_deployment(slug)
+
+    logger.info("Cleared credentials for %s", slug)
+    return {"status": "cleared"}
+
+
 # ---------------------------------------------------------------------------
 # API: Users (owner only)
 # ---------------------------------------------------------------------------

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -767,6 +767,7 @@ const CP = (() => {
         <div style="display:flex; gap:8px; margin-top:14px;">
           <button class="btn btn-primary btn-sm" onclick="CP.saveCredentialModal()">Save</button>
           <button class="btn btn-ghost btn-sm" onclick="CP.closeModal('cred-modal')">Cancel</button>
+          <button class="btn btn-ghost btn-sm" style="color:#ef4444; margin-left:auto;" onclick="CP.clearServiceCredentials('${escapeHtml(slug)}', '${escapeHtml(col.name)}'); CP.closeModal('cred-modal');">Clear</button>
         </div>`;
     } catch (err) {
       if (body) body.innerHTML = `<p style="color:#ef4444;">Failed to load: ${escapeHtml(err.message)}</p>`;
@@ -1903,6 +1904,9 @@ const CP = (() => {
           </div>
         </div>`;
       }).join('');
+      const clearBtn = configured && _isOwner
+        ? `<div style="margin-top:8px; text-align:right;"><button class="btn btn-ghost btn-sm" style="color:#ef4444; font-size:0.75rem;" onclick="CP.clearServiceCredentials('${escapeHtml(col.slug)}', '${escapeHtml(col.name)}')">Clear Credentials</button></div>`
+        : '';
       return `
       <details class="collector-section" id="collector-${col.slug}">
         <summary class="collector-header">
@@ -1911,6 +1915,7 @@ const CP = (() => {
         </summary>
         <div class="collector-body">
           ${fields}
+          ${clearBtn}
         </div>
       </details>`;
     }).join('');
@@ -1939,6 +1944,17 @@ const CP = (() => {
       loadSettings();
     } catch (err) {
       toast(`Save failed: ${err.message}`, 'error');
+    }
+  }
+
+  async function clearServiceCredentials(slug, name) {
+    if (!confirm(`Remove all credentials for ${name}? This will stop earnings collection for this service.`)) return;
+    try {
+      await api(`/api/config/${encodeURIComponent(slug)}`, { method: 'DELETE' });
+      toast(`${name} credentials cleared`, 'success');
+      loadSettings();
+    } catch (err) {
+      toast(`Clear failed: ${err.message}`, 'error');
     }
   }
 
@@ -2284,5 +2300,6 @@ const CP = (() => {
     loadWorkerLogs,
     openCredentialModal,
     saveCredentialModal,
+    clearServiceCredentials,
   };
 })();


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/config/{slug}` endpoint to remove all stored credentials and signup bonus for a service
- Cleans up auto-created "external" deployment records for non-Docker services (e.g. Salad, Grass)
- Adds "Clear Credentials" button in Settings > Earnings Collection for configured services
- Adds "Clear" button in the credential modal (from dashboard)

Closes #22

## Changes
- `app/database.py` — new `delete_config_keys()` function
- `app/main.py` — new `DELETE /api/config/{slug}` route
- `app/static/js/app.js` — `clearServiceCredentials()` function, UI buttons in both settings and modal

## Test plan
- [x] `ruff check` passes
- [ ] CI tests pass
- [ ] Configure a service, verify "Clear Credentials" button appears
- [ ] Click clear, confirm dialog, verify credentials removed and badge changes to "Not configured"
- [ ] For external services (no Docker), verify deployment record is also removed