### PR TITLE
fix: correct Presearch env var name to REGISTRATION_CODE

### DIFF
--- a/services/depin/presearch.yml
+++ b/services/depin/presearch.yml
@@ -17,7 +17,7 @@ docker:
   image: presearch/node
   platforms: [linux/amd64, linux/arm64]
   env:
-    - key: PRESEARCH_REGISTRATION_CODE
+    - key: REGISTRATION_CODE
       label: "Registration Code"
       required: true
       secret: true


### PR DESCRIPTION
## Summary
- Fix Presearch environment variable name from `PRESEARCH_REGISTRATION_CODE` to `REGISTRATION_CODE` per [official docs](https://docs.presearch.io/nodes/setup#generic-setup-steps)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration parameter name for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/CashPilot/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->