### PR TITLE
fix: reject deploy of dead services and gate release on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,23 @@ permissions:
   packages: write
 
 jobs:
+  ci:
+    name: Verify CI passes
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt ruff
+      - name: Lint
+        run: ruff check . && ruff format --check .
+      - name: Test
+        run: pytest
+
   release:
+    needs: ci
     name: Bump version and release
     runs-on: [self-hosted, linux, x64]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - name: Install dependencies
-        run: pip install -r requirements.txt -r requirements-dev.txt ruff
+        run: pip install -r requirements.txt -r requirements-dev.txt --quiet
       - name: Lint
         run: ruff check . && ruff format --check .
       - name: Test

--- a/app/main.py
+++ b/app/main.py
@@ -797,7 +797,7 @@ async def api_deploy(request: Request, slug: str, body: DeployRequest, worker_id
     if not svc:
         raise HTTPException(status_code=404, detail=f"Service '{slug}' not found")
     if svc.get("status") == "dead":
-        raise HTTPException(status_code=400, detail=f"Service '{slug}' is no longer available (dead/discontinued)")
+        raise HTTPException(status_code=410, detail=f"Service '{slug}' is no longer available (dead/discontinued)")
 
     docker_conf = svc.get("docker", {})
     image = docker_conf.get("image")

--- a/app/main.py
+++ b/app/main.py
@@ -796,6 +796,8 @@ async def api_deploy(request: Request, slug: str, body: DeployRequest, worker_id
     svc = catalog.get_service(slug)
     if not svc:
         raise HTTPException(status_code=404, detail=f"Service '{slug}' not found")
+    if svc.get("status") == "dead":
+        raise HTTPException(status_code=400, detail=f"Service '{slug}' is no longer available (dead/discontinued)")
 
     docker_conf = svc.get("docker", {})
     image = docker_conf.get("image")

--- a/docs/guides/peer2profit.md
+++ b/docs/guides/peer2profit.md
@@ -1,5 +1,8 @@
 # Peer2Profit
 
+> [!CAUTION]
+> **Deprecated:** Peer2Profit is no longer operational and has been marked as dead in CashPilot. Deployment is blocked. This guide is kept for reference only.
+
 > **Category:** Bandwidth Sharing | **Status:** Dead
 > **Website:** [https://peer2profit.com](https://peer2profit.com)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest>=8.0
 pytest-asyncio>=0.23
 pytest-cov>=5.0
+ruff>=0.11.0
 tzdata>=2024.1

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -125,6 +125,17 @@ class TestApiDeploy:
             resp = client.post("/api/deploy/grass", json={})
             assert resp.status_code == 400
 
+    def test_deploy_dead_service(self, client):
+        svc = {"slug": "peer2profit", "name": "Peer2Profit", "status": "dead", "docker": {"image": "x"}}
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[_online_worker()]),
+            patch("app.main.catalog.get_service", return_value=svc),
+        ):
+            resp = client.post("/api/deploy/peer2profit", json={})
+            assert resp.status_code == 410
+            assert "no longer available" in resp.json()["detail"]
+
     def test_deploy_no_auth(self, client):
         with _no_auth():
             resp = client.post("/api/deploy/honeygain", json={})


### PR DESCRIPTION
## Summary
- Block deployment of services with `status: dead` in the deploy endpoint (`/api/deploy/{slug}`) with a 400 error, preventing users from deploying discontinued services like peer2profit
- Add deprecation notice to `docs/guides/peer2profit.md`
- Gate the release workflow on CI (ruff lint + pytest) by adding a `ci` job that `release` depends on, preventing publishing before tests pass

## Test plan
- [ ] Verify `POST /api/deploy/peer2profit` returns 400 with appropriate message
- [ ] Verify deploy of active services still works normally
- [ ] Verify release workflow YAML is valid and `release` job has `needs: ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deploy requests now reject services marked as dead/discontinued, returning HTTP 410 with a clear message.

* **Documentation**
  * Peer2Profit guide marked deprecated and noted as no longer deployable; retained for reference.

* **Chores**
  * Release workflow updated to require CI (lint + tests) before publishing.

* **Tests**
  * Added test verifying deployments against dead services return the expected error.

* **Chores**
  * Added development linting tool to dev requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/CashPilot/pull/47)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->