### PR TITLE
fix: container crash when started with --user flag (Unraid)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
+# Already running as non-root (e.g. Unraid --user flag) — skip privilege setup
+if [ "$(id -u)" != "0" ]; then
+  exec "$@"
+fi
+
+# Ensure data and fleet directories are writable by cashpilot
+chown cashpilot:root /data 2>/dev/null || true
+if [ -d "/fleet" ]; then
+  chown cashpilot:root /fleet 2>/dev/null || true
+fi
+
 # If Docker socket exists, ensure the cashpilot user can access it
 SOCK=/var/run/docker.sock
 if [ -S "$SOCK" ]; then
@@ -10,11 +21,6 @@ if [ -S "$SOCK" ]; then
     # GID 0 means root owns the socket — add cashpilot to root group
     addgroup cashpilot root 2>/dev/null || true
   fi
-fi
-
-# Ensure fleet key directory is writable by cashpilot
-if [ -d "/fleet" ]; then
-  chown cashpilot:root /fleet 2>/dev/null || true
 fi
 
 exec su-exec cashpilot "$@"


### PR DESCRIPTION
## Summary
- Skip `su-exec` when container is already running as non-root (e.g. Unraid `--user 99:100`)
- Move `/data` ownership fix before privilege drop so bind-mounted host dirs get correct permissions

## Root Cause
Unraid starts containers with `--user 99:100` (nobody:users). The entrypoint called `su-exec cashpilot` which internally calls `setgroups()` — this requires `CAP_SETGID` which is unavailable when already non-root. Result: immediate crash with `su-exec: setgroups: Operation not permitted`.

## Test Plan
- [x] Container starts normally (root entrypoint → su-exec drop to cashpilot)
- [x] Container starts with `--user 99:100` (Unraid pattern)
- [x] Container starts with bind-mounted `/data` volume
- [x] `/fleet` permission error is non-fatal warning (expected without fleet volume)

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container startup handling for non-root execution scenarios
  * Enhanced directory permission setup to ensure proper access when running as root
  * Increased robustness of initialization process by gracefully handling permission-related errors during startup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/CashPilot/pull/49)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->