### PR TITLE
feat: drop privileged from all services, rewrite earnfm to token auth

### DIFF
--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -56,7 +56,7 @@ _COLLECTOR_ARGS: dict[str, list[str]] = {
     "repocket": ["email", "password"],
     "proxyrack": ["api_key"],
     "bitping": ["email", "password"],
-    "earnfm": ["email", "password"],
+    "earnfm": ["token"],
     "packetstream": ["auth_token"],
     "grass": ["access_token"],
     "bytelixir": ["session_cookie"],

--- a/app/collectors/earnfm.py
+++ b/app/collectors/earnfm.py
@@ -1,87 +1,43 @@
 """Earn.fm earnings collector.
 
-Authenticates via Supabase (sb.earn.fm) and fetches balance from
-the Earn.fm harvester API.
+Authenticates via a UUID API key (EARNFM_TOKEN) obtained from the
+Earn.fm dashboard at app.earn.fm > Account Settings.
 """
 
 from __future__ import annotations
 
 import logging
 
-import httpx
+import httpx  # noqa: F401 — needed for test patching
 
 from app.collectors.base import BaseCollector, EarningsResult
 
 logger = logging.getLogger(__name__)
 
-SUPABASE_URL = "https://sb.earn.fm"
-SUPABASE_ANON_KEY = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    "ewogICJyb2xlIjogImFub24iLAogICJpc3MiOiAic3VwYWJhc2UiLAog"
-    "ICJpYXQiOiAxNjkyNjU1MjAwLAogICJleHAiOiAxODUwNTA4MDAwCn0."
-    "jp-Uj5ro0jj7MHnlE8HHZRsZAFOI1d_T9n_9tnE09vM"
-)
 API_BASE = "https://api.earn.fm/v2"
 
 
 class EarnFMCollector(BaseCollector):
-    """Collect earnings from Earn.fm's API via Supabase auth."""
+    """Collect earnings from Earn.fm's API using a token."""
 
     platform = "earnfm"
 
-    def __init__(self, email: str, password: str) -> None:
+    def __init__(self, token: str) -> None:
         super().__init__()
-        self.email = email
-        self.password = password
-        self._access_token: str | None = None
-        self._refresh_token: str | None = None
-
-    async def _authenticate(self, client: httpx.AsyncClient) -> str:
-        """Obtain Supabase access token via email/password."""
-        resp = await client.post(
-            f"{SUPABASE_URL}/auth/v1/token?grant_type=password",
-            json={"email": self.email, "password": self.password},
-            headers={
-                "apikey": SUPABASE_ANON_KEY,
-                "Content-Type": "application/json",
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        self._access_token = data.get("access_token", "")
-        self._refresh_token = data.get("refresh_token", "")
-        if not self._access_token:
-            raise ValueError("No access_token in Supabase login response")
-        return self._access_token
-
-    async def _refresh(self, client: httpx.AsyncClient) -> str:
-        """Refresh Supabase access token."""
-        if not self._refresh_token:
-            return await self._authenticate(client)
-        resp = await client.post(
-            f"{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token",
-            json={"refresh_token": self._refresh_token},
-            headers={
-                "apikey": SUPABASE_ANON_KEY,
-                "Content-Type": "application/json",
-            },
-        )
-        if resp.status_code in (401, 403):
-            return await self._authenticate(client)
-        resp.raise_for_status()
-        data = resp.json()
-        self._access_token = data.get("access_token", "")
-        self._refresh_token = data.get("refresh_token", self._refresh_token)
-        return self._access_token
+        self._token = token.strip()
 
     async def collect(self) -> EarningsResult:
         """Fetch current Earn.fm balance."""
+        if not self._token:
+            return EarningsResult(
+                platform=self.platform,
+                balance=0.0,
+                error="No token configured — copy API key from app.earn.fm > Settings",
+            )
+
         try:
             client = self._get_client(timeout=30)
-            if not self._access_token:
-                await self._authenticate(client)
-
-            headers = {"X-API-Key": self._access_token}
+            headers = {"X-API-Key": self._token}
 
             async def _fetch_balance() -> httpx.Response:
                 return await client.get(
@@ -91,10 +47,12 @@ class EarnFMCollector(BaseCollector):
 
             resp = await self._retry(_fetch_balance)
 
-            if resp.status_code == 401:
-                await self._refresh(client)
-                headers = {"X-API-Key": self._access_token}
-                resp = await self._retry(_fetch_balance)
+            if resp.status_code in (401, 403):
+                return EarningsResult(
+                    platform=self.platform,
+                    balance=0.0,
+                    error="Token invalid or expired — refresh API key from app.earn.fm",
+                )
 
             resp.raise_for_status()
             data = resp.json()

--- a/app/main.py
+++ b/app/main.py
@@ -1468,7 +1468,7 @@ async def api_collectors_meta(request: Request) -> list[dict[str, Any]]:
         "bitping": "Use your Bitping account email and password (same as nodes.bitping.com).",
         "bytelixir": "Log in at dash.bytelixir.com (tick Remember Me), press F12 → Application → Cookies, copy the <b>bytelixir_session</b> value.",
         "earnapp": "Log in at earnapp.com, press F12 → Application → Cookies, copy the <b>oauth-refresh-token</b> value.",
-        "earnfm": "Use your Earn.fm account email and password (same as earn.fm).",
+        "earnfm": "Copy your UUID API key from app.earn.fm → Account Settings.",
         "grass": "Log in at app.getgrass.io, press F12 → Application → Local Storage, copy the <b>accessToken</b> value.",
         "honeygain": "Use your Honeygain account email and password (same as dashboard.honeygain.com).",
         "iproyal": "Use your IPRoyal Pawns account email and password (same as pawns.app).",

--- a/docs/guides/earnfm.md
+++ b/docs/guides/earnfm.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Earn.fm pays you for sharing your internet bandwidth. It authenticates via Supabase using email and password. Lightweight Docker image with straightforward deployment.
+Earn.fm pays you for sharing your internet bandwidth. Authenticates via a UUID API key from the dashboard. Lightweight Docker image with straightforward deployment.
 
 ## Earning Estimates
 
@@ -35,13 +35,13 @@ Earn.fm pays you for sharing your internet bandwidth. It authenticates via Supab
 
 Sign up at [Earn.fm](https://earn.fm/ref/GEISYB91).
 
-### 2. Get your credentials
+### 2. Get your API key
 
-After signing up, you'll use your account email and password for Docker deployment.
+After signing up, go to [app.earn.fm](https://app.earn.fm) > Account Settings and copy your UUID API key.
 
 ### 3. Deploy with CashPilot
 
-In the CashPilot web UI, find **Earn.fm** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
+In the CashPilot web UI, find **Earn.fm** in the service catalog and click **Deploy**. Enter your API token and CashPilot will handle the rest.
 
 ## Docker Configuration
 
@@ -52,5 +52,4 @@ In the CashPilot web UI, find **Earn.fm** in the service catalog and click **Dep
 
 | Variable | Label | Required | Secret | Description |
 |----------|-------|:--------:|:------:|-------------|
-| `EARNFM_EMAIL` | Email | Yes | No | Your Earn.fm account email |
-| `EARNFM_PASSWORD` | Password | Yes | Yes | Your Earn.fm account password (used for Supabase auth) |
+| `EARNFM_TOKEN` | API Key | Yes | Yes | UUID API key from app.earn.fm > Account Settings |

--- a/services/bandwidth/bitping.yml
+++ b/services/bandwidth/bitping.yml
@@ -23,7 +23,7 @@ docker:
     - "bitping-data:/root/.bitping"
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
   notes: >
     Initial authentication is interactive via the container's web UI.
     Credentials are then persisted in the /root/.bitping volume mount.

--- a/services/bandwidth/earnapp.yml
+++ b/services/bandwidth/earnapp.yml
@@ -33,7 +33,7 @@ docker:
     - "earnapp-data:/etc/earnapp"
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true

--- a/services/bandwidth/earnfm.yml
+++ b/services/bandwidth/earnfm.yml
@@ -4,10 +4,10 @@ category: bandwidth
 status: active
 website: https://earn.fm
 description: >
-  Earn.fm pays you for sharing your internet bandwidth. It authenticates via
-  Supabase using email and password. Lightweight Docker image with
+  Earn.fm pays you for sharing your internet bandwidth. Authenticates via
+  a UUID API key from the dashboard. Lightweight Docker image with
   straightforward deployment.
-short_description: Bandwidth sharing - email/password auth, lightweight client
+short_description: Bandwidth sharing - API key auth, lightweight client
 
 referral:
   signup_url: "https://earn.fm/ref/GEISYB91"
@@ -16,21 +16,16 @@ docker:
   image: earnfm/earnfm-client
   platforms: [linux/amd64, linux/arm64]
   env:
-    - key: EARNFM_EMAIL
-      label: "Email"
-      required: true
-      secret: false
-      description: "Your Earn.fm account email"
-    - key: EARNFM_PASSWORD
-      label: "Password"
+    - key: EARNFM_TOKEN
+      label: "API Key"
       required: true
       secret: true
-      description: "Your Earn.fm account password (used for Supabase auth)"
+      description: "UUID API key from app.earn.fm > Account Settings"
   ports: []
   volumes: []
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true
@@ -62,4 +57,4 @@ platforms: [docker, linux]
 
 collector:
   type: api
-  notes: "Supabase auth via email/password. Dashboard at app.earn.fm shows earnings."
+  notes: "API key auth. Dashboard at app.earn.fm shows earnings."

--- a/services/bandwidth/honeygain.yml
+++ b/services/bandwidth/honeygain.yml
@@ -37,7 +37,7 @@ docker:
   volumes: []
   command: "-tou-accept -email ${HONEYGAIN_EMAIL} -pass ${HONEYGAIN_PASSWORD} -device ${HONEYGAIN_DEVICE_NAME}"
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true

--- a/services/bandwidth/iproyal.yml
+++ b/services/bandwidth/iproyal.yml
@@ -44,7 +44,7 @@ docker:
   volumes: []
   command: "-email ${IPROYALPAWNS_EMAIL} -password ${IPROYALPAWNS_PASSWORD} -device-name ${IPROYALPAWNS_DEVICE_NAME} -device-id ${IPROYALPAWNS_DEVICE_ID} -accept-tos"
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true

--- a/services/bandwidth/mysterium.yml
+++ b/services/bandwidth/mysterium.yml
@@ -25,7 +25,7 @@ docker:
   command: "--ui.address=0.0.0.0 --tequilapi.address=0.0.0.0 service --agreed-terms-and-conditions"
   network_mode: "host"
   cap_add: [NET_ADMIN]
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: false

--- a/services/bandwidth/packetstream.yml
+++ b/services/bandwidth/packetstream.yml
@@ -27,7 +27,7 @@ docker:
   volumes: []
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true

--- a/services/bandwidth/proxyrack.yml
+++ b/services/bandwidth/proxyrack.yml
@@ -38,7 +38,7 @@ docker:
   volumes: []
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: false

--- a/services/bandwidth/repocket.yml
+++ b/services/bandwidth/repocket.yml
@@ -31,7 +31,7 @@ docker:
   volumes: []
   command: ""
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: true

--- a/services/bandwidth/traffmonetizer.yml
+++ b/services/bandwidth/traffmonetizer.yml
@@ -33,7 +33,7 @@ docker:
   volumes: []
   command: "start accept --token ${TRAFFMONETIZER_TOKEN} --device-name ${TRAFFMONETIZER_DEVICE_NAME}"
   network_mode: ""
-  privileged: true
+  privileged: false
 
 requirements:
   residential_ip: false

--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -190,24 +190,20 @@ class TestTraffmonetizerDeep:
 
 
 class TestEarnFMDeep:
-    def test_collect_with_token_refresh(self):
+    def test_collect_401_returns_error(self):
         from app.collectors.earnfm import EarnFMCollector
 
-        login_resp = _mock_response(200, {"access_token": "at", "refresh_token": "rt"})
         expired_resp = MagicMock()
         expired_resp.status_code = 401
-        refresh_resp = _mock_response(200, {"access_token": "new-at", "refresh_token": "new-rt"})
-        ok_resp = _mock_response(200, {"data": {"totalBalance": 1.25}})
 
         client = _make_async_client()
-        client.post.side_effect = [login_resp, refresh_resp]
-        client.get.side_effect = [expired_resp, ok_resp]
+        client.get.return_value = expired_resp
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(email="test@test.com", password="pass")
+            c = EarnFMCollector(token="test-uuid-token")
             result = asyncio.run(c.collect())
-        assert result.error is None
-        assert result.balance == 1.25
+        assert result.error is not None
+        assert "invalid" in result.error.lower() or "expired" in result.error.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_collectors_extended.py
+++ b/tests/test_collectors_extended.py
@@ -367,15 +367,13 @@ class TestEarnFMCollector:
     def test_collect_success(self):
         from app.collectors.earnfm import EarnFMCollector
 
-        login_resp = _mock_response(200, {"access_token": "auth-tok", "refresh_token": "ref-tok"})
         balance_resp = _mock_response(200, {"data": {"totalBalance": 0.50}})
 
         client = _make_async_client()
-        client.post.return_value = login_resp
         client.get.return_value = balance_resp
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(email="test@test.com", password="pass")
+            c = EarnFMCollector(token="test-uuid-token")
             result = asyncio.run(c.collect())
         assert result.error is None
         assert result.balance == 0.50
@@ -384,10 +382,10 @@ class TestEarnFMCollector:
         from app.collectors.earnfm import EarnFMCollector
 
         client = _make_async_client()
-        client.post.side_effect = Exception("Failed")
+        client.get.side_effect = Exception("Failed")
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(email="bad", password="bad")
+            c = EarnFMCollector(token="bad-token")
             result = asyncio.run(c.collect())
         assert result.error is not None
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -887,18 +887,14 @@ class TestCollectorSmallGaps:
         # Should either succeed with 0 or have an error
         assert isinstance(result, EarningsResult)
 
-    def test_earnfm_login_response_missing_token(self):
-        """Cover earnfm.py lines 53, 59: login without access_token."""
+    def test_earnfm_empty_token(self):
+        """Cover earnfm.py: empty token returns error."""
         from app.collectors.earnfm import EarnFMCollector
 
-        login_resp = _mock_response(200, {})  # missing access_token
-        client = _make_async_client()
-        client.post.return_value = login_resp
-
-        with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(email="test@test.com", password="pass")
-            result = asyncio.run(c.collect())
-        assert isinstance(result, EarningsResult)
+        c = EarnFMCollector(token="")
+        result = asyncio.run(c.collect())
+        assert result.error is not None
+        assert "No token" in result.error
 
     def test_bitping_login_missing_cookie(self):
         """Cover bitping.py lines 45-48: login without cookie set."""


### PR DESCRIPTION
## Summary
- Set `privileged: false` across all 10 service YAMLs — none need it (verified via Docker Hub docs for each image). Mysterium correctly uses `cap_add: [NET_ADMIN]` + `network_mode: host` instead.
- Rewrite earnfm collector from Supabase email/password to UUID API token (`EARNFM_TOKEN`)
- Update `_COLLECTOR_ARGS`, UI credential hints, service YAML, docs guide, and all tests

**Research**: Checked all 10 images' official Docker Hub pages. Only `mysteriumnetwork/myst` needs elevated caps (`NET_ADMIN` for VPN tunneling), which is already correctly configured via `cap_add` without `privileged: true`.

Fixes #58, fixes #59

Thanks @franko-c for catching the broader scope.