### PR TITLE
chore: build dispatch version input + pin compose v0.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ on:
         description: 'Build Worker image'
         type: boolean
         default: true
+      version:
+        description: 'Version tag (e.g. v0.2.1) — leave empty for latest'
+        type: string
+        default: ''
 
 concurrency:
   group: build-${{ inputs.version || github.ref }}

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:v0.6.1
+    image: drumsergio/cashpilot:v0.6.2
     container_name: cashpilot-ui
     ports:
       - "8080:8080"
@@ -29,7 +29,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:v0.6.1
+    image: drumsergio/cashpilot-worker:v0.6.2
     container_name: cashpilot-worker
     ports:
       - "8081:8081"
@@ -55,7 +55,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:v0.6.1
+#      image: drumsergio/cashpilot-worker:v0.6.2
 #      container_name: cashpilot-worker
 #      ports:
 #        - "8081:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 services:
   cashpilot-ui:
     build: .
-    image: drumsergio/cashpilot:v0.6.1
+    image: drumsergio/cashpilot:v0.6.2
     container_name: cashpilot-ui
     ports:
       - "8080:8080"
@@ -29,7 +29,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.worker
-    image: drumsergio/cashpilot-worker:v0.6.1
+    image: drumsergio/cashpilot-worker:v0.6.2
     container_name: cashpilot-worker
     expose:
       - "8081"


### PR DESCRIPTION
## Summary
- Add `version` input to build workflow dispatch (allows manual versioned builds)
- Update docker-compose pins to v0.6.2

## Test plan
- [ ] After merge, trigger build workflow with version=v0.6.2