### PR TITLE
fix: Docker uvicorn shebang path mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ VOLUME /data
 EXPOSE 8080
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--no-access-log"]
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--no-access-log"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -51,4 +51,4 @@ VOLUME /data
 EXPOSE 8081
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.worker_api:app", "--host", "0.0.0.0", "--port", "8081", "--no-access-log"]
+CMD ["python", "-m", "uvicorn", "app.worker_api:app", "--host", "0.0.0.0", "--port", "8081", "--no-access-log"]


### PR DESCRIPTION
## Summary
- uv creates venv scripts with shebangs pointing to `/build/.venv/bin/python` (build stage)
- Runtime stage copies venv to `/app/.venv/` but shebangs still reference `/build/`
- Fix: use `python -m uvicorn` in CMD which works correctly

## Test plan
- [ ] Containers start without "No such file or directory" error