### PR TITLE
fix: sanitize credential values on save and improve Bytelixir hints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1489,7 +1489,7 @@ async def api_collectors_meta(request: Request) -> list[dict[str, Any]]:
     # Per-service hints on how to obtain the credentials
     hints: dict[str, str] = {
         "bitping": "Use your Bitping account email and password (same as <a href='https://nodes.bitping.com' target='_blank'>nodes.bitping.com</a>).",
-        "bytelixir": "Log in at <a href='https://dash.bytelixir.com' target='_blank'>dash.bytelixir.com</a> (tick Remember Me), press F12 → Application → Cookies, copy the <b>bytelixir_session</b> value.",
+        "bytelixir": "Log in at <a href='https://dash.bytelixir.com' target='_blank'>dash.bytelixir.com</a> (tick Remember Me), press F12 → Application → expand <b>Cookies</b> in the left sidebar → click <code>https://dash.bytelixir.com</code> → find <b>bytelixir_session</b> → copy its Value.",
         "earnapp": "Log in at <a href='https://earnapp.com' target='_blank'>earnapp.com</a>, press F12 → Application → Cookies, copy the <b>oauth-refresh-token</b> value.",
         "earnfm": "Copy your UUID API key from <a href='https://app.earn.fm' target='_blank'>app.earn.fm</a> → Account Settings.",
         "grass": "Log in at <a href='https://app.getgrass.io' target='_blank'>app.getgrass.io</a>, press F12 → Application → Local Storage, copy the <b>accessToken</b> value.",
@@ -1549,10 +1549,25 @@ class ConfigUpdate(BaseModel):
     data: dict[str, str]
 
 
+def _sanitize_credential(value: str) -> str:
+    """Clean common copy-paste artifacts from credential values."""
+    from urllib.parse import unquote
+
+    v = value.strip()
+    if v.startswith('"') and v.endswith('"'):
+        v = v[1:-1]
+    if v.startswith("'") and v.endswith("'"):
+        v = v[1:-1]
+    if "%3D" in v or "%3d" in v or "%2F" in v or "%2f" in v or "%2B" in v or "%2b" in v:
+        v = unquote(v)
+    return v
+
+
 @app.post("/api/config")
 async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]:
     _require_owner(request)
-    await database.set_config_bulk(body.data)
+    sanitized = {k: _sanitize_credential(v) for k, v in body.data.items()}
+    await database.set_config_bulk(sanitized)
 
     # Auto-create "external" deployment records for manual-only services
     # whose collector credentials were just saved.  Without a deployment
@@ -1563,7 +1578,7 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
         required_keys = [f"{slug}_{a.lstrip('?')}" for a in arg_keys if not a.startswith("?")]
         if not required_keys:
             continue
-        if not all(body.data.get(k) for k in required_keys):
+        if not all(sanitized.get(k) for k in required_keys):
             continue
         svc = catalog.get_service(slug)
         if not svc:

--- a/services/bandwidth/bytelixir.yml
+++ b/services/bandwidth/bytelixir.yml
@@ -21,17 +21,17 @@ docker:
       label: "Session Cookie"
       required: true
       secret: true
-      description: "Log in at <a href=\"https://dash.bytelixir.com\">dash.bytelixir.com</a>, press F12 → Application → Cookies → click <code>https://dash.bytelixir.com</code> → copy the <code>bytelixir_session</code> value (a long JWT starting with eyJ)"
+      description: "Log in at <a href=\"https://dash.bytelixir.com\">dash.bytelixir.com</a>, press F12 → Application → expand <b>Cookies</b> in the left sidebar → click the sub-item <code>https://dash.bytelixir.com</code> → in the cookie list on the right, find <code>bytelixir_session</code> → copy its Value (a long JWT starting with eyJ)"
     - key: BYTELIXIR_REMEMBER_WEB
       label: "Remember Web Cookie"
       required: false
       secret: true
-      description: "Same location as above → copy the <code>remember_web_*</code> cookie value (optional, extends session lifetime)"
+      description: "Same location (Cookies → <code>https://dash.bytelixir.com</code>) → find the cookie named <code>remember_web_...</code> → copy its Value (optional, extends session lifetime)"
     - key: BYTELIXIR_XSRF_TOKEN
       label: "XSRF Token"
       required: false
       secret: true
-      description: "Same location → copy the <code>XSRF-TOKEN</code> cookie value (optional)"
+      description: "Same location → find <code>XSRF-TOKEN</code> → copy its Value (optional)"
   ports: []
   volumes: []
   command: ""


### PR DESCRIPTION
## Summary
- Strip URL-encoded characters (%3D, %2F, %2B), whitespace, and surrounding quotes from credential values at save time — prevents copy-paste artifacts from breaking session cookies
- Clarifies Bytelixir credential description to explicitly show Cookies is expandable and the domain is a sub-item

## Test plan
- [ ] Paste a Bytelixir cookie ending with `%3D` — verify it's stored decoded
- [ ] Paste a token with leading/trailing whitespace — verify it's trimmed
- [ ] Paste a quoted token — verify quotes are stripped
- [ ] Existing credentials already in DB still work (unquote in collector remains as safety net)