### PR TITLE
fix: Bytelixir collector rejects valid session at /

### DIFF
--- a/app/collectors/bytelixir.py
+++ b/app/collectors/bytelixir.py
@@ -153,9 +153,9 @@ class BytelixirCollector(BaseCollector):
 
             html_resp = await self._retry(_fetch_html)
 
-            # A redirect away from a dashboard path means session expired.
+            # A redirect to /login means session expired.
             final_path = html_resp.url.path
-            if not final_path.startswith(("/en", "/es", "/dashboard", "/home")):
+            if final_path.startswith("/login"):
                 return EarningsResult(
                     platform=self.platform,
                     balance=0.0,


### PR DESCRIPTION
## Summary
- The session expiry check used an allowlist of paths (`/en`, `/es`, `/dashboard`, `/home`) but the authenticated dashboard actually stays at `/`
- Changed to only detect expiry when redirected to `/login`
- Tested: cookie returns 200 with balance $0.87770 — parsing works correctly

## Test plan
- [x] Verified inside container: cookie fetches dashboard, balance parses to 0.87770
- [ ] After deploy, Bytelixir should show "connected" in CashPilot UI