### PR TITLE
fix: update Earn.fm tests for Supabase auth

### DIFF
--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -193,17 +193,19 @@ class TestEarnFMDeep:
     def test_collect_401_returns_error(self):
         from app.collectors.earnfm import EarnFMCollector
 
+        auth_resp = _mock_response(200, {"access_token": "tok"})
         expired_resp = MagicMock()
         expired_resp.status_code = 401
 
         client = _make_async_client()
+        client.post.return_value = auth_resp
         client.get.return_value = expired_resp
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(token="test-uuid-token")
+            c = EarnFMCollector(email="a@b.com", password="pass")
             result = asyncio.run(c.collect())
         assert result.error is not None
-        assert "invalid" in result.error.lower() or "expired" in result.error.lower()
+        assert "rejected" in result.error.lower() or "credentials" in result.error.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_collectors_extended.py
+++ b/tests/test_collectors_extended.py
@@ -367,13 +367,15 @@ class TestEarnFMCollector:
     def test_collect_success(self):
         from app.collectors.earnfm import EarnFMCollector
 
+        auth_resp = _mock_response(200, {"access_token": "tok"})
         balance_resp = _mock_response(200, {"data": {"totalBalance": 0.50}})
 
         client = _make_async_client()
+        client.post.return_value = auth_resp
         client.get.return_value = balance_resp
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(token="test-uuid-token")
+            c = EarnFMCollector(email="a@b.com", password="pass")
             result = asyncio.run(c.collect())
         assert result.error is None
         assert result.balance == 0.50
@@ -382,10 +384,10 @@ class TestEarnFMCollector:
         from app.collectors.earnfm import EarnFMCollector
 
         client = _make_async_client()
-        client.get.side_effect = Exception("Failed")
+        client.post.side_effect = Exception("Failed")
 
         with patch("app.collectors.earnfm.httpx.AsyncClient", return_value=client):
-            c = EarnFMCollector(token="bad-token")
+            c = EarnFMCollector(email="a@b.com", password="bad")
             result = asyncio.run(c.collect())
         assert result.error is not None
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -887,14 +887,14 @@ class TestCollectorSmallGaps:
         # Should either succeed with 0 or have an error
         assert isinstance(result, EarningsResult)
 
-    def test_earnfm_empty_token(self):
-        """Cover earnfm.py: empty token returns error."""
+    def test_earnfm_empty_credentials(self):
+        """Cover earnfm.py: empty credentials returns error."""
         from app.collectors.earnfm import EarnFMCollector
 
-        c = EarnFMCollector(token="")
+        c = EarnFMCollector(email="", password="")
         result = asyncio.run(c.collect())
         assert result.error is not None
-        assert "No token" in result.error
+        assert "No credentials" in result.error
 
     def test_bitping_login_missing_cookie(self):
         """Cover bitping.py lines 45-48: login without cookie set."""


### PR DESCRIPTION
## Summary
- Tests used old `EarnFMCollector(token=...)` constructor which no longer exists after PR #72
- Updated to `EarnFMCollector(email=..., password=...)` matching the Supabase auth rewrite

## Test plan
- [x] All 4 affected tests pass locally (4 passed in 0.28s)