### PR TITLE
fix: auto-purge stale offline workers from fleet page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -241,16 +241,23 @@ async def _run_data_retention() -> None:
 
 
 async def _check_stale_workers() -> None:
-    """Mark workers as offline if they haven't sent a heartbeat recently."""
+    """Mark workers as offline if stale, and purge workers offline > 1 hour."""
     try:
         workers = await database.list_workers()
-        cutoff = datetime.now(UTC) - timedelta(seconds=STALE_WORKER_SECONDS)
+        now = datetime.now(UTC)
+        cutoff = now - timedelta(seconds=STALE_WORKER_SECONDS)
+        purge_cutoff = now - timedelta(hours=1)
         for w in workers:
-            if w["status"] == "online" and w.get("last_heartbeat"):
-                last = datetime.fromisoformat(w["last_heartbeat"]).replace(tzinfo=UTC)
-                if last < cutoff:
-                    await database.set_worker_status(w["id"], "offline")
-                    logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], w["last_heartbeat"])
+            last_hb = w.get("last_heartbeat")
+            if not last_hb:
+                continue
+            last = datetime.fromisoformat(last_hb).replace(tzinfo=UTC)
+            if w["status"] == "online" and last < cutoff:
+                await database.set_worker_status(w["id"], "offline")
+                logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], last_hb)
+            elif w["status"] == "offline" and last < purge_cutoff:
+                await database.delete_worker(w["id"])
+                logger.info("Purged stale worker '%s' (offline since %s)", w["name"], last_hb)
     except Exception as exc:
         logger.warning("Stale worker check error: %s", exc)
 


### PR DESCRIPTION
## Summary
- Workers offline for > 1 hour are auto-deleted from the database
- Prevents fleet page from filling with stale entries after container recreations
- Immediately purged 6 stale workers from current DB

## Test plan
- [x] 880 tests pass
- [x] Manually deleted 6 stale workers from prod DB
- [ ] After deploy, fleet page shows only active workers