### PR TITLE
feat: add Anyone Protocol collector and fix CI worker manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create UI manifests
-        if: inputs.build_ui
+        if: inputs.build_ui && needs.build-ui-amd64.result == 'success' && needs.build-ui-arm64.result == 'success'
         run: |
           TAGS="${{ needs.resolve-tags.outputs.ui_tags }}"
           VER="${{ needs.resolve-tags.outputs.version }}"
@@ -184,7 +184,7 @@ jobs:
               "drumsergio/cashpilot:${VER}-arm64"
           done
       - name: Create Worker manifests
-        if: inputs.build_worker
+        if: inputs.build_worker && needs.build-worker-amd64.result == 'success' && needs.build-worker-arm64.result == 'success'
         run: |
           TAGS="${{ needs.resolve-tags.outputs.worker_tags }}"
           VER="${{ needs.resolve-tags.outputs.version }}"

--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.collectors.anyone import AnyoneCollector
 from app.collectors.base import BaseCollector, EarningsResult
 from app.collectors.bitping import BitpingCollector
 from app.collectors.bytelixir import BytelixirCollector
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 # slug -> collector class
 COLLECTOR_MAP: dict[str, type[BaseCollector]] = {
+    "anyone-protocol": AnyoneCollector,
     "honeygain": HoneygainCollector,
     "earnapp": EarnAppCollector,
     "iproyal": IPRoyalCollector,
@@ -47,6 +49,7 @@ COLLECTOR_MAP: dict[str, type[BaseCollector]] = {
 
 # Map of slug -> list of config keys needed to instantiate the collector
 _COLLECTOR_ARGS: dict[str, list[str]] = {
+    "anyone-protocol": ["fingerprints"],
     "honeygain": ["email", "password"],
     "earnapp": ["oauth_token"],
     "iproyal": ["email", "password"],

--- a/app/collectors/anyone.py
+++ b/app/collectors/anyone.py
@@ -96,7 +96,7 @@ class AnyoneCollector(BaseCollector):
             total_tokens = 0.0
 
             for fp in self.fingerprints:
-                tokens = await self._get_rewards_for_fingerprint(client, fp)
+                tokens = await self._retry(lambda fp=fp: self._get_rewards_for_fingerprint(client, fp))
                 total_tokens += tokens
                 logger.debug("Fingerprint %s: %.6f ANYONE", fp, tokens)
 
@@ -107,7 +107,7 @@ class AnyoneCollector(BaseCollector):
                     currency="ANYONE",
                 )
 
-            price = await self._get_token_price(client)
+            price = await self._retry(lambda: self._get_token_price(client))
             if price <= 0:
                 return EarningsResult(
                     platform=self.platform,

--- a/app/collectors/anyone.py
+++ b/app/collectors/anyone.py
@@ -1,0 +1,130 @@
+"""Anyone Protocol (formerly ATOR) earnings collector.
+
+Queries the relay-rewards AO smart contract via dry-run to get
+accumulated ANYONE token rewards per relay fingerprint, then converts
+to USD via CoinGecko.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.collectors.base import BaseCollector, EarningsResult
+
+logger = logging.getLogger(__name__)
+
+RELAY_REWARDS_PROCESS_ID = "QZJTY63XZtHOHo_qPaEX7VdtemZh4rpj821xcanPGXA"
+AO_CU_URL = "https://cu.anyone.tech"
+RELAY_API = "https://api.ec.anyone.tech"
+COINGECKO_ID = "airtor-protocol"
+TOKEN_DECIMALS = 18
+
+
+class AnyoneCollector(BaseCollector):
+    """Collect earnings from Anyone Protocol relays via AO dry-run."""
+
+    platform = "anyone-protocol"
+
+    def __init__(self, fingerprints: str) -> None:
+        super().__init__()
+        self.fingerprints = [fp.strip() for fp in fingerprints.split(",") if fp.strip()]
+
+    async def _get_rewards_for_fingerprint(self, client: httpx.AsyncClient, fingerprint: str) -> float:
+        """Query AO relay-rewards contract for a single fingerprint's total reward."""
+        payload = {
+            "Id": "1234",
+            "Target": RELAY_REWARDS_PROCESS_ID,
+            "Owner": "1234",
+            "Anchor": "0",
+            "Tags": [
+                {"name": "Action", "value": "Get-Rewards"},
+                {"name": "Fingerprint", "value": fingerprint},
+                {"name": "Address", "value": "0x0000000000000000000000000000000000000000"},
+                {"name": "Data-Protocol", "value": "ao"},
+                {"name": "Type", "value": "Message"},
+                {"name": "Variant", "value": "ao.TN.1"},
+            ],
+            "Data": "1234",
+        }
+        resp = await client.post(
+            f"{AO_CU_URL}/dry-run",
+            params={"process-id": RELAY_REWARDS_PROCESS_ID},
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        result = resp.json()
+
+        if "error" in result:
+            raise RuntimeError(f"AO CU error: {result['error']}")
+
+        messages = result.get("Messages", [])
+        if not messages:
+            logger.debug("No messages returned for fingerprint %s", fingerprint)
+            return 0.0
+
+        data = messages[0].get("Data", "0")
+        if not data or data == "null":
+            return 0.0
+
+        raw_tokens = int(data)
+        return raw_tokens / (10**TOKEN_DECIMALS)
+
+    async def _get_token_price(self, client: httpx.AsyncClient) -> float:
+        """Fetch ANYONE token price in USD from CoinGecko."""
+        resp = await client.get(
+            "https://api.coingecko.com/api/v3/simple/price",
+            params={"ids": COINGECKO_ID, "vs_currencies": "usd"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return float(data.get(COINGECKO_ID, {}).get("usd", 0))
+
+    async def collect(self) -> EarningsResult:
+        if not self.fingerprints:
+            return EarningsResult(
+                platform=self.platform,
+                balance=0.0,
+                error="No fingerprints configured",
+            )
+
+        try:
+            client = self._get_client(timeout=30)
+            total_tokens = 0.0
+
+            for fp in self.fingerprints:
+                tokens = await self._get_rewards_for_fingerprint(client, fp)
+                total_tokens += tokens
+                logger.debug("Fingerprint %s: %.6f ANYONE", fp, tokens)
+
+            if total_tokens <= 0:
+                return EarningsResult(
+                    platform=self.platform,
+                    balance=0.0,
+                    currency="ANYONE",
+                )
+
+            price = await self._get_token_price(client)
+            if price <= 0:
+                return EarningsResult(
+                    platform=self.platform,
+                    balance=round(total_tokens, 6),
+                    currency="ANYONE",
+                )
+
+            usd_value = total_tokens * price
+            return EarningsResult(
+                platform=self.platform,
+                balance=round(usd_value, 2),
+                currency="USD",
+            )
+        except Exception as exc:
+            logger.error("Anyone Protocol collection failed: %s", exc, exc_info=True)
+            return EarningsResult(
+                platform=self.platform,
+                balance=0.0,
+                error=str(exc),
+            )

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -59,5 +59,13 @@ cashout:
 platforms: [docker, linux]
 
 collector:
-  type: manual
-  notes: "Open source relay. Earnings tracked on-chain."
+  type: auto
+  credentials:
+    - key: fingerprints
+      label: "Relay Fingerprints"
+      hint: >
+        Comma-separated relay fingerprints. Find yours with:
+        docker exec cashpilot-anyone-protocol anon --list-fingerprint
+        or check https://api.ec.anyone.tech/relays/{fingerprint}
+      type: text
+  notes: "Queries AO relay-rewards contract by fingerprint, converts ANYONE tokens to USD via CoinGecko."

--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -500,3 +500,86 @@ class TestBitpingDeep:
             result = asyncio.run(c.collect())
         assert result.error is None
         assert result.balance == 0.25
+
+
+# ---------------------------------------------------------------------------
+# Anyone Protocol — AO dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestAnyoneProtocolDeep:
+    def test_collect_success(self):
+        from app.collectors.anyone import AnyoneCollector
+
+        ao_resp = _mock_response(
+            200,
+            {"Messages": [{"Data": "5000000000000000000"}]},
+        )
+        price_resp = _mock_response(200, {"airtor-protocol": {"usd": 0.10}})
+
+        client = _make_async_client()
+        client.post.return_value = ao_resp
+        client.get.return_value = price_resp
+
+        with patch("app.collectors.anyone.httpx.AsyncClient", return_value=client):
+            c = AnyoneCollector(fingerprints="ABC123")
+            result = asyncio.run(c.collect())
+        assert result.error is None
+        assert result.balance == 0.50
+        assert result.currency == "USD"
+
+    def test_collect_no_fingerprints(self):
+        from app.collectors.anyone import AnyoneCollector
+
+        c = AnyoneCollector(fingerprints="")
+        result = asyncio.run(c.collect())
+        assert result.error is not None
+        assert "fingerprints" in result.error.lower()
+
+    def test_collect_ao_error(self):
+        from app.collectors.anyone import AnyoneCollector
+
+        ao_resp = _mock_response(200, {"error": "Process scheduler not found"})
+
+        client = _make_async_client()
+        client.post.return_value = ao_resp
+
+        with patch("app.collectors.anyone.httpx.AsyncClient", return_value=client):
+            c = AnyoneCollector(fingerprints="ABC123")
+            result = asyncio.run(c.collect())
+        assert result.error is not None
+        assert "AO CU error" in result.error
+
+    def test_collect_multiple_fingerprints(self):
+        from app.collectors.anyone import AnyoneCollector
+
+        ao_resp1 = _mock_response(200, {"Messages": [{"Data": "2000000000000000000"}]})
+        ao_resp2 = _mock_response(200, {"Messages": [{"Data": "3000000000000000000"}]})
+        price_resp = _mock_response(200, {"airtor-protocol": {"usd": 0.10}})
+
+        client = _make_async_client()
+        client.post.side_effect = [ao_resp1, ao_resp2]
+        client.get.return_value = price_resp
+
+        with patch("app.collectors.anyone.httpx.AsyncClient", return_value=client):
+            c = AnyoneCollector(fingerprints="FP1,FP2")
+            result = asyncio.run(c.collect())
+        assert result.error is None
+        assert result.balance == 0.50
+
+    def test_collect_no_price_returns_tokens(self):
+        from app.collectors.anyone import AnyoneCollector
+
+        ao_resp = _mock_response(200, {"Messages": [{"Data": "1000000000000000000"}]})
+        price_resp = _mock_response(200, {})
+
+        client = _make_async_client()
+        client.post.return_value = ao_resp
+        client.get.return_value = price_resp
+
+        with patch("app.collectors.anyone.httpx.AsyncClient", return_value=client):
+            c = AnyoneCollector(fingerprints="ABC123")
+            result = asyncio.run(c.collect())
+        assert result.error is None
+        assert result.balance == 1.0
+        assert result.currency == "ANYONE"


### PR DESCRIPTION
## Summary
- Add `AnyoneCollector` that queries the AO relay-rewards smart contract (`relay-rewards.lua`) by relay fingerprint, converts ANYONE tokens to USD via CoinGecko
- Fix `build.yml` manifest step: only creates multi-arch manifests when the corresponding arch-specific builds actually succeeded (was trying to create worker manifests from non-existent arch tags when worker builds were skipped)
- Register `anyone-protocol` in collector registry with `fingerprints` credential

## Details

**Anyone Protocol Collector:**
- Queries AO Compute Unit at `cu.anyone.tech` with `Get-Rewards` action by fingerprint
- Converts raw token amounts (18 decimals) to ANYONE tokens
- Fetches USD price from CoinGecko (`airtor-protocol`)
- Falls back to reporting in ANYONE if price unavailable
- Note: Anyone's AO infrastructure is currently returning scheduler errors — collector will work once their infra stabilizes

**CI Fix:**
- Added `needs.build-worker-amd64.result == 'success'` guards to manifest creation steps
- Prevents `manifest unknown` errors when only UI is rebuilt

## Test plan
- [x] 885 tests pass (5 new Anyone collector tests)
- [x] Lint + format clean
- [ ] CI passes on this PR
- [ ] After merge, verify worker manifest isn't attempted on UI-only releases
- [ ] Once Anyone AO infra is stable, configure fingerprints and verify earnings show

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anyone Protocol earnings collection: enter relay fingerprints to fetch relay rewards and convert ANYONE tokens to USD.
* **Configuration**
  * Connector now accepts a fingerprints credential to enable automatic relay-rewards queries.
* **Tests**
  * Added deep tests covering success, multiple fingerprints, error handling, missing fingerprints, and missing price scenarios.
* **Chores**
  * CI manifest creation now waits for multi-arch image builds to complete before running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/CashPilot/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->