### PR TITLE
fix: Repocket container env should be RP_EMAIL + RP_API_KEY (#82)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -22,7 +22,7 @@ Individual setup and configuration guides for every supported service.
 - [ProxyBase](proxybase.md) -- Bandwidth sharing - crypto payout, user ID auth
 - [ProxyLite](proxylite.md) -- Bandwidth sharing - 15% lifetime referral, works on VPS
 - [ProxyRack](proxyrack.md) -- Bandwidth sharing - UUID per device, works on VPS
-- [Repocket](repocket.md) -- Bandwidth sharing - residential only, max 5 devices, env-based auth
+- [Repocket](repocket.md) -- Bandwidth sharing - residential only, max 5 devices, API key auth
 - [SpeedShare](speedshare.md) -- Bandwidth sharing - residential only, no official Docker
 - [Spide](spide.md) -- Bandwidth sharing - machine ID based
 - [Traffmonetizer](traffmonetizer.md) -- Bandwidth sharing - works on VPS, token-based auth

--- a/docs/guides/repocket.md
+++ b/docs/guides/repocket.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Repocket lets you earn passive income by sharing your unused internet bandwidth. Residential IPs earn the most; VPS/datacenter IPs are accepted at lower rates. Max 5 devices and 5 active sessions per account. Authenticates via Firebase using email and password. The Docker image uses environment variables directly.
+Repocket lets you earn passive income by sharing your unused internet bandwidth. Residential IPs earn the most; VPS/datacenter IPs are accepted at lower rates. Max 5 devices and 5 active sessions per account. The Docker container authenticates with your account email and an API key from the Repocket dashboard (not your password).
 
 ## Earning Estimates
 
@@ -35,9 +35,9 @@ Repocket lets you earn passive income by sharing your unused internet bandwidth.
 
 Sign up at [Repocket](https://repocket.com/).
 
-### 2. Get your credentials
+### 2. Get your API key
 
-After signing up, you'll use your account email and password for Docker deployment.
+Log in at [app.repocket.com](https://app.repocket.com/bandwidth-earnings) and copy the **API key** shown on the bandwidth-earnings page. This API key — not your account password — is what the Docker container uses to authenticate.
 
 ### 3. Deploy with CashPilot
 
@@ -52,5 +52,5 @@ In the CashPilot web UI, find **Repocket** in the service catalog and click **De
 
 | Variable | Label | Required | Secret | Description |
 |----------|-------|:--------:|:------:|-------------|
-| `REPOCKET_EMAIL` | Email | Yes | No | Your Repocket account email |
-| `REPOCKET_PASSWORD` | Password | Yes | Yes | Your Repocket account password (used for Firebase auth) |
+| `RP_EMAIL` | Email | Yes | No | Your Repocket account email |
+| `RP_API_KEY` | API Key | Yes | Yes | Your Repocket API key from the dashboard's bandwidth-earnings page (not your account password) |

--- a/services/bandwidth/repocket.yml
+++ b/services/bandwidth/repocket.yml
@@ -6,9 +6,10 @@ website: https://repocket.com
 description: >
   Repocket lets you earn passive income by sharing your unused internet bandwidth.
   Residential IPs earn the most; VPS/datacenter IPs are accepted at lower rates.
-  Max 5 devices and 5 active sessions per account. Authenticates via Firebase
-  using email and password. The Docker image uses environment variables directly.
-short_description: Bandwidth sharing - max 5 devices, email/password auth
+  Max 5 devices and 5 active sessions per account. The Docker container
+  authenticates with your account email and an API key from the Repocket
+  dashboard (not your password).
+short_description: Bandwidth sharing - max 5 devices, API key auth
 
 referral:
   signup_url: "https://repocket.com/"
@@ -17,16 +18,16 @@ docker:
   image: repocket/repocket
   platforms: [linux/amd64, linux/arm64]
   env:
-    - key: REPOCKET_EMAIL
+    - key: RP_EMAIL
       label: "Email"
       required: true
       secret: false
       description: "Your Repocket account email"
-    - key: REPOCKET_PASSWORD
-      label: "Password"
+    - key: RP_API_KEY
+      label: "API Key"
       required: true
       secret: true
-      description: "Your Repocket account password (used for Firebase auth)"
+      description: "Your Repocket API key — log in at <a href=\"https://app.repocket.com/bandwidth-earnings\">app.repocket.com</a> and copy the API key shown on the bandwidth-earnings page (this is NOT your account password)"
   ports: []
   volumes: []
   command: ""
@@ -64,4 +65,4 @@ platforms: [docker, windows, macos, linux, android]
 
 collector:
   type: api
-  notes: "Firebase auth via email/password. Per-device earnings visible."
+  notes: "Earnings collector authenticates separately via Firebase (account email/password) to read the balance — distinct from the container's RP_API_KEY. Per-device earnings visible."

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -88,3 +88,24 @@ def test_no_duplicate_slugs():
         slugs.append(data["slug"])
     duplicates = [s for s in slugs if slugs.count(s) > 1]
     assert not duplicates, f"Duplicate slugs found: {set(duplicates)}"
+
+
+def test_repocket_container_env_keys():
+    """Regression for #82: the repocket/repocket image reads RP_EMAIL + RP_API_KEY.
+
+    A prior 'audit' (PR #46) renamed these to REPOCKET_EMAIL/REPOCKET_PASSWORD to
+    match the earnings collector's auth model, which silently broke deployment —
+    the container ignores unknown env vars and logs 'User credentials are missing!'.
+    The container env contract is independent of the collector's Firebase login.
+    """
+    repocket = SERVICES_DIR / "bandwidth" / "repocket.yml"
+    with open(repocket) as f:
+        data = yaml.safe_load(f)
+    env_keys = {e["key"] for e in data["docker"]["env"]}
+    assert env_keys == {"RP_EMAIL", "RP_API_KEY"}, (
+        f"Repocket container env must be exactly RP_EMAIL + RP_API_KEY, got {env_keys}"
+    )
+    by_key = {e["key"]: e for e in data["docker"]["env"]}
+    assert by_key["RP_API_KEY"]["secret"] is True, "RP_API_KEY must be marked secret"
+    assert by_key["RP_API_KEY"]["required"] is True, "RP_API_KEY must be required"
+    assert by_key["RP_EMAIL"]["required"] is True, "RP_EMAIL must be required"

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -141,6 +141,45 @@ class TestApiDeploy:
             resp = client.post("/api/deploy/honeygain", json={})
             assert resp.status_code == 401
 
+    def test_deploy_repocket_emits_rp_env_keys(self, client):
+        """#82 guard at the deploy layer: the real repocket catalog entry must
+        produce RP_EMAIL/RP_API_KEY in the container spec sent to the worker.
+
+        Uses the real catalog (no get_service mock), so a future regression that
+        renames the YAML keys OR a refactor of api_deploy that mangles env names
+        is caught independently of the catalog-level test.
+        """
+        captured: dict = {}
+
+        async def _capture_deploy(worker_id, slug, spec):
+            captured["spec"] = spec
+            return {"container_id": "abc123"}
+
+        # Reload the real catalog from disk so this test is independent of any
+        # earlier test that swapped SERVICES_DIR and left the cache polluted.
+        from app import catalog
+
+        catalog.load_services()
+
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_worker_deploy", side_effect=_capture_deploy),
+            patch("app.main.database.save_deployment", new_callable=AsyncMock),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
+        ):
+            resp = client.post(
+                "/api/deploy/repocket",
+                json={"env": {"RP_EMAIL": "me@example.com", "RP_API_KEY": "key123"}},
+            )
+            assert resp.status_code == 200, resp.text
+            spec_env = captured["spec"]["env"]
+            assert set(spec_env) == {"RP_EMAIL", "RP_API_KEY"}, (
+                f"repocket container spec must carry exactly RP_EMAIL + RP_API_KEY, got {set(spec_env)}"
+            )
+            assert spec_env["RP_API_KEY"] == "key123"
+            assert spec_env["RP_EMAIL"] == "me@example.com"
+
 
 # ---------------------------------------------------------------------------
 # Stop / Restart / Start / Remove (service management routes)


### PR DESCRIPTION
## Summary

Fixes #82. The Repocket Docker container repeatedly logged `User credentials are missing! Please declare environment variables RP_EMAIL and RP_API_KEY` — and even pasting the API key into the "Password" field failed.

**Root cause:** the `repocket/repocket` image reads `RP_EMAIL` + `RP_API_KEY` (an API key from the dashboard). CashPilot originally shipped exactly those, but PR #46 ("ecosystem audit findings") renamed them to `REPOCKET_EMAIL` / `REPOCKET_PASSWORD` to align with the *earnings collector's* Firebase auth model. The container ignores those unknown env var names, so it never receives credentials regardless of the value entered — which is why the API-key-in-password-field also failed.

The container and the earnings collector authenticate with **different secrets** via **independent code paths**:
- **Container** → `RP_EMAIL` + `RP_API_KEY` (API key from `app.repocket.com/bandwidth-earnings`)
- **Earnings collector** (`app/collectors/repocket.py`) → Firebase login with account **email + password**

This PR only corrects the container env (the YAML) and leaves the collector untouched.

## Changes
- `services/bandwidth/repocket.yml` — `docker.env` keys → `RP_EMAIL` + `RP_API_KEY` (label "API Key", `secret: true`), with help text pointing to the dashboard page where the key is shown. Clarified the `collector.notes` so the container/collector credential distinction is explicit (this conflation is what caused the regression).
- `docs/guides/repocket.md` — description, "Get your API key" step, and env-var table updated.
- `docs/guides/README.md` — "env-based auth" → "API key auth".
- `tests/test_catalog.py` — **new regression test** asserting Repocket's container env is exactly `RP_EMAIL` + `RP_API_KEY` (secret + required), so a future "align with collector" edit can't silently break deploys again.

## Verification
- `RP_*` names confirmed against the official `repocket/repocket` image and 14 other passive-income managers (money4band, income-generator, CashFactory, …) — all unanimous.
- `pytest tests/` (catalog + collectors + deploy/compose/routes): **613 passed**; new regression test green.
- `ruff check .`: clean.
- Catalog loader confirms the container now receives `RP_EMAIL` + `RP_API_KEY`.

## Backward compatibility
Container env is not persisted in CashPilot's DB — affected users just **redeploy** Repocket and paste the API key. The collector's stored `repocket_password` is untouched, so earnings tracking keeps working.

## Notes for users
The API key is **not** your account password — copy it from the Repocket dashboard's bandwidth-earnings page.