### PR TITLE
ci: build multi-arch images via QEMU (no ARM64 runner needed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,12 +80,16 @@ jobs:
       - run: pip install ruff
       - run: ruff check app/ && ruff format --check app/
 
-  build-ui-amd64:
+  # Multi-arch build (amd64 + arm64) in a single QEMU-emulated job on the X64
+  # runner. buildx pushes the multi-platform manifest under all tags directly,
+  # so no separate ARM64 runner and no manifest-merge job are needed.
+  build-ui:
     needs: [lint, resolve-tags]
     if: inputs.build_ui
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -95,39 +99,19 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: drumsergio/cashpilot:${{ needs.resolve-tags.outputs.version }}-amd64
-          cache-from: type=gha,scope=ui-amd64
-          cache-to: type=gha,mode=max,scope=ui-amd64
+          tags: ${{ needs.resolve-tags.outputs.ui_tags }}
+          cache-from: type=gha,scope=ui
+          cache-to: type=gha,mode=max,scope=ui
 
-  build-ui-arm64:
-    needs: [lint, resolve-tags]
-    if: inputs.build_ui
-    runs-on: [self-hosted, Linux, ARM64]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/arm64
-          push: true
-          tags: drumsergio/cashpilot:${{ needs.resolve-tags.outputs.version }}-arm64
-          cache-from: type=gha,scope=ui-arm64
-          cache-to: type=gha,mode=max,scope=ui-arm64
-
-  build-worker-amd64:
+  build-worker:
     needs: [lint, resolve-tags]
     if: inputs.build_worker
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -137,59 +121,8 @@ jobs:
         with:
           context: .
           file: Dockerfile.worker
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: drumsergio/cashpilot-worker:${{ needs.resolve-tags.outputs.version }}-amd64
-          cache-from: type=gha,scope=worker-amd64
-          cache-to: type=gha,mode=max,scope=worker-amd64
-
-  build-worker-arm64:
-    needs: [lint, resolve-tags]
-    if: inputs.build_worker
-    runs-on: [self-hosted, Linux, ARM64]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.worker
-          platforms: linux/arm64
-          push: true
-          tags: drumsergio/cashpilot-worker:${{ needs.resolve-tags.outputs.version }}-arm64
-          cache-from: type=gha,scope=worker-arm64
-          cache-to: type=gha,mode=max,scope=worker-arm64
-
-  manifest:
-    needs: [resolve-tags, build-ui-amd64, build-ui-arm64, build-worker-amd64, build-worker-arm64]
-    if: always() && !cancelled()
-    runs-on: [self-hosted, Linux, X64]
-    steps:
-      - uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create UI manifests
-        if: inputs.build_ui && needs.build-ui-amd64.result == 'success' && needs.build-ui-arm64.result == 'success'
-        run: |
-          TAGS="${{ needs.resolve-tags.outputs.ui_tags }}"
-          VER="${{ needs.resolve-tags.outputs.version }}"
-          for tag in $TAGS; do
-            docker buildx imagetools create -t "$tag" \
-              "drumsergio/cashpilot:${VER}-amd64" \
-              "drumsergio/cashpilot:${VER}-arm64"
-          done
-      - name: Create Worker manifests
-        if: inputs.build_worker && needs.build-worker-amd64.result == 'success' && needs.build-worker-arm64.result == 'success'
-        run: |
-          TAGS="${{ needs.resolve-tags.outputs.worker_tags }}"
-          VER="${{ needs.resolve-tags.outputs.version }}"
-          for tag in $TAGS; do
-            docker buildx imagetools create -t "$tag" \
-              "drumsergio/cashpilot-worker:${VER}-amd64" \
-              "drumsergio/cashpilot-worker:${VER}-arm64"
-          done
+          tags: ${{ needs.resolve-tags.outputs.worker_tags }}
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker


### PR DESCRIPTION
## Problem
The release Docker build never publishes a multi-arch image. The `build-ui-arm64` / `build-worker-arm64` jobs require `runs-on: [self-hosted, Linux, ARM64]`, but the only registered runner is `watchtower-cashpilot` (**X64**). Those jobs queue forever, and the `manifest` job (which needs all 4 arch jobs) never runs. v0.6.12's arm64 jobs are *still* stuck weeks later for the same reason — so the published `:latest`/`:x.y.z` tags were only ever the per-arch `-amd64`/`-arm64` suffixed images, never a merged manifest.

## Fix
Replace the 4 per-arch jobs + manifest-merge with **one QEMU-emulated buildx job per image** that builds `linux/amd64,linux/arm64` together and pushes the multi-platform manifest directly under all tags (`:latest`, `:x.y.z`, `:x.y`). Adds `docker/setup-qemu-action@v3`.

- No ARM64 runner required — runs entirely on the existing X64 runner.
- `runs-on: [self-hosted, Linux, X64]` so GitHub schedules whichever X64 runner (watchtower / geiserback) is free.
- `build-push-action` produces the manifest natively when pushing multiple platforms, so the separate `manifest` job is removed.

## Notes
- Base image `python:3.14-alpine` is multi-arch; Dockerfiles have no hardcoded-arch downloads, so arm64 builds cleanly under emulation.
- arm64 via QEMU is slower (emulated), but correct and unblocked.

## Test plan
- [ ] Merge → next release builds and pushes a true multi-arch manifest for both `cashpilot` and `cashpilot-worker`
- [ ] `docker manifest inspect drumsergio/cashpilot:latest` shows both amd64 + arm64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD workflow by consolidating multi-architecture Docker image builds into unified jobs, reducing build pipeline complexity and improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->