### PR TITLE
fix: make `docker compose pull && up -d` the correct update path (#84)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .github
+docker-compose*.yml
 __pycache__
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ On each additional server, deploy only a worker pointing to the UI:
 services:
   cashpilot-worker:
     image: drumsergio/cashpilot-worker:latest
+    pull_policy: always
     container_name: cashpilot-worker
     ports:
       - "8081:8081"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,20 +1,18 @@
-# CashPilot - Self-hosted passive income orchestrator
+# CashPilot - build from source (for contributors / local development)
 # https://github.com/GeiserX/CashPilot
 #
-# UI + Worker on the same server. For multi-server fleet, see docker-compose.fleet.yml
+# This file builds the UI and worker images from the local checkout instead of
+# pulling the published releases. Use it when developing changes:
 #
-#   Start / update:  docker compose pull && docker compose up -d
+#   docker compose -f docker-compose.build.yml up -d --build
 #
-# Images track the `latest` tag (pull_policy: always), so a plain `up -d`
-# always launches the newest published release — no rebuild needed. To pin a
-# specific version instead, replace `:latest` with e.g. `:0.6.13` (see
-# https://hub.docker.com/r/drumsergio/cashpilot/tags) and drop pull_policy.
-# Building from source? Use: docker compose -f docker-compose.build.yml up -d
+# Regular users should use the default docker-compose.yml, which pulls the
+# published `latest` image (no build toolchain required).
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:latest
-    pull_policy: always
+    build: .
+    image: drumsergio/cashpilot:dev
     container_name: cashpilot-ui
     ports:
       - "8080:8080"
@@ -34,8 +32,10 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:latest
-    pull_policy: always
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    image: drumsergio/cashpilot-worker:dev
     container_name: cashpilot-worker
     expose:
       - "8081"

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,8 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:v0.6.2
+    image: drumsergio/cashpilot:latest
+    pull_policy: always
     container_name: cashpilot-ui
     ports:
       - "8080:8080"
@@ -29,7 +30,8 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:v0.6.2
+    image: drumsergio/cashpilot-worker:latest
+    pull_policy: always
     container_name: cashpilot-worker
     ports:
       - "8081:8081"
@@ -55,7 +57,8 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:v0.6.2
+#      image: drumsergio/cashpilot-worker:latest
+#      pull_policy: always
 #      container_name: cashpilot-worker
 #      ports:
 #        - "8081:8081"

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -52,6 +52,7 @@ On each additional server, deploy only a worker pointing back to the UI:
 services:
   cashpilot-worker:
     image: drumsergio/cashpilot-worker:latest
+    pull_policy: always
     container_name: cashpilot-worker
     ports:
       - "8081:8081"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,6 +86,7 @@ graph LR
 services:
   cashpilot-ui:
     image: drumsergio/cashpilot:latest
+    pull_policy: always
     container_name: cashpilot-ui
     ports:
       - "8080:8080"
@@ -99,6 +100,7 @@ services:
 
   cashpilot-worker:
     image: drumsergio/cashpilot-worker:latest
+    pull_policy: always
     container_name: cashpilot-worker
     ports:
       - "8081:8081"
@@ -126,6 +128,49 @@ volumes:
 
 !!! tip "Passwords and secrets in the UI"
     Change your own password any time from the avatar menu -> **Change password** (available to all roles); this signs out your other sessions. In **Settings**, stored secrets are write-only: enter a value to change it, or leave the field blank to keep the existing one. Saved credentials are never sent back to the browser.
+
+## Updating CashPilot
+
+The published images use floating tags, so updating is just a pull + recreate:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+`docker compose pull` fetches the newest published image and `up -d` recreates
+only the containers whose image changed. The shipped compose files set
+`pull_policy: always`, so even a bare `docker compose up -d` will pull the
+latest image first.
+
+!!! note "You do **not** need to rebuild"
+    CashPilot ships prebuilt multi-arch images on Docker Hub
+    ([`drumsergio/cashpilot`](https://hub.docker.com/r/drumsergio/cashpilot),
+    [`drumsergio/cashpilot-worker`](https://hub.docker.com/r/drumsergio/cashpilot-worker)).
+    `docker compose build` / `--build` is only relevant if you deliberately
+    build from source with `docker-compose.build.yml`. For normal installs,
+    `pull` + `up -d` is the complete and correct update procedure.
+
+### Pinning a specific version
+
+`:latest` always tracks the newest release. To stay on a fixed version,
+replace the tag (e.g. `drumsergio/cashpilot:0.6.13`) and remove
+`pull_policy: always`. Browse available tags on
+[Docker Hub](https://hub.docker.com/r/drumsergio/cashpilot/tags). The minor
+tag (e.g. `:0.6`) tracks the latest patch within that minor series.
+
+### Automating updates (optional)
+
+If you want hands-off updates, point a scheduler at the same two commands —
+for example a daily cron entry:
+
+```cron
+0 4 * * *  cd /path/to/cashpilot && docker compose pull && docker compose up -d
+```
+
+Or run an auto-updater such as [Watchtower](https://containrrr.dev/watchtower/)
+or [Diun](https://crazymax.dev/diun/) against the CashPilot containers. These
+are entirely optional — CashPilot does not bundle an updater.
 
 ## Supported Services
 


### PR DESCRIPTION
Fixes #84.

## Problem
A user reported that `docker compose pull && docker compose up -d` doesn't apply CashPilot updates — they had to `docker compose down && docker compose build --no-cache && docker compose up -d`. Investigation found two compounding defects in the shipped compose files:

1. **`docker-compose.yml` declared BOTH `build: .` and `image:`.** With a `build:` section and no `pull_policy`, `docker compose up -d` reuses the locally-built image and `pull` doesn't authoritatively refresh it. So updates silently didn't apply unless the user force-rebuilt — which is why their `--no-cache` workaround "worked." **The build was never needed**: prebuilt multi-arch images are published to Docker Hub on every release.
2. **The pinned tag `v0.6.2` isn't published.** CI pushes *unprefixed* tags (`0.6.2`, `0.6`, `latest`), so a clean `pull` of `v0.6.2` couldn't even resolve. It was also 11 releases stale (latest is 0.6.13).

## Fix
- **`docker-compose.yml` / `docker-compose.fleet.yml`**: remove `build:`, pull `:latest` with **`pull_policy: always`**. Now `docker compose up -d` always launches the newest published release, and `docker compose pull && up -d` is the complete, correct update procedure.
- **New `docker-compose.build.yml`** for contributors who genuinely want to build from source (preserves the old behavior, clearly named, `:dev` tag).
- **`docs/getting-started.md`**: new "Updating CashPilot" section (pull + up -d, explicitly "you do not need to rebuild"), version-pinning guidance, and an **optional** auto-update section (cron / Watchtower / Diun) — nothing bundled, all opt-in.
- Aligned README + fleet doc snippets with `pull_policy: always`.
- `.dockerignore`: exclude compose files from the build context.

## Verification
- All three compose files pass `docker compose config` (incl. `pull_policy` schema).
- `drumsergio/cashpilot:latest` confirmed resolvable on Docker Hub (same digest as `:0.6.13`).
- No remaining `v0.6.2` or stray `build:` references outside the dedicated build file.

## Notes
- This is the right fix vs. the reporter's "always rebuild" suggestion, which would entrench building from source for every user (slow, defeats the published images, and can drift from the tested CI builds).
- Tag policy chosen: `:latest` + `pull_policy: always` for the example/quick-start files, with documented pinning for users who prefer fixed versions.