### PR TITLE
fix(services): raise bitping mem_limit 128m->192m to prevent OOM

### DIFF
--- a/services/bandwidth/bitping.yml
+++ b/services/bandwidth/bitping.yml
@@ -18,7 +18,7 @@ docker:
   image: bitping/bitpingd
   platforms: [linux/amd64, linux/arm64]
   resources:
-    mem_limit: "128m"
+    mem_limit: "192m"
     oom_score_adj: 200
   env: []
   ports: []


### PR DESCRIPTION
bitping was OOM-killed at its 128 MiB cgroup limit on geiserback (confirmed via dmesg memcg OOM during the fleet sweep). Raising `mem_limit` to 192m gives headroom; `oom_score_adj` stays 200 (still sacrificed first under host memory pressure).

This makes permanent the live `docker update --memory 192m` already applied on geiserback. After merge -> auto-release -> new image, redeploying bitping applies 192m durably on all hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the container memory limit, which may help improve stability under heavier load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->