### PR TITLE
feat(dashboard): unstable health badge + /metrics exposure warning

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -528,6 +528,10 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "health_score": health.get("score"),
             "uptime_pct": health.get("uptime_pct"),
             "restarts_7d": health.get("restarts", 0),
+            "crashes_7d": health.get("crashes", 0),
+            # "unstable" flags a service that has crashed repeatedly in the health window
+            # so the dashboard can surface it at a glance (not just via the score number).
+            "unstable": health.get("crashes", 0) >= 3,
             "instances": len(agg["instances"]),
             "instance_details": instance_details,
             "collector_disconnected": slug in alert_slugs,
@@ -567,6 +571,8 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "health_score": None,
             "uptime_pct": None,
             "restarts_7d": 0,
+            "crashes_7d": 0,
+            "unstable": False,
             "instances": 0,
             "instance_details": [],
             "collector_disconnected": slug in alert_slugs,

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -17,11 +17,14 @@ Metrics exposed:
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import re
 import time
 
 from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
 
 METRICS_ENABLED = os.getenv("CASHPILOT_METRICS_ENABLED", "").lower() in ("1", "true", "yes")
 
@@ -230,6 +233,15 @@ def setup(app: FastAPI) -> None:
         return
 
     _init_metrics()
+
+    # /metrics is served UNAUTHENTICATED (Prometheus convention). It exposes earnings and
+    # health totals, so warn on startup: keep it behind a reverse proxy / auth and never
+    # expose the app's port directly to an untrusted network.
+    logger.warning(
+        "Prometheus /metrics is ENABLED and served UNAUTHENTICATED — it exposes your "
+        "earnings and health data to anyone who can reach this port. Keep it behind a "
+        "reverse proxy with auth; do not expose the port directly to an untrusted network."
+    )
 
     from fastapi import Response
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -434,8 +434,16 @@ const CP = (() => {
     let healthBadge = '<span style="color:var(--text-muted);">--</span>';
     if (!isExternal && svc.health_score !== null && svc.health_score !== undefined) {
       const score = svc.health_score;
-      const hClass = score >= 80 ? 'badge-running' : score >= 50 ? 'badge-error' : 'badge-stopped';
-      healthBadge = `<span class="badge ${hClass}" title="Health ${score}/100">${score}</span>`;
+      const crashes = svc.crashes_7d || 0;
+      const restarts = svc.restarts_7d || 0;
+      const unstable = svc.unstable === true;
+      // Unstable (repeated crashes in the 7-day window) takes the worst tone + an explicit
+      // label so a crash-looping service is legible at a glance, not just via a low number.
+      const hClass = (unstable || score < 50) ? 'badge-stopped' : score >= 80 ? 'badge-running' : 'badge-error';
+      const uptime = (svc.uptime_pct !== null && svc.uptime_pct !== undefined) ? `${svc.uptime_pct}% uptime · ` : '';
+      const title = `Health ${score}/100 · ${uptime}${restarts} restarts · ${crashes} crashes (7d)`;
+      const label = unstable ? `unstable · ${crashes} crashes` : String(score);
+      healthBadge = `<span class="badge ${hClass}" title="${title}">${label}</span>`;
     }
 
     // Balance + delta from breakdown

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -639,6 +639,62 @@ class TestApiServices:
             row = next(r for r in resp.json() if r["slug"] == "repocket")
             assert row["collector_needs_setup"] is False
 
+    def test_deployed_row_flags_unstable_on_repeated_crashes(self, client):
+        """A service with >=3 crashes in the health window is flagged unstable so the
+        dashboard can surface a crash-looping earner at a glance."""
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": json.dumps({"docker_available": True}),
+                "containers": json.dumps([{"slug": "repocket", "name": "rp", "status": "running"}]),
+                "apps": "[]",
+            }
+        ]
+        scores = [{"slug": "repocket", "score": 30, "uptime_pct": 40, "restarts": 5, "crashes": 4}]
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_health_scores", new_callable=AsyncMock, return_value=scores),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.main.catalog.get_service", return_value={"name": "Repocket", "category": "bandwidth"}),
+        ):
+            resp = client.get("/api/services/deployed")
+            assert resp.status_code == 200
+            row = next(r for r in resp.json() if r["slug"] == "repocket")
+            assert row["unstable"] is True
+            assert row["crashes_7d"] == 4
+
+    def test_deployed_row_not_unstable_below_threshold(self, client):
+        """Fewer than 3 crashes is not flagged unstable (crashes_7d is still surfaced)."""
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": json.dumps({"docker_available": True}),
+                "containers": json.dumps([{"slug": "repocket", "name": "rp", "status": "running"}]),
+                "apps": "[]",
+            }
+        ]
+        scores = [{"slug": "repocket", "score": 85, "uptime_pct": 98, "restarts": 1, "crashes": 2}]
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_health_scores", new_callable=AsyncMock, return_value=scores),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.main.catalog.get_service", return_value={"name": "Repocket", "category": "bandwidth"}),
+        ):
+            resp = client.get("/api/services/deployed")
+            row = next(r for r in resp.json() if r["slug"] == "repocket")
+            assert row["unstable"] is False
+            assert row["crashes_7d"] == 2
+
     def test_deployed_disconnected_takes_precedence_over_needs_setup(self, client):
         # When the collector has actually errored, show the error state, not "needs setup".
         workers = [

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -112,6 +112,27 @@ class TestMetricsSetup:
         app.add_middleware.assert_not_called()
         metrics.METRICS_ENABLED = orig
 
+    def test_setup_enabled_mounts_and_warns(self):
+        """With metrics enabled, setup mounts /metrics and logs the
+        unauthenticated-exposure security warning."""
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        orig_enabled = metrics.METRICS_ENABLED
+        orig_registry = metrics._registry
+        orig_metrics = metrics._metrics.copy()
+        metrics.METRICS_ENABLED = True
+        try:
+            with patch("app.metrics.logger.warning") as warn:
+                metrics.setup(app)
+            assert warn.called
+            assert "UNAUTHENTICATED" in warn.call_args[0][0]
+            assert any(getattr(r, "path", None) == "/metrics" for r in app.routes)
+        finally:
+            metrics.METRICS_ENABLED = orig_enabled
+            metrics._registry = orig_registry
+            metrics._metrics = orig_metrics
+
     def test_normalize_path(self):
         assert metrics._normalize_path("/api/services/earnapp") == "/api/services/{slug}"
         assert metrics._normalize_path("/api/deploy/honeygain") == "/api/deploy/{slug}"


### PR DESCRIPTION
Ports two improvements from **CashPilot-Desktop** (the Go port) back to the web app — applied only where web didn't already have them.

Context: while auditing the desktop app I compared it against this web app and found web is the more mature parent (it already collects concurrently via `asyncio.gather`, has the earnings indexes, a clean collector ABC, etc.). Most desktop fixes were port-catch-up. These two are the genuine gaps:

## 1. Unstable health badge
The desktop added a crash-loop "unstable" indicator. Web already computes `restarts`/`crashes` per service in `get_health_scores`, and surfaces `restarts_7d` — but not crashes or an at-a-glance unstable flag.
- **backend** (`main.py`): add `crashes_7d` + an `unstable` flag (>= 3 crashes in the 7-day window) to each deployed service row.
- **frontend** (`app.js`): a service flagged unstable gets the worst badge tone + an explicit `unstable · N crashes` label, and the tooltip now shows uptime · restarts · crashes. A crash-looping earner is legible at a glance, not just via a lower score number.

## 2. /metrics exposure warning
Web's `/metrics` is served unauthenticated (Prometheus convention) and exposes earnings/health. Added a startup `logger.warning` when `CASHPILOT_METRICS_ENABLED` is set, reminding to keep it behind a reverse proxy and off untrusted networks (a homelabber who exposes the UI port directly would otherwise leak it).

## Tests / verification
Two new deployed-row tests (unstable at/above vs below the threshold). `ruff` clean; full suite **997 passed**.

(A flaky-timing spot-check of the pytest suite was the third recommendation — web has zero fixed `sleep()` in `tests/`, so nothing to fix there.)