### PR TITLE
fix(security): code-audit findings — container escape, event-loop stalls, authz, error surfacing

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -89,7 +89,13 @@ def decrypt_value(value: str) -> str:
     try:
         return _fernet.decrypt(value[len(_ENC_PREFIX) :].encode()).decode()
     except InvalidToken:
-        _logger.warning("Failed to decrypt config value — key may have changed")
+        _logger.warning(
+            "Failed to decrypt config value: the Fernet ENCRYPTION KEY (CASHPILOT_SECRET_KEY / "
+            "%s) does not match the key this value was encrypted with. This is NOT a bad "
+            "credential — re-enter the affected credentials, or restore the original encryption "
+            "key, to recover.",
+            _FERNET_KEY_FILE,
+        )
         return ""
 
 

--- a/app/exchange_rates.py
+++ b/app/exchange_rates.py
@@ -108,6 +108,7 @@ def get_all() -> dict[str, Any]:
         "fiat": dict(_fiat_rates),
         "crypto_usd": dict(_crypto_usd),
         "last_updated": _last_fetch,
+        "stale": rates_stale(),
     }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -68,6 +68,7 @@ def _spawn(coro) -> asyncio.Task:
     task.add_done_callback(_on_done)
     return task
 
+
 # Login rate limiting
 _login_attempts: dict[str, list[float]] = defaultdict(list)
 _LOGIN_MAX_ATTEMPTS = 5

--- a/app/main.py
+++ b/app/main.py
@@ -528,6 +528,10 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "health_score": health.get("score"),
             "uptime_pct": health.get("uptime_pct"),
             "restarts_7d": health.get("restarts", 0),
+            "crashes_7d": health.get("crashes", 0),
+            # "unstable" flags a service that has crashed repeatedly in the health window
+            # so the dashboard can surface it at a glance (not just via the score number).
+            "unstable": health.get("crashes", 0) >= 3,
             "instances": len(agg["instances"]),
             "instance_details": instance_details,
             "collector_disconnected": slug in alert_slugs,
@@ -567,6 +571,8 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "health_score": None,
             "uptime_pct": None,
             "restarts_7d": 0,
+            "crashes_7d": 0,
+            "unstable": False,
             "instances": 0,
             "instance_details": [],
             "collector_disconnected": slug in alert_slugs,

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,29 @@ scheduler = AsyncIOScheduler()
 # In-memory store for the latest collector alerts (errors from last run)
 _collector_alerts: list[dict[str, str]] = []
 _collection_lock = asyncio.Lock()
+_collection_semaphore = asyncio.Semaphore(8)
+
+# Fire-and-forget background tasks (e.g. triggered collection runs). Keeping a
+# reference prevents the task from being garbage-collected mid-run and lets us
+# retrieve/log any exception it raised (bare `asyncio.create_task(...)` drops
+# the reference and silently swallows exceptions).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn(coro) -> asyncio.Task:
+    """Fire-and-forget a coroutine while keeping a reference and logging errors."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _background_tasks.discard(t)
+        if not t.cancelled():
+            exc = t.exception()
+            if exc is not None:
+                logger.error("Background task failed: %s", exc, exc_info=exc)
+
+    task.add_done_callback(_on_done)
+    return task
 
 # Login rate limiting
 _login_attempts: dict[str, list[float]] = defaultdict(list)
@@ -179,6 +202,12 @@ async def _run_health_check() -> None:
         logger.warning("Health check skipped: %s", exc)
 
 
+async def _collect_bounded(collector) -> Any:
+    """Run a single collector's `collect()` under the shared concurrency limit."""
+    async with _collection_semaphore:
+        return await collector.collect()
+
+
 async def _run_collection() -> None:
     """Collect earnings from all deployed services that have collectors."""
     global _collector_alerts
@@ -186,9 +215,10 @@ async def _run_collection() -> None:
         logger.info("Collection already in progress, skipping")
         return
     async with _collection_lock:
-        start_time = metrics.record_collection_start()
         success = True
+        start_time = 0.0
         try:
+            start_time = metrics.record_collection_start()
             deployments = await database.get_deployments()
             config = await database.get_config() or {}
             if not isinstance(config, dict):
@@ -197,7 +227,7 @@ async def _run_collection() -> None:
 
             collectors = make_collectors(deployments, config)
             await _close_stale()
-            results = await asyncio.gather(*(c.collect() for c in collectors), return_exceptions=True)
+            results = await asyncio.gather(*(_collect_bounded(c) for c in collectors), return_exceptions=True)
             alerts: list[dict[str, str]] = []
             platforms_ok = 0
             for result in results:
@@ -335,7 +365,7 @@ async def lifespan(app: FastAPI):
     )
     scheduler.start()
     await exchange_rates.refresh()
-    asyncio.create_task(_run_collection())
+    _spawn(_run_collection())
     logger.info("CashPilot UI started (container ops via workers)")
 
     yield
@@ -756,7 +786,7 @@ async def api_deploy(request: Request, slug: str, body: DeployRequest, worker_id
     await database.save_deployment(slug=slug, container_id=container_id)
     await database.record_health_event(slug, "start", f"deployed to worker {worker_id}")
     metrics.record_container_lifecycle("deploy", slug)
-    asyncio.create_task(_run_collection())
+    _spawn(_run_collection())
     return {"status": "deployed", "container_id": container_id}
 
 
@@ -765,6 +795,7 @@ async def api_stop(request: Request, slug: str, worker_id: int | None = None) ->
     _require_writer(request)
     worker_id = await _resolve_worker_id(worker_id)
     result = await _proxy_worker_command(worker_id, "stop", slug)
+    await database.record_health_event(slug, "stop")
     metrics.record_container_lifecycle("stop", slug)
     return result
 
@@ -774,6 +805,7 @@ async def api_restart(request: Request, slug: str, worker_id: int | None = None)
     _require_writer(request)
     worker_id = await _resolve_worker_id(worker_id)
     result = await _proxy_worker_command(worker_id, "restart", slug)
+    await database.record_health_event(slug, "restart")
     metrics.record_container_lifecycle("restart", slug)
     return result
 
@@ -787,6 +819,7 @@ async def api_remove(
     params = {"delete_volumes": "true"} if delete_volumes else None
     result = await _proxy_worker_command(worker_id, "remove", slug, params=params)
     await database.remove_deployment(slug)
+    await database.record_health_event(slug, "remove")
     metrics.record_container_lifecycle("remove", slug)
     return result
 
@@ -878,6 +911,9 @@ def _validate_worker_url(raw_url: str) -> str:
 
     Resolves hostnames and validates the resolved IP(s) so a DNS name that
     points at a metadata/loopback address is rejected (DNS-rebinding guard).
+    Synchronous — its only blocking op is DNS resolution; event-loop callers
+    MUST invoke it via ``asyncio.to_thread`` (see _get_verified_worker_url) so a
+    slow/hanging resolver never blocks the whole UI.
     """
     parsed = urlparse(raw_url)
     if parsed.scheme not in _ALLOWED_WORKER_SCHEMES:
@@ -924,7 +960,7 @@ def _validate_worker_url(raw_url: str) -> str:
     return raw_url.rstrip("/")
 
 
-def _get_verified_worker_url(worker: dict[str, Any]) -> tuple[str, dict[str, str]]:
+async def _get_verified_worker_url(worker: dict[str, Any]) -> tuple[str, dict[str, str]]:
     """Validate a worker record and return (url, headers)."""
     if not worker:
         raise HTTPException(status_code=404, detail="Worker not found")
@@ -932,7 +968,7 @@ def _get_verified_worker_url(worker: dict[str, Any]) -> tuple[str, dict[str, str
         raise HTTPException(status_code=503, detail="Worker is offline")
     if not worker["url"]:
         raise HTTPException(status_code=503, detail="Worker URL not known")
-    url = _validate_worker_url(worker["url"])
+    url = await asyncio.to_thread(_validate_worker_url, worker["url"])
     headers: dict[str, str] = {}
     if FLEET_API_KEY:
         headers["Authorization"] = f"Bearer {FLEET_API_KEY}"
@@ -944,7 +980,7 @@ async def _proxy_worker_command(
 ) -> dict[str, Any]:
     """Forward a container command (restart/stop/start/remove) to a worker."""
     worker = await database.get_worker(worker_id)
-    url, headers = _get_verified_worker_url(worker)
+    url, headers = await _get_verified_worker_url(worker)
 
     try:
         async with httpx.AsyncClient(timeout=30) as client:
@@ -964,7 +1000,7 @@ async def _proxy_worker_command(
 async def _proxy_worker_deploy(worker_id: int, slug: str, spec: dict[str, Any]) -> dict[str, Any]:
     """Forward a deploy command with full spec to a worker."""
     worker = await database.get_worker(worker_id)
-    url, headers = _get_verified_worker_url(worker)
+    url, headers = await _get_verified_worker_url(worker)
 
     try:
         async with httpx.AsyncClient(timeout=60) as client:
@@ -981,7 +1017,7 @@ async def _proxy_worker_deploy(worker_id: int, slug: str, spec: dict[str, Any]) 
 async def _proxy_worker_logs(worker_id: int, slug: str, lines: int = 50) -> dict[str, str]:
     """Forward a logs request to a worker."""
     worker = await database.get_worker(worker_id)
-    url, headers = _get_verified_worker_url(worker)
+    url, headers = await _get_verified_worker_url(worker)
 
     try:
         async with httpx.AsyncClient(timeout=30) as client:
@@ -1010,6 +1046,7 @@ async def api_service_restart(request: Request, slug: str, worker_id: int | None
     worker_id = await _resolve_worker_id(worker_id)
     result = await _proxy_worker_command(worker_id, "restart", slug)
     await database.record_health_event(slug, "restart")
+    metrics.record_container_lifecycle("restart", slug)
     return result
 
 
@@ -1019,6 +1056,7 @@ async def api_service_stop(request: Request, slug: str, worker_id: int | None = 
     worker_id = await _resolve_worker_id(worker_id)
     result = await _proxy_worker_command(worker_id, "stop", slug)
     await database.record_health_event(slug, "stop")
+    metrics.record_container_lifecycle("stop", slug)
     return result
 
 
@@ -1028,6 +1066,7 @@ async def api_service_start(request: Request, slug: str, worker_id: int | None =
     worker_id = await _resolve_worker_id(worker_id)
     result = await _proxy_worker_command(worker_id, "start", slug)
     await database.record_health_event(slug, "start")
+    metrics.record_container_lifecycle("start", slug)
     return result
 
 
@@ -1049,6 +1088,8 @@ async def api_service_remove(
     params = {"delete_volumes": "true"} if delete_volumes else None
     result = await _proxy_worker_command(worker_id, "remove", slug, params=params)
     await database.remove_deployment(slug)
+    await database.record_health_event(slug, "remove")
+    metrics.record_container_lifecycle("remove", slug)
     return result
 
 
@@ -1241,7 +1282,7 @@ async def api_health_scores(request: Request, days: int = 7) -> list[dict[str, A
 @app.post("/api/collect")
 async def api_collect(request: Request) -> dict[str, str]:
     _require_writer(request)
-    asyncio.create_task(_run_collection())
+    _spawn(_run_collection())
     return {"status": "collection_started"}
 
 
@@ -1331,7 +1372,7 @@ async def api_set_preferences(request: Request, body: PreferencesUpdate) -> dict
     )
     # If setup is completed, trigger an immediate collection
     if body.setup_completed:
-        asyncio.create_task(_run_collection())
+        _spawn(_run_collection())
     return {"status": "saved"}
 
 
@@ -1409,17 +1450,11 @@ async def api_collectors_meta(request: Request) -> list[dict[str, Any]]:
     _require_owner(request)
     from app.collectors import _COLLECTOR_ARGS, COLLECTOR_MAP
 
-    secret_args = {
-        "password",
-        "token",
-        "auth_token",
-        "access_token",
-        "api_key",
-        "session_cookie",
-        "auth_cookie",
-        "oauth_token",
-        "brd_sess_id",
-    }
+    # Single-sourced from database.SECRET_CONFIG_KEYS so this endpoint can never
+    # disagree with the encryption-at-rest / masking logic about which config
+    # keys are secret (a hand-maintained duplicate here previously missed
+    # `remember_web` and `xsrf_token`, unmasking them).
+    secret_args = database.SECRET_CONFIG_KEYS
     # Per-service hints on how to obtain the credentials
     hints: dict[str, str] = {
         "bitping": "Use your Bitping account email and password (same as <a href='https://nodes.bitping.com' target='_blank'>nodes.bitping.com</a>).",
@@ -1711,10 +1746,15 @@ class WorkerCommand(BaseModel):
 @app.post("/api/workers/{worker_id}/command")
 async def api_worker_command(request: Request, worker_id: int, body: WorkerCommand) -> dict[str, Any]:
     """Send a command to a worker by proxying to its REST API."""
-    _require_writer(request)
+    # Deploy is owner-gated everywhere else (see /api/deploy/{slug}); a writer
+    # must not be able to bypass that gate by sending command="deploy" here.
+    if body.command == "deploy":
+        _require_owner(request)
+    else:
+        _require_writer(request)
 
     worker = await database.get_worker(worker_id)
-    url, headers = _get_verified_worker_url(worker)
+    url, headers = await _get_verified_worker_url(worker)
 
     try:
         async with httpx.AsyncClient(timeout=30) as client:

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -17,11 +17,14 @@ Metrics exposed:
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import re
 import time
 
 from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
 
 METRICS_ENABLED = os.getenv("CASHPILOT_METRICS_ENABLED", "").lower() in ("1", "true", "yes")
 
@@ -230,6 +233,15 @@ def setup(app: FastAPI) -> None:
         return
 
     _init_metrics()
+
+    # /metrics is served UNAUTHENTICATED (Prometheus convention). It exposes earnings and
+    # health totals, so warn on startup: keep it behind a reverse proxy / auth and never
+    # expose the app's port directly to an untrusted network.
+    logger.warning(
+        "Prometheus /metrics is ENABLED and served UNAUTHENTICATED — it exposes your "
+        "earnings and health data to anyone who can reach this port. Keep it behind a "
+        "reverse proxy with auth; do not expose the port directly to an untrusted network."
+    )
 
     from fastapi import Response
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -7,6 +7,7 @@ avoid the direct-import problem. Handlers reference shared state through
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -43,6 +44,10 @@ async def api_update_user_role(request: Request, user_id: int, body: UserRoleUpd
         if owner_count <= 1:
             raise HTTPException(status_code=400, detail="Cannot remove the last owner")
     await main.database.update_user_role(user_id, body.role)
+    # Invalidate any outstanding session tokens for this user — they carry the
+    # old role and must not be trusted until re-issued (same mechanism used
+    # for password changes).
+    main.auth.set_user_pwd_epoch(user_id, time.time())
     return {"status": "updated"}
 
 
@@ -55,4 +60,8 @@ async def api_delete_user(request: Request, user_id: int) -> dict[str, str]:
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     await main.database.delete_user(user_id)
+    # Invalidate any outstanding session tokens for the now-deleted account.
+    # The epoch cache is in-memory keyed by uid, so it survives the row being
+    # gone from the DB — decode_session_token rejects the token on iat alone.
+    main.auth.set_user_pwd_epoch(user_id, time.time())
     return {"status": "deleted"}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -434,8 +434,16 @@ const CP = (() => {
     let healthBadge = '<span style="color:var(--text-muted);">--</span>';
     if (!isExternal && svc.health_score !== null && svc.health_score !== undefined) {
       const score = svc.health_score;
-      const hClass = score >= 80 ? 'badge-running' : score >= 50 ? 'badge-error' : 'badge-stopped';
-      healthBadge = `<span class="badge ${hClass}" title="Health ${score}/100">${score}</span>`;
+      const crashes = svc.crashes_7d || 0;
+      const restarts = svc.restarts_7d || 0;
+      const unstable = svc.unstable === true;
+      // Unstable (repeated crashes in the 7-day window) takes the worst tone + an explicit
+      // label so a crash-looping service is legible at a glance, not just via a low number.
+      const hClass = (unstable || score < 50) ? 'badge-stopped' : score >= 80 ? 'badge-running' : 'badge-error';
+      const uptime = (svc.uptime_pct !== null && svc.uptime_pct !== undefined) ? `${svc.uptime_pct}% uptime · ` : '';
+      const title = `Health ${score}/100 · ${uptime}${restarts} restarts · ${crashes} crashes (7d)`;
+      const label = unstable ? `unstable · ${crashes} crashes` : String(score);
+      healthBadge = `<span class="badge ${hClass}" title="${title}">${label}</span>`;
     }
 
     // Balance + delta from breakdown

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -75,13 +75,19 @@ const CP = (() => {
   function sanitizeHint(html) {
     const el = document.createElement('div');
     el.innerHTML = html;
+    const allowedSchemes = ['http:', 'https:', 'mailto:'];
     el.querySelectorAll('*').forEach(node => {
       if (!['A', 'B', 'CODE'].includes(node.tagName)) {
         node.replaceWith(document.createTextNode(node.textContent));
         return;
       }
       for (const attr of [...node.attributes]) {
-        if (node.tagName === 'A' && (attr.name === 'href' || attr.name === 'target')) continue;
+        if (node.tagName === 'A' && attr.name === 'href') {
+          const scheme = (attr.value || '').trim().toLowerCase();
+          if (!allowedSchemes.some(s => scheme.startsWith(s))) node.removeAttribute('href');
+          continue;
+        }
+        if (node.tagName === 'A' && attr.name === 'target') continue;
         node.removeAttribute(attr.name);
       }
     });
@@ -178,7 +184,9 @@ const CP = (() => {
   async function loadExchangeRates() {
     try {
       _exchangeRates = await api('/api/exchange-rates');
-    } catch { /* keep defaults */ }
+    } catch (err) {
+      console.warn('Could not refresh exchange rates, keeping previous values:', err);
+    }
   }
 
   async function loadTopbarEarnings() {
@@ -186,8 +194,9 @@ const CP = (() => {
       await loadExchangeRates();
       const data = await api('/api/earnings/summary');
       setTextContent('topbar-total', formatCurrency(data.total || 0));
-    } catch {
-      setTextContent('topbar-total', formatCurrency(0));
+    } catch (err) {
+      // Keep whatever was already shown rather than fabricating $0.
+      console.warn('Could not refresh topbar earnings, keeping previous value:', err);
     }
   }
 
@@ -239,12 +248,9 @@ const CP = (() => {
         setChangeIndicator('month-change', data.month_change);
       }
     } catch (err) {
-      // API not yet implemented — fill with placeholder
-      setTextContent('total-earnings', formatCurrency(0));
-      setTextContent('today-earnings', formatCurrency(0));
-      setTextContent('month-earnings', formatCurrency(0));
-      setTextContent('active-services', '0');
-      setTextContent('topbar-total', formatCurrency(0));
+      // Keep whatever was already displayed — a transient fetch failure
+      // must not look like the dashboard's earnings dropped to zero.
+      toast(err.message || 'Could not refresh dashboard', 'error');
     }
   }
 
@@ -401,9 +407,15 @@ const CP = (() => {
         }
       });
     } catch (err) {
-      // Keep existing table if we had one; only show spinner on truly empty state
+      // Keep the existing table on a refresh failure. Only replace the
+      // perpetual "Loading..." spinner with a clear error + retry affordance
+      // when there was nothing on screen yet.
       if (!container.querySelector('.breakdown-table')) {
-        container.innerHTML = `<div style="display:flex; align-items:center; justify-content:center; gap:8px; padding:24px 0; color:var(--text-muted);"><div class="spinner"></div> Loading services...</div>`;
+        container.innerHTML = `
+          <div style="display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; padding:24px 0; color:var(--text-muted); text-align:center;">
+            <span>Couldn't load services${err && err.message ? `: ${escapeHtml(err.message)}` : ''}.</span>
+            <button class="btn btn-ghost btn-sm" onclick="CP.loadServicesTable()">Retry</button>
+          </div>`;
       }
     }
   }
@@ -509,7 +521,7 @@ const CP = (() => {
       ? (eligible ? 'Cash out earnings' : 'View payout details')
       : 'No payout info available';
     const claimDisabled = !co.dashboard_url;
-    const claimBtn = `<button class="btn btn-icon ${eligible ? 'btn-success' : ''}" onclick="${claimDisabled ? '' : `CP.openClaimModal('${svc.slug}')`}" title="${claimTitle}"${claimDisabled ? ' disabled' : ''}>
+    const claimBtn = `<button class="btn btn-icon ${eligible ? 'btn-success' : ''}" onclick="${claimDisabled ? '' : `CP.openClaimModal('${escapeHtml(svc.slug)}')`}" title="${claimTitle}"${claimDisabled ? ' disabled' : ''}>
            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
          </button>`;
 
@@ -528,7 +540,7 @@ const CP = (() => {
     // For single instance: show action buttons directly
     let actionBtns;
     if (isMulti) {
-      const chevron = `<button class="btn btn-icon expand-toggle" onclick="event.stopPropagation(); CP.toggleInstances('${svc.slug}')" title="Expand instances">
+      const chevron = `<button class="btn btn-icon expand-toggle" onclick="event.stopPropagation(); CP.toggleInstances('${escapeHtml(svc.slug)}')" title="Expand instances">
         <svg class="expand-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
       </button>`;
       actionBtns = `<div class="action-btns">${claimBtn}${settingsBtn}${chevron}</div>`;
@@ -544,13 +556,13 @@ const CP = (() => {
           ${claimBtn}
           ${settingsBtn}
           ${_canWrite ? `
-          <button class="btn btn-icon" onclick="CP.restartService('${svc.slug}${wParam})" title="Restart"${disabledAttr}>
+          <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart"${disabledAttr}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
           </button>
-          <button class="btn btn-icon" onclick="CP.stopService('${svc.slug}${wParam})" title="Stop"${disabledAttr}>
+          <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop"${disabledAttr}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
           </button>
-          <button class="btn btn-icon" onclick="CP.viewLogs('${svc.slug}${wParam})" title="Logs"${disabledAttr}>
+          <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs"${disabledAttr}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
           </button>` : ''}
         </div>`;
@@ -598,13 +610,13 @@ const CP = (() => {
           <td style="text-align:center; white-space:nowrap;">
             <div class="action-btns">
               ${_canWrite ? `
-              <button class="btn btn-icon" onclick="CP.restartService('${svc.slug}${wParam})" title="Restart on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart on ${nodeLabel}"${disabledAttr}>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
               </button>
-              <button class="btn btn-icon" onclick="CP.stopService('${svc.slug}${wParam})" title="Stop on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop on ${nodeLabel}"${disabledAttr}>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
               </button>
-              <button class="btn btn-icon" onclick="CP.viewLogs('${svc.slug}${wParam})" title="Logs on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs on ${nodeLabel}"${disabledAttr}>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
               </button>` : ''}
             </div>
@@ -826,7 +838,7 @@ const CP = (() => {
     inputs.forEach(input => {
       const key = input.dataset.config;
       const val = input.value.trim();
-      if (val && val !== '********') data[key] = val;
+      if (val) data[key] = val;
     });
     if (!Object.keys(data).length) {
       toast('Enter at least one credential', 'warning');
@@ -926,8 +938,6 @@ const CP = (() => {
   // -----------------------------------------------------------
   // Claim Modal
   // -----------------------------------------------------------
-  let _breakdownCache = [];
-
   async function openClaimModal(platform) {
     openModal('claim-modal');
     const title = document.getElementById('claim-modal-title');
@@ -1766,7 +1776,7 @@ const CP = (() => {
         <div style="font-size:0.8rem; color:var(--text-muted); background:var(--bg-subtle, rgba(255,255,255,0.03)); border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin:10px 0;">
           The credentials above run the service. To also see its <strong>balance</strong> on the dashboard,
           add earnings-tracking credentials under
-          <a href="#" onclick="event.preventDefault(); CP.openCredentialModal('${svc.slug}')" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
+          <a href="#" onclick="event.preventDefault(); CP.openCredentialModal('${escapeHtml(svc.slug)}')" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
           after deploying. This is optional — the service earns either way.
         </div>`;
       }
@@ -1982,7 +1992,7 @@ const CP = (() => {
     const data = {};
     inputs.forEach(input => {
       const val = input.value.trim();
-      if (val && val !== '********') {
+      if (val) {
         data[input.dataset.envKey] = val;
       }
     });
@@ -2064,7 +2074,7 @@ const CP = (() => {
     inputs.forEach(input => {
       const key = input.dataset.config;
       const val = input.value.trim();
-      if (val && val !== '********') {
+      if (val) {
         data[key] = val;
       }
     });
@@ -2202,6 +2212,10 @@ const CP = (() => {
 
     try {
       const alerts = await api('/api/collector-alerts');
+      // Clear any muted "alerts unavailable" styling left over from a prior
+      // failed poll now that the fetch succeeded.
+      badge.style.background = '';
+      badge.title = '';
       if (!alerts || alerts.length === 0) {
         badge.style.display = 'none';
         list.innerHTML = '<div class="notify-empty">All collectors healthy</div>';
@@ -2223,7 +2237,14 @@ const CP = (() => {
         </div>
       `).join('');
     } catch {
-      badge.style.display = 'none';
+      // The bell's own fetch failed — this is unknown, not healthy. Show a
+      // neutral/muted indicator rather than hiding the badge (which would
+      // read as "all collectors healthy").
+      badge.style.display = '';
+      badge.style.background = 'var(--text-muted)';
+      badge.textContent = '?';
+      badge.title = 'Alerts unavailable';
+      list.innerHTML = '<div class="notify-empty">Alerts unavailable — could not reach the server</div>';
     }
   }
 
@@ -2433,6 +2454,7 @@ const CP = (() => {
     filterCatalog,
     refreshServices,
     openClaimModal,
+    loadServicesTable,
     toggleInstances,
     deployServiceToWorkers,
     workerAction,

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -94,7 +94,7 @@ async def _send_heartbeat() -> None:
             "os": f"{platform.system()} {platform.release()}",
             "arch": platform.machine(),
             "hostname": socket.gethostname(),
-            "docker_available": orchestrator.docker_available(),
+            "docker_available": await asyncio.to_thread(orchestrator.docker_available),
         },
     }
 
@@ -148,7 +148,7 @@ async def lifespan(app: FastAPI):
     global _heartbeat_task
 
     logger.info("CashPilot Worker '%s' starting", WORKER_NAME)
-    docker_mode = "direct" if orchestrator.docker_available() else "monitor-only"
+    docker_mode = "direct" if await asyncio.to_thread(orchestrator.docker_available) else "monitor-only"
     logger.info("Docker: %s", docker_mode)
 
     if UI_URL:
@@ -177,8 +177,9 @@ app = FastAPI(title="CashPilot Worker", version="0.1.0", lifespan=lifespan)
 
 
 @app.get("/", response_class=HTMLResponse)
-async def worker_status_page():
+async def worker_status_page(request: Request):
     """Self-contained HTML status page for the worker."""
+    _verify_api_key(request)
     containers = []
     try:
         containers = await asyncio.to_thread(orchestrator.get_status_cached)
@@ -237,7 +238,7 @@ async def worker_status_page():
             <div><label>Name</label><span>{_esc(WORKER_NAME)}</span></div>
             <div><label>Host</label><span>{_esc(socket.gethostname())}</span></div>
             <div><label>Platform</label><span>{_esc(platform.system())} {_esc(platform.machine())}</span></div>
-            <div><label>Docker</label><span>{"Available" if orchestrator.docker_available() else "Not available"}</span></div>
+            <div><label>Docker</label><span>{"Available" if await asyncio.to_thread(orchestrator.docker_available) else "Not available"}</span></div>
             <div><label>UI Connection</label><span>{ui_status}</span></div>
             <div><label>Last Heartbeat</label><span>{_last_heartbeat}</span></div>
         </div>
@@ -285,8 +286,29 @@ class DeploySpec(BaseModel):
     resources: ResourceSpec | None = None
 
 
-_BLOCKED_VOLUME_SOURCES = {"/", "/etc", "/var/run/docker.sock", "/root", "/proc", "/sys"}
+_BLOCKED_VOLUME_ROOTS = {
+    "/",
+    "/etc",
+    "/root",
+    "/proc",
+    "/sys",
+    "/boot",
+    "/dev",
+    "/var",
+    "/usr",
+    "/home",
+    "/lib",
+    "/lib64",
+    "/bin",
+    "/sbin",
+    "/var/run",
+    "/run",
+    "/var/lib/docker",
+}
 _BLOCKED_CAPS = {"ALL", "SYS_ADMIN", "SYS_PTRACE"}
+# Named volumes (bridge/none/unset) and mysterium's legitimate host networking are allowed;
+# `container:<id>` (namespace join) and any other value are rejected.
+_ALLOWED_NETWORK_MODES = {None, "", "bridge", "none", "host"}
 # Docker memory size syntax: a positive integer with an optional b/k/m/g unit.
 _MEM_LIMIT_RE = re.compile(r"^\d+[bkmgBKMG]?$")
 
@@ -298,12 +320,14 @@ def _validate_deploy_spec(spec: DeploySpec) -> None:
         blocked = _BLOCKED_CAPS & {c.upper() for c in spec.cap_add}
         if blocked:
             raise HTTPException(status_code=403, detail=f"Blocked capabilities: {', '.join(blocked)}")
+    if spec.network_mode not in _ALLOWED_NETWORK_MODES:
+        raise HTTPException(status_code=403, detail=f"Network mode '{spec.network_mode}' is not allowed")
     for source in spec.volumes:
-        normalized = "/" + source.strip("/")
-        if normalized == "/":
-            raise HTTPException(status_code=403, detail=f"Volume mount '{source}' is blocked")
-        for blocked in _BLOCKED_VOLUME_SOURCES:
-            if normalized == blocked or normalized.startswith(blocked + "/"):
+        if not source.startswith("/"):
+            continue  # named volume (e.g. "mysterium-data") — always allowed
+        real = os.path.realpath(source)
+        for blocked in _BLOCKED_VOLUME_ROOTS:
+            if real == blocked or real.startswith(blocked + "/"):
                 raise HTTPException(status_code=403, detail=f"Volume mount '{source}' is blocked")
     _validate_resources(spec.resources)
 
@@ -335,7 +359,7 @@ async def api_worker_status(request: Request) -> dict[str, Any]:
         logger.warning("Failed to get container status: %s", exc)
     return {
         "name": WORKER_NAME,
-        "docker_available": orchestrator.docker_available(),
+        "docker_available": await asyncio.to_thread(orchestrator.docker_available),
         "ui_connected": _ui_connected,
         "container_count": len(containers),
         "running_count": sum(1 for c in containers if c.get("status") == "running"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,21 @@ def _reset_shared_db():
     # No usable loop (e.g. one is already running) — best-effort cleanup.
     with contextlib.suppress(RuntimeError):
         asyncio.run(_drain())
+
+
+@pytest.fixture(autouse=True)
+def _reset_login_attempts():
+    """Clear the in-process login rate-limit bucket before every test.
+
+    ``app.main._login_attempts`` is a module-level dict keyed by client host that
+    persists for the whole test process, and TestClient's host is a constant
+    ("testclient"), so failed-login attempts from one test would otherwise leak
+    into later tests that hit /login — an order-dependent landmine (and the reason
+    a real rate-limit test couldn't be added safely before). Start each test with
+    an empty bucket.
+    """
+    with contextlib.suppress(Exception):
+        from app import main
+
+        main._login_attempts.clear()
+    yield

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -705,7 +705,7 @@ class TestMainWorkerCommandHttpError:
         mock_client.post.return_value = error_resp
 
         with (
-            _auth_writer(),
+            _auth_owner(),  # deploy via command is owner-gated
             patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -343,6 +343,7 @@ class TestServiceManagement:
             patch("app.main.database.remove_deployment", new_callable=AsyncMock),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
         ):
             resp = client.delete("/api/services/honeygain")
             assert resp.status_code == 200
@@ -374,6 +375,7 @@ class TestServiceManagement:
             patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
         ):
             resp = client.post("/api/stop/honeygain")
             assert resp.status_code == 200
@@ -386,6 +388,7 @@ class TestServiceManagement:
             patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
         ):
             resp = client.post("/api/restart/honeygain")
             assert resp.status_code == 200
@@ -399,6 +402,7 @@ class TestServiceManagement:
             patch("app.main.database.remove_deployment", new_callable=AsyncMock),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
         ):
             resp = client.delete("/api/remove/honeygain")
             assert resp.status_code == 200
@@ -412,6 +416,7 @@ class TestServiceManagement:
             patch("app.main.database.remove_deployment", new_callable=AsyncMock),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
         ):
             resp = client.delete("/api/services/honeygain?delete_volumes=true")
             assert resp.status_code == 200
@@ -507,9 +512,11 @@ class TestWorkerCommand:
         return worker, mock_client
 
     def test_command_deploy(self, client):
+        # Deploy via the command route is OWNER-gated (matching /api/deploy/{slug}),
+        # so it must not be reachable with a mere writer role — use owner here.
         worker, mock_client = self._setup()
         with (
-            _auth_writer(),
+            _auth_owner(),
             patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
             patch("app.main.httpx.AsyncClient", return_value=mock_client),
             patch("app.main.FLEET_API_KEY", "test-key"),
@@ -523,6 +530,23 @@ class TestWorkerCommand:
                 },
             )
             assert resp.status_code == 200
+
+    def test_command_deploy_writer_denied(self, client):
+        """A writer must NOT be able to deploy via /api/workers/{id}/command — deploy is
+        owner-only, so this route must not become an owner-gate bypass (writer stays
+        allowed for stop/restart/remove, tested separately)."""
+        worker, mock_client = self._setup()
+        with (
+            _auth_writer(),
+            patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
+            patch("app.main.httpx.AsyncClient", return_value=mock_client),
+            patch("app.main.FLEET_API_KEY", "test-key"),
+        ):
+            resp = client.post(
+                "/api/workers/1/command",
+                json={"command": "deploy", "slug": "honeygain", "spec": {"image": "test"}},
+            )
+            assert resp.status_code == 403
 
     def test_command_stop(self, client):
         worker, mock_client = self._setup()

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -639,6 +639,62 @@ class TestApiServices:
             row = next(r for r in resp.json() if r["slug"] == "repocket")
             assert row["collector_needs_setup"] is False
 
+    def test_deployed_row_flags_unstable_on_repeated_crashes(self, client):
+        """A service with >=3 crashes in the health window is flagged unstable so the
+        dashboard can surface a crash-looping earner at a glance."""
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": json.dumps({"docker_available": True}),
+                "containers": json.dumps([{"slug": "repocket", "name": "rp", "status": "running"}]),
+                "apps": "[]",
+            }
+        ]
+        scores = [{"slug": "repocket", "score": 30, "uptime_pct": 40, "restarts": 5, "crashes": 4}]
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_health_scores", new_callable=AsyncMock, return_value=scores),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.main.catalog.get_service", return_value={"name": "Repocket", "category": "bandwidth"}),
+        ):
+            resp = client.get("/api/services/deployed")
+            assert resp.status_code == 200
+            row = next(r for r in resp.json() if r["slug"] == "repocket")
+            assert row["unstable"] is True
+            assert row["crashes_7d"] == 4
+
+    def test_deployed_row_not_unstable_below_threshold(self, client):
+        """Fewer than 3 crashes is not flagged unstable (crashes_7d is still surfaced)."""
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": json.dumps({"docker_available": True}),
+                "containers": json.dumps([{"slug": "repocket", "name": "rp", "status": "running"}]),
+                "apps": "[]",
+            }
+        ]
+        scores = [{"slug": "repocket", "score": 85, "uptime_pct": 98, "restarts": 1, "crashes": 2}]
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_health_scores", new_callable=AsyncMock, return_value=scores),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.main.catalog.get_service", return_value={"name": "Repocket", "category": "bandwidth"}),
+        ):
+            resp = client.get("/api/services/deployed")
+            row = next(r for r in resp.json() if r["slug"] == "repocket")
+            assert row["unstable"] is False
+            assert row["crashes_7d"] == 2
+
     def test_deployed_disconnected_takes_precedence_over_needs_setup(self, client):
         # When the collector has actually errored, show the error state, not "needs setup".
         workers = [


### PR DESCRIPTION
Fixes from a full-codebase **8-lens `/review-code!` audit** (architecture, security, complexity, dead-code, error-handling, test-health, consistency, performance). Overall health **7/10** — strong bones (clean collector ABC, uniform DB layer, Fernet+bcrypt, DNS-rebinding-aware SSRF guard, parameterized SQL, CodeQL+Dependabot, 88% coverage); the risk concentrated in the UI↔worker Docker channel + a few real correctness bugs. This closes the high-value, safe findings; the large refactors are deferred (below).

## Security
- **Container escape (HIGH)** — the worker deploy-spec used a bypassable volume **denylist** (blocked `/var/run/docker.sock` but not the parent `/var/run` → mount it → socket → host root) and never validated `network_mode`. Now: `realpath`-normalized checks that block `/var/run`+`/run`+all sensitive roots, and a `network_mode` **allowlist** (`host` kept for mysterium, `container:` blocked). Verified against the catalog (only mysterium needs `host`; no service mounts a host path).
- **Owner-gate bypass** — `/api/deploy/{slug}` is owner-only but the same deploy via `/api/workers/{id}/command` was writer-only. Now owner-gated everywhere (+ a `test_command_deploy_writer_denied` regression test).
- **Unmasked secret** — `main.py`s 9-key secret list vs `database.SECRET_CONFIG_KEYS`s 11 left `remember_web`/`xsrf_token` shown unmasked by `/api/collectors/meta`; now single-sourced from the DB list.
- **Stale sessions** — a demoted/deleted user kept access until token expiry; now the per-user epoch is bumped on role-change + deletion.
- **Unauth worker mini-UI** status page now requires the fleet key; `sanitizeHint` blocks `javascript:` hrefs.

## Correctness (event-loop stalls)
- **`_validate_worker_url`** did a blocking `socket.getaddrinfo` in async context — one slow-DNS worker stalled the **entire UI event loop**. Now threaded via `asyncio.to_thread` at the sole call site (validator kept sync → no test churn).
- **`docker_available()`** unthreaded in 4 spots (blocked when Docker was degraded) → `to_thread`.
- Fire-and-forget collection tasks now keep a reference + log exceptions (`_spawn`); `record_collection_start` moved inside the `try`; the hourly collector `gather` is bounded by a semaphore.

## Consistency / error-surfacing
- Both container-action route families now record **both** the health event and the metrics lifecycle (they diverged, so health/metrics could disagree by URL).
- The previously-dead `rates_stale()` is wired into `get_all()` so the UI can flag stale FX.
- Frontend stops fabricating `$0.00` / eternal spinners / a false-healthy bell on fetch errors — surfaces the error, keeps last values; removes dead code (`_breakdownCache`, the `********` sentinel); consistent slug escaping.

## Verification
`ruff` clean; full `pytest` **998 passed** (updated the route-side-effect + deploy-gate tests to the new secure behavior, added the deploy-writer-denied test + a `_login_attempts` autouse reset fixture that removes a latent order-dependent flake).

## Deferred — with rationale (need their own PR / your call)
- **Per-worker fleet keys** (today one shared key authenticates both directions + maps to a writer role) and a **proxy-aware first-run guard** (the "private network only" check is proxy-blind → pre-auth owner takeover behind a reverse proxy) — both are auth-model changes touching deployment; high value, but they deserve dedicated design + your input on the trusted-proxy/setup-token approach.
- **`main.py` god-module extraction** (fleet-proxy / dashboard / earnings-view) + build-enforcing the UI/worker Docker boundary + a shared `contracts.py` — structural refactors.
- **`orchestrator.py`/`worker_api.py` test coverage** (38%/44% — the Docker-socket code) + true end-to-end (real-DB) tests — a focused test effort.
- **`health_events` growth** — needs an uptime-aware redesign (a naive dedup would break the uptime% metric), not a simple change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Service dashboards now display recent crash counts and flag services as unstable.
  - Exchange-rate responses now include whether cached rates are stale.

- **Security**
  - Worker deployment via the generic worker command now requires owner access.
  - Worker status pages are now authenticated, and worker URL/proxy verification is strengthened.
  - Deployment safety checks are tighter for container specs (including network mode and volume mount paths).
  - Role changes and account deletions now invalidate existing active sessions.

- **Improvements**
  - Metrics now warn that `/metrics` is unauthenticated.
  - Frontend refresh/saving behaviors are more resilient (safer hint rendering, preserved figures on API failures, and “Retry” flows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->