### PR TITLE
fix(proxybase): migrate to GHCR peer-cli image + Access Token credentials (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to CashPilot are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **ProxyBase migrated to the current client** (#103). ProxyBase retired its Docker Hub image and old GHCR org and moved to `proxybase.org`, so the catalog entry no longer worked. The image is now `ghcr.io/proxybaseorg/peer-cli` (digest-pinned, multi-arch amd64/arm64/armv7 — arm64/Raspberry Pi now supported), credentials are the client's current `ID` (relabelled **Access Token**, masked) and `NAME` env vars, every URL points at `proxybase.org`, and datacenter IPs are now marked as accepted (residential still earns most). Existing ProxyBase deployments must be re-deployed with a fresh Access Token — see the [updated guide](docs/guides/proxybase.md)
+
 ### Security
 - Write-only secrets: `GET /api/config` and `/api/env-info` no longer return stored credential values — only a set/not-set indicator. `CASHPILOT_SECRET_KEY` is never sent to the browser
 - Fleet key no longer sent on page load — revealed only via explicit owner-only action (`POST /api/fleet/api-key/reveal`)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Services CashPilot can deploy and manage automatically via Docker.
 | [MystNodes](https://mystnodes.co/?referral_code=do7v7YOoBBpbOstKQovX2pUvZYKia4ZhH3QIdNtE) | [Guide](docs/guides/mysterium.md) | ✅ | ✅ | Unlimited | Unlimited | Crypto (MYST) |
 | [PacketStream](https://packetstream.io/?psr=7xgZ) | [Guide](docs/guides/packetstream.md) | ✅ | ❌ | Unlimited | 1 | PayPal |
 | [Presearch](https://presearch.com/signup?rid=4872322) | [Guide](docs/guides/presearch.md) | ✅ | ✅ | Unlimited | 1 | Crypto (PRE) |
-| [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO) | [Guide](docs/guides/proxybase.md) | ✅ | ❌ | Unlimited | 1 | Crypto |
+| [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO) | [Guide](docs/guides/proxybase.md) | ✅ | ✅ | Unlimited | 1 | Crypto |
 | [ProxyLite](https://proxylite.ru/?r=KMUPRZIZ) | [Guide](docs/guides/proxylite.md) | ✅ | ✅ | Unlimited | 1 | Crypto, PayPal |
 | [ProxyRack](https://peer.proxyrack.com/ref/mpwiok3xlaxeycnn5znqlg7ipjeutxyxr6xl7vmn) | [Guide](docs/guides/proxyrack.md) | ✅ | ✅ | 500 | 1 | PayPal, Crypto |
 | [Repocket](https://repocket.com/) | [Guide](docs/guides/repocket.md) | ✅ | ❌ | 5 | 2 | PayPal, Crypto |

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -67,9 +67,14 @@ const CP = (() => {
   }
 
   function escapeHtml(str) {
-    const d = document.createElement('div');
-    d.textContent = str;
-    return d.innerHTML;
+    // Escape quotes too (the textContent/innerHTML trick doesn't), so values
+    // interpolated into attributes like placeholder="..." can't break out.
+    return String(str ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
   }
 
   function sanitizeHint(html) {

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -19,7 +19,7 @@ Individual setup and configuration guides for every supported service.
 - [PacketShare](packetshare.md) -- Bandwidth sharing - official Docker image, email/password auth
 - [PacketStream](packetstream.md) -- Bandwidth sharing - simple CID-based setup
 - [Peer2Profit](peer2profit.md) -- Bandwidth sharing - works on residential and datacenter IPs
-- [ProxyBase](proxybase.md) -- Bandwidth sharing - crypto payout, user ID auth
+- [ProxyBase](proxybase.md) -- Bandwidth sharing - crypto payout, Access Token auth
 - [ProxyLite](proxylite.md) -- Bandwidth sharing - 15% lifetime referral, works on VPS
 - [ProxyRack](proxyrack.md) -- Bandwidth sharing - UUID per device, works on VPS
 - [Repocket](repocket.md) -- Bandwidth sharing - residential only, max 5 devices, API key auth

--- a/docs/guides/proxybase.md
+++ b/docs/guides/proxybase.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for sharing their unused internet connection. You authenticate the peer client with an **Access Token** from your dashboard. Residential IPs earn the most, but datacenter IPs are also supported (at lower traffic). Official multi-arch Docker image (amd64/arm64/armv7).
+ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for sharing their unused internet connection. You authenticate the peer client with an **Access Token** from your dashboard. Residential IPs earn the most, but datacenter IPs are also supported — they currently receive less traffic than residential. Official multi-arch Docker image (amd64/arm64/armv7).
 
 ## Earning Estimates
 
@@ -23,7 +23,8 @@ ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for 
 
 | Requirement | Value |
 |-------------|-------|
-| Residential IP | Not required -- residential earns the most; datacenter IPs are supported at lower traffic |
+| Residential IP | No |
+| VPS/Datacenter IP | Yes -- supported, but currently receives less traffic than residential |
 | Minimum bandwidth | None |
 | GPU required | No |
 | Minimum storage | None |
@@ -55,4 +56,16 @@ In the CashPilot web UI, find **ProxyBase** in the service catalog and click **D
 | Variable | Label | Required | Secret | Description |
 |----------|-------|:--------:|:------:|-------------|
 | `ID` | Access Token | Yes | Yes | Your ProxyBase Access Token from the dashboard |
-| `NAME` | Device Name | Yes | No | Any name to identify this device in your ProxyBase dashboard -- the client won't start without it (default: `cashpilot-{hostname}`) |
+| `NAME` | Device Name | Yes | No | Any name to identify this device in your ProxyBase dashboard (default: `cashpilot-{hostname}`) |
+
+## Troubleshooting
+
+### ProxyBase shows "running" but earnings stopped (or dropped to $0)
+
+If ProxyBase was deployed before the migration to the new client, the container is still running ProxyBase's **retired** image — it looks healthy in the dashboard but no longer earns, because the old backend was shut down. The dashboard cannot tell the retired client from the current one.
+
+Fix: **Remove** the ProxyBase service, then **Deploy** it again from the catalog and paste a fresh **Access Token** from [your dashboard](https://peer.proxybase.org/dashboard). The redeploy pulls the current `ghcr.io/proxybaseorg/peer-cli` image.
+
+### Container exits immediately after deploy
+
+The client exits with `Missing ID and NAME` when it starts without credentials. CashPilot's deploy form requires both fields, so this normally can't happen — but if you deployed with an exported compose file, make sure the `ID` and `NAME` environment variables are filled in.

--- a/docs/guides/proxybase.md
+++ b/docs/guides/proxybase.md
@@ -1,11 +1,11 @@
 # ProxyBase
 
 > **Category:** Bandwidth Sharing | **Status:** Active
-> **Website:** [https://proxybase.io](https://proxybase.io)
+> **Website:** [https://proxybase.org](https://proxybase.org)
 
 ## Description
 
-ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for sharing their unused internet connection. Uses a simple user ID-based authentication system. Works on residential connections. Official Docker image available.
+ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for sharing their unused internet connection. You authenticate the peer client with an **Access Token** from your dashboard. Residential IPs earn the most, but datacenter IPs are also supported (at lower traffic). Official multi-arch Docker image (amd64/arm64/armv7).
 
 ## Earning Estimates
 
@@ -23,34 +23,36 @@ ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for 
 
 | Requirement | Value |
 |-------------|-------|
-| Residential IP | Yes |
+| Residential IP | Not required -- residential earns the most; datacenter IPs are supported at lower traffic |
 | Minimum bandwidth | None |
 | GPU required | No |
 | Minimum storage | None |
-| Supported platforms | Docker, Windows, Linux |
+| Supported platforms | Docker (amd64/arm64/armv7), Windows, Linux |
 
 ## Setup Instructions
 
 ### 1. Create an account
 
-Sign up at [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO).
+Sign up at [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO). If the referral field is not pre-filled, enter referral code `nXzS3c6iTO` in the **Referral Code** box before creating your account.
 
-### 2. Get your credentials
+### 2. Get your Access Token
 
-After signing up and verifying your email, go to [peer.proxybase.org](https://peer.proxybase.org) and find your User ID in the dashboard. It looks like a short alphanumeric string (e.g. `nXzS3c6iTO`).
+After signing up and verifying your email, open your [dashboard](https://peer.proxybase.org/dashboard) and copy your **Access Token** — it is shown in the Docker command on the setup page and looks like a short alphanumeric string.
 
 ### 3. Deploy with CashPilot
 
-In the CashPilot web UI, find **ProxyBase** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
+In the CashPilot web UI, find **ProxyBase** in the service catalog and click **Deploy**. Enter your Access Token and a device name, and CashPilot will handle the rest.
+
+> **Upgrading from an older CashPilot?** ProxyBase moved to a new client image and renamed its credentials (the old `USER_ID`/`DEVICE_NAME` are now the **Access Token** and **Device Name**). Re-deploy ProxyBase from the catalog and re-enter your Access Token so the new client can authenticate — existing containers built on the old image will stop earning.
 
 ## Docker Configuration
 
-- **Image:** `proxybase/proxybase`
-- **Platforms:** linux/amd64
+- **Image:** `ghcr.io/proxybaseorg/peer-cli` (pinned by digest)
+- **Platforms:** linux/amd64, linux/arm64, linux/arm/v7
 
 ### Environment Variables
 
 | Variable | Label | Required | Secret | Description |
 |----------|-------|:--------:|:------:|-------------|
-| `USER_ID` | User ID | Yes | No | Your ProxyBase user ID from the dashboard |
-| `DEVICE_NAME` | Device Name | Yes | No | Name shown in your ProxyBase dashboard -- container crashes without it (default: `cashpilot-{hostname}`) |
+| `ID` | Access Token | Yes | Yes | Your ProxyBase Access Token from the dashboard |
+| `NAME` | Device Name | Yes | No | Any name to identify this device in your ProxyBase dashboard -- the client won't start without it (default: `cashpilot-{hostname}`) |

--- a/docs/guides/proxybase.md
+++ b/docs/guides/proxybase.md
@@ -44,11 +44,11 @@ After signing up and verifying your email, open your [dashboard](https://peer.pr
 
 In the CashPilot web UI, find **ProxyBase** in the service catalog and click **Deploy**. Enter your Access Token and a device name, and CashPilot will handle the rest.
 
-> **Upgrading from an older CashPilot?** ProxyBase moved to a new client image and renamed its credentials (the old `USER_ID`/`DEVICE_NAME` are now the **Access Token** and **Device Name**). Re-deploy ProxyBase from the catalog and re-enter your Access Token so the new client can authenticate — existing containers built on the old image will stop earning.
+> **Upgrading from an older CashPilot?** ProxyBase moved to a new client image and replaced its credentials: the old `USER_ID`/`DEVICE_NAME` values are retired and cannot be reused. Generate a fresh **Access Token** in your [dashboard](https://peer.proxybase.org/dashboard), then re-deploy ProxyBase from the catalog with it (plus a Device Name) — existing containers built on the old image have stopped earning.
 
 ## Docker Configuration
 
-- **Image:** `ghcr.io/proxybaseorg/peer-cli` (pinned by digest)
+- **Image:** `ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e` (digest-pinned; the catalog entry is authoritative if they ever differ)
 - **Platforms:** linux/amd64, linux/arm64, linux/arm/v7
 
 ### Environment Variables

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -14,7 +14,7 @@ referral:
   signup_url: "https://peer.proxybase.org?referral=nXzS3c6iTO"
 
 docker:
-  image: ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e
+  image: "ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e"
   platforms: [linux/amd64, linux/arm64, linux/arm/v7]
   resources:
     mem_limit: "128m"
@@ -29,7 +29,7 @@ docker:
       label: "Device Name"
       required: true
       secret: false
-      description: "Any name to identify this device in your ProxyBase dashboard (required — the client won't start without it)"
+      description: "Any name to identify this device in your ProxyBase dashboard"
       default: "cashpilot-{hostname}"
   ports: []
   volumes: []

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -2,33 +2,34 @@ name: ProxyBase
 slug: proxybase
 category: bandwidth
 status: active
-website: https://proxybase.io
+website: https://proxybase.org
 description: >
   ProxyBase is a bandwidth-sharing platform that pays users in cryptocurrency for
-  sharing their unused internet connection. Uses a simple user ID-based authentication
-  system. Works on residential connections. Official Docker image available.
-short_description: Bandwidth sharing - crypto payout, user ID auth
+  sharing their unused internet connection. You authenticate the peer client with an
+  Access Token from your dashboard. Residential IPs earn the most, but datacenter IPs
+  are also supported. Official multi-arch Docker image (amd64/arm64/armv7).
+short_description: Bandwidth sharing - crypto payout, Access Token auth
 
 referral:
   signup_url: "https://peer.proxybase.org?referral=nXzS3c6iTO"
 
 docker:
-  image: proxybase/proxybase
-  platforms: [linux/amd64]
+  image: ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e
+  platforms: [linux/amd64, linux/arm64, linux/arm/v7]
   resources:
     mem_limit: "128m"
     oom_score_adj: 300
   env:
-    - key: USER_ID
-      label: "User ID"
+    - key: ID
+      label: "Access Token"
       required: true
-      secret: false
-      description: "Log in at <a href=\"https://dashboard.proxybase.io\">dashboard.proxybase.io</a> → your User ID is shown in the Docker command on the setup page"
-    - key: DEVICE_NAME
+      secret: true
+      description: "Log in at <a href=\"https://peer.proxybase.org/dashboard\">peer.proxybase.org/dashboard</a> → copy your Access Token (shown in the Docker command on the setup page)"
+    - key: NAME
       label: "Device Name"
       required: true
       secret: false
-      description: "Name shown in your ProxyBase dashboard (container crashes without it)"
+      description: "Any name to identify this device in your ProxyBase dashboard (required — the client won't start without it)"
       default: "cashpilot-{hostname}"
   ports: []
   volumes: []
@@ -36,7 +37,8 @@ docker:
   network_mode: ""
 
 requirements:
-  residential_ip: true
+  residential_ip: false
+  vps_ip: true
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -109,3 +109,37 @@ def test_repocket_container_env_keys():
     assert by_key["RP_API_KEY"]["secret"] is True, "RP_API_KEY must be marked secret"
     assert by_key["RP_API_KEY"]["required"] is True, "RP_API_KEY must be required"
     assert by_key["RP_EMAIL"]["required"] is True, "RP_EMAIL must be required"
+
+
+def test_proxybase_container_contract():
+    """Regression for #103: ProxyBase migrated off Docker Hub to the GHCR peer-cli.
+
+    The current client (ghcr.io/proxybaseorg/peer-cli) reads env vars ID + NAME
+    (verified against the image's own --help: 'ProxyBase-Peer [<ID> [<NAME>]]',
+    'set env var ID' / 'set env var NAME'). It does NOT read the old
+    USER_ID/DEVICE_NAME, so a container built on those silently fails with
+    'Missing ID and NAME'. Pin by digest — never fall back to the retired
+    proxybase/proxybase image or a floating tag.
+    """
+    proxybase = SERVICES_DIR / "bandwidth" / "proxybase.yml"
+    with open(proxybase) as f:
+        data = yaml.safe_load(f)
+
+    image = data["docker"]["image"]
+    assert image.startswith("ghcr.io/proxybaseorg/peer-cli@sha256:"), (
+        f"ProxyBase must use the digest-pinned GHCR peer-cli image, got {image}"
+    )
+    assert "proxybase/proxybase" not in image, "ProxyBase must not use the retired Docker Hub image"
+
+    env_keys = {e["key"] for e in data["docker"]["env"]}
+    assert env_keys == {"ID", "NAME"}, (
+        f"ProxyBase container env must be exactly ID + NAME (the peer-cli contract), got {env_keys}"
+    )
+    by_key = {e["key"]: e for e in data["docker"]["env"]}
+    assert by_key["ID"]["required"] is True, "ID (Access Token) must be required"
+    assert by_key["NAME"]["required"] is True, "NAME (Device Name) must be required"
+
+    # Domain migrated proxybase.io -> proxybase.org across every user-facing URL.
+    assert "proxybase.io" not in data["website"], "website must use proxybase.org"
+    for e in data["docker"]["env"]:
+        assert "proxybase.io" not in e.get("description", ""), f"env {e['key']} description still links proxybase.io"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -129,7 +129,9 @@ def test_proxybase_container_contract():
     assert image.startswith("ghcr.io/proxybaseorg/peer-cli@sha256:"), (
         f"ProxyBase must use the digest-pinned GHCR peer-cli image, got {image}"
     )
-    assert "proxybase/proxybase" not in image, "ProxyBase must not use the retired Docker Hub image"
+    assert "linux/arm64" in data["docker"]["platforms"], (
+        "ProxyBase must keep arm64 (the peer-cli image is multi-arch; Raspberry Pi support)"
+    )
 
     env_keys = {e["key"] for e in data["docker"]["env"]}
     assert env_keys == {"ID", "NAME"}, (
@@ -137,7 +139,17 @@ def test_proxybase_container_contract():
     )
     by_key = {e["key"]: e for e in data["docker"]["env"]}
     assert by_key["ID"]["required"] is True, "ID (Access Token) must be required"
+    assert by_key["ID"]["secret"] is True, "ID (Access Token) must be marked secret (masked in the UI)"
     assert by_key["NAME"]["required"] is True, "NAME (Device Name) must be required"
+
+    # Referral revenue guard: the signup URL must keep the referral code.
+    assert data["referral"]["signup_url"] == "https://peer.proxybase.org?referral=nXzS3c6iTO", (
+        f"ProxyBase signup_url must keep the referral code, got {data['referral']['signup_url']}"
+    )
+
+    # Datacenter/VPS IPs are accepted (per the ProxyBase team); drives the UI badge.
+    assert data["requirements"]["residential_ip"] is False, "ProxyBase no longer requires a residential IP"
+    assert data["requirements"]["vps_ip"] is True, "ProxyBase must mark VPS/datacenter IPs as supported"
 
     # Domain migrated proxybase.io -> proxybase.org across every user-facing URL.
     assert "proxybase.io" not in data["website"], "website must use proxybase.org"


### PR DESCRIPTION
Fixes #103.

ProxyBase retired its Docker Hub image and its old GHCR org (`proxybase-org-company`, now 404/registry-403), changed the credential contract, and consolidated on **proxybase.org**. Verified against primary sources: I pulled the current image and ran its `--help`, and fetched the live site.

## Root cause
The catalog still shipped the gen-1 Docker Hub client (`proxybase/proxybase`, bare tag = implicit `:latest`) with `USER_ID`/`DEVICE_NAME` env vars and `.io` URLs. The current client is a different image with a different env contract, so existing deployments silently stop earning.

## Changes
| File | Change |
|------|--------|
| `services/bandwidth/proxybase.yml` | image → `ghcr.io/proxybaseorg/peer-cli@sha256:b78dda39…` (digest-pinned, multi-arch **amd64/arm64/armv7**); env `USER_ID`/`DEVICE_NAME` → **`ID`/`NAME`**; credential relabelled **Access Token** + `secret: true`; `proxybase.io` → `proxybase.org`; `residential_ip: false` + `vps_ip: true` (datacenter now accepted) |
| `docs/guides/proxybase.md` | domain + Access Token + datacenter; **upgrade re-entry note**; referral code preserved with manual-paste fallback |
| `docs/guides/README.md` | short-description terminology |
| `tests/test_catalog.py` | regression test pinning the GHCR image + exact `ID`/`NAME` contract (mirrors the #82/#83 pattern) |

## Verified
- Image `--help`: `ProxyBase-Peer [<ID> [<NAME>]]`, *'set env var ID' / 'set env var NAME'* — confirms the `ID`/`NAME` env contract and that the old vars are ignored.
- Multi-arch index digest includes linux/arm64 (the reporter runs a Raspberry Pi) + armv7.
- `ruff check` + `ruff format --check` clean; **1100 tests pass**.

## Backward compatibility
Breaking for existing ProxyBase deployments: the new client won't read the old `USER_ID`/`DEVICE_NAME`. Users must re-deploy ProxyBase and paste their **Access Token** (guide documents this). No stored-credential migration — the old value is a different credential type.

## Notes for the maintainer
- Datacenter-IP wording follows the ProxyBase team's guidance; their public FAQ still lists residential-only, so revisit if that changes.
- Your own fleet (3 servers on the old env) will need re-deploy + a fresh Access Token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ProxyBase guides to use Access Token authentication.
  * Refreshed ProxyBase platform, setup, upgrade notes, and troubleshooting for the new credential scheme.
  * Updated references to websites, image, and environment variables; clarified residential vs datacenter IP guidance.

* **Service Updates**
  * Updated ProxyBase service metadata and Docker setup to the digest-pinned GHCR image.
  * Renamed environment variables to `ID`/`NAME`, with Access Tokens marked as required secrets.
  * Enabled VPS IP support and adjusted residential IP settings.

* **Tests**
  * Added a regression test validating ProxyBase’s container contract, requirements, and referral-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->