### PR TITLE
Security + reliability + docs: whole-repo audit follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           BUILD_UI=false
           BUILD_WORKER=false
 
-          if echo "$CHANGED" | grep -qE '^(Dockerfile|pyproject\.toml|uv\.lock|app/(main|database|catalog|auth|compose_generator|exchange_rates|constants|collectors|templates|static))'; then
+          if echo "$CHANGED" | grep -qE '^(Dockerfile|pyproject\.toml|uv\.lock|app/(main|database|catalog|auth|compose_generator|exchange_rates|constants|collectors|templates|static|routers|deps|metrics|setup_token))'; then
             BUILD_UI=true
           fi
           if echo "$CHANGED" | grep -qE '^services/'; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Self-hosted passive income platform with a web UI that guides setup, deploys Doc
 
 | Technology | Purpose |
 |---|---|
-| FastAPI | Backend framework (Python 3.12, async) |
+| FastAPI | Backend framework (Python 3.14, async) |
 | Jinja2 | Server-rendered HTML templates |
 | SQLite | Database (aiosqlite, zero-config, stored in `/data`) |
 | Docker SDK for Python | Container lifecycle management via socket |
@@ -16,7 +16,7 @@ Self-hosted passive income platform with a web UI that guides setup, deploys Doc
 | httpx | Async HTTP client for earnings collectors |
 | cryptography (Fernet) | At-rest encryption for stored credentials |
 | Chart.js | Frontend earnings charts |
-| tini | PID 1 init (Dockerfile) |
+| su-exec | Drops root to the `cashpilot` user after entrypoint setup (Dockerfile) |
 | pytest | Testing |
 | MkDocs | Documentation |
 
@@ -56,12 +56,15 @@ Two containers: `cashpilot-ui` (port 8080, web dashboard + earnings collection) 
 ```
 cashpilot/
   app/                  # FastAPI application
-    main.py             # App entrypoint, lifespan, UI routes (no Docker dependency)
+    main.py             # App entrypoint, lifespan, container/fleet/earnings routes
+    deps.py             # Shared auth guards + Jinja2 template environment
+    routers/            # Route groups split out of main.py: auth, pages, users
     catalog.py          # Loads YAML service definitions, caches, SIGHUP reload
     orchestrator.py     # Docker SDK: deploy, stop, restart, remove, logs
-    database.py         # Async SQLite: earnings, config, deployments, workers tables
+    database.py         # Async SQLite: earnings, config, deployments, users, workers tables
     worker_api.py       # Worker REST API: heartbeat, container commands, mini-UI
-    ui_api.py           # UI API: worker registration, fleet view, earnings
+    setup_token.py      # First-run setup-token gate (owner-account creation)
+    metrics.py          # Optional Prometheus metrics (/metrics)
     exchange_rates.py   # Crypto/fiat conversion (CoinGecko + Frankfurter)
     collectors/         # Earnings collectors (one module per service, UI only)
       base.py           # BaseCollector ABC + EarningsResult dataclass
@@ -79,7 +82,7 @@ cashpilot/
     compute/            # 4 services (vast-ai, salad, nosana, golem)
   docs/guides/          # Per-service setup guides (manually maintained)
   unraid/               # Unraid-specific deployment templates
-  Dockerfile            # UI image: multi-stage python:3.12-slim, tini, non-root
+  Dockerfile            # UI image: multi-stage python:3.14-alpine, su-exec, non-root
   Dockerfile.worker     # Worker image: minimal deps, no collectors/templates
   docker-compose.yml    # Example deployment (UI + worker on same server)
   docker-compose.fleet.yml  # Multi-server example (UI + remote workers)
@@ -129,7 +132,7 @@ Two separate Docker images:
 │  Server A        │     │  Server B        │     │  Server C        │
 │  CashPilot UI    │◄────│  CashPilot Worker│     │  CashPilot Worker│
 │  CashPilot Worker│◄────│  Reports health  │     │  Reports health  │
-│  Port 8085 (UI)  │     │  Port 8081       │     │  Port 8081       │
+│  Port 8080 (UI)  │     │  Port 8081       │     │  Port 8081       │
 │  Port 8081 (wkr) │     │                  │     │                  │
 └──────────────────┘     └──────────────────┘     └──────────────────┘
 ```
@@ -204,7 +207,7 @@ Triggers on version tags (`v*`). Lints with ruff, builds multi-arch (amd64 + arm
 
 ## Collector Implementation Status
 
-Working collectors (12/12 deployed services):
+Working collectors (15 total, in `app/collectors/__init__.py` `COLLECTOR_MAP`):
 - **Honeygain** — JWT auth, `/v1/users/tokens` + `/v1/users/balances`
 - **EarnApp** — XSRF rotation + cookie auth, `/money`. Auto-redeem: Amazon ($50), Wise ($10), PayPal ($10)
 - **MystNodes** — Cloud API (`my.mystnodes.com/api/v2`), email/password auth. Per-node earnings via `GET /api/v2/node`
@@ -218,6 +221,8 @@ Working collectors (12/12 deployed services):
 - **Storj** — API URL-based
 - **Grass** — Bearer token from localStorage, `api.getgrass.io`. GRASS token converted via CoinGecko
 - **Bytelixir** — Laravel session cookie (~3.5h), `dash.bytelixir.com`. hCaptcha blocks automated login
+- **Anyone Protocol** — AO smart-contract dry-run (relay-rewards process) per relay fingerprint, ANYONE price via CoinGecko
+- **Salad** — `auth` cookie (ASP.NET Core double-submit XSRF), `app-api.salad.com/api/v1/profile/balance`
 
 ### Per-Node/Per-Device Earnings
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This starts two containers:
 - **cashpilot-ui** -- Web dashboard, earnings collection, service catalog (port 8080)
 - **cashpilot-worker** -- Docker agent that deploys and monitors service containers (port 8081, requires Docker socket)
 
-Then open [http://localhost:8080](http://localhost:8080) and follow the setup wizard.
+Then open [http://localhost:8080](http://localhost:8080) and follow the setup wizard. On first start, CashPilot prints a one-time **setup token** to the `cashpilot-ui` container logs (`docker compose logs cashpilot-ui`) — enter it on the registration form to create the first (owner) account. See [Getting Started](https://geiserx.github.io/CashPilot/getting-started/) for details.
 
 > **Note:** The worker container requires access to the Docker socket (`/var/run/docker.sock`) to deploy and manage service containers. Both containers are required for full functionality.
 
@@ -158,9 +158,10 @@ cashpilot/
 | `TZ` | `UTC` | Timezone for scheduling and display |
 | `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Encryption key for stored credentials |
 | `CASHPILOT_API_KEY` | -- | Enrollment/bootstrap key; each worker then gets its own key (per-worker fleet keys, v1.0.0+) |
-| `CASHPILOT_COLLECTION_INTERVAL` | `3600` | Seconds between earnings collection cycles |
-| `CASHPILOT_PORT` | `8080` | Web UI port inside the container |
+| `CASHPILOT_COLLECT_INTERVAL` | `60` | Minutes between earnings collection cycles |
 | `CASHPILOT_METRICS_ENABLED` | `false` | Set to `true` to expose Prometheus metrics at `/metrics` |
+
+The UI's web port is fixed at `8080` (set via the container's `CMD`, not an environment variable).
 
 ### Worker Environment Variables
 
@@ -170,6 +171,8 @@ cashpilot/
 | `CASHPILOT_UI_URL` | -- | URL of the UI container, e.g. `http://cashpilot-ui:8080` |
 | `CASHPILOT_API_KEY` | -- | Must match the UI's API key |
 | `CASHPILOT_WORKER_NAME` | *(hostname)* | Display name for this worker in the fleet dashboard |
+| `CASHPILOT_WORKER_URL` | *(auto-detected)* | URL the UI uses to reach this worker, e.g. `http://192.168.10.50:8081`. Set explicitly for remote/cross-host workers |
+| `CASHPILOT_PORT` | `8081` | Mini-UI/API port the worker listens on |
 
 ## Multi-Node Fleet Management
 
@@ -211,6 +214,7 @@ services:
       - CASHPILOT_UI_URL=http://main-server:8080
       - CASHPILOT_API_KEY=your-shared-api-key
       - CASHPILOT_WORKER_NAME=server-b
+      - CASHPILOT_WORKER_URL=http://server-b:8081
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -219,7 +223,7 @@ volumes:
   cashpilot_worker_data:
 ```
 
-Workers connect outbound to the UI via HTTP -- no port forwarding needed on the worker side. The UI's fleet dashboard shows all connected workers, their containers, and live status. The UI can push commands (deploy, stop, restart) to any worker remotely.
+Communication goes both ways: workers connect outbound to the UI via HTTP for heartbeats, and the UI connects outbound to each worker's `:8081` API to push commands (deploy, stop, restart). This means **the worker must be reachable from the UI** (LAN, Tailscale, or port forwarding) -- set `CASHPILOT_WORKER_URL` to the address the UI should use, since auto-detection falls back to the container's own network interface, which is often unreachable from another host. The UI's fleet dashboard shows all connected workers, their containers, and live status.
 
 ## FAQ
 
@@ -303,7 +307,7 @@ Services that were evaluated but are no longer listed in the catalog due to bein
 | Historical charts | **Yes** | No | No | No | No |
 | Multi-node fleet management | **Yes** | No | No | No | No |
 | Service catalog with guides | **49 services** | 17 | 8 | 14 | 8 |
-| Automated earnings collection | **13 collectors** | 0 | 0 | 0 | 0 |
+| Automated earnings collection | **15 collectors** | 0 | 0 | 0 | 0 |
 | Multi-arch (amd64 + arm64) | **Yes** | Yes | Yes | No | No |
 | Credential encryption | **Yes** | No | No | No | No |
 | Compose export | **Yes** | Yes | Yes | Yes | Yes |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,9 +87,9 @@ CashPilot requires access to the Docker socket (`/var/run/docker.sock`) for cont
 
 ### Authentication
 
-- **UI users**: Session-based authentication with bcrypt-hashed passwords. Sessions are signed JWT tokens stored in HTTP-only cookies.
-- **Worker-to-UI**: Shared API key (`CASHPILOT_API_KEY`) sent as Bearer token. All fleet management endpoints require this key.
-- **Role-based access**: Three roles (viewer, writer, owner) with escalating permissions. Container management requires writer or owner role.
+- **UI users**: Session-based authentication with bcrypt-hashed passwords. Sessions are signed tokens stored in HTTP-only cookies.
+- **Worker-to-UI**: Per-worker fleet keys (since v1.0.0). `CASHPILOT_API_KEY` is only a shared enrollment/bootstrap credential -- on a worker's first heartbeat the UI issues it a unique key (stored encrypted, returned once), and every subsequent request in *either* direction (worker heartbeat, UI command) authenticates with that worker's own key. The shared key is rejected once a worker is enrolled, so a leaked worker key only affects that one worker.
+- **Role-based access**: Three roles (viewer, writer, owner) with escalating permissions, plus an implicit `fleet` role for authenticated worker requests. Container management requires writer or owner role.
 
 ### Data Storage
 
@@ -105,6 +105,16 @@ CashPilot is designed to run on **private, trusted networks** (home lab, VPN, LA
 - Place it behind a reverse proxy with TLS termination (e.g., Caddy, Traefik, nginx)
 - Restrict access via firewall rules or VPN
 - Use a strong `CASHPILOT_SECRET_KEY` and `CASHPILOT_API_KEY`
+- Set the reverse-proxy-aware environment variables below so cookies, client-IP logging, and session invalidation behave correctly behind TLS termination
+
+These variables only matter when CashPilot sits behind a reverse proxy; a direct/private-network deployment can leave them unset:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CASHPILOT_TRUSTED_PROXY` | unset (off) | Opt-in. When set (`1`/`true`/`yes`/`on`), trusts the right-most `X-Forwarded-For` entry as the real client IP. Only enable this behind exactly one reverse proxy you control -- the header is otherwise attacker-controlled |
+| `CASHPILOT_BASE_URL` | -- | The externally-visible base URL (e.g. `https://cashpilot.example.com`). Used by `CASHPILOT_SECURE_COOKIE=auto` to detect HTTPS |
+| `CASHPILOT_SECURE_COOKIE` | `auto` | Controls the session cookie's `Secure` flag. `auto` sets it when `CASHPILOT_BASE_URL` starts with `https`; override with a truthy (`true`/`1`/`yes`/`on`) or falsy (`false`/`0`/`no`/`off`) value |
+| `CASHPILOT_SESSION_EPOCH` | `0` | Unix timestamp. Bump it to mass-invalidate every existing session (e.g. after a credential leak) -- any session token issued before this timestamp is rejected |
 
 ### Worker URL Validation (SSRF)
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -164,11 +164,28 @@ def get_current_user(request: Request) -> dict[str, Any] | None:
 
 _SECURE_COOKIE = os.getenv("CASHPILOT_SECURE_COOKIE", "auto").lower()
 
+# Recognized explicit values for CASHPILOT_SECURE_COOKIE. Anything else --
+# including the "auto" default and unrecognized values/typos -- falls back to
+# the https-base-url auto-detect below rather than silently forcing Secure off.
+_SECURE_COOKIE_TRUE = {"true", "1", "yes", "on"}
+_SECURE_COOKIE_FALSE = {"false", "0", "no", "off"}
+
 
 def set_session_cookie(response: RedirectResponse, token: str) -> RedirectResponse:
-    use_secure = _SECURE_COOKIE == "true" or (
-        _SECURE_COOKIE == "auto" and os.getenv("CASHPILOT_BASE_URL", "").startswith("https")
-    )
+    # Secure-flag precedence (highest wins):
+    #   1. CASHPILOT_SECURE_COOKIE explicitly truthy -> Secure on
+    #   2. CASHPILOT_SECURE_COOKIE explicitly falsy   -> Secure off (e.g. TLS is
+    #      terminated by a reverse proxy this process can't see)
+    #   3. Otherwise ("auto" / unset / unrecognized)  -> auto-detect from whether
+    #      CASHPILOT_BASE_URL starts with "https". Never hardcoded on by default,
+    #      so plain-HTTP local dev isn't broken by a Secure cookie the browser
+    #      would silently refuse to send back.
+    if _SECURE_COOKIE in _SECURE_COOKIE_TRUE:
+        use_secure = True
+    elif _SECURE_COOKIE in _SECURE_COOKIE_FALSE:
+        use_secure = False
+    else:
+        use_secure = os.getenv("CASHPILOT_BASE_URL", "").startswith("https")
     response.set_cookie(
         SESSION_COOKIE,
         token,

--- a/app/collectors/storj.py
+++ b/app/collectors/storj.py
@@ -51,8 +51,7 @@ class StorjCollector(BaseCollector):
             elif "currentMonthExpectations" in data:
                 balance = data["currentMonthExpectations"] / 100.0
             else:
-                # Fallback: try /api/sno for totalPayout
-                balance = 0.0
+                raise ValueError("Unrecognized storagenode API response shape — no known payout field found")
 
             return EarningsResult(
                 platform=self.platform,

--- a/app/database.py
+++ b/app/database.py
@@ -1050,7 +1050,8 @@ async def get_worker_key(client_id: str) -> str | None:
 
 async def get_worker_key_state(client_id: str) -> tuple[str | None, bool]:
     """Return (key, confirmed) for a worker: the decrypted per-worker key (or None
-    if unenrolled) and whether the worker has confirmed it by using it."""
+    if unenrolled, or if the stored key can no longer be decrypted) and whether the
+    worker has confirmed it by using it."""
     db = await _get_db()
     try:
         cursor = await db.execute(
@@ -1061,7 +1062,25 @@ async def get_worker_key_state(client_id: str) -> tuple[str | None, bool]:
         if not row:
             return None, False
         enc = row["api_key_enc"]
-        key = decrypt_value(enc) if enc else None
+        if not enc:
+            return None, bool(row["key_confirmed"])
+        key = decrypt_value(enc)
+        if not key:
+            # decrypt_value() returns "" (after logging its own warning) when the
+            # Fernet key can't decrypt this value -- e.g. CASHPILOT_SECRET_KEY was
+            # rotated or restored from a different value. A real per-worker key is
+            # always a secrets.token_urlsafe(32) string and can never legitimately
+            # be empty, so "" here unambiguously means "undecryptable", not "empty
+            # key". Report it as NOT enrolled (None) rather than as a real key that
+            # can never match, so callers fall back to the shared bootstrap key and
+            # the worker can re-enroll instead of being permanently bricked.
+            _logger.error(
+                "Worker '%s' per-worker key is undecryptable (CASHPILOT_SECRET_KEY "
+                "changed?) -- treating as unenrolled so it can re-enroll via the "
+                "shared key",
+                client_id,
+            )
+            return None, False
         return key, bool(row["key_confirmed"])
     finally:
         await db.close()

--- a/app/exchange_rates.py
+++ b/app/exchange_rates.py
@@ -33,12 +33,26 @@ STALE_THRESHOLD = 2 * CACHE_TTL  # 30 minutes
 # In-memory caches
 _fiat_rates: dict[str, float] = {"USD": 1.0}
 _crypto_usd: dict[str, float] = {}
+# Crypto (CoinGecko) and fiat (Frankfurter) are independent sources with their own
+# staleness clocks, each advanced ONLY on that source's own HTTP 200 -- a failure
+# on one source must never mark the other source's rates stale, and must never be
+# papered over as "fresh" for the source that actually failed.
+_crypto_last_fetch: float = 0
+_fiat_last_fetch: float = 0
+# Aggregate clock kept for backward-compat callers (rates_stale()/get_all()). It
+# reflects the WORSE of the two sources (the older of the two timestamps), so a
+# partial failure is never reported as fully fresh.
 _last_fetch: float = 0
 
 
 async def refresh() -> None:
-    """Fetch latest exchange rates from external APIs."""
-    global _fiat_rates, _crypto_usd, _last_fetch
+    """Fetch latest exchange rates from external APIs.
+
+    Only a genuine HTTP 200 from a source advances THAT source's own last-fetch
+    time -- a non-200 (or an unreachable API) leaves it untouched so staleness is
+    tracked per-source and a partial failure can't mislabel the other source.
+    """
+    global _fiat_rates, _crypto_usd, _last_fetch, _crypto_last_fetch, _fiat_last_fetch
 
     try:
         async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
@@ -55,12 +69,17 @@ async def refresh() -> None:
                         price = (data.get(cg_id) or {}).get("usd")
                         if price is not None:
                             _crypto_usd[token] = float(price)
+                    _crypto_last_fetch = time.time()
                 else:
                     logger.warning(
                         "exchange rate fetch got HTTP %s from %s",
                         resp.status_code,
                         "CoinGecko",
                     )
+            else:
+                # Nothing to fetch -- don't let an empty crypto map hold the
+                # aggregate staleness clock back forever.
+                _crypto_last_fetch = time.time()
 
             # --- Fiat rates from Frankfurter (free, no key) ---
             resp = await client.get(
@@ -73,6 +92,7 @@ async def refresh() -> None:
                 for code, rate in data.get("rates", {}).items():
                     new_rates[code] = float(rate)
                 _fiat_rates = new_rates
+                _fiat_last_fetch = time.time()
             else:
                 logger.warning(
                     "exchange rate fetch got HTTP %s from %s",
@@ -80,7 +100,7 @@ async def refresh() -> None:
                     "Frankfurter",
                 )
 
-        _last_fetch = time.time()
+        _last_fetch = min(_crypto_last_fetch, _fiat_last_fetch)
         logger.info(
             "Exchange rates updated: %d fiat currencies, %d crypto tokens",
             len(_fiat_rates),
@@ -95,11 +115,23 @@ def rates_stale() -> bool:
 
     Rates are stale once more than ``STALE_THRESHOLD`` seconds have elapsed
     since the last successful fetch (``_last_fetch`` is only updated on
-    success).  A never-fetched cache (``_last_fetch == 0``) is also stale.
-    Callers can use this to avoid silently summing balances against rates
-    that may be badly out of date.
+    success, and reflects the WORSE of the crypto/fiat sources -- see
+    ``crypto_rates_stale()``/``fiat_rates_stale()`` for the per-source signal).
+    A never-fetched cache (``_last_fetch == 0``) is also stale. Callers can use
+    this to avoid silently summing balances against rates that may be badly
+    out of date.
     """
     return time.time() - _last_fetch > STALE_THRESHOLD
+
+
+def crypto_rates_stale() -> bool:
+    """Return True if crypto rates are stale (CoinGecko refreshes are failing)."""
+    return time.time() - _crypto_last_fetch > STALE_THRESHOLD
+
+
+def fiat_rates_stale() -> bool:
+    """Return True if fiat rates are stale (Frankfurter refreshes are failing)."""
+    return time.time() - _fiat_last_fetch > STALE_THRESHOLD
 
 
 def get_all() -> dict[str, Any]:
@@ -109,6 +141,8 @@ def get_all() -> dict[str, Any]:
         "crypto_usd": dict(_crypto_usd),
         "last_updated": _last_fetch,
         "stale": rates_stale(),
+        "crypto_stale": crypto_rates_stale(),
+        "fiat_stale": fiat_rates_stale(),
     }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,6 @@ import os
 import re
 import secrets
 import socket
-from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from time import monotonic
@@ -70,22 +69,28 @@ def _spawn(coro) -> asyncio.Task:
     return task
 
 
-# Login rate limiting
-_login_attempts: dict[str, list[float]] = defaultdict(list)
+# Login rate limiting. Plain dict (not defaultdict) so a stale/empty bucket
+# never lingers forever — every distinct client IP that ever hits /login
+# would otherwise leave a permanent key behind, even after its attempts have
+# all aged out, growing unbounded over the process lifetime.
+_login_attempts: dict[str, list[float]] = {}
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW_SECONDS = 300
 
 
 def _check_login_rate(ip: str) -> None:
     now = monotonic()
-    attempts = _login_attempts[ip]
-    _login_attempts[ip] = [t for t in attempts if now - t < _LOGIN_WINDOW_SECONDS]
-    if len(_login_attempts[ip]) >= _LOGIN_MAX_ATTEMPTS:
+    attempts = [t for t in _login_attempts.get(ip, []) if now - t < _LOGIN_WINDOW_SECONDS]
+    if attempts:
+        _login_attempts[ip] = attempts
+    else:
+        _login_attempts.pop(ip, None)
+    if len(attempts) >= _LOGIN_MAX_ATTEMPTS:
         raise HTTPException(status_code=429, detail="Too many login attempts. Try again in a few minutes.")
 
 
 def _record_failed_login(ip: str) -> None:
-    _login_attempts[ip].append(monotonic())
+    _login_attempts.setdefault(ip, []).append(monotonic())
 
 
 def _safe_json(raw: str, fallback: Any = None) -> Any:
@@ -185,6 +190,16 @@ async def _run_health_check() -> None:
     Deduplicates by slug: if *any* instance of a service is running,
     record a single check_ok for that slug (avoids penalising services
     deployed on multiple nodes where one may be stopped).
+
+    A service that vanishes from the heartbeat entirely (container removed
+    outside CashPilot, crash-removed, worker's Docker daemon down) previously
+    got no health event at all — it just stopped appearing, so its score
+    stayed frozen wherever it last was (often green) forever. Any known
+    Docker-backed deployment missing from every online worker's current data
+    now gets an explicit check_down. Scoped to "at least one worker online"
+    so a fully-offline fleet (no heartbeat data to trust either way) never
+    triggers false check_downs; "external" deployments (e.g. Grass, Bytelixir)
+    have no container and are excluded since no worker ever reports them.
     """
     try:
         statuses = await _get_all_worker_containers()
@@ -200,6 +215,15 @@ async def _run_health_check() -> None:
                 await database.record_health_event(slug, "check_ok")
             else:
                 await database.record_health_event(slug, "check_down", status)
+
+        workers = await database.list_workers()
+        if any(w.get("status") == "online" for w in workers):
+            deployments = await database.get_deployments()
+            for d in deployments:
+                slug = d["slug"]
+                if d.get("status") == "external" or slug in slug_best:
+                    continue
+                await database.record_health_event(slug, "check_down", "missing from heartbeat")
     except Exception as exc:
         logger.warning("Health check skipped: %s", exc)
 
@@ -284,13 +308,27 @@ async def _run_vacuum() -> None:
 
 
 async def _check_stale_workers() -> None:
-    """Mark workers as offline if stale, and purge workers offline > 1 hour."""
+    """Mark workers as offline if stale, and purge never-enrolled workers offline > 1 hour.
+
+    A worker that HAS enrolled a per-worker key (``api_key_enc`` set) is never
+    auto-deleted here, even after a long outage: the host persists that same
+    key locally and re-presents it on its next heartbeat. Deleting the row
+    would leave no match for that key, and since a confirmed worker's shared
+    bootstrap key is refused too, it would be rejected forever with no way to
+    re-enroll — a permanent fleet lockout after a reboot/maintenance window.
+    Only a worker that never completed enrollment is purged automatically;
+    removing an enrolled worker is a deliberate action via the UI.
+    """
     try:
         workers = await database.list_workers()
-        now = datetime.now(UTC)
-        cutoff = now - timedelta(seconds=STALE_WORKER_SECONDS)
-        purge_cutoff = now - timedelta(hours=1)
-        for w in workers:
+    except Exception as exc:
+        logger.warning("Stale worker check error: %s", exc)
+        return
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(seconds=STALE_WORKER_SECONDS)
+    purge_cutoff = now - timedelta(hours=1)
+    for w in workers:
+        try:
             last_hb = w.get("last_heartbeat")
             if not last_hb:
                 continue
@@ -298,11 +336,11 @@ async def _check_stale_workers() -> None:
             if w["status"] == "online" and last < cutoff:
                 await database.set_worker_status(w["id"], "offline")
                 logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], last_hb)
-            elif w["status"] == "offline" and last < purge_cutoff:
+            elif w["status"] == "offline" and last < purge_cutoff and not w.get("api_key_enc"):
                 await database.delete_worker(w["id"])
-                logger.info("Purged stale worker '%s' (offline since %s)", w["name"], last_hb)
-    except Exception as exc:
-        logger.warning("Stale worker check error: %s", exc)
+                logger.info("Purged stale unenrolled worker '%s' (offline since %s)", w["name"], last_hb)
+        except Exception as exc:
+            logger.warning("Stale worker check error for worker '%s': %s", w.get("name", w.get("id")), exc)
 
 
 FLEET_API_KEY = fleet_key.resolve_fleet_key()

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -216,9 +216,14 @@ CASHPILOT_WORKER_NAME=server-name</code>
   }
 
   function esc(str) {
-    const d = document.createElement('div');
-    d.textContent = str || '';
-    return d.innerHTML;
+    // Escape quotes too (the textContent/innerHTML trick doesn't), so values
+    // interpolated into attributes like data-worker-name="..." can't break out.
+    return String(str ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
   }
 
   window.toggleApiKey = async function() {

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -33,6 +33,12 @@ from pydantic import BaseModel
 
 from app import fleet_key, orchestrator
 
+try:
+    from app.catalog import get_services as _catalog_get_services
+except ImportError:
+    # Worker image may not include the catalog module in some builds.
+    _catalog_get_services = None  # type: ignore[assignment]
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
@@ -73,15 +79,24 @@ def _load_worker_key() -> str | None:
     return None
 
 
-def _save_worker_key(key: str) -> None:
-    global _worker_key
-    _worker_key = key
+def _save_worker_key(key: str) -> bool:
+    """Persist the newly issued per-worker key to disk, then adopt it in memory.
+
+    Returns True once the key is durably on disk. On persistence failure the
+    key is NOT adopted -- we keep authenticating with whatever key was active
+    before, so a write failure here can never leave us relying on a key that
+    only exists in memory and vanishes on the next restart (lockout).
+    """
     try:
         _WORKER_KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
         _WORKER_KEY_FILE.write_text(key)
         _WORKER_KEY_FILE.chmod(0o600)
     except OSError as exc:
-        logger.warning("Could not persist per-worker key: %s", exc)
+        logger.error("Could not persist per-worker key — NOT adopting it: %s", exc)
+        return False
+    global _worker_key
+    _worker_key = key
+    return True
 
 
 _worker_key: str | None = _load_worker_key()
@@ -152,12 +167,19 @@ async def _send_heartbeat() -> None:
             with contextlib.suppress(Exception):
                 issued = resp.json().get("worker_key")
             if issued and issued != _worker_key:
-                _save_worker_key(issued)
-                logger.info("Enrolled: received and persisted this worker's own fleet key")
+                if _save_worker_key(issued):
+                    logger.info("Enrolled: received and persisted this worker's own fleet key")
+                else:
+                    logger.error("Received per-worker key but could not persist it — staying on shared key")
             _ui_connected = True
             _last_heartbeat = datetime.now(UTC).strftime("%H:%M:%S UTC")
             _last_error = ""
             logger.debug("Heartbeat sent to %s", UI_URL)
+    except httpx.HTTPStatusError as exc:
+        _ui_connected = False
+        status = exc.response.status_code
+        _last_error = f"authentication rejected ({status})" if status in (401, 403) else "connection failed"
+        logger.warning("Heartbeat failed: %s", exc)
     except Exception as exc:
         _ui_connected = False
         _last_error = "connection failed"
@@ -350,26 +372,60 @@ _BLOCKED_VOLUME_ROOTS = {
     "/bin",
     "/sbin",
     "/var/run",
-    "/run",
+    "/run",  # also covers /run/docker.sock (modern /var/run -> /run symlink)
     "/var/lib/docker",
+    "/mnt",  # e.g. Unraid array root (/mnt/user/appdata/<app>) — co-located apps' secrets
+    "/media",
+    "/opt",
+    "/srv",
+    "/data",  # per-container app data roots, incl. this worker's own /data
+    "/tmp",
 }
-_BLOCKED_CAPS = {"ALL", "SYS_ADMIN", "SYS_PTRACE"}
-# Named volumes (bridge/none/unset) and mysterium's legitimate host networking are allowed;
-# `container:<id>` (namespace join) and any other value are rejected.
-_ALLOWED_NETWORK_MODES = {None, "", "bridge", "none", "host"}
 # Docker memory size syntax: a positive integer with an optional b/k/m/g unit.
 _MEM_LIMIT_RE = re.compile(r"^\d+[bkmgBKMG]?$")
 
 
-def _validate_deploy_spec(spec: DeploySpec) -> None:
+def _catalog_allowed_capabilities() -> set[str]:
+    """Union of cap_add values any bundled catalog service actually declares.
+
+    Derived from services/*.yml (the single source of truth) instead of a
+    hardcoded list, so it stays correct as the catalog changes. A capability
+    no catalog service asks for is refused, whatever it is.
+    """
+    if not _catalog_get_services:
+        return set()
+    caps: set[str] = set()
+    for svc in _catalog_get_services():
+        for cap in (svc.get("docker") or {}).get("cap_add") or []:
+            caps.add(str(cap).upper())
+    return caps
+
+
+def _catalog_host_network_slugs() -> set[str]:
+    """Slugs whose catalog definition legitimately declares network_mode: host."""
+    if not _catalog_get_services:
+        return set()
+    return {svc["slug"] for svc in _catalog_get_services() if (svc.get("docker") or {}).get("network_mode") == "host"}
+
+
+# Named volumes (bridge/none/unset) are always allowed. `host` is allowed only for
+# catalog services that declare it (checked separately below, by slug). `container:<id>`
+# (namespace join) and any other value are rejected outright.
+_ALLOWED_NETWORK_MODES = {None, "", "bridge", "none", "host"}
+
+
+def _validate_deploy_spec(spec: DeploySpec, slug: str | None = None) -> None:
     if spec.privileged:
         raise HTTPException(status_code=403, detail="Privileged containers are not allowed")
     if spec.cap_add:
-        blocked = _BLOCKED_CAPS & {c.upper() for c in spec.cap_add}
+        requested = {c.upper() for c in spec.cap_add}
+        blocked = requested - _catalog_allowed_capabilities()
         if blocked:
-            raise HTTPException(status_code=403, detail=f"Blocked capabilities: {', '.join(blocked)}")
+            raise HTTPException(status_code=403, detail=f"Blocked capabilities: {', '.join(sorted(blocked))}")
     if spec.network_mode not in _ALLOWED_NETWORK_MODES:
         raise HTTPException(status_code=403, detail=f"Network mode '{spec.network_mode}' is not allowed")
+    if spec.network_mode == "host" and slug not in _catalog_host_network_slugs():
+        raise HTTPException(status_code=403, detail=f"Network mode 'host' is not allowed for '{slug}'")
     for source in spec.volumes:
         if not source.startswith("/"):
             continue  # named volume (e.g. "mysterium-data") — always allowed
@@ -428,7 +484,7 @@ async def api_list_containers(request: Request) -> list[dict[str, Any]]:
 async def api_deploy_container(request: Request, slug: str, spec: DeploySpec) -> dict[str, str]:
     """Deploy a container from spec sent by UI."""
     _verify_api_key(request)
-    _validate_deploy_spec(spec)
+    _validate_deploy_spec(spec, slug=slug)
     try:
         container_id = await asyncio.to_thread(
             orchestrator.deploy_raw,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@
 #
 # Images track the `latest` tag (pull_policy: always), so a plain `up -d`
 # always launches the newest published release — no rebuild needed. To pin a
-# specific version instead, replace `:latest` with e.g. `:0.6.13` (see
+# specific version instead, replace `:latest` with e.g. `:1.0.1` (see
 # https://hub.docker.com/r/drumsergio/cashpilot/tags) and drop pull_policy.
+# NOTE: versions before 1.0.0 predate the per-worker fleet-key auth cutover and
+# are not compatible with a worker running 1.x -- pin UI and worker together.
 # Building from source? Use: docker compose -f docker-compose.build.yml up -d
 
 services:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ There is **no standalone mode**. Every server that runs Docker containers needs 
 2. **Workers must be privileged.** A worker without Docker socket is useless. If you don't need Docker management, just run the UI alone to track earnings.
 3. **Single source of truth.** The UI instance is the only one that collects earnings, stores historical data, and serves the dashboard. Workers never collect earnings.
 4. **Earnings are never duplicated.** Since only the UI collects, there is no risk of the same account being counted twice.
-5. **Workers are stateless satellites.** A worker knows which containers to keep running and the UI URL to report to. It has a tiny local SQLite for config persistence but no earnings data.
+5. **Workers are stateless satellites.** A worker knows which containers to keep running and the UI URL to report to. It persists only its own fleet key to a local file (no database, no earnings data).
 6. **YAML is truth.** Every service lives in `services/{category}/{slug}.yml`. The UI, deployment, docs, and compose export all derive from these files.
 
 ## Directory Structure
@@ -25,12 +25,15 @@ There is **no standalone mode**. Every server that runs Docker containers needs 
 ```
 cashpilot/
   app/                      # FastAPI application
-    main.py                 # App entrypoint, lifespan, UI routes
+    main.py                 # App entrypoint, lifespan, container/fleet/earnings routes
+    deps.py                 # Shared auth guards + Jinja2 template environment
+    routers/                # Route groups split out of main.py: auth, pages, users
     catalog.py              # Loads YAML service definitions, caches, SIGHUP reload
     orchestrator.py         # Docker SDK: deploy, stop, restart, remove, logs
-    database.py             # Async SQLite: earnings, config, deployments, workers
+    database.py             # Async SQLite: earnings, config, deployments, users, workers
     worker_api.py           # Worker REST API: heartbeat, container commands, mini-UI
-    ui_api.py               # UI API: worker registration, fleet view, earnings
+    setup_token.py          # First-run setup-token gate (owner-account creation)
+    metrics.py              # Optional Prometheus metrics (/metrics)
     exchange_rates.py       # Crypto/fiat conversion via CoinGecko + Frankfurter
     collectors/             # Earnings collectors (one module per service, UI only)
       base.py               # BaseCollector ABC + EarningsResult dataclass
@@ -48,7 +51,7 @@ cashpilot/
     compute/                # GPU compute services
   docs/                     # Documentation and guides
     guides/                 # Per-service setup guides
-  Dockerfile                # UI image: multi-stage python:3.12-slim, tini, non-root
+  Dockerfile                # UI image: multi-stage python:3.14-alpine, su-exec, non-root
   Dockerfile.worker         # Worker image: minimal deps, no collectors/templates
   docker-compose.yml        # Single-server deployment
   docker-compose.fleet.yml  # Multi-server fleet deployment
@@ -89,9 +92,9 @@ sequenceDiagram
 Every 60 seconds, each worker sends:
 
 - Container list with status (running, stopped, exited)
-- Per-container resource usage (CPU, memory, network)
-- System info (OS, architecture, Docker version)
-- Health check results
+- Per-container resource usage (CPU percent, memory MB)
+- System info (OS, architecture, hostname, Docker availability)
+- Its self-reported URL (explicit `CASHPILOT_WORKER_URL` or an auto-detected fallback)
 
 The UI stores this in its SQLite database and displays it on the fleet dashboard.
 
@@ -119,7 +122,7 @@ The worker **never handles or stores credentials**:
 
 The UI runs scheduled collectors for each configured service:
 
-- **13 automated collectors** fetch balances via service APIs (JWT auth, cookie auth, API keys)
+- **15 automated collectors** fetch balances via service APIs (JWT auth, cookie auth, API keys)
 - Results stored in SQLite with native currency (USD, MYST, GRASS, STORJ, etc.)
 - Exchange rates fetched from CoinGecko (crypto) and Frankfurter (fiat), cached 15 minutes
 - Dashboard converts and displays in the user's preferred currency
@@ -128,7 +131,7 @@ The UI runs scheduled collectors for each configured service:
 
 | Technology | Purpose |
 |---|---|
-| FastAPI | Backend framework (Python 3.12, async) |
+| FastAPI | Backend framework (Python 3.14, async) |
 | Jinja2 | Server-rendered HTML templates |
 | SQLite | Database (aiosqlite, zero-config, stored in `/data`) |
 | Docker SDK for Python | Container lifecycle management via socket |
@@ -137,22 +140,24 @@ The UI runs scheduled collectors for each configured service:
 | httpx | Async HTTP client for earnings collectors |
 | cryptography (Fernet) | At-rest encryption for stored credentials |
 | Chart.js | Frontend earnings charts |
-| tini | PID 1 init (Dockerfile) |
+| su-exec | Drops root to the `cashpilot` user after entrypoint setup (Dockerfile) |
 
 ## Database
 
 SQLite with 400-day data retention. Key tables:
 
 - **earnings** -- Historical earnings per service (timestamp, slug, balance, currency)
-- **deployments** -- Active container deployments (slug, node, status, config)
+- **deployments** -- Active container deployments (slug, container ID, encrypted env vars, status)
 - **config** -- Key-value settings and encrypted credentials
+- **users** -- Accounts (username, bcrypt password hash, role)
+- **user_preferences** -- Per-user onboarding state (setup mode, selected categories, timezone)
 - **health_events** -- Container health history (start, stop, crash, check_ok, check_down)
-- **nodes** -- Fleet node registry (name, token, last_seen, system info)
+- **workers** -- Fleet worker registry (client ID, name, URL, status, last heartbeat, encrypted per-worker fleet key)
 
 ## Security Model
 
 - All credentials encrypted at rest using Fernet symmetric encryption
-- Worker-to-UI authentication via shared API key
+- Worker-to-UI authentication via per-worker fleet keys (`CASHPILOT_API_KEY` is only the enrollment/bootstrap credential)
 - Managed containers run with `--security-opt no-new-privileges`
 - Container naming convention: `cashpilot-{slug}` with labels `cashpilot.managed=true`
 - UI container has **no** Docker socket access

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -64,6 +64,7 @@ services:
       - CASHPILOT_UI_URL=http://main-server:8080
       - CASHPILOT_API_KEY=your-shared-api-key
       - CASHPILOT_WORKER_NAME=server-b
+      - CASHPILOT_WORKER_URL=http://server-b:8081
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -71,6 +72,9 @@ services:
 volumes:
   cashpilot_worker_data:
 ```
+
+!!! important "CASHPILOT_WORKER_URL"
+    Set this to the address the UI should use to reach this worker (e.g. its LAN IP or Tailscale MagicDNS name, port 8081). Without it, the worker auto-detects its own outbound IP, which inside a container is often the Docker bridge address -- unreachable from the UI on another host.
 
 !!! important "API Key"
     The `CASHPILOT_API_KEY` must be identical on the UI and all workers. It is the **enrollment key** each worker uses on first contact; after that, each worker uses its own automatically-issued key.
@@ -136,6 +140,8 @@ If a worker goes offline (no heartbeat for 180 seconds):
 | `CASHPILOT_UI_URL` | Yes | -- | URL of the CashPilot UI (e.g. `http://192.168.10.100:8080`) |
 | `CASHPILOT_API_KEY` | Yes | -- | Must match the UI's API key |
 | `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker in the fleet dashboard |
+| `CASHPILOT_WORKER_URL` | No | *(auto-detected)* | URL the UI uses to reach this worker. Set explicitly for remote/cross-host workers -- auto-detection can report an unreachable address |
+| `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
 
 ### Worker URL Validation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,23 @@ This starts two containers:
 
 ### 2. Open the dashboard
 
-Navigate to [http://localhost:8080](http://localhost:8080) in your browser. The onboarding wizard will guide you through initial setup.
+Navigate to [http://localhost:8080](http://localhost:8080) in your browser. Since no account exists yet, you'll be redirected to onboarding and then to the registration form.
+
+!!! warning "First-run setup token required"
+    On first start, CashPilot generates a one-time setup token and prints it to the **cashpilot-ui** container logs:
+
+    ```bash
+    docker compose logs cashpilot-ui
+    ```
+
+    Look for a line like:
+
+    ```
+    FIRST-RUN SETUP: no account exists yet. Open /register and enter this
+    one-time setup token to create the owner account: <token>
+    ```
+
+    Copy that token into the **Setup Token** field on the registration form to create the first (owner) account. It's only ever shown in the logs — never in a URL — and is discarded permanently once the owner account exists.
 
 ### 3. Browse the service catalog
 
@@ -68,8 +84,9 @@ graph LR
 | `TZ` | `UTC` | Timezone for scheduling and display |
 | `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Encryption key for stored credentials. Set this to persist encryption across container recreations |
 | `CASHPILOT_API_KEY` | -- | Shared secret between UI and workers for API authentication |
-| `CASHPILOT_COLLECTION_INTERVAL` | `3600` | Seconds between earnings collection cycles |
-| `CASHPILOT_PORT` | `8080` | Web UI port inside the container |
+| `CASHPILOT_COLLECT_INTERVAL` | `60` | Minutes between earnings collection cycles |
+
+The UI's web port is fixed at `8080` (set via the container's `CMD`, not an environment variable).
 
 ### Worker Environment Variables
 
@@ -79,6 +96,8 @@ graph LR
 | `CASHPILOT_UI_URL` | -- | URL of the UI container, e.g. `http://cashpilot-ui:8080` |
 | `CASHPILOT_API_KEY` | -- | Must match the UI's API key |
 | `CASHPILOT_WORKER_NAME` | *(hostname)* | Display name for this worker in the fleet dashboard |
+| `CASHPILOT_WORKER_URL` | *(auto-detected)* | URL the UI uses to reach this worker, e.g. `http://192.168.10.50:8081`. Set explicitly for cross-host fleets — auto-detection can report an unreachable container-internal IP |
+| `CASHPILOT_PORT` | `8081` | Mini-UI/API port the worker listens on |
 
 ### Docker Compose Example
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - Getting Started: getting-started.md
   - Architecture: architecture.md
   - Fleet Management: fleet.md
+  - Prometheus Metrics: guides/prometheus-metrics.md
   - Upgrade to v1.0.0: upgrade-v1.md
   - Service Guides:
     - guides/README.md

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
 
 import pytest
+from cryptography.fernet import Fernet
 
 from app import database
 
@@ -479,6 +480,31 @@ class TestWorkerKeys:
     def test_get_worker_key_state_missing_worker(self, db):
         async def run():
             assert await database.get_worker_key_state("nope") == (None, False)
+
+        asyncio.run(run())
+
+    def test_undecryptable_key_treated_as_unenrolled_not_empty_string(self, db):
+        """Regression: if CASHPILOT_SECRET_KEY changes/rotates, a previously
+        enrolled worker's encrypted key can no longer be decrypted.
+        decrypt_value() maps that failure to "" -- get_worker_key_state() must
+        NOT pass "" through as a real (never-matching) key, which would brick
+        the worker in both directions (it can't authenticate with its old key,
+        and it can't fall back to the shared bootstrap key either since it's
+        already confirmed). It must report "no usable key" (None) so callers
+        fall back to the shared key and the worker can re-enroll."""
+
+        async def run():
+            await database.upsert_worker("c1", "w1")
+            await database.set_worker_key("c1", "real-worker-key")
+            await database.confirm_worker_key("c1")
+
+            # Simulate CASHPILOT_SECRET_KEY having changed: the stored ciphertext
+            # was encrypted with the OLD key and can no longer be decrypted.
+            with patch.object(database, "_fernet", Fernet(Fernet.generate_key())):
+                key, confirmed = await database.get_worker_key_state("c1")
+                assert key is None  # NOT "" -- "" would look like a real key
+                assert confirmed is False
+                assert await database.get_worker_key("c1") is None
 
         asyncio.run(run())
 

--- a/tests/test_exchange_rates.py
+++ b/tests/test_exchange_rates.py
@@ -2,12 +2,20 @@
 
 import os
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
 
 import pytest
 
 from app import exchange_rates
+
+
+def _mock_response(status_code=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    return resp
 
 
 class TestToUsd:
@@ -90,3 +98,90 @@ class TestRefresh:
 
         with patch("app.exchange_rates.httpx.AsyncClient", return_value=mock_client):
             await exchange_rates.refresh()
+
+
+class TestPerSourceStaleness:
+    """A partial refresh failure must not mislabel the OTHER source's freshness:
+    a CoinGecko failure must not mark fiat stale, and a Frankfurter failure must
+    not mark crypto stale (or get papered over as fully fresh either)."""
+
+    def _client(self, crypto_resp, fiat_resp):
+        client = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.get.side_effect = [crypto_resp, fiat_resp]
+        return client
+
+    @pytest.mark.asyncio
+    async def test_crypto_failure_leaves_fiat_fresh(self):
+        client = self._client(_mock_response(500), _mock_response(200, {"rates": {"EUR": 0.92}}))
+
+        orig = (exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch)
+        try:
+            exchange_rates._crypto_last_fetch = 0
+            exchange_rates._fiat_last_fetch = 0
+            with patch("app.exchange_rates.httpx.AsyncClient", return_value=client):
+                await exchange_rates.refresh()
+
+            assert exchange_rates.crypto_rates_stale() is True  # CoinGecko failed -> still stale
+            assert exchange_rates.fiat_rates_stale() is False  # Frankfurter succeeded -> fresh
+        finally:
+            exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch = orig
+
+    @pytest.mark.asyncio
+    async def test_fiat_failure_leaves_crypto_fresh(self):
+        client = self._client(_mock_response(200, {"mysterium": {"usd": 0.10}}), _mock_response(503))
+
+        orig = (exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch)
+        try:
+            exchange_rates._crypto_last_fetch = 0
+            exchange_rates._fiat_last_fetch = 0
+            with patch("app.exchange_rates.httpx.AsyncClient", return_value=client):
+                await exchange_rates.refresh()
+
+            assert exchange_rates.crypto_rates_stale() is False  # CoinGecko succeeded -> fresh
+            assert exchange_rates.fiat_rates_stale() is True  # Frankfurter failed -> still stale
+        finally:
+            exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch = orig
+
+    @pytest.mark.asyncio
+    async def test_aggregate_stale_reflects_the_worse_source(self):
+        """rates_stale()/get_all() must not report the aggregate as fresh just
+        because ONE of the two sources succeeded."""
+        client = self._client(_mock_response(200, {"mysterium": {"usd": 0.10}}), _mock_response(503))
+
+        orig = (exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch)
+        try:
+            exchange_rates._crypto_last_fetch = 0
+            exchange_rates._fiat_last_fetch = 0
+            with patch("app.exchange_rates.httpx.AsyncClient", return_value=client):
+                await exchange_rates.refresh()
+
+            assert exchange_rates.rates_stale() is True
+            result = exchange_rates.get_all()
+            assert result["crypto_stale"] is False
+            assert result["fiat_stale"] is True
+            assert result["stale"] is True
+        finally:
+            exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch = orig
+
+    @pytest.mark.asyncio
+    async def test_both_succeed_aggregate_is_fresh(self):
+        client = self._client(
+            _mock_response(200, {"mysterium": {"usd": 0.10}}),
+            _mock_response(200, {"rates": {"EUR": 0.92}}),
+        )
+
+        orig = (exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch)
+        try:
+            exchange_rates._crypto_last_fetch = 0
+            exchange_rates._fiat_last_fetch = 0
+            with patch("app.exchange_rates.httpx.AsyncClient", return_value=client):
+                await exchange_rates.refresh()
+
+            assert exchange_rates.crypto_rates_stale() is False
+            assert exchange_rates.fiat_rates_stale() is False
+            assert exchange_rates.rates_stale() is False
+            assert exchange_rates._last_fetch > 0
+        finally:
+            exchange_rates._crypto_last_fetch, exchange_rates._fiat_last_fetch, exchange_rates._last_fetch = orig

--- a/tests/test_worker_api_coverage.py
+++ b/tests/test_worker_api_coverage.py
@@ -95,6 +95,21 @@ class TestEndpointAuthRejection:
         resp = _client().get("/api/status", headers={"Authorization": "Bearer nope"})
         assert resp.status_code == 401
 
+    def test_deploy_endpoint_rejects_missing_auth(self):
+        # api_deploy_container is the socket-privileged endpoint (host-RCE trust
+        # boundary via orchestrator/Docker) -- an unauthenticated request must
+        # be rejected before the deploy spec is even validated.
+        resp = _client().post("/api/containers/honeygain/deploy", json={"image": "img"})
+        assert resp.status_code == 401
+
+    def test_deploy_endpoint_rejects_wrong_key(self):
+        resp = _client().post(
+            "/api/containers/honeygain/deploy",
+            json={"image": "img"},
+            headers={"Authorization": "Bearer nope"},
+        )
+        assert resp.status_code == 401
+
     def test_health_endpoint_requires_no_auth(self):
         resp = _client().get("/api/health")
         assert resp.status_code == 200
@@ -125,7 +140,17 @@ class TestValidateDeploySpecRejections:
             _validate_deploy_spec(spec)
         assert ei.value.status_code == 403
 
+    @pytest.mark.parametrize("cap", ["SYS_MODULE", "DAC_READ_SEARCH", "SYS_RAWIO", "BPF", "SYS_BOOT"])
+    def test_capability_not_declared_by_any_catalog_service_rejected(self, cap):
+        # Allowlist, not a denylist: only mysterium's NET_ADMIN is in the catalog,
+        # so anything else -- including caps the old 3-entry denylist missed -- is refused.
+        spec = DeploySpec(image="x", cap_add=[cap])
+        with pytest.raises(HTTPException) as ei:
+            _validate_deploy_spec(spec)
+        assert ei.value.status_code == 403
+
     def test_allowed_capability_passes(self):
+        # NET_ADMIN is allowed because mysterium.yml declares cap_add: [NET_ADMIN].
         _validate_deploy_spec(DeploySpec(image="x", cap_add=["NET_ADMIN"]))  # must not raise
 
     def test_disallowed_network_mode_rejected(self):
@@ -134,14 +159,23 @@ class TestValidateDeploySpecRejections:
             _validate_deploy_spec(spec)
         assert ei.value.status_code == 403
 
-    def test_host_network_mode_allowed(self):
-        # mysterium legitimately needs host networking.
-        _validate_deploy_spec(DeploySpec(image="x", network_mode="host"))  # must not raise
+    def test_host_network_mode_allowed_for_mysterium(self):
+        # mysterium.yml is the only catalog service declaring network_mode: host.
+        _validate_deploy_spec(DeploySpec(image="x", network_mode="host"), slug="mysterium")  # must not raise
+
+    @pytest.mark.parametrize("slug", ["honeygain", "storj", "not-a-real-slug", None])
+    def test_host_network_mode_rejected_for_non_allowlisted_slug(self, slug):
+        spec = DeploySpec(image="x", network_mode="host")
+        with pytest.raises(HTTPException) as ei:
+            _validate_deploy_spec(spec, slug=slug)
+        assert ei.value.status_code == 403
 
     def test_bridge_network_mode_allowed(self):
         _validate_deploy_spec(DeploySpec(image="x", network_mode="bridge"))  # must not raise
 
-    @pytest.mark.parametrize("root", ["/etc", "/root", "/var/run", "/proc"])
+    @pytest.mark.parametrize(
+        "root", ["/etc", "/root", "/var/run", "/proc", "/mnt", "/data", "/opt", "/media", "/srv", "/tmp"]
+    )
     def test_blocked_volume_root_rejected(self, root):
         # Patch realpath to identity: on macOS dev machines /etc and /var/run
         # are themselves symlinks (-> /private/etc, /private/var/run), which
@@ -164,13 +198,25 @@ class TestValidateDeploySpecRejections:
             _validate_deploy_spec(spec)
         assert ei.value.status_code == 403
 
+    def test_unraid_array_bind_mount_rejected(self):
+        # The concrete attack this closes: a fleet-key holder bind-mounting the
+        # whole Unraid array to read co-located apps' secrets under /mnt/user.
+        spec = DeploySpec(image="x", volumes={"/mnt/user/appdata/some-other-app": {"bind": "/x", "mode": "ro"}})
+        with (
+            patch("app.worker_api.os.path.realpath", side_effect=lambda p: p),
+            pytest.raises(HTTPException) as ei,
+        ):
+            _validate_deploy_spec(spec)
+        assert ei.value.status_code == 403
+
     def test_named_volume_always_allowed(self):
         # Not an absolute path -> named volume (e.g. mysterium-data), always allowed.
         spec = DeploySpec(image="x", volumes={"mysterium-data": {"bind": "/data", "mode": "rw"}})
         _validate_deploy_spec(spec)  # must not raise
 
     def test_allowed_bind_mount_passes(self):
-        spec = DeploySpec(image="x", volumes={"/data/honeygain": {"bind": "/data", "mode": "rw"}})
+        # A custom absolute path that isn't under any blocked root still works.
+        spec = DeploySpec(image="x", volumes={"/storage/honeygain": {"bind": "/data", "mode": "rw"}})
         _validate_deploy_spec(spec)  # must not raise
 
 

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -9,6 +9,7 @@ os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
 import pytest  # noqa: E402
 
 try:
+    import httpx  # noqa: E402
     from fastapi import HTTPException  # noqa: E402
 
     import app.worker_api as w  # noqa: E402
@@ -90,3 +91,99 @@ class TestHeartbeatEnrollment:
             # The issued key was persisted and adopted.
             assert f.read_text() == "issued-key"
             assert w._worker_key == "issued-key"
+
+    def test_heartbeat_does_not_adopt_key_when_persist_fails(self):
+        # Regression: previously the worker adopted the issued key in memory
+        # (_worker_key = key) BEFORE attempting to persist it, so a failed
+        # write still left the new key active for the rest of this process's
+        # life. On restart _load_worker_key() would find nothing on disk and
+        # fall back to the shared key -- which the UI (having seen this worker
+        # authenticate with its own key) may no longer accept: a lockout.
+        fake_file = MagicMock()
+        fake_file.parent.mkdir = MagicMock()
+        fake_file.write_text = MagicMock(side_effect=OSError("read-only filesystem"))
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"status": "ok", "worker_id": 1, "worker_key": "issued-key"})
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=resp)
+
+        with (
+            patch.object(w, "_WORKER_KEY_FILE", fake_file),
+            patch.object(w, "_worker_key", None),
+            patch.object(w, "UI_URL", "http://ui:8080"),
+            patch.object(w, "API_KEY", "shared"),
+            patch("app.worker_api.orchestrator.get_status", return_value=[]),
+            patch("app.worker_api.orchestrator.docker_available", return_value=True),
+            patch("app.worker_api.httpx.AsyncClient", return_value=mock_client),
+        ):
+            asyncio.run(w._send_heartbeat())
+            # NOT adopted -- still None, so _active_key() keeps using the shared key.
+            assert w._worker_key is None
+            assert w._active_key() == "shared"
+
+
+class TestKeyPersistFailure:
+    def test_persist_failure_returns_false_and_does_not_adopt(self):
+        fake_file = MagicMock()
+        fake_file.parent.mkdir = MagicMock()
+        fake_file.write_text = MagicMock(side_effect=OSError("disk full"))
+        with patch.object(w, "_WORKER_KEY_FILE", fake_file), patch.object(w, "_worker_key", None):
+            result = w._save_worker_key("new-key")
+            assert result is False
+            assert w._worker_key is None
+
+    def test_persist_success_returns_true_and_adopts(self, tmp_path):
+        f = tmp_path / ".worker_key"
+        with patch.object(w, "_WORKER_KEY_FILE", f), patch.object(w, "_worker_key", None):
+            result = w._save_worker_key("new-key")
+            assert result is True
+            assert w._worker_key == "new-key"
+            assert f.read_text() == "new-key"
+
+
+class TestHeartbeatErrorClassification:
+    """worker_api.py:163 nit: distinguish auth rejection (401/403) from network errors."""
+
+    def _client_returning_status(self, status_code: int):
+        request = httpx.Request("POST", "http://ui:8080/api/workers/heartbeat")
+        response = httpx.Response(status_code, request=request)
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=response)
+        return mock_client
+
+    def _run_heartbeat_with(self, mock_client):
+        with (
+            patch.object(w, "_worker_key", "own"),
+            patch.object(w, "UI_URL", "http://ui:8080"),
+            patch("app.worker_api.orchestrator.get_status", return_value=[]),
+            patch("app.worker_api.orchestrator.docker_available", return_value=True),
+            patch("app.worker_api.httpx.AsyncClient", return_value=mock_client),
+        ):
+            asyncio.run(w._send_heartbeat())
+
+    def test_401_sets_distinct_auth_rejected_message(self):
+        self._run_heartbeat_with(self._client_returning_status(401))
+        assert w._last_error == "authentication rejected (401)"
+        assert w._ui_connected is False
+
+    def test_403_sets_distinct_auth_rejected_message(self):
+        self._run_heartbeat_with(self._client_returning_status(403))
+        assert w._last_error == "authentication rejected (403)"
+
+    def test_other_http_error_keeps_generic_message(self):
+        self._run_heartbeat_with(self._client_returning_status(500))
+        assert w._last_error == "connection failed"
+
+    def test_network_error_keeps_generic_message(self):
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+        self._run_heartbeat_with(mock_client)
+        assert w._last_error == "connection failed"

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,7 +1,9 @@
-"""Tests for worker heartbeat, fleet summary, and Android app support.
+"""Tests for worker heartbeat, fleet summary, Android app support, stale-worker
+purge, health-check gap detection, and login rate-limit cleanup.
 
-Exercises /api/workers/heartbeat, /api/workers, /api/fleet/summary, and
-the DB migration (client_id identity, apps column).
+Exercises /api/workers/heartbeat, /api/workers, /api/fleet/summary, the DB
+migration (client_id identity, apps column), _check_stale_workers,
+_run_health_check, and the login-attempt rate limiter.
 
 Requires fastapi + httpx (installed in CI via requirements.txt).
 Skipped automatically in minimal local environments.
@@ -16,6 +18,11 @@ import pytest  # noqa: E402
 
 try:
     from app.main import (  # noqa: E402
+        _authenticate_worker_heartbeat,
+        _check_login_rate,
+        _check_stale_workers,
+        _record_failed_login,
+        _run_health_check,
         api_fleet_summary,
         api_list_workers,
         api_worker_heartbeat,
@@ -26,8 +33,13 @@ except ImportError:
         allow_module_level=True,
     )
 
+from time import monotonic  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+from fastapi import HTTPException  # noqa: E402
+
+from app import main  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,6 +67,7 @@ def _worker_row(
     system_info: str = "{}",
     last_heartbeat: str = "2026-04-04T12:00:00",
     registered_at: str = "2026-04-01T00:00:00",
+    api_key_enc: str | None = None,
 ):
     return {
         "id": id,
@@ -67,6 +80,7 @@ def _worker_row(
         "system_info": system_info,
         "last_heartbeat": last_heartbeat,
         "registered_at": registered_at,
+        "api_key_enc": api_key_enc,
     }
 
 
@@ -291,3 +305,201 @@ class TestWorkerList:
         w = result[0]
         assert w["container_count"] == 2
         assert w["running_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Stale-worker purge — enrolled workers must survive long outages
+# ---------------------------------------------------------------------------
+
+
+class TestStaleWorkerPurge:
+    def test_enrolled_worker_offline_over_1h_not_deleted(self):
+        """A worker that completed enrollment (has api_key_enc) must never be
+        auto-deleted, even after a long outage — deleting the row would strand
+        its persisted per-worker key with no matching row, locking it out
+        forever on its next heartbeat (it no longer holds the shared key)."""
+        workers = [
+            _worker_row(
+                id=1,
+                status="offline",
+                last_heartbeat="2020-01-01T00:00:00",  # long past the 1h purge cutoff
+                api_key_enc="encrypted-key-blob",
+            ),
+        ]
+        mock_delete = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.set_worker_status", new_callable=AsyncMock),
+            patch("app.main.database.delete_worker", mock_delete),
+        ):
+            _run(_check_stale_workers())
+        mock_delete.assert_not_called()
+
+    def test_unenrolled_worker_offline_over_1h_still_purged(self):
+        """A worker that never completed enrollment (no api_key_enc) holds no
+        identity worth preserving, so it is still purged after a long outage —
+        the fix must not turn purging off entirely."""
+        workers = [
+            _worker_row(
+                id=2,
+                client_id="srv-2",
+                name="never-enrolled",
+                status="offline",
+                last_heartbeat="2020-01-01T00:00:00",
+                api_key_enc=None,
+            ),
+        ]
+        mock_delete = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.set_worker_status", new_callable=AsyncMock),
+            patch("app.main.database.delete_worker", mock_delete),
+        ):
+            _run(_check_stale_workers())
+        mock_delete.assert_called_once_with(2)
+
+    def test_enrolled_worker_can_reauthenticate_after_surviving_outage(self):
+        """After surviving a long outage (not deleted), the worker's own
+        per-worker key must still authenticate normally."""
+        worker_key = "worker-own-key-abc"
+        with patch(
+            "app.main.database.get_worker_key_state",
+            new_callable=AsyncMock,
+            return_value=(worker_key, True),
+        ):
+            state = _run(_authenticate_worker_heartbeat(_request(worker_key), "srv-1"))
+        assert state == "ok"
+
+    def test_bad_worker_entry_does_not_abort_others(self):
+        """A malformed last_heartbeat on one worker must not stop the others
+        in the same batch from being processed (per-worker error boundary)."""
+        bad = _worker_row(id=4, name="bad", status="online", last_heartbeat="not-a-real-timestamp")
+        good = _worker_row(id=3, name="good", status="online", last_heartbeat="2020-01-01T00:00:00")
+        mock_set_status = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[bad, good]),
+            patch("app.main.database.set_worker_status", mock_set_status),
+            patch("app.main.database.delete_worker", new_callable=AsyncMock),
+        ):
+            _run(_check_stale_workers())
+        mock_set_status.assert_called_once_with(3, "offline")
+
+
+# ---------------------------------------------------------------------------
+# Health check — a service vanished entirely from the heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCheckVanishedService:
+    def test_known_deployment_missing_from_heartbeat_gets_check_down(self):
+        """A Docker-backed deployment absent from every online worker's
+        current data (not merely stopped — genuinely missing) must get an
+        explicit check_down so its health score reflects reality instead of
+        freezing wherever it last was."""
+        workers = [_worker_row(id=1, status="online", containers="[]")]
+        deployments = [{"slug": "honeygain", "status": "running"}]
+        mock_record = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=deployments),
+            patch("app.main.database.record_health_event", mock_record),
+        ):
+            _run(_run_health_check())
+        mock_record.assert_any_call("honeygain", "check_down", "missing from heartbeat")
+
+    def test_external_deployment_never_flagged_missing(self):
+        """External (no-container) deployments like Grass/Bytelixir are never
+        reported by any worker, so they must never be flagged 'missing' —
+        that would flag them as down on every single check cycle."""
+        workers = [_worker_row(id=1, status="online", containers="[]")]
+        deployments = [{"slug": "grass", "status": "external"}]
+        mock_record = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=deployments),
+            patch("app.main.database.record_health_event", mock_record),
+        ):
+            _run(_run_health_check())
+        mock_record.assert_not_called()
+
+    def test_fully_offline_fleet_does_not_flag_missing(self):
+        """With no worker online there is no heartbeat data to trust either
+        way, so a known deployment must not be flagged check_down — that
+        would misreport downtime we can't actually observe."""
+        workers = [_worker_row(id=1, status="offline", containers="[]")]
+        deployments = [{"slug": "honeygain", "status": "running"}]
+        mock_record = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=deployments),
+            patch("app.main.database.record_health_event", mock_record),
+        ):
+            _run(_run_health_check())
+        mock_record.assert_not_called()
+
+    def test_service_present_in_heartbeat_not_double_flagged(self):
+        """A service still reported by a worker must get exactly one health
+        event — the normal per-instance one — never a second 'missing' event
+        stacked on top of it (no double-counting)."""
+        workers = [
+            _worker_row(
+                id=1,
+                status="online",
+                containers='[{"slug":"honeygain","status":"running"}]',
+            )
+        ]
+        deployments = [{"slug": "honeygain", "status": "running"}]
+        mock_record = AsyncMock()
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=deployments),
+            patch("app.main.database.record_health_event", mock_record),
+        ):
+            _run(_run_health_check())
+        mock_record.assert_called_once_with("honeygain", "check_ok")
+
+
+# ---------------------------------------------------------------------------
+# Login rate limiting — the attempts dict must not grow forever
+# ---------------------------------------------------------------------------
+
+
+class TestLoginRateLimitCleanup:
+    def test_key_removed_once_attempts_age_out(self):
+        """Once a client's failed-attempt timestamps all age past the
+        window, its dict entry must be deleted entirely — not left behind as
+        an empty list forever (the unbounded-growth bug: one key per
+        distinct IP ever seen, never reclaimed)."""
+        main._login_attempts.clear()
+        ip = "203.0.113.5"
+        main._login_attempts[ip] = [monotonic() - (main._LOGIN_WINDOW_SECONDS + 10)]
+        _check_login_rate(ip)
+        assert ip not in main._login_attempts
+
+    def test_never_failed_ip_leaves_no_key(self):
+        """An IP that merely checks in (e.g. a successful first-try login)
+        must not leave any dict entry behind at all."""
+        main._login_attempts.clear()
+        ip = "203.0.113.8"
+        _check_login_rate(ip)
+        assert ip not in main._login_attempts
+
+    def test_key_present_while_within_window(self):
+        """A recent failed attempt is still tracked — the cleanup fix must
+        not break real rate limiting."""
+        main._login_attempts.clear()
+        ip = "203.0.113.6"
+        _record_failed_login(ip)
+        _check_login_rate(ip)
+        assert ip in main._login_attempts
+
+    def test_rate_limit_still_triggers_after_cleanup_fix(self):
+        """5 failed attempts within the window still 429 (behavior preserved
+        by the cleanup fix)."""
+        main._login_attempts.clear()
+        ip = "203.0.113.7"
+        for _ in range(main._LOGIN_MAX_ATTEMPTS):
+            _record_failed_login(ip)
+        with pytest.raises(HTTPException) as exc_info:
+            _check_login_rate(ip)
+        assert exc_info.value.status_code == 429


### PR DESCRIPTION
Follow-ups from a 12-lens whole-repo audit (security-weighted). Every critical/high finding was adversarially verified before inclusion. This PR fixes the **bounded, clearly-correct** security/correctness/docs findings; the larger refactors and one product decision are tracked as issues (see below) rather than bundled here.

## Security (commit 19a39d7)
- **Worker deploy-spec validation → allowlist.** Capabilities and `network_mode: host` are now permitted only if a real `services/*.yml` catalog entry declares them (derived live from the catalog, fail-closed), replacing a 3-entry capability denylist that missed `SYS_MODULE`/`DAC_READ_SEARCH`/etc. Blocked bind-mount roots expanded (`/mnt,/media,/opt,/srv,/data,/tmp`). Added the missing auth-rejection test on the socket-privileged deploy endpoint. *(Verified the worker image ships `services/` + `catalog.py`, so mysterium's NET_ADMIN + host-network deploy still passes.)*
- **Stored DOM-XSS closed** in `fleet.html`: `esc()` now escapes quotes, so a worker name can't break out of `data-worker-name="…"`.
- **Fleet-key robustness:** an undecryptable per-worker key (secret-key rotation) now reports the worker unenrolled → re-enrolls on the shared key, instead of an empty string that bricks auth both ways; and the worker only adopts an issued key after it's durably persisted (no memory-only key lost on restart).
- `CASHPILOT_SECURE_COOKIE` accepts the usual truthy/falsy spellings.

## Reliability (commit 916b357)
- **Fleet lockout fixed:** the stale-worker reaper no longer deletes an *enrolled* worker after 1h offline (that dropped its key → permanent lockout on reboot); enrolled workers are only marked offline. Per-worker error boundary added.
- **Vanished-service downtime is now visible:** health records `check_down` for a known non-external service missing from an online worker's heartbeat, instead of freezing green.
- Login rate-limit dict releases keys (no unbounded per-IP growth); per-source exchange-rate staleness; Storj unrecognized-shape now raises instead of silent $0.

## Docs + CI (commit 068e007)
- **`release.yml` change-detection filter was stale** — it omitted `app/routers`, `app/deps`, `app/metrics`, `app/setup_token`, so fixes to those (including auth/API-key guards) never triggered a release/image build. Now included.
- Docs reconciled with the post-refactor/v1.0.0 app: first-run setup token documented; `CASHPILOT_COLLECT_INTERVAL`/`CASHPILOT_PORT` corrected; worker reachability + `CASHPILOT_WORKER_URL`; SECURITY.md per-worker fleet-key model; architecture.md (python:3.14-alpine/su-exec, workers table); Prometheus guide added to nav; CLAUDE.md refreshed; compose pin example → 1.0.1.

## Verification
`ruff check .` + `ruff format --check .` clean; **1142 tests pass** (regression tests added for every code fix above).

## Tracked separately (not in this PR)
Larger refactors + one product call, filed as issues: auth-revocation durability across restart (needs a schema migration — **highest-priority follow-up**), worker `client_id` protocol, SSRF DNS-rebind TOCTOU, CSP `unsafe-inline`/inline-onclick refactor, main.py/app.js god-module + duplicate-deploy-path consolidation, DB connection-proxy cleanup, perf batch, `:latest` policy decision for our own images, test-coverage hardening, dead-code removal.

Not auto-merging — flagging for review since this touches the just-shipped v1.0.0 fleet-key code.