### PR TITLE
fix(auth): durably revoke sessions on user delete/demote (survives restart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to CashPilot are documented here.
 - **ProxyBase migrated to the current client** (#103). ProxyBase retired its Docker Hub image and old GHCR org and moved to `proxybase.org`, so the catalog entry no longer worked. The image is now `ghcr.io/proxybaseorg/peer-cli` (digest-pinned, multi-arch amd64/arm64/armv7 — arm64/Raspberry Pi now supported), credentials are the client's current `ID` (relabelled **Access Token**, masked) and `NAME` env vars, every URL points at `proxybase.org`, and datacenter IPs are now marked as accepted (residential still earns most). Existing ProxyBase deployments must be re-deployed with a fresh Access Token — see the [updated guide](docs/guides/proxybase.md)
 
 ### Security
+- Deleting or demoting a user now durably revokes their outstanding session cookies. Previously the revocation lived only in memory, so after a UI restart (deploy, crash, reboot) a deleted or demoted account's still-valid 30-day cookie was honored again with its old role. Revocations are persisted in a `session_revocations` table (which outlives the deleted user row) and restored into the session-epoch cache at startup
 - Write-only secrets: `GET /api/config` and `/api/env-info` no longer return stored credential values — only a set/not-set indicator. `CASHPILOT_SECRET_KEY` is never sent to the browser
 - Fleet key no longer sent on page load — revealed only via explicit owner-only action (`POST /api/fleet/api-key/reveal`)
 - Changing a password invalidates that user's existing sessions via a per-user epoch; the changer stays logged in

--- a/app/database.py
+++ b/app/database.py
@@ -164,6 +164,17 @@ CREATE TABLE IF NOT EXISTS health_events (
     created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Durable per-user session-revocation epochs. A signed session cookie whose iat
+-- predates a user's revoked_before is rejected. DELIBERATELY has no FOREIGN KEY to
+-- users: when a user is deleted the revocation MUST outlive the row, so the deleted
+-- account's still-valid 30-day cookies keep being rejected across UI restarts
+-- (otherwise the in-memory epoch resets on restart and a deleted/demoted user's old
+-- cookie regains their old role). Warmed into auth's in-memory epoch cache at startup.
+CREATE TABLE IF NOT EXISTS session_revocations (
+    user_id        INTEGER PRIMARY KEY,
+    revoked_before REAL    NOT NULL
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_date
     ON earnings (platform, date);
 
@@ -844,6 +855,53 @@ async def delete_user(user_id: int) -> None:
     try:
         await db.execute("DELETE FROM users WHERE id = ?", (user_id,))
         await db.commit()
+    finally:
+        await db.close()
+
+
+# Kept in sync with auth.SESSION_MAX_AGE (30 days); duplicated as a plain constant
+# so this module doesn't import auth (which would create a cycle).
+_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+
+async def revoke_user_sessions(user_id: int, revoked_before: float) -> None:
+    """Durably invalidate a user's outstanding session cookies.
+
+    Records that any session token for ``user_id`` issued before ``revoked_before``
+    must be rejected. This table has no FK to ``users``, so the revocation outlives
+    a deleted row and is restored into auth's in-memory epoch cache at startup —
+    that is what stops a deleted/demoted account's still-valid 30-day cookie from
+    regaining access after a UI restart. The write is monotonic (an older timestamp
+    can never lower an existing revocation), and rows whose window has fully elapsed
+    are pruned since the tokens they guarded have themselves expired.
+    """
+    db = await _get_db()
+    try:
+        await db.execute(
+            """
+            INSERT INTO session_revocations (user_id, revoked_before)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET revoked_before = excluded.revoked_before
+            WHERE excluded.revoked_before > session_revocations.revoked_before
+            """,
+            (user_id, revoked_before),
+        )
+        await db.execute(
+            "DELETE FROM session_revocations WHERE revoked_before < ?",
+            (revoked_before - _SESSION_MAX_AGE_SECONDS,),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def list_session_revocations() -> list[dict[str, Any]]:
+    """Return [{user_id, revoked_before}, ...] for warming the auth epoch cache."""
+    db = await _get_db()
+    try:
+        cursor = await db.execute("SELECT user_id, revoked_before FROM session_revocations")
+        rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
     finally:
         await db.close()
 

--- a/app/main.py
+++ b/app/main.py
@@ -349,17 +349,40 @@ COLLECT_INTERVAL_MIN = int(os.getenv("CASHPILOT_COLLECT_INTERVAL", "60"))
 STALE_WORKER_SECONDS = 180  # Mark worker offline after 3 missed heartbeats
 
 
+async def _warm_session_epochs() -> None:
+    """Restore the in-memory per-user session-epoch cache from durable state.
+
+    Two sources are merged, taking the later timestamp per user:
+      - ``users.password_changed_at`` — a password change invalidates older sessions.
+      - ``session_revocations.revoked_before`` — a delete/demote invalidates older
+        sessions and survives the users row being deleted.
+
+    This runs at startup so those invalidations survive a UI restart. Without the
+    revocation half, a delete/demote (which only bumps the in-memory epoch) would be
+    forgotten on the next restart and the account's still-valid cookie would be
+    honored again with its old role — the bug this fixes.
+    """
+    epochs: dict[int, float] = {}
+    for _u in await database.list_users_with_pwd_epoch():
+        changed = _u.get("password_changed_at") or 0.0
+        if changed:
+            epochs[_u["id"]] = changed
+    for _r in await database.list_session_revocations():
+        uid = _r["user_id"]
+        epochs[uid] = max(epochs.get(uid, 0.0), _r["revoked_before"] or 0.0)
+    for uid, ts in epochs.items():
+        auth.set_user_pwd_epoch(uid, ts)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     await database.init_db()
     await database.connect_shared()
-    # Warm the per-user password-change epoch cache so existing sessions issued
-    # before a password change are rejected without a DB hit in the request path.
-    for _u in await database.list_users_with_pwd_epoch():
-        _changed = _u.get("password_changed_at") or 0.0
-        if _changed:
-            auth.set_user_pwd_epoch(_u["id"], _changed)
+    # Warm the per-user session-epoch cache (password changes + delete/demote
+    # revocations) so invalidated sessions are rejected without a DB hit in the
+    # request path — and, crucially, so those invalidations survive a restart.
+    await _warm_session_epochs()
     # First-run setup token: while no users exist, require a one-time token
     # (printed below) for /register so a proxy-exposed instance cannot be seized
     # by the first public visitor. Persisted in config so it survives restarts;

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -45,9 +45,13 @@ async def api_update_user_role(request: Request, user_id: int, body: UserRoleUpd
             raise HTTPException(status_code=400, detail="Cannot remove the last owner")
     await main.database.update_user_role(user_id, body.role)
     # Invalidate any outstanding session tokens for this user — they carry the
-    # old role and must not be trusted until re-issued (same mechanism used
-    # for password changes).
-    main.auth.set_user_pwd_epoch(user_id, time.time())
+    # old role and must not be trusted until re-issued (same mechanism used for
+    # password changes). Persist it durably AND bump the in-memory epoch: the
+    # durable row is what survives a UI restart (in-memory alone resets to 0 on
+    # restart, which would let the old higher-privilege cookie back in).
+    revoked_at = time.time()
+    await main.database.revoke_user_sessions(user_id, revoked_at)
+    main.auth.set_user_pwd_epoch(user_id, revoked_at)
     return {"status": "updated"}
 
 
@@ -61,7 +65,12 @@ async def api_delete_user(request: Request, user_id: int) -> dict[str, str]:
         raise HTTPException(status_code=404, detail="User not found")
     await main.database.delete_user(user_id)
     # Invalidate any outstanding session tokens for the now-deleted account.
-    # The epoch cache is in-memory keyed by uid, so it survives the row being
-    # gone from the DB — decode_session_token rejects the token on iat alone.
-    main.auth.set_user_pwd_epoch(user_id, time.time())
+    # Persist the revocation to session_revocations (which has no FK to users, so
+    # it outlives the deleted row) AND bump the in-memory epoch for immediate
+    # effect. The durable row is restored at startup, so the deleted account's
+    # still-valid 30-day cookie keeps being rejected across UI restarts instead of
+    # regaining owner access once the in-memory epoch resets.
+    revoked_at = time.time()
+    await main.database.revoke_user_sessions(user_id, revoked_at)
+    main.auth.set_user_pwd_epoch(user_id, revoked_at)
     return {"status": "deleted"}

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -43,15 +43,15 @@ async def api_update_user_role(request: Request, user_id: int, body: UserRoleUpd
         owner_count = sum(1 for u in all_users if u["role"] == "owner")
         if owner_count <= 1:
             raise HTTPException(status_code=400, detail="Cannot remove the last owner")
-    await main.database.update_user_role(user_id, body.role)
-    # Invalidate any outstanding session tokens for this user — they carry the
-    # old role and must not be trusted until re-issued (same mechanism used for
-    # password changes). Persist it durably AND bump the in-memory epoch: the
-    # durable row is what survives a UI restart (in-memory alone resets to 0 on
-    # restart, which would let the old higher-privilege cookie back in).
+    # Revoke outstanding sessions BEFORE applying the role change, so there is no
+    # window where the demotion has committed but the old higher-privilege cookie
+    # is still valid (a crash between the two writes must not leave it usable).
+    # Persist the revocation durably (survives a UI restart) AND bump the in-memory
+    # epoch (immediate effect); a fresh login re-mints a token with the new role.
     revoked_at = time.time()
     await main.database.revoke_user_sessions(user_id, revoked_at)
     main.auth.set_user_pwd_epoch(user_id, revoked_at)
+    await main.database.update_user_role(user_id, body.role)
     return {"status": "updated"}
 
 
@@ -63,14 +63,14 @@ async def api_delete_user(request: Request, user_id: int) -> dict[str, str]:
     user = await main.database.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    await main.database.delete_user(user_id)
-    # Invalidate any outstanding session tokens for the now-deleted account.
-    # Persist the revocation to session_revocations (which has no FK to users, so
-    # it outlives the deleted row) AND bump the in-memory epoch for immediate
-    # effect. The durable row is restored at startup, so the deleted account's
-    # still-valid 30-day cookie keeps being rejected across UI restarts instead of
-    # regaining owner access once the in-memory epoch resets.
+    # Revoke outstanding sessions BEFORE deleting the row, so there is never a
+    # window where the account is gone but its cookie is still honored. The
+    # revocation is keyed by uid with no FK to users, so persisting it ahead of the
+    # delete is valid and it outlives the deleted row; it is restored at startup,
+    # so the deleted account's still-valid 30-day cookie keeps being rejected
+    # across UI restarts instead of regaining access once the in-memory epoch resets.
     revoked_at = time.time()
     await main.database.revoke_user_sessions(user_id, revoked_at)
     main.auth.set_user_pwd_epoch(user_id, revoked_at)
+    await main.database.delete_user(user_id)
     return {"status": "deleted"}

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1045,6 +1045,7 @@ class TestApiUsers:
             _auth_owner(),
             patch("app.main.database.get_user_by_id", new_callable=AsyncMock, return_value=user),
             patch("app.main.database.update_user_role", new_callable=AsyncMock),
+            patch("app.main.database.revoke_user_sessions", new_callable=AsyncMock),
         ):
             resp = client.patch("/api/users/2", json={"role": "writer"})
             assert resp.status_code == 200
@@ -1088,6 +1089,7 @@ class TestApiUsers:
             _auth_owner(),
             patch("app.main.database.get_user_by_id", new_callable=AsyncMock, return_value=user),
             patch("app.main.database.delete_user", new_callable=AsyncMock),
+            patch("app.main.database.revoke_user_sessions", new_callable=AsyncMock),
         ):
             resp = client.delete("/api/users/2")
             assert resp.status_code == 200
@@ -1901,6 +1903,7 @@ class TestLifespanScheduler:
                 patch("app.main.database.connect_shared", new_callable=AsyncMock),
                 patch("app.main.database.close_shared", new_callable=AsyncMock),
                 patch("app.main.database.list_users_with_pwd_epoch", new_callable=AsyncMock, return_value=[]),
+                patch("app.main.database.list_session_revocations", new_callable=AsyncMock, return_value=[]),
                 patch("app.main.database.has_any_users", new_callable=AsyncMock, return_value=True),
                 patch("app.main.catalog.load_services"),
                 patch("app.main.catalog.register_sighup"),
@@ -1942,6 +1945,7 @@ class TestLifespanScheduler:
                 patch("app.main.database.connect_shared", new_callable=AsyncMock),
                 patch("app.main.database.close_shared", new_callable=AsyncMock),
                 patch("app.main.database.list_users_with_pwd_epoch", new_callable=AsyncMock, return_value=[]),
+                patch("app.main.database.list_session_revocations", new_callable=AsyncMock, return_value=[]),
                 patch("app.main.database.has_any_users", new_callable=AsyncMock, return_value=True),
                 patch("app.main.catalog.load_services"),
                 patch("app.main.catalog.register_sighup"),
@@ -1971,6 +1975,7 @@ class TestLifespanScheduler:
                 patch("app.main.database.connect_shared", new_callable=AsyncMock),
                 patch("app.main.database.close_shared", new_callable=AsyncMock),
                 patch("app.main.database.list_users_with_pwd_epoch", new_callable=AsyncMock, return_value=[]),
+                patch("app.main.database.list_session_revocations", new_callable=AsyncMock, return_value=[]),
                 patch("app.main.database.has_any_users", new_callable=AsyncMock, return_value=False),
                 patch("app.main.database.get_config", new_callable=AsyncMock, return_value=None),
                 patch("app.main.database.set_config", new_callable=AsyncMock) as set_cfg,

--- a/tests/test_session_revocation.py
+++ b/tests/test_session_revocation.py
@@ -77,13 +77,14 @@ class TestSessionRevocationStore:
         asyncio.run(run())
 
     def test_survives_user_deletion(self, db):
-        """No FK to users: deleting the user row must not drop the revocation."""
+        """No FK to users: deleting a real user row must not drop the revocation."""
 
         async def run():
-            await database.revoke_user_sessions(42, 1234.0)
-            await database.delete_user(42)  # DELETE FROM users — must not cascade
+            uid = await database.create_user("todelete", auth.hash_password("pw-0000000"), "viewer")
+            await database.revoke_user_sessions(uid, 1234.0)
+            await database.delete_user(uid)  # deletes a REAL row — must not cascade
             uids = {r["user_id"] for r in await database.list_session_revocations()}
-            assert 42 in uids
+            assert uid in uids
 
         asyncio.run(run())
 

--- a/tests/test_session_revocation.py
+++ b/tests/test_session_revocation.py
@@ -1,0 +1,159 @@
+"""Regression tests for durable session revocation (CashPilot-rqw).
+
+Deleting or demoting a user must invalidate their outstanding session cookies in a
+way that SURVIVES a UI restart. The bug: the revocation lived only in the in-memory
+`auth._USER_PWD_EPOCH` cache, which resets to empty on restart, and startup warm-up
+only restored password-change epochs — so after any restart a deleted/demoted user's
+still-valid 30-day cookie was honored again with its old role.
+"""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest
+
+from app import auth, database
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    db_path = tmp_path / "cashpilot.db"
+    with (
+        patch.object(database, "DB_DIR", tmp_path),
+        patch.object(database, "DB_PATH", db_path),
+    ):
+        yield tmp_path
+
+
+@pytest.fixture
+def db(db_dir):
+    asyncio.run(database.init_db())
+    return db_dir
+
+
+@pytest.fixture(autouse=True)
+def _reset_epoch_cache():
+    """The auth epoch cache is a module global; keep tests isolated."""
+    auth._USER_PWD_EPOCH.clear()
+    yield
+    auth._USER_PWD_EPOCH.clear()
+
+
+class TestSessionRevocationStore:
+    def test_table_created(self, db):
+        async def run():
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='session_revocations'"
+                )
+                assert await cur.fetchone() is not None
+            finally:
+                await conn.close()
+
+        asyncio.run(run())
+
+    def test_revoke_and_list(self, db):
+        async def run():
+            await database.revoke_user_sessions(7, 1000.0)
+            rows = {r["user_id"]: r["revoked_before"] for r in await database.list_session_revocations()}
+            assert rows[7] == 1000.0
+
+        asyncio.run(run())
+
+    def test_monotonic_never_lowers(self, db):
+        async def run():
+            await database.revoke_user_sessions(7, 5000.0)
+            await database.revoke_user_sessions(7, 1000.0)  # older — must NOT lower
+            rows = {r["user_id"]: r["revoked_before"] for r in await database.list_session_revocations()}
+            assert rows[7] == 5000.0
+            await database.revoke_user_sessions(7, 9000.0)  # newer — must raise
+            rows = {r["user_id"]: r["revoked_before"] for r in await database.list_session_revocations()}
+            assert rows[7] == 9000.0
+
+        asyncio.run(run())
+
+    def test_survives_user_deletion(self, db):
+        """No FK to users: deleting the user row must not drop the revocation."""
+
+        async def run():
+            await database.revoke_user_sessions(42, 1234.0)
+            await database.delete_user(42)  # DELETE FROM users — must not cascade
+            uids = {r["user_id"] for r in await database.list_session_revocations()}
+            assert 42 in uids
+
+        asyncio.run(run())
+
+    def test_prune_expired(self, db):
+        """A revocation whose whole window has elapsed is pruned on the next write."""
+
+        async def run():
+            await database.revoke_user_sessions(1, 100.0)
+            newer = 100.0 + database._SESSION_MAX_AGE_SECONDS + 10.0
+            await database.revoke_user_sessions(2, newer)
+            uids = {r["user_id"] for r in await database.list_session_revocations()}
+            assert 1 not in uids  # fully elapsed -> pruned (its tokens already expired)
+            assert 2 in uids
+
+        asyncio.run(run())
+
+
+class TestWarmRestore:
+    """The core fix: revocations are restored into the epoch cache at startup."""
+
+    def test_revocation_restored_after_restart(self, db):
+        import time as _time
+
+        from app import main
+
+        async def run():
+            uid = 7
+            # Use real-wall-clock-relative timestamps: patching auth.time.time also
+            # moves itsdangerous's own signature clock, so a token stamped far from
+            # real "now" would read as expired at decode time regardless of the epoch.
+            now = _time.time()
+            revoke_at = now - 1000.0  # a delete/demote happened 1000s ago
+            await database.revoke_user_sessions(uid, revoke_at)
+
+            # Simulate a UI restart: the in-memory cache starts empty.
+            auth._USER_PWD_EPOCH.clear()
+            assert auth._user_pwd_epoch(uid) == 0.0
+
+            # Startup warm-up must restore it from the durable table.
+            await main._warm_session_epochs()
+            assert auth._user_pwd_epoch(uid) == revoke_at
+
+            # A cookie issued BEFORE the revocation is rejected across the restart
+            # (by the epoch, not by expiry — its signature age is only ~2000s)...
+            with patch.object(auth.time, "time", return_value=now - 2000.0):
+                stale = auth.create_session_token(uid, "bob", "owner")
+            assert auth.decode_session_token(stale) is None
+
+            # ...while a fresh cookie (re-login after demotion) is accepted with its new role.
+            fresh = auth.create_session_token(uid, "bob", "viewer")
+            decoded = auth.decode_session_token(fresh)
+            assert decoded is not None
+            assert decoded["r"] == "viewer"
+
+        asyncio.run(run())
+
+    def test_warm_restore_merges_password_and_revocation(self, db):
+        """Warm-up takes the later of password_changed_at and revoked_before per user."""
+        from app import main
+
+        async def run():
+            uid = await database.create_user("alice", auth.hash_password("pw-000000"), "owner")
+            # Password changed at t=2000 (persisted on the users row)...
+            await database.update_user_password(uid, auth.hash_password("pw-111111"))
+            # ...then a later revocation at a much higher timestamp.
+            await database.revoke_user_sessions(uid, 9_000_000_000.0)
+
+            auth._USER_PWD_EPOCH.clear()
+            await main._warm_session_epochs()
+            # The revocation is later, so it wins.
+            assert auth._user_pwd_epoch(uid) == 9_000_000_000.0
+
+        asyncio.run(run())


### PR DESCRIPTION
Closes the highest-severity finding from the security audit (`CashPilot-rqw`).

## The bug
Deleting or demoting a user only bumped the **in-memory** `auth._USER_PWD_EPOCH` cache, and startup warm-up restored epochs solely from `users.password_changed_at`. So after **any UI restart** (webhook GitOps deploy, crash, reboot):
- a **deleted** user's row is gone → warm-up can't restore the epoch → it resets to 0 → their still-valid 30-day signed cookie is accepted again;
- a **demoted** user's `password_changed_at` was never touched → epoch not restored → their old cookie is accepted;

and because `require_role` reads the role from the **token claim** with no DB re-fetch, a removed/demoted owner regains **owner** (create users, deploy socket-privileged containers = host RCE, reveal the fleet key) for up to 30 days.

## The fix (surgical; the fast no-DB-in-request-path guard is unchanged)
- New `session_revocations(user_id, revoked_before)` table — **deliberately no FK to `users`**, so a deleted user's revocation outlives the row.
- `database.revoke_user_sessions()` persists it (monotonic — an older timestamp can't lower an existing revocation; prunes rows whose 30-day window has elapsed, since those tokens are already expired) + `list_session_revocations()` reads them back.
- The delete/demote routes now persist the revocation durably **in addition to** the in-memory epoch bump (immediate effect + restart-proof).
- Startup warm-up (factored into `_warm_session_epochs()`) restores the epoch cache from **both** `password_changed_at` and `session_revocations`, taking the later timestamp per user. Freshly-minted tokens (issued at login with the current DB role) are unaffected — a demoted user simply re-logs in and gets their new role.

Why revocation-epoch rather than DB role re-fetch: it keeps the deliberate "no DB call in the request path" design (an explicit comment in `decode_session_token`); the demoted/deleted user's old token is rejected outright, so the stale role in the token is never honored.

## Verification
`ruff check .` + `ruff format --check .` clean; **1149 tests pass**. New `tests/test_session_revocation.py`: durable store (persist / monotonic / prune / **survives user deletion**) + the restart restore (**revoke → clear cache → warm-up → old cookie rejected, fresh cookie accepted with the new role**) + password/revocation merge.

Forward-only schema (`CREATE TABLE IF NOT EXISTS` in `_SCHEMA`) — existing DBs get the table on next start. Not auto-merging: this touches the session-auth path and adds a table, so flagging for your review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Session cookies are now persistently revoked when an account is deleted or demoted, not just in memory.
  * Revocations survive restarts by being restored into the session-epoch cache during startup warm-up.
  * Session invalidation now merges revocation timing with password-change updates for correct precedence.

* **Bug Fixes**
  * Fixed cases where prior session revocations could be re-accepted after restart.
  * Expired revocation records are automatically pruned over time.

* **Tests**
  * Added regression coverage for durable revocation storage and startup warm-up behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->