### PR TITLE
perf: bcrypt off event loop + earnings(date) index + bounded metrics cardinality (CashPilot-apm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to CashPilot are documented here.
 
 ### Performance
 - SQLite connection sharing: a single pooled connection per event loop instead of open-per-query — faster dashboard loads and less write contention
+- bcrypt password hashing/verification now runs off the event loop (`asyncio.to_thread`), so a login or password change no longer blocks every other request on the single uvicorn loop for ~200-500ms
+- Added an index on `earnings(date)` (date-filtered history/summary queries no longer full-scan), and the "all-time" history query is defensively capped so a long-lived DB can't return an unbounded row set
+- Prometheus HTTP metrics bound their `path` label: `/api/workers/{id}` collapses per-id paths and unknown/scanner paths fold into a single `/{other}` label, so probe traffic can't grow label cardinality without limit
 
 ### Added
 - Self-service password change `POST /api/users/me/password` (all roles, via the avatar menu) and owner reset `POST /api/users/{id}/password`

--- a/app/auth.py
+++ b/app/auth.py
@@ -5,6 +5,7 @@ Session-based auth using signed cookies (itsdangerous) and bcrypt password hashi
 
 from __future__ import annotations
 
+import asyncio
 import hmac
 import logging
 import os
@@ -111,6 +112,16 @@ def hash_password(password: str) -> str:
 def verify_password(password: str, hashed: str) -> bool:
     pw = password.encode("utf-8")[:72]
     return _bcrypt.checkpw(pw, hashed.encode("ascii"))
+
+
+async def hash_password_async(password: str) -> str:
+    """bcrypt is CPU-bound (~200-500ms); run it off the event loop so a login or
+    password change doesn't block every other request on the single uvicorn loop."""
+    return await asyncio.to_thread(hash_password, password)
+
+
+async def verify_password_async(password: str, hashed: str) -> bool:
+    return await asyncio.to_thread(verify_password, password, hashed)
 
 
 def create_session_token(user_id: int, username: str, role: str) -> str:

--- a/app/database.py
+++ b/app/database.py
@@ -181,6 +181,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_date
 CREATE INDEX IF NOT EXISTS idx_earnings_created
     ON earnings (created_at);
 
+CREATE INDEX IF NOT EXISTS idx_earnings_date
+    ON earnings (date);
+
 CREATE INDEX IF NOT EXISTS idx_workers_status
     ON workers (status);
 
@@ -428,8 +431,11 @@ async def get_earnings_history(
                 (f"-{days} days",),
             )
         else:
+            # period="all": defensively cap the result so a very long-lived DB can't
+            # return an unbounded row set into a single response/chart. Most-recent
+            # first; 50k rows spans years of daily per-service earnings.
             cursor = await db.execute(
-                "SELECT platform, balance, currency, date FROM earnings ORDER BY date DESC, platform"
+                "SELECT platform, balance, currency, date FROM earnings ORDER BY date DESC, platform LIMIT 50000"
             )
         rows = await cursor.fetchall()
         return [dict(r) for r in rows]

--- a/app/main.py
+++ b/app/main.py
@@ -1757,14 +1757,14 @@ async def api_change_own_password(request: Request, body: PasswordChange) -> JSO
     record = await database.get_user_by_id(uid)
     if not record:
         raise HTTPException(status_code=404, detail="User not found")
-    if not auth.verify_password(body.current_password, record["password"]):
+    if not await auth.verify_password_async(body.current_password, record["password"]):
         raise HTTPException(status_code=403, detail="Current password is incorrect")
     if len(body.new_password) < 10:
         raise HTTPException(status_code=400, detail="Password must be at least 10 characters")
     if body.new_password == body.current_password:
         raise HTTPException(status_code=400, detail="New password must differ from the current password")
 
-    hashed = auth.hash_password(body.new_password)
+    hashed = await auth.hash_password_async(body.new_password)
     await database.update_user_password(uid, hashed)
     changed = await database.get_user_by_id(uid)
     auth.set_user_pwd_epoch(uid, changed["password_changed_at"])
@@ -1782,7 +1782,7 @@ async def api_admin_set_password(request: Request, user_id: int, body: AdminPass
         raise HTTPException(status_code=404, detail="User not found")
     if len(body.new_password) < 10:
         raise HTTPException(status_code=400, detail="Password must be at least 10 characters")
-    hashed = auth.hash_password(body.new_password)
+    hashed = await auth.hash_password_async(body.new_password)
     await database.update_user_password(user_id, hashed)
     changed = await database.get_user_by_id(user_id)
     auth.set_user_pwd_epoch(user_id, changed["password_changed_at"])

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -305,13 +305,24 @@ def setup(app: FastAPI) -> None:
 
 
 _PATH_SLUG_RE = re.compile(r"/api/(?:services|deploy|stop|restart|remove|compose)/[^/]+")
+_WORKER_ID_RE = re.compile(r"(/api/workers)/\d+")
+# Top-level prefixes the app actually serves. Anything else is scanner/probe noise
+# (/wp-admin, /.env, ...) and must not each become its own Prometheus label.
+_KNOWN_PREFIXES = ("/api", "/static", "/login", "/logout", "/register", "/onboarding", "/setup", "/metrics")
 
 
 def _normalize_path(path: str) -> str:
-    """Collapse dynamic path segments to reduce cardinality."""
-    path = _PATH_SLUG_RE.sub(lambda m: m.group(0).rsplit("/", 1)[0] + "/{slug}", path)
+    """Collapse dynamic path segments to bounded labels so per-id paths and scanner
+    traffic can't grow Prometheus label cardinality without limit."""
     if path.startswith("/static/"):
-        path = "/static/{file}"
+        return "/static/{file}"
+    # /api/services/{slug}[/action], /api/deploy/{slug}, /api/stop/{slug}, ...
+    path = _PATH_SLUG_RE.sub(lambda m: m.group(0).rsplit("/", 1)[0] + "/{slug}", path)
+    # /api/workers/{id}[/...]
+    path = _WORKER_ID_RE.sub(r"\1/{id}", path)
+    # Fold anything outside the app's own route space into one label.
+    if path != "/" and not path.startswith(_KNOWN_PREFIXES):
+        return "/{other}"
     return path
 
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -52,7 +52,7 @@ async def do_login(
         main.metrics.record_rate_limit()
         raise
     user = await main.database.get_user_by_username(username)
-    if not user or not main.auth.verify_password(password, user["password"]):
+    if not user or not await main.auth.verify_password_async(password, user["password"]):
         main._record_failed_login(client_ip)
         main.metrics.record_login(success=False)
         return main.templates.TemplateResponse(
@@ -196,7 +196,7 @@ async def do_register(
 
     # First user is always owner
     role = "owner" if is_first else "viewer"
-    hashed = main.auth.hash_password(password)
+    hashed = await main.auth.hash_password_async(password)
     if is_first:
         # Atomic: only one concurrent first-run registration can win, so a single
         # setup token can't be raced into minting two owners.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -138,3 +138,19 @@ class TestRequireRole:
 
     def test_empty_roles_returns_false(self):
         assert require_role({"r": "owner"}) is False
+
+
+class TestAsyncPasswordWrappers:
+    """The async wrappers run bcrypt off the event loop (apm perf)."""
+
+    def test_hash_and_verify_async_roundtrip(self):
+        import asyncio
+
+        from app.auth import hash_password_async, verify_password_async
+
+        async def run():
+            h = await hash_password_async("correct-horse-battery-staple")
+            assert await verify_password_async("correct-horse-battery-staple", h) is True
+            assert await verify_password_async("wrong-password", h) is False
+
+        asyncio.run(run())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -184,6 +184,15 @@ class TestMetricsSetup:
         assert metrics._normalize_path("/static/js/app.js") == "/static/{file}"
         assert metrics._normalize_path("/api/earnings") == "/api/earnings"
         assert metrics._normalize_path("/login") == "/login"
+        # Per-worker id is collapsed (was unbounded cardinality).
+        assert metrics._normalize_path("/api/workers/42") == "/api/workers/{id}"
+        assert metrics._normalize_path("/api/workers/42/command") == "/api/workers/{id}/command"
+        # Two-segment service actions keep the action.
+        assert metrics._normalize_path("/api/services/honeygain/stop") == "/api/services/{slug}/stop"
+        # Scanner/probe noise folds into one label instead of one per URL.
+        assert metrics._normalize_path("/wp-admin") == "/{other}"
+        assert metrics._normalize_path("/.env") == "/{other}"
+        assert metrics._normalize_path("/") == "/"
 
 
 class TestRefreshGauges:


### PR DESCRIPTION
Addresses bead `CashPilot-apm` (the high-value, low-risk perf items).

- **bcrypt off the event loop** — `hash_password_async`/`verify_password_async` (`asyncio.to_thread`); a login/password-change no longer blocks every other request on the single uvicorn loop for ~200-500ms. All 5 call sites updated.
- **`earnings(date)` index** — date-filtered history/summary queries no longer full-scan.
- **Bounded history** — `period=all` is capped (`LIMIT 50000`, most-recent-first) so a long-lived DB can't return an unbounded row set.
- **Bounded metrics cardinality** — `_normalize_path` now collapses `/api/workers/{id}` and folds unknown/scanner paths into a single `/{other}` label.

**Deferred (in the bead):** VACUUM is inherently a file-level lock (it's off-peak weekly, low impact — moving it off the shared connection doesn't remove the lock); httpx client reuse in the worker-proxy helpers.

`ruff` clean, full suite **1156 passing**. Merge-as-you-go authorized.