### PR TITLE
test: harden security-path coverage + fix weak/flaky tests (CashPilot-cm6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: pytest tests/ -v --tb=short
 
       - name: Run tests with coverage
-        run: pytest tests/ --cov=app --cov-report=term-missing --cov-report=xml
+        run: pytest tests/ --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=90
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,8 +23,6 @@ comment:
   require_head: true
 
 ignore:
-  - "app/orchestrator.py"
-  - "app/worker_api.py"
   - "**/*_test.py"
   - "**/tests/**"
   - "**/conftest.py"

--- a/tests/test_auth_extended.py
+++ b/tests/test_auth_extended.py
@@ -74,7 +74,8 @@ class TestSetSessionCookie:
         result = auth.set_session_cookie(resp, "test-token")
         resp.set_cookie.assert_called_once()
         args = resp.set_cookie.call_args
-        assert args[1]["httponly"] is True or args[0][1] == "test-token"
+        assert args[1]["httponly"] is True
+        assert args[0][1] == "test-token"
         assert result is resp
 
     def test_secure_cookie_auto_https(self):

--- a/tests/test_fleet_key.py
+++ b/tests/test_fleet_key.py
@@ -87,9 +87,9 @@ class TestResolveFleetKey:
             # In practice this returns "" after retries, which is the correct
             # "broken state" signal.
             key = fleet_key.resolve_fleet_key()
-        # The function tried O_EXCL on existing file, retried reads, all empty
-        # This is a degenerate state — key will be empty
-        assert isinstance(key, str)
+        # The function tried O_EXCL on existing file, retried reads, all empty —
+        # a degenerate state whose defined result is the empty string.
+        assert key == ""
 
     def test_unwritable_dir_returns_empty(self, tmp_path: Path):
         """When the fleet directory can't be created, return empty string."""

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1583,7 +1583,9 @@ class TestValidateWorkerUrl:
     def test_trailing_slash_stripped(self):
         from app.main import _validate_worker_url
 
-        assert _validate_worker_url("http://host:8081/")[0] == "http://host:8081"
+        # Patch DNS so the test is deterministic and never hits the real resolver.
+        with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.1.9", 8081))]):
+            assert _validate_worker_url("http://host:8081/")[0] == "http://host:8081"
 
     def test_invalid_scheme(self):
         from app.main import _validate_worker_url
@@ -1613,8 +1615,10 @@ class TestValidateWorkerUrl:
         from app.main import _validate_worker_url
 
         # Exact-match (not substring) so CodeQL's url-substring-sanitization rule
-        # isn't tripped by a test assertion.
-        result = _validate_worker_url("http://worker.mango.ts.net:8081")
+        # isn't tripped by a test assertion. Patch DNS to a Tailscale CGNAT IP so the
+        # test is deterministic and never hits the real resolver.
+        with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("100.100.100.100", 8081))]):
+            result = _validate_worker_url("http://worker.mango.ts.net:8081")
         assert result[0] == "http://worker.mango.ts.net:8081"
 
     def test_tailscale_cgnat_ip_allowed(self):

--- a/tests/test_worker_resources.py
+++ b/tests/test_worker_resources.py
@@ -132,6 +132,41 @@ class TestDeployRawResources:
         assert "mem_reservation" not in kwargs
         assert "oom_score_adj" not in kwargs
 
+    def test_forwards_container_spec(self):
+        client = self._mock_client()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.deploy_raw(
+                slug="svc",
+                image="img",
+                env={"ID": "tok", "NAME": "dev"},
+                ports={"8081/tcp": 9000},
+                volumes={"/host": {"bind": "/data", "mode": "rw"}},
+                cap_add=["NET_ADMIN"],
+                command="run",
+                hostname="myhost",
+            )
+        kwargs = client.containers.run.call_args.kwargs
+        assert kwargs["environment"] == {"ID": "tok", "NAME": "dev"}
+        assert kwargs["ports"] == {"8081/tcp": 9000}
+        assert kwargs["volumes"] == {"/host": {"bind": "/data", "mode": "rw"}}
+        assert kwargs["cap_add"] == ["NET_ADMIN"]
+        assert kwargs["command"] == "run"
+        assert kwargs["hostname"] == "myhost"
+
+    def test_ports_suppressed_in_host_network(self):
+        client = self._mock_client()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.deploy_raw(
+                slug="mysterium",
+                image="img",
+                ports={"4449/tcp": 4449},
+                network_mode="host",
+            )
+        kwargs = client.containers.run.call_args.kwargs
+        # Host networking ignores published ports; deploy_raw must not pass them.
+        assert kwargs["ports"] is None
+        assert kwargs["network_mode"] == "host"
+
 
 # ---------------------------------------------------------------------------
 # Worker /deploy endpoint (spec -> deploy_raw)


### PR DESCRIPTION
Addresses bead `CashPilot-cm6`.

- **Cover the socket-privileged modules**: removed `orchestrator.py` + `worker_api.py` from the codecov ignore list, and added a **`--cov-fail-under=90`** floor in CI so coverage can't silently collapse (currently **93.8%**).
- **`deploy_raw` spec assertions**: previously only resource kwargs were checked; now env/ports/volumes/cap_add/network_mode/command/hostname are asserted, plus the **host-networking port-suppression** branch the audit flagged as unverified.
- **Fixed weak tests**: a tautological assert in `test_auth_extended` (the `or token` clause could never fail) and a vacuous one in `test_fleet_key` (`isinstance str` → the defined empty-string result).
- **De-flaked**: the two worker-URL validator tests that hit the real DNS resolver now patch `getaddrinfo`.

Note: SSRF-wiring and worker-auth-rejection coverage were already added in the drz PR and the earlier audit work. `ruff` clean; full suite **1158 passing**.