### PR TITLE
ci(test): install docker SDK so CI runs the full suite (fix red main)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-asyncio pyyaml tzdata
+          pip install pytest pytest-cov pytest-asyncio pyyaml tzdata docker
 
       - name: Run tests
         run: pytest tests/ -v --tb=short


### PR DESCRIPTION
**Hotfix for main** (went red after #114). Root cause: the CI `test` job installed `requirements.txt` + a short pip list that **omitted the `docker` SDK**. Every test module that `import docker` (orchestrator, worker_api, worker_resources) failed to collect, so CI silently ran **962 of 1158** tests and reported **81.65%** coverage instead of the real **~94%**. When #114 added `--cov-fail-under=90`, that correctly failed — exposing a long-standing gap where CI never ran the Docker-SDK tests.

Fix: add `docker` to the test install so CI collects the full suite; the 90% floor now reflects reality. One-line change.