### PR TITLE
feat(catalog): stricter loader validation to catch malformed entries (CashPilot-keb)

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -27,12 +27,52 @@ _by_slug: dict[str, dict[str, Any]] = {}
 _REQUIRED_FIELDS = {"name", "slug", "category", "status", "description", "docker"}
 
 
+_CATEGORIES = {"bandwidth", "depin", "storage", "compute"}
+_VALID_STATUSES = {"active", "beta", "broken", "dead", "dropped"}
+
+
 def _validate(data: dict[str, Any], path: Path) -> list[str]:
-    """Return a list of validation errors (empty = OK)."""
+    """Return a list of validation errors (empty = OK).
+
+    A service with ANY error is skipped at load (it silently disappears from the
+    UI), so these checks only assert invariants every real entry already satisfies
+    — they exist to catch a malformed NEW entry, not to drop valid ones.
+    """
     errors: list[str] = []
     missing = _REQUIRED_FIELDS - set(data.keys())
     if missing:
         errors.append(f"{path.name}: missing required fields: {missing}")
+
+    category = data.get("category")
+    if category is not None and category not in _CATEGORIES:
+        errors.append(f"{path.name}: invalid category {category!r} (expected one of {sorted(_CATEGORIES)})")
+
+    status = data.get("status")
+    if status is not None and status not in _VALID_STATUSES:
+        errors.append(f"{path.name}: invalid status {status!r} (expected one of {sorted(_VALID_STATUSES)})")
+
+    docker = data.get("docker")
+    if isinstance(docker, dict):
+        image = docker.get("image")
+        # Extension/app-only services legitimately have an empty (or absent) image —
+        # they are listed but not Docker-deployable. Only reject a non-string image.
+        if image is not None and not isinstance(image, str):
+            errors.append(f"{path.name}: docker.image must be a string")
+        env = docker.get("env")
+        if env is not None and not isinstance(env, list):
+            errors.append(f"{path.name}: docker.env must be a list")
+        elif isinstance(env, list):
+            for i, item in enumerate(env):
+                key = item.get("key") if isinstance(item, dict) else None
+                if not isinstance(key, str) or not key.strip():
+                    errors.append(f"{path.name}: docker.env[{i}] must have a non-empty string 'key'")
+
+    reqs = data.get("requirements")
+    if isinstance(reqs, dict):
+        for field in ("residential_ip", "vps_ip", "gpu"):
+            if field in reqs and not isinstance(reqs[field], bool):
+                errors.append(f"{path.name}: requirements.{field} must be a boolean")
+
     return errors
 
 

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -169,3 +169,32 @@ class TestValidate:
         errors = catalog._validate(data, tmp_path / "test.yml")
         assert len(errors) == 1
         assert "missing" in errors[0]
+
+    def _base(self):
+        return {
+            "name": "Test",
+            "slug": "test",
+            "category": "bandwidth",
+            "status": "active",
+            "description": "desc",
+            "docker": {"image": "test:latest", "env": [{"key": "K"}]},
+        }
+
+    def test_validate_rejects_bad_category_and_status(self, tmp_path):
+        assert catalog._validate({**self._base(), "category": "bogus"}, tmp_path / "t.yml")
+        assert catalog._validate({**self._base(), "status": "nope"}, tmp_path / "t.yml")
+
+    def test_validate_rejects_malformed_docker_and_requirements(self, tmp_path):
+        p = tmp_path / "t.yml"
+        assert catalog._validate({**self._base(), "docker": {"image": 123}}, p)  # non-string image
+        assert catalog._validate({**self._base(), "docker": {"image": "i", "env": [{"label": "no key"}]}}, p)
+        assert catalog._validate({**self._base(), "docker": {"image": "i", "env": "notalist"}}, p)
+        assert catalog._validate({**self._base(), "requirements": {"gpu": "yes"}}, p)  # non-bool
+
+    def test_validate_allows_empty_image_for_non_deployable(self, tmp_path):
+        # Extension/app-only services list an empty image and must still load.
+        assert catalog._validate({**self._base(), "docker": {"image": ""}}, tmp_path / "t.yml") == []
+
+    def test_all_shipped_services_pass_validation(self):
+        # Guard: no real catalog entry is dropped by the loader's validation.
+        assert len(catalog.load_services()) >= 40


### PR DESCRIPTION
Addresses bead `CashPilot-keb` (the loader-validation portion). A service that fails `_validate` is silently **skipped** at load, so a malformed entry would vanish from the UI unnoticed — yet validation only checked top-level key presence.

Now also validates: category/status enums, `docker.image` type (empty string allowed — extension/app-only services aren't deployable), `docker.env` shape (list of dicts, each with a non-empty `key`), and `requirements` bool fields. These are invariants every shipped entry already satisfies — **verified all 49 services still load** (the initial over-strict 'non-empty image' rule dropped 29 non-deployable services; caught + relaxed).

**Deferred (in the bead):** a catalog-wide `@sha256` image-pin gate (most web images are still floating tags — pinning all ~40 is its own effort), the `<a href>` env-description rendering (systemic across 10 services), and dropping the dead `env_vars_encrypted` column (schema migration).

`ruff` clean; full suite **1162 passing** (incl. new validation tests).