### PR TITLE
feat: detect deployed-image vs catalog-image drift and warn (CashPilot-5wi)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -565,6 +565,37 @@ def _collector_needs_setup(slug: str, config: dict[str, str]) -> bool:
     return False
 
 
+def _split_image(ref: str) -> tuple[str, str, str]:
+    """Split a Docker image reference into (repository, tag, digest)."""
+    digest = ""
+    if "@" in ref:
+        ref, digest = ref.split("@", 1)
+    repo, tag = ref, ""
+    # A ':' is a tag only if it comes after the last '/', else it's a registry port.
+    last_colon = ref.rfind(":")
+    if last_colon > ref.rfind("/"):
+        repo, tag = ref[:last_colon], ref[last_colon + 1 :]
+    return repo, tag, digest
+
+
+def _image_outdated(deployed: str, catalog_image: str) -> bool:
+    """True when a running container's image no longer matches the catalog entry.
+
+    Flags the case a provider changed its image path (the ProxyBase migration) or the
+    catalog re-pinned to a new digest — so the dashboard can prompt a re-deploy instead
+    of showing a healthy-looking container that is silently running a retired image.
+    Deliberately conservative: unknown/empty images and a pure tag-vs-digest difference
+    of the same repository are NOT flagged.
+    """
+    if not deployed or not catalog_image:
+        return False
+    d_repo, _, d_digest = _split_image(deployed)
+    c_repo, _, c_digest = _split_image(catalog_image)
+    if d_repo != c_repo:
+        return True
+    return bool(c_digest and d_digest and c_digest != d_digest)
+
+
 @app.get("/api/services/deployed")
 async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
     """Return deployed services with container status, balance, CPU, memory.
@@ -665,6 +696,10 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "instance_details": instance_details,
             "collector_disconnected": slug in alert_slugs,
             "collector_needs_setup": slug not in alert_slugs and _collector_needs_setup(slug, config),
+            # True when the running container's image no longer matches the catalog
+            # (provider migrated / re-pinned) — the dashboard prompts a re-deploy so a
+            # retired image doesn't keep looking healthy while it silently stops earning.
+            "image_outdated": False,
         }
         if svc:
             cashout = svc.get("cashout", {})
@@ -674,6 +709,7 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             if referral:
                 entry["referral_url"] = referral.get("signup_url", "")
             entry["website"] = svc.get("website", "")
+            entry["image_outdated"] = _image_outdated(agg["image"], (svc.get("docker") or {}).get("image", ""))
         result.append(entry)
 
     # Include external services (no Docker container, e.g. Grass, Bytelixir)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -477,6 +477,13 @@ const CP = (() => {
     const bonusLabel = signupBonus > 0
       ? `<div style="font-size:0.6rem; color:var(--text-muted);">\u2212${formatCurrency(signupBonus, currency)} promo</div>`
       : '';
+    // Image drift: the running container no longer matches the catalog image
+    // (provider migrated or re-pinned). Prompt a re-deploy — otherwise a retired
+    // image keeps looking healthy while it silently stops earning.
+    const outdatedBadge = svc.image_outdated === true
+      ? ` <span class="badge badge-stopped" title="This service is running an image that no longer matches the catalog (the provider changed or re-pinned it). Re-deploy it from the catalog to update.">update available</span>`
+      : '';
+
     // Earnings-collector state. "disconnected" = collector ran and failed
     // (e.g. wrong credentials). "needs setup" = the service is deployed and
     // earning, but its (separate) earnings-tracking credentials aren't set yet.
@@ -577,7 +584,7 @@ const CP = (() => {
     let html = `
     <tr class="breakdown-row${isMulti ? ' expandable' : ''}" data-slug="${escapeHtml(svc.slug)}"${isMulti ? ` onclick="CP.toggleInstances('${escapeHtml(svc.slug)}', event)" style="cursor:pointer;"` : ''}>
       <td>${nameHtml}<div style="font-size:0.7rem; color:var(--text-muted);">${subtitle}</div></td>
-      <td style="text-align:center;"><span class="badge badge-${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span>${instanceLabel}</td>
+      <td style="text-align:center;"><span class="badge badge-${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span>${instanceLabel}${outdatedBadge}</td>
       <td style="text-align:center;">${healthBadge}</td>
       <td style="text-align:right; font-weight:600;">${balanceHtml}</td>
       <td style="text-align:right;"><span class="stat-change ${deltaClass}">${deltaStr}</span></td>

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -2153,3 +2153,35 @@ class TestLoginRateLimitMetric:
             resp = client.post("/login", data={"username": "x", "password": "y"}, follow_redirects=False)
             assert resp.status_code == 429
             mock_metric.assert_called_once()
+
+
+class TestImageDrift:
+    """CashPilot-5wi: flag a deployed container whose image drifted from the catalog."""
+
+    def test_split_image(self):
+        from app.main import _split_image
+
+        assert _split_image("ghcr.io/proxybaseorg/peer-cli@sha256:abc") == (
+            "ghcr.io/proxybaseorg/peer-cli",
+            "",
+            "sha256:abc",
+        )
+        assert _split_image("proxybase/proxybase:latest") == ("proxybase/proxybase", "latest", "")
+        assert _split_image("repo") == ("repo", "", "")
+        # A registry:port is not mistaken for a tag.
+        assert _split_image("localhost:5000/img:1.0")[0] == "localhost:5000/img"
+
+    def test_image_outdated(self):
+        from app.main import _image_outdated
+
+        # Provider migrated the image path (the ProxyBase case) -> outdated.
+        assert _image_outdated("proxybase/proxybase@sha256:old", "ghcr.io/proxybaseorg/peer-cli@sha256:new") is True
+        # Same repo, re-pinned to a new digest -> outdated.
+        assert _image_outdated("repo@sha256:aaa", "repo@sha256:bbb") is True
+        # Same image -> not flagged.
+        assert _image_outdated("repo@sha256:aaa", "repo@sha256:aaa") is False
+        # Missing/empty images -> conservative, not flagged.
+        assert _image_outdated("", "repo@sha256:x") is False
+        assert _image_outdated("repo:1.0", "") is False
+        # Same repo, tag vs digest (unresolvable) -> not flagged.
+        assert _image_outdated("repo:1.0", "repo@sha256:x") is False


### PR DESCRIPTION
## What

Detects when a running container's image no longer matches its catalog entry and surfaces an **update available** badge in the dashboard.

When a provider changes or re-pins its Docker image (the ProxyBase `proxybase/proxybase` → `ghcr.io/proxybaseorg/peer-cli` migration is the motivating case), a deployed container keeps reporting healthy while silently running a retired image. The operator has no signal to re-deploy.

## How

- `_split_image(ref)` — parses `repo`/`tag`/`digest` from a Docker ref (a `:` after the last `/` is a tag; before it is a registry port).
- `_image_outdated(deployed, catalog_image)` — True when the repo path changed, or both sides are digest-pinned to *different* digests. **Conservative:** empty/unknown images and a pure tag-vs-digest difference of the same repo are not flagged.
- `/api/services/deployed` now returns `image_outdated` per container-backed service.
- `app.js` renders a small `update available` badge (with an explanatory tooltip) in the status cell.

## Tests

`TestImageDrift` covers `_split_image` (digest, tag, bare, registry-port) and `_image_outdated` (repo migration, digest re-pin, identical, empty, tag-vs-digest). Full suite: 1164 passing, ruff clean.

Closes bead CashPilot-5wi.