### PR TITLE
fix: stable worker client_id instead of mutable hostname (CashPilot-ng1)

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -20,6 +20,7 @@ import os
 import platform
 import re
 import socket
+import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from html import escape as _esc
@@ -102,6 +103,40 @@ def _save_worker_key(key: str) -> bool:
 _worker_key: str | None = _load_worker_key()
 
 
+# Stable per-worker identity. The UI keys a worker's DB row (and its per-worker key) on
+# this client_id, NOT on the mutable display name: two hosts sharing a default hostname
+# (ubuntu/raspberrypi/docker-desktop) must not collapse onto one identity, and renaming
+# CASHPILOT_WORKER_NAME must not mint a new identity that locks the worker out.
+_WORKER_ID_FILE = Path(os.getenv("CASHPILOT_DATA_DIR", "/data")) / ".worker_id"
+
+
+def _load_or_create_client_id() -> str:
+    """Return this worker's stable client_id, generating and persisting one on first run.
+
+    Migration: a worker already enrolled under the pre-client_id scheme has a persisted
+    per-worker key but no id file. It keeps the identity the UI already knows it by --
+    its WORKER_NAME -- so upgrading never orphans its row or forces a re-enrollment that
+    its own (already cut-over) key could not complete. A brand-new worker gets a random id.
+    """
+    try:
+        existing = _WORKER_ID_FILE.read_text().strip()
+        if existing:
+            return existing
+    except OSError:
+        pass
+    cid = WORKER_NAME if _worker_key else uuid.uuid4().hex
+    try:
+        _WORKER_ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _WORKER_ID_FILE.write_text(cid)
+        _WORKER_ID_FILE.chmod(0o600)
+    except OSError as exc:
+        logger.warning("Could not persist worker client_id — using in-memory id: %s", exc)
+    return cid
+
+
+CLIENT_ID: str = _load_or_create_client_id()
+
+
 def _active_key() -> str:
     """The key we authenticate with: our own once enrolled, else the shared key."""
     return _worker_key or API_KEY
@@ -144,6 +179,7 @@ async def _send_heartbeat() -> None:
 
     payload = {
         "name": WORKER_NAME,
+        "client_id": CLIENT_ID,
         "url": WORKER_URL or f"http://{_get_local_ip()}:{WORKER_PORT}",
         "containers": containers,
         "system_info": {
@@ -306,6 +342,7 @@ async def worker_status_page(request: Request):
         <h2>Worker Info</h2>
         <div class="info">
             <div><label>Name</label><span>{_esc(WORKER_NAME)}</span></div>
+            <div><label>ID</label><span>{_esc(CLIENT_ID)}</span></div>
             <div><label>Host</label><span>{_esc(socket.gethostname())}</span></div>
             <div><label>Platform</label><span>{_esc(platform.system())} {_esc(platform.machine())}</span></div>
             <div><label>Docker</label><span>{"Available" if await asyncio.to_thread(orchestrator.docker_available) else "Not available"}</span></div>
@@ -463,6 +500,7 @@ async def api_worker_status(request: Request) -> dict[str, Any]:
         logger.warning("Failed to get container status: %s", exc)
     return {
         "name": WORKER_NAME,
+        "client_id": CLIENT_ID,
         "docker_available": await asyncio.to_thread(orchestrator.docker_available),
         "ui_connected": _ui_connected,
         "container_count": len(containers),

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -187,3 +187,79 @@ class TestHeartbeatErrorClassification:
         mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
         self._run_heartbeat_with(mock_client)
         assert w._last_error == "connection failed"
+
+
+class TestClientId:
+    """CashPilot-ng1: stable worker identity (client_id) decoupled from the display name."""
+
+    def test_returns_existing_id_file(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        f.write_text("stable-123\n")
+        with patch.object(w, "_WORKER_ID_FILE", f):
+            assert w._load_or_create_client_id() == "stable-123"
+
+    def test_mints_random_id_for_brand_new_worker(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        with patch.object(w, "_WORKER_ID_FILE", f), patch.object(w, "_worker_key", None):
+            cid = w._load_or_create_client_id()
+            assert cid == f.read_text()  # persisted
+            # A fresh random id, never the mutable display name.
+            assert cid != w.WORKER_NAME
+            assert len(cid) >= 16
+
+    def test_preserves_name_identity_for_already_enrolled_worker(self, tmp_path):
+        # Migration: an already-enrolled worker (has a key) with no id file yet keeps the
+        # identity the UI knows it by (WORKER_NAME), so the upgrade never re-enrolls it.
+        f = tmp_path / ".worker_id"
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "_worker_key", "already-enrolled-key"),
+            patch.object(w, "WORKER_NAME", "my-host"),
+        ):
+            assert w._load_or_create_client_id() == "my-host"
+            assert f.read_text() == "my-host"
+
+    def test_id_is_stable_across_calls(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        with patch.object(w, "_WORKER_ID_FILE", f), patch.object(w, "_worker_key", None):
+            first = w._load_or_create_client_id()
+            assert w._load_or_create_client_id() == first
+
+    def test_persist_failure_falls_back_to_in_memory_id(self):
+        fake = MagicMock()
+        fake.parent.mkdir = MagicMock()
+        fake.write_text = MagicMock(side_effect=OSError("read-only fs"))
+        fake.read_text = MagicMock(side_effect=OSError("missing"))
+        with patch.object(w, "_WORKER_ID_FILE", fake), patch.object(w, "_worker_key", None):
+            cid = w._load_or_create_client_id()
+            # A usable id is still returned even though it could not be persisted.
+            assert len(cid) >= 16
+
+    def test_heartbeat_payload_includes_client_id(self, tmp_path):
+        captured: dict = {}
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"status": "ok", "worker_id": 1})
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        async def _post(_url, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return resp
+
+        mock_client.post = AsyncMock(side_effect=_post)
+        with (
+            patch.object(w, "_WORKER_KEY_FILE", tmp_path / ".worker_key"),
+            patch.object(w, "_worker_key", None),
+            patch.object(w, "CLIENT_ID", "cid-abc"),
+            patch.object(w, "UI_URL", "http://ui:8080"),
+            patch.object(w, "API_KEY", "shared"),
+            patch("app.worker_api.orchestrator.get_status", return_value=[]),
+            patch("app.worker_api.orchestrator.docker_available", return_value=True),
+            patch("app.worker_api.httpx.AsyncClient", return_value=mock_client),
+        ):
+            asyncio.run(w._send_heartbeat())
+        # Identity travels as client_id; name remains present but display-only.
+        assert captured.get("client_id") == "cid-abc"
+        assert captured.get("name") == w.WORKER_NAME


### PR DESCRIPTION
## The bug (audit HIGH — worker_api.py:130, main.py:1751)

The bundled worker never sent a `client_id`, so the UI derived identity from the worker's **name**, which defaults to `socket.gethostname()`. Consequences:

- **Hostname collision:** two hosts sharing a common default hostname (`ubuntu`, `raspberrypi`, `docker-desktop`) collapse onto one identity. Once host A enrolls and gets its per-worker key, host B's shared-key heartbeats are `401`'d forever.
- **Rename lockout:** changing `CASHPILOT_WORKER_NAME` mints a brand-new identity, but the worker still presents its *old* persisted per-worker key → the UI rejects it → lockout.

## The fix

- Generate and persist a stable `client_id` in `/data/.worker_id` (random `uuid4().hex`), send it in the heartbeat, and key identity on it. **Name is now display-only.**
- Also surfaced on `/api/status` and the worker's config page for operator visibility.

## Migration (why it's safe to ship worker + UI together)

The auth path means a naive "always mint a UUID" would **lock out the existing fleet**: an already-enrolled worker holds its own key `K`, but a fresh UUID has no key on the UI and the worker never falls back to the shared key → permanent `401`. So:

- **Already-enrolled worker** (has `/data/.worker_key` but no `.worker_id`) → seeds `.worker_id` = its `WORKER_NAME`, i.e. the identity the UI already knows it by. No orphan row, no re-enrollment.
- **Brand-new worker** (no key) → random `uuid4().hex`.
- The UI already keys on `client_id` with a `name` fallback (`cid = body.client_id or body.name`), so old-worker/new-UI and new-worker/old-UI both interoperate.

## Tests

New `TestClientId` (6 cases): existing-id-file read, random mint for a brand-new worker (≠ display name), **migration preserves WORKER_NAME identity for an enrolled worker**, stability across calls, persist-failure fallback to an in-memory id, and the heartbeat payload carrying `client_id` while `name` stays present. Full suite: 1168 passing, ruff clean.

Closes bead CashPilot-ng1.