### PR TITLE
fix(ui): unify deploy flows so the detail view validates + surfaces errors (CashPilot-cyc, part 1)

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1491,18 +1491,20 @@ const CP = (() => {
     </div>`;
   }
 
-  async function deployService(slug) {
+  // Deploy `slug` to the given worker node ids: collect the env inputs, validate the
+  // required fields, POST per worker, and surface each per-worker failure. Shared by both
+  // deploy entry points (the setup wizard and the catalog/detail view) so validation and
+  // error reporting are identical — the detail view previously skipped validation and
+  // swallowed server errors silently.
+  async function _deployToWorkers(slug, workerIds) {
     const statusEl = document.getElementById(`deploy-status-${slug}`);
-    const checkboxes = document.querySelectorAll(`.setup-deploy-worker-cb[data-slug="${slug}"]:checked:not(:disabled)`);
-    const workerIds = Array.from(checkboxes).map(cb => parseInt(cb.dataset.wid));
-
     if (workerIds.length === 0) {
       toast('Select at least one worker node', 'warning');
       if (statusEl) statusEl.textContent = 'Select at least one node.';
       return;
     }
 
-    // Collect env vars (only env inputs, not worker checkboxes)
+    // Collect env vars (only env inputs carry data-key, not the worker checkboxes).
     const envInputs = document.querySelectorAll(`input[data-slug="${slug}"][data-key]`);
     const env = {};
     let missingRequired = false;
@@ -1547,6 +1549,17 @@ const CP = (() => {
         wizardState.deployed.push(slug);
       }
     }
+  }
+
+  // Parse the checked worker ids from a checkbox selector (dropping any unparseable id).
+  function _selectedWorkerIds(selector) {
+    return Array.from(document.querySelectorAll(selector))
+      .map(cb => parseInt(cb.dataset.wid))
+      .filter(id => !Number.isNaN(id));
+  }
+
+  async function deployService(slug) {
+    await _deployToWorkers(slug, _selectedWorkerIds(`.setup-deploy-worker-cb[data-slug="${slug}"]:checked:not(:disabled)`));
   }
 
   // -----------------------------------------------------------
@@ -1767,7 +1780,7 @@ const CP = (() => {
         if (!deployed) allDeployed = false;
         workerRows += `
         <label style="display:flex; align-items:center; gap:8px; padding:6px 0; ${deployed ? 'opacity:0.5;' : ''}">
-          <input type="checkbox" class="deploy-worker-cb" data-wid="${w.id}" ${deployed ? 'disabled checked' : ''}>
+          <input type="checkbox" class="deploy-worker-cb" data-slug="${svc.slug}" data-wid="${w.id}" ${deployed ? 'disabled checked' : ''}>
           <span>${escapeHtml(w.name)}</span>
           ${deployed ? '<span class="badge badge-deployed" style="font-size:0.75rem;">Deployed</span>' : '<span class="badge badge-available" style="font-size:0.75rem;">Available</span>'}
         </label>`;
@@ -1842,35 +1855,7 @@ const CP = (() => {
   }
 
   async function deployServiceToWorkers(slug) {
-    const statusEl = document.getElementById(`deploy-status-${slug}`);
-    const checkboxes = document.querySelectorAll('.deploy-worker-cb:checked:not(:disabled)');
-    const workerIds = Array.from(checkboxes).map(cb => parseInt(cb.dataset.wid));
-
-    if (workerIds.length === 0) {
-      if (statusEl) statusEl.textContent = 'Select at least one node.';
-      return;
-    }
-
-    // Collect env vars
-    const envInputs = document.querySelectorAll(`input[data-slug="${slug}"]`);
-    const env = {};
-    envInputs.forEach(input => { if (input.dataset.key) env[input.dataset.key] = input.value; });
-
-    if (statusEl) statusEl.innerHTML = '<span class="spinner" style="display:inline-block;width:14px;height:14px;vertical-align:middle;"></span> Deploying...';
-
-    let ok = 0, fail = 0;
-    for (const wid of workerIds) {
-      try {
-        await api(`/api/deploy/${slug}?worker_id=${wid}`, { method: 'POST', body: { env } });
-        ok++;
-      } catch (err) {
-        fail++;
-      }
-    }
-    if (statusEl) {
-      statusEl.textContent = fail === 0 ? `Deployed to ${ok} node(s)` : `${ok} ok, ${fail} failed`;
-      statusEl.style.color = fail === 0 ? 'var(--success)' : 'var(--error)';
-    }
+    await _deployToWorkers(slug, _selectedWorkerIds(`.deploy-worker-cb[data-slug="${slug}"]:checked:not(:disabled)`));
   }
 
   async function workerAction(slug, action, workerId) {


### PR DESCRIPTION
## The bug

The catalog/detail view's `deployServiceToWorkers` was a **weaker duplicate** of the setup wizard's `deployService` (audit: app.js:1837). It:
- skipped **required-field validation**,
- **swallowed per-worker server errors silently** — a failed deploy looked successful to the user,
- used a non-slug-scoped checkbox class (`.deploy-worker-cb` vs `.setup-deploy-worker-cb[data-slug]`),
- never updated wizard state.

## The fix

Extract the proven `deployService` body into a shared **`_deployToWorkers(slug, workerIds)`** (validation → env collection → per-worker POST → per-worker error toasts → status + wizard state), and make **both** entry points thin wrappers over it with consistent slug-scoped selectors. Added `data-slug` to the detail-view checkbox so its selector matches; the env-collection `[data-key]` filter keeps the worker checkboxes out of the env payload.

## Scope

This lands the **duplicate-deploy-flow** part of `CashPilot-cyc`. The larger HTML-builder componentization (`renderServiceRow`, the setup/detail form builders) and inline-`onclick` removal remain open — they change rendered markup and every handler's wiring, so they need **browser verification against a running UI** (and feed directly into the CSP-tightening bead `guw`). The bead stays open for that.

## Verification

- `node --check` clean.
- `deployService` is behavior-identical (verbatim body extraction, unchanged selector).
- `deployServiceToWorkers`' new slug-scoped selectors are backed by the rendered `data-slug`/`data-key` attributes (static analysis).
- Full Python suite still 1172 green.
- *Browser smoke test was not possible in this environment (Chrome extension unavailable); verification is static + syntax.*

Partial progress on bead CashPilot-cyc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service deployment validation across the Setup Wizard and Service Detail views.
  * Added clearer progress indicators and per-worker failure notifications during deployment.
  * Fixed worker selection to ensure deployments target the correct workers.
  * Deployment status now updates consistently after successful operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->