### PR TITLE
refactor: extract SSRF worker-URL validation into app/worker_proxy.py (CashPilot-sux)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,18 +9,15 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hmac
-import ipaddress
 import json
 import logging
 import os
 import re
 import secrets
-import socket
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from time import monotonic
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 import httpx
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_MISSED
@@ -32,6 +29,7 @@ from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app import auth, catalog, compose_generator, database, exchange_rates, fleet_key, metrics, setup_token
+from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
 
 logging.basicConfig(
     level=logging.INFO,
@@ -980,164 +978,6 @@ async def api_remove(
 # ---------------------------------------------------------------------------
 # Helpers: proxy commands / logs to worker nodes
 # ---------------------------------------------------------------------------
-
-_ALLOWED_WORKER_SCHEMES = {"http", "https"}
-
-# SSRF guard for worker URLs. The worker `url` arrives in the (fleet-key-authed)
-# heartbeat body and is later fetched WITH the fleet bearer token attached, so an
-# attacker holding the fleet key could otherwise turn the UI into a confused-deputy
-# proxy into the internal network. Policy is OPT-IN: the default ("permissive")
-# preserves today's behaviour — LAN (RFC1918) and Tailscale (CGNAT 100.64.0.0/10)
-# workers keep working out of the box — while always closing the free gaps
-# (cloud-metadata IPs, IPv6 loopback/link-local, IPv4-mapped bypasses, DNS rebinding).
-# "strict" mode restricts to CASHPILOT_WORKER_ALLOWED_HOSTS (CIDRs + *.suffix names).
-_WORKER_URL_POLICY = os.getenv("CASHPILOT_WORKER_URL_POLICY", "permissive").strip().lower()
-_WORKER_ALLOW_METADATA = os.getenv("CASHPILOT_WORKER_ALLOW_METADATA", "false").strip().lower() == "true"
-
-# Cloud metadata endpoints — never a valid worker; always blocked (unless the
-# explicit escape hatch is set). The IPv6 one is inside ULA fd00::/8 so a
-# "permissive" policy would otherwise allow it.
-_METADATA_IPS = frozenset(
-    {
-        ipaddress.ip_address("169.254.169.254"),  # AWS/GCP/Azure IMDS (IPv4)
-        ipaddress.ip_address("fd00:ec2::254"),  # AWS IMDS over IPv6
-    }
-)
-# Loopback + link-local, IPv4 and IPv6 — always blocked.
-_BLOCKED_NETWORKS = (
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fe80::/10"),
-)
-
-
-def _parse_worker_allowlist() -> tuple[list[ipaddress._BaseNetwork], list[str], set[str]]:
-    """Parse CASHPILOT_WORKER_ALLOWED_HOSTS into (cidrs, host_suffixes, exact_hosts)."""
-    cidrs: list[ipaddress._BaseNetwork] = []
-    suffixes: list[str] = []
-    exact: set[str] = set()
-    for entry in os.getenv("CASHPILOT_WORKER_ALLOWED_HOSTS", "").split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        if entry.startswith("*."):
-            suffixes.append(entry[2:].lower())
-            continue
-        try:
-            cidrs.append(ipaddress.ip_network(entry, strict=False))
-        except ValueError:
-            exact.add(entry.lower())
-    return cidrs, suffixes, exact
-
-
-_WORKER_ALLOWED_CIDRS, _WORKER_ALLOWED_SUFFIXES, _WORKER_ALLOWED_HOSTS = _parse_worker_allowlist()
-
-
-def _normalize_ip(addr: ipaddress.IPv4Address | ipaddress.IPv6Address):
-    """Collapse IPv4-mapped IPv6 (::ffff:a.b.c.d) to the underlying IPv4 address."""
-    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
-        return addr.ipv4_mapped
-    return addr
-
-
-def _assert_ip_not_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
-    """Always-on checks: metadata + loopback/link-local, regardless of policy."""
-    addr = _normalize_ip(addr)
-    if not _WORKER_ALLOW_METADATA and addr in _METADATA_IPS:
-        raise HTTPException(status_code=400, detail="Worker URL points to a cloud metadata address")
-    for net in _BLOCKED_NETWORKS:
-        if addr.version == net.version and addr in net:
-            raise HTTPException(status_code=400, detail="Worker URL points to loopback/link-local address")
-
-
-def _assert_ip_strict_allowed(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
-    """In strict mode, the resolved IP must fall inside an allowed CIDR."""
-    addr = _normalize_ip(addr)
-    if any(addr.version == c.version and addr in c for c in _WORKER_ALLOWED_CIDRS):
-        return
-    raise HTTPException(status_code=400, detail="Worker URL not in allowed hosts (strict mode)")
-
-
-def _validate_worker_url(raw_url: str) -> tuple[str, str | None]:
-    """Validate a worker URL; raise 400 on SSRF-risky targets.
-
-    Returns ``(safe_url, pinned_ip)``. ``pinned_ip`` is a validated IP the caller
-    should connect to directly instead of re-resolving the hostname — this closes
-    the DNS-rebinding TOCTOU where a name that resolved to a safe address here flips
-    to a metadata/loopback address when httpx re-resolves at request time. It is
-    ``None`` when the host is already a literal IP (nothing to re-resolve) or, in
-    permissive mode, when the host could not be resolved (best-effort).
-
-    Resolves hostnames and validates the resolved IP(s) so a DNS name that points at
-    a metadata/loopback address is rejected (DNS-rebinding guard). Synchronous — its
-    only blocking op is DNS resolution; event-loop callers MUST invoke it via
-    ``asyncio.to_thread`` (see _get_verified_worker_url) so a slow/hanging resolver
-    never blocks the whole UI.
-    """
-    parsed = urlparse(raw_url)
-    if parsed.scheme not in _ALLOWED_WORKER_SCHEMES:
-        raise HTTPException(status_code=400, detail=f"Invalid worker URL scheme: {parsed.scheme}")
-    host = parsed.hostname or ""
-    if not host:
-        raise HTTPException(status_code=400, detail="Worker URL has no host")
-    if host in ("localhost", "localhost.localdomain"):
-        raise HTTPException(status_code=400, detail="Worker URL points to localhost")
-
-    # Case A: literal IP — classify directly, no DNS needed.
-    try:
-        addr = ipaddress.ip_address(host)
-    except ValueError:
-        addr = None
-    if addr is not None:
-        _assert_ip_not_blocked(addr)
-        if _WORKER_URL_POLICY == "strict":
-            _assert_ip_strict_allowed(addr)
-        # Already a literal IP — httpx won't re-resolve, so no pinning needed.
-        return raw_url.rstrip("/"), None
-
-    # Case B: hostname. In strict mode an explicit name/suffix match short-circuits
-    # the CIDR check (so Tailscale MagicDNS names work by name), but the resolved
-    # IPs are still checked against the always-blocked set.
-    hostname_allowed = host.lower() in _WORKER_ALLOWED_HOSTS or any(
-        host.lower() == s or host.lower().endswith("." + s) for s in _WORKER_ALLOWED_SUFFIXES
-    )
-    try:
-        infos = socket.getaddrinfo(host, parsed.port, proto=socket.IPPROTO_TCP)
-        resolved = {ipaddress.ip_address(info[4][0]) for info in infos}
-    except (socket.gaierror, ValueError):
-        # Unresolvable: fatal in strict (can't prove it's allowed), non-fatal in
-        # permissive (the request itself will fail if the host is truly dead; we
-        # don't want a transiently-unresolvable worker to hard-400).
-        if _WORKER_URL_POLICY == "strict" and not hostname_allowed:
-            raise HTTPException(status_code=400, detail="Worker URL host does not resolve") from None
-        # Permissive + unresolvable: best-effort, nothing to pin.
-        return raw_url.rstrip("/"), None
-
-    for addr in resolved:
-        _assert_ip_not_blocked(addr)
-    if _WORKER_URL_POLICY == "strict" and not hostname_allowed:
-        for addr in resolved:
-            _assert_ip_strict_allowed(addr)
-    # Pin one validated IP for the actual request so a rebinding record that
-    # resolved safe here can't flip to a blocked address when httpx re-resolves.
-    # Deterministic pick over the just-checked set.
-    return raw_url.rstrip("/"), str(min(resolved, key=str))
-
-
-def _pin_url_to_ip(url: str, ip: str) -> tuple[str, str]:
-    """Rewrite ``url``'s host to the validated ``ip`` and return (pinned_url, host_header).
-
-    Connecting to the already-checked IP (with the original hostname carried in the
-    Host header) means httpx never re-resolves the name, so a DNS-rebinding flip
-    between validation and the request cannot redirect us to a blocked address.
-    """
-    parsed = urlparse(url)
-    port = parsed.port
-    host_header = f"{parsed.hostname}:{port}" if port else (parsed.hostname or "")
-    ip_host = f"[{ip}]" if ":" in ip else ip  # bracket IPv6 literals
-    netloc = f"{ip_host}:{port}" if port else ip_host
-    return urlunparse(parsed._replace(netloc=netloc)), host_header
 
 
 async def _get_verified_worker_url(worker: dict[str, Any]) -> tuple[str, dict[str, str]]:

--- a/app/worker_proxy.py
+++ b/app/worker_proxy.py
@@ -1,0 +1,177 @@
+"""SSRF-safe worker-URL validation for the CashPilot UI.
+
+A worker's ``url`` arrives in the (fleet-key-authed) heartbeat body and is later
+fetched WITH the fleet bearer token attached, so an attacker holding the fleet key
+could otherwise turn the UI into a confused-deputy proxy into the internal network.
+These helpers validate the URL and pin it to a checked IP (closing the DNS-rebinding
+TOCTOU) before the UI ever connects. Kept as its own module so the policy/SSRF logic
+is isolated and unit-testable apart from the request-handling in main.py; main.py's
+``_get_verified_worker_url`` composes ``_validate_worker_url`` + ``_pin_url_to_ip``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse, urlunparse
+
+from fastapi import HTTPException
+
+_ALLOWED_WORKER_SCHEMES = {"http", "https"}
+
+# SSRF guard for worker URLs. The worker `url` arrives in the (fleet-key-authed)
+# heartbeat body and is later fetched WITH the fleet bearer token attached, so an
+# attacker holding the fleet key could otherwise turn the UI into a confused-deputy
+# proxy into the internal network. Policy is OPT-IN: the default ("permissive")
+# preserves today's behaviour — LAN (RFC1918) and Tailscale (CGNAT 100.64.0.0/10)
+# workers keep working out of the box — while always closing the free gaps
+# (cloud-metadata IPs, IPv6 loopback/link-local, IPv4-mapped bypasses, DNS rebinding).
+# "strict" mode restricts to CASHPILOT_WORKER_ALLOWED_HOSTS (CIDRs + *.suffix names).
+_WORKER_URL_POLICY = os.getenv("CASHPILOT_WORKER_URL_POLICY", "permissive").strip().lower()
+_WORKER_ALLOW_METADATA = os.getenv("CASHPILOT_WORKER_ALLOW_METADATA", "false").strip().lower() == "true"
+
+# Cloud metadata endpoints — never a valid worker; always blocked (unless the
+# explicit escape hatch is set). The IPv6 one is inside ULA fd00::/8 so a
+# "permissive" policy would otherwise allow it.
+_METADATA_IPS = frozenset(
+    {
+        ipaddress.ip_address("169.254.169.254"),  # AWS/GCP/Azure IMDS (IPv4)
+        ipaddress.ip_address("fd00:ec2::254"),  # AWS IMDS over IPv6
+    }
+)
+# Loopback + link-local, IPv4 and IPv6 — always blocked.
+_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def _parse_worker_allowlist() -> tuple[list[ipaddress._BaseNetwork], list[str], set[str]]:
+    """Parse CASHPILOT_WORKER_ALLOWED_HOSTS into (cidrs, host_suffixes, exact_hosts)."""
+    cidrs: list[ipaddress._BaseNetwork] = []
+    suffixes: list[str] = []
+    exact: set[str] = set()
+    for entry in os.getenv("CASHPILOT_WORKER_ALLOWED_HOSTS", "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if entry.startswith("*."):
+            suffixes.append(entry[2:].lower())
+            continue
+        try:
+            cidrs.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            exact.add(entry.lower())
+    return cidrs, suffixes, exact
+
+
+_WORKER_ALLOWED_CIDRS, _WORKER_ALLOWED_SUFFIXES, _WORKER_ALLOWED_HOSTS = _parse_worker_allowlist()
+
+
+def _normalize_ip(addr: ipaddress.IPv4Address | ipaddress.IPv6Address):
+    """Collapse IPv4-mapped IPv6 (::ffff:a.b.c.d) to the underlying IPv4 address."""
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
+def _assert_ip_not_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    """Always-on checks: metadata + loopback/link-local, regardless of policy."""
+    addr = _normalize_ip(addr)
+    if not _WORKER_ALLOW_METADATA and addr in _METADATA_IPS:
+        raise HTTPException(status_code=400, detail="Worker URL points to a cloud metadata address")
+    for net in _BLOCKED_NETWORKS:
+        if addr.version == net.version and addr in net:
+            raise HTTPException(status_code=400, detail="Worker URL points to loopback/link-local address")
+
+
+def _assert_ip_strict_allowed(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    """In strict mode, the resolved IP must fall inside an allowed CIDR."""
+    addr = _normalize_ip(addr)
+    if any(addr.version == c.version and addr in c for c in _WORKER_ALLOWED_CIDRS):
+        return
+    raise HTTPException(status_code=400, detail="Worker URL not in allowed hosts (strict mode)")
+
+
+def _validate_worker_url(raw_url: str) -> tuple[str, str | None]:
+    """Validate a worker URL; raise 400 on SSRF-risky targets.
+
+    Returns ``(safe_url, pinned_ip)``. ``pinned_ip`` is a validated IP the caller
+    should connect to directly instead of re-resolving the hostname — this closes
+    the DNS-rebinding TOCTOU where a name that resolved to a safe address here flips
+    to a metadata/loopback address when httpx re-resolves at request time. It is
+    ``None`` when the host is already a literal IP (nothing to re-resolve) or, in
+    permissive mode, when the host could not be resolved (best-effort).
+
+    Resolves hostnames and validates the resolved IP(s) so a DNS name that points at
+    a metadata/loopback address is rejected (DNS-rebinding guard). Synchronous — its
+    only blocking op is DNS resolution; event-loop callers MUST invoke it via
+    ``asyncio.to_thread`` (see _get_verified_worker_url) so a slow/hanging resolver
+    never blocks the whole UI.
+    """
+    parsed = urlparse(raw_url)
+    if parsed.scheme not in _ALLOWED_WORKER_SCHEMES:
+        raise HTTPException(status_code=400, detail=f"Invalid worker URL scheme: {parsed.scheme}")
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(status_code=400, detail="Worker URL has no host")
+    if host in ("localhost", "localhost.localdomain"):
+        raise HTTPException(status_code=400, detail="Worker URL points to localhost")
+
+    # Case A: literal IP — classify directly, no DNS needed.
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        addr = None
+    if addr is not None:
+        _assert_ip_not_blocked(addr)
+        if _WORKER_URL_POLICY == "strict":
+            _assert_ip_strict_allowed(addr)
+        # Already a literal IP — httpx won't re-resolve, so no pinning needed.
+        return raw_url.rstrip("/"), None
+
+    # Case B: hostname. In strict mode an explicit name/suffix match short-circuits
+    # the CIDR check (so Tailscale MagicDNS names work by name), but the resolved
+    # IPs are still checked against the always-blocked set.
+    hostname_allowed = host.lower() in _WORKER_ALLOWED_HOSTS or any(
+        host.lower() == s or host.lower().endswith("." + s) for s in _WORKER_ALLOWED_SUFFIXES
+    )
+    try:
+        infos = socket.getaddrinfo(host, parsed.port, proto=socket.IPPROTO_TCP)
+        resolved = {ipaddress.ip_address(info[4][0]) for info in infos}
+    except (socket.gaierror, ValueError):
+        # Unresolvable: fatal in strict (can't prove it's allowed), non-fatal in
+        # permissive (the request itself will fail if the host is truly dead; we
+        # don't want a transiently-unresolvable worker to hard-400).
+        if _WORKER_URL_POLICY == "strict" and not hostname_allowed:
+            raise HTTPException(status_code=400, detail="Worker URL host does not resolve") from None
+        # Permissive + unresolvable: best-effort, nothing to pin.
+        return raw_url.rstrip("/"), None
+
+    for addr in resolved:
+        _assert_ip_not_blocked(addr)
+    if _WORKER_URL_POLICY == "strict" and not hostname_allowed:
+        for addr in resolved:
+            _assert_ip_strict_allowed(addr)
+    # Pin one validated IP for the actual request so a rebinding record that
+    # resolved safe here can't flip to a blocked address when httpx re-resolves.
+    # Deterministic pick over the just-checked set.
+    return raw_url.rstrip("/"), str(min(resolved, key=str))
+
+
+def _pin_url_to_ip(url: str, ip: str) -> tuple[str, str]:
+    """Rewrite ``url``'s host to the validated ``ip`` and return (pinned_url, host_header).
+
+    Connecting to the already-checked IP (with the original hostname carried in the
+    Host header) means httpx never re-resolves the name, so a DNS-rebinding flip
+    between validation and the request cannot redirect us to a blocked address.
+    """
+    parsed = urlparse(url)
+    port = parsed.port
+    host_header = f"{parsed.hostname}:{port}" if port else (parsed.hostname or "")
+    ip_host = f"[{ip}]" if ":" in ip else ip  # bracket IPv6 literals
+    netloc = f"{ip_host}:{port}" if port else ip_host
+    return urlunparse(parsed._replace(netloc=netloc)), host_header

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1584,7 +1584,7 @@ class TestValidateWorkerUrl:
         from app.main import _validate_worker_url
 
         # Patch DNS so the test is deterministic and never hits the real resolver.
-        with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.1.9", 8081))]):
+        with patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.1.9", 8081))]):
             assert _validate_worker_url("http://host:8081/")[0] == "http://host:8081"
 
     def test_invalid_scheme(self):
@@ -1617,7 +1617,7 @@ class TestValidateWorkerUrl:
         # Exact-match (not substring) so CodeQL's url-substring-sanitization rule
         # isn't tripped by a test assertion. Patch DNS to a Tailscale CGNAT IP so the
         # test is deterministic and never hits the real resolver.
-        with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("100.100.100.100", 8081))]):
+        with patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("100.100.100.100", 8081))]):
             result = _validate_worker_url("http://worker.mango.ts.net:8081")
         assert result[0] == "http://worker.mango.ts.net:8081"
 
@@ -1664,7 +1664,7 @@ class TestValidateWorkerUrl:
 
         with (
             patch(
-                "app.main.socket.getaddrinfo",
+                "app.worker_proxy.socket.getaddrinfo",
                 return_value=[(2, 1, 6, "", ("169.254.169.254", 80))],
             ),
             pytest.raises(Exception, match="metadata"),
@@ -1676,7 +1676,7 @@ class TestValidateWorkerUrl:
         # directly, defeating a rebinding flip between validation and the request.
         from app.main import _validate_worker_url
 
-        with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.20.7", 8081))]):
+        with patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.20.7", 8081))]):
             assert _validate_worker_url("http://wk.example:8081") == ("http://wk.example:8081", "192.168.20.7")
 
     def test_pin_url_to_ip_rewrites_host_keeps_host_header(self):
@@ -1700,7 +1700,7 @@ class TestValidateWorkerUrl:
 
         worker = {"status": "online", "url": "http://wk.example:8081", "client_id": ""}
         with (
-            patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.30.9", 8081))]),
+            patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.30.9", 8081))]),
             patch("app.main.database.get_worker_key", new_callable=AsyncMock, return_value=None),
         ):
             url, headers = asyncio.run(main._get_verified_worker_url(worker))
@@ -1708,7 +1708,7 @@ class TestValidateWorkerUrl:
         assert headers["Host"] == "wk.example:8081"
 
     def test_strict_mode_allows_listed_cidr(self):
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = (main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS)
         try:
@@ -1719,7 +1719,7 @@ class TestValidateWorkerUrl:
             main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS = orig
 
     def test_strict_mode_blocks_unlisted_ip(self):
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = (main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS)
         try:
@@ -1734,7 +1734,7 @@ class TestValidateWorkerUrl:
         # The escape hatch un-blocks the metadata check only. Use the IPv6 IMDS
         # address (ULA fd00::/8, not link-local) so the loopback/link-local guard
         # doesn't independently block it — proving the hatch works in isolation.
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = main._WORKER_ALLOW_METADATA
         try:
@@ -1745,13 +1745,13 @@ class TestValidateWorkerUrl:
 
     def test_strict_mode_hostname_resolves_into_allowed_cidr(self):
         # Strict mode, Case B: hostname resolving to an allowed CIDR is accepted.
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = (main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS)
         try:
             main._WORKER_URL_POLICY = "strict"
             main._WORKER_ALLOWED_CIDRS = [main.ipaddress.ip_network("192.168.10.0/24")]
-            with patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.10.50", 8081))]):
+            with patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("192.168.10.50", 8081))]):
                 # Hostname resolves into the allowed CIDR -> accepted, and the
                 # validated IP is pinned for the request (anti-rebinding).
                 assert main._validate_worker_url("http://wk.local:8081") == ("http://wk.local:8081", "192.168.10.50")
@@ -1759,14 +1759,14 @@ class TestValidateWorkerUrl:
             main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS = orig
 
     def test_strict_mode_hostname_resolves_outside_allowed_cidr_blocked(self):
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = (main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS)
         try:
             main._WORKER_URL_POLICY = "strict"
             main._WORKER_ALLOWED_CIDRS = [main.ipaddress.ip_network("192.168.10.0/24")]
             with (
-                patch("app.main.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 8081))]),
+                patch("app.worker_proxy.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 8081))]),
                 pytest.raises(Exception, match="strict mode"),
             ):
                 main._validate_worker_url("http://wk.local:8081")
@@ -1774,13 +1774,13 @@ class TestValidateWorkerUrl:
             main._WORKER_URL_POLICY, main._WORKER_ALLOWED_CIDRS = orig
 
     def test_strict_mode_unresolvable_hostname_blocked(self):
-        import app.main as main
+        import app.worker_proxy as main
 
         orig = main._WORKER_URL_POLICY
         try:
             main._WORKER_URL_POLICY = "strict"
             with (
-                patch("app.main.socket.getaddrinfo", side_effect=socket.gaierror),
+                patch("app.worker_proxy.socket.getaddrinfo", side_effect=socket.gaierror),
                 pytest.raises(Exception, match="does not resolve"),
             ):
                 main._validate_worker_url("http://nope.invalid:8081")
@@ -2125,7 +2125,7 @@ class TestDepsGuards:
 
 class TestWorkerAllowlistParsing:
     def test_parse_allowlist_mixed_entries(self):
-        import app.main as main
+        import app.worker_proxy as main
 
         with patch.dict(
             os.environ,


### PR DESCRIPTION
Splits a cohesive, self-contained slice out of the `main.py` god module — the architect-endorsed least-coupled candidate from bead `CashPilot-sux`.

## What moved

The SSRF/worker-URL guard → new **`app/worker_proxy.py`**:
- policy constants (`_WORKER_URL_POLICY`, metadata/loopback block sets, allowlist),
- `_parse_worker_allowlist`, `_normalize_ip`, `_assert_ip_not_blocked`, `_assert_ip_strict_allowed`,
- `_validate_worker_url` (DNS-rebinding-safe validation), `_pin_url_to_ip`.

`main.py`'s `_get_verified_worker_url` composes them and **stays** in main (it also needs `FLEET_API_KEY` + `database`). `worker_proxy` imports nothing from `main`, so **no new import cycle**. main.py drops ~160 lines and the SSRF policy is now isolated and unit-testable on its own.

## Test seams

- The 8 `app.main.socket.getaddrinfo` patches → `app.worker_proxy.socket` (that's where `_validate_worker_url` resolves the host).
- The strict-mode / allowlist tests that mutate the policy constants repoint their `main` alias to `app.worker_proxy` (where `_validate_worker_url` reads them).
- The `_validate_worker_url` / `_pin_url_to_ip` patches keep working via `main`'s import binding — unchanged.

## Verification

Behavior-preserving: **1172 tests green**; `ruff check` + `ruff format --check` clean; verified `worker_proxy` imports nothing from `app.main`.

## Scope

This lands the module-extraction half of `sux`. The other half — resolving the `main → routers → main` import cycle — is **intentionally left as-is**: it's benign and documented, and breaking it churns ~40 `app.main.*` test seams for no correctness gain (per the architect review). The bead can close on the extraction or stay open for the cosmetic cycle cleanup — your call.

Addresses bead CashPilot-sux (extraction half).