### PR TITLE
fix(security): HSTS + CSP hardening + cookie Secure behind a trusted proxy

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -181,22 +181,32 @@ _SECURE_COOKIE = os.getenv("CASHPILOT_SECURE_COOKIE", "auto").lower()
 _SECURE_COOKIE_TRUE = {"true", "1", "yes", "on"}
 _SECURE_COOKIE_FALSE = {"false", "0", "no", "off"}
 
+# Only trust an X-Forwarded-Proto header (to detect TLS terminated at a reverse proxy)
+# when the operator opts in — matches app.deps._TRUST_PROXY; read here to avoid importing
+# deps into auth (deps imports auth, so the reverse would be a cycle).
+_TRUST_PROXY = os.getenv("CASHPILOT_TRUSTED_PROXY", "").strip().lower() in ("1", "true", "yes", "on")
 
-def set_session_cookie(response: RedirectResponse, token: str) -> RedirectResponse:
+
+def set_session_cookie(response: RedirectResponse, token: str, request=None) -> RedirectResponse:
     # Secure-flag precedence (highest wins):
     #   1. CASHPILOT_SECURE_COOKIE explicitly truthy -> Secure on
     #   2. CASHPILOT_SECURE_COOKIE explicitly falsy   -> Secure off (e.g. TLS is
     #      terminated by a reverse proxy this process can't see)
-    #   3. Otherwise ("auto" / unset / unrecognized)  -> auto-detect from whether
-    #      CASHPILOT_BASE_URL starts with "https". Never hardcoded on by default,
-    #      so plain-HTTP local dev isn't broken by a Secure cookie the browser
-    #      would silently refuse to send back.
+    #   3. Otherwise ("auto" / unset / unrecognized)  -> auto-detect: Secure on when
+    #      CASHPILOT_BASE_URL starts with "https", OR (behind a trusted proxy) when the
+    #      request arrived as https per X-Forwarded-Proto. This closes the common gap
+    #      where TLS terminates at Caddy, the operator configures the domain there (not
+    #      via CASHPILOT_BASE_URL), and the session cookie would otherwise ship non-Secure
+    #      over the proxy hop. Never hardcoded on by default, so plain-HTTP local dev
+    #      isn't broken by a Secure cookie the browser would silently refuse to send back.
     if _SECURE_COOKIE in _SECURE_COOKIE_TRUE:
         use_secure = True
     elif _SECURE_COOKIE in _SECURE_COOKIE_FALSE:
         use_secure = False
     else:
         use_secure = os.getenv("CASHPILOT_BASE_URL", "").startswith("https")
+        if not use_secure and request is not None and _TRUST_PROXY:
+            use_secure = request.headers.get("x-forwarded-proto", "").lower() == "https"
     response.set_cookie(
         SESSION_COOKIE,
         token,

--- a/app/main.py
+++ b/app/main.py
@@ -482,6 +482,12 @@ app = FastAPI(
 metrics.setup(app)
 
 
+# Whether a trusted reverse proxy sits in front (opt-in). Only then do we believe an
+# X-Forwarded-Proto header for deciding HTTPS (matches app.deps._TRUST_PROXY semantics;
+# read here directly to avoid importing deps into the middleware).
+_HSTS_TRUST_PROXY = os.getenv("CASHPILOT_TRUSTED_PROXY", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 # Security headers middleware
 class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
@@ -490,6 +496,10 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+        # 'unsafe-inline' stays on script-src/style-src until the UI drops inline handlers
+        # (bead guw). base-uri/object-src/form-action are additive hardening that costs
+        # nothing today: block <base> hijack of relative script URLs, disallow plugins,
+        # and stop a form from POSTing credentials off-origin if an XSS is ever found.
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
             "script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "
@@ -497,8 +507,17 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "font-src 'self' https://fonts.gstatic.com; "
             "img-src 'self' data:; "
             "connect-src 'self' https://cdn.jsdelivr.net; "
-            "frame-ancestors 'none'"
+            "frame-ancestors 'none'; "
+            "base-uri 'none'; "
+            "object-src 'none'; "
+            "form-action 'self'"
         )
+        # HSTS only when the request is actually HTTPS, so plain-HTTP local dev is never
+        # pinned to https (which would hard-break it). Behind a trusted proxy that
+        # terminates TLS the app sees http, so honor X-Forwarded-Proto there.
+        proto = request.headers.get("x-forwarded-proto") if _HSTS_TRUST_PROXY else request.url.scheme
+        if proto == "https":
+            response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
         return response
 
 
@@ -1644,7 +1663,7 @@ async def api_change_own_password(request: Request, body: PasswordChange) -> JSO
     auth.set_user_pwd_epoch(uid, changed["password_changed_at"])
     # Re-mint the session cookie so the caller stays logged in after the epoch bump.
     token = auth.create_session_token(uid, user["u"], user["r"])
-    return auth.set_session_cookie(JSONResponse({"status": "password_changed"}), token)
+    return auth.set_session_cookie(JSONResponse({"status": "password_changed"}), token, request)
 
 
 @app.post("/api/users/{user_id}/password")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -74,7 +74,7 @@ async def do_login(
     main.metrics.record_login(success=True)
     token = main.auth.create_session_token(user["id"], user["username"], user["role"])
     response = RedirectResponse("/", status_code=303)
-    return main.auth.set_session_cookie(response, token)
+    return main.auth.set_session_cookie(response, token, request)
 
 
 @router.get("/register", response_class=HTMLResponse)
@@ -228,7 +228,7 @@ async def do_register(
     token = main.auth.create_session_token(user_id, username, role)
     dest = "/setup" if is_first else "/"
     response = RedirectResponse(dest, status_code=303)
-    return main.auth.set_session_cookie(response, token)
+    return main.auth.set_session_cookie(response, token, request)
 
 
 @router.get("/logout")

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -220,7 +220,7 @@ class TestLoginRoute:
             patch("app.main.database.get_user_by_username", new_callable=AsyncMock, return_value=user),
             patch("app.main.auth.verify_password", return_value=True),
             patch("app.main.auth.create_session_token", return_value="tok"),
-            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t: r),
+            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t, req=None: r),
         ):
             resp = client.post("/login", data={"username": "admin", "password": "pass"}, follow_redirects=False)
             assert resp.status_code == 303
@@ -266,7 +266,7 @@ class TestRegisterRoute:
             patch("app.main.database.create_first_owner", new_callable=AsyncMock, return_value=1),
             patch("app.main.database.delete_config_keys", new_callable=AsyncMock),
             patch("app.main.auth.create_session_token", return_value="tok"),
-            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t: r),
+            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t, req=None: r),
         ):
             resp = client.post(
                 "/register",
@@ -312,7 +312,7 @@ class TestRegisterRoute:
             patch("app.main.database.create_first_owner", new_callable=AsyncMock, return_value=1),
             patch("app.main.database.delete_config_keys", new_callable=AsyncMock) as del_keys,
             patch("app.main.auth.create_session_token", return_value="tok"),
-            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t: r),
+            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t, req=None: r),
         ):
             resp = client.post(
                 "/register",
@@ -1130,7 +1130,7 @@ class TestChangeOwnPassword:
             patch("app.main.database.update_user_password", new_callable=AsyncMock) as mock_upd,
             patch("app.main.auth.set_user_pwd_epoch") as mock_epoch,
             patch("app.main.auth.create_session_token", return_value="tok"),
-            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t: r),
+            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t, req=None: r),
         ):
             resp = client.post(
                 "/api/users/me/password",
@@ -1159,7 +1159,7 @@ class TestChangeOwnPassword:
             patch("app.main.database.update_user_password", new_callable=AsyncMock),
             patch("app.main.auth.set_user_pwd_epoch"),
             patch("app.main.auth.create_session_token", return_value="fresh-tok") as mock_tok,
-            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t: r) as mock_cookie,
+            patch("app.main.auth.set_session_cookie", side_effect=lambda r, t, req=None: r) as mock_cookie,
         ):
             resp = client.post(
                 "/api/users/me/password",
@@ -1880,6 +1880,71 @@ class TestSecurityHeaders:
             resp = client.get("/api/mode")
             assert resp.headers.get("X-Content-Type-Options") == "nosniff"
             assert resp.headers.get("X-Frame-Options") == "DENY"
+            csp = resp.headers.get("Content-Security-Policy", "")
+            # Additive CSP hardening (US-004); unsafe-inline stays until the guw refactor.
+            assert "base-uri 'none'" in csp
+            assert "object-src 'none'" in csp
+            assert "form-action 'self'" in csp
+
+    def test_hsts_absent_on_plain_http(self, client):
+        with _auth_owner():
+            resp = client.get("/api/mode")
+            # A plain-HTTP (dev) request must never be pinned to https.
+            assert "Strict-Transport-Security" not in resp.headers
+
+    def test_hsts_present_when_forwarded_https_and_proxy_trusted(self, client):
+        with _auth_owner(), patch("app.main._HSTS_TRUST_PROXY", True):
+            resp = client.get("/api/mode", headers={"X-Forwarded-Proto": "https"})
+            assert resp.headers.get("Strict-Transport-Security", "").startswith("max-age=")
+
+    def test_hsts_ignores_forwarded_proto_when_proxy_untrusted(self, client):
+        with _auth_owner(), patch("app.main._HSTS_TRUST_PROXY", False):
+            resp = client.get("/api/mode", headers={"X-Forwarded-Proto": "https"})
+            # An untrusted (spoofable) header must not trigger HSTS.
+            assert "Strict-Transport-Security" not in resp.headers
+
+
+class TestSessionCookieSecure:
+    """CASHPILOT_SECURE_COOKIE=auto must set Secure when TLS terminates at a trusted proxy."""
+
+    def _resp(self):
+        from starlette.responses import RedirectResponse
+
+        return RedirectResponse("/", status_code=303)
+
+    def _req(self, xf_proto=None):
+        r = MagicMock()
+        r.headers = {"x-forwarded-proto": xf_proto} if xf_proto else {}
+        return r
+
+    def test_secure_from_forwarded_proto_when_trusted(self):
+        import app.auth as a
+
+        with patch.object(a, "_SECURE_COOKIE", "auto"), patch.object(a, "_TRUST_PROXY", True):
+            resp = a.set_session_cookie(self._resp(), "tok", self._req("https"))
+        assert "Secure" in resp.headers.get("set-cookie", "")
+
+    def test_not_secure_when_proxy_untrusted(self):
+        import app.auth as a
+
+        with patch.object(a, "_SECURE_COOKIE", "auto"), patch.object(a, "_TRUST_PROXY", False):
+            resp = a.set_session_cookie(self._resp(), "tok", self._req("https"))
+        assert "Secure" not in resp.headers.get("set-cookie", "")
+
+    def test_explicit_true_overrides(self):
+        import app.auth as a
+
+        with patch.object(a, "_SECURE_COOKIE", "true"):
+            resp = a.set_session_cookie(self._resp(), "tok", self._req())
+        assert "Secure" in resp.headers.get("set-cookie", "")
+
+    def test_backward_compat_no_request_arg(self):
+        # Callers that don't pass request still work (auto falls back to BASE_URL).
+        import app.auth as a
+
+        with patch.object(a, "_SECURE_COOKIE", "auto"), patch.dict("os.environ", {"CASHPILOT_BASE_URL": ""}):
+            resp = a.set_session_cookie(self._resp(), "tok")
+        assert "Secure" not in resp.headers.get("set-cookie", "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Backend-only security hardening surfaced by the research security panel (items #2 session-cookie, #3 headers). **Keeps the current `'unsafe-inline'`** — dropping it is the separate `guw` refactor (which needs the inline-handler removal first).

## Changes

**CSP — additive hardening (zero UI impact today):**
- `base-uri 'none'` — blocks a `<base>` tag hijacking relative `/static/js/app.js`.
- `object-src 'none'` — no plugins.
- `form-action 'self'` — a form can't POST credentials off-origin if an XSS is ever found.

**HSTS — emitted only on real HTTPS:**
- `Strict-Transport-Security: max-age=63072000; includeSubDomains` when the request scheme is https, or `X-Forwarded-Proto: https` **when `CASHPILOT_TRUSTED_PROXY` is set**. Plain-HTTP local dev is never pinned (which would hard-break it), and an untrusted/spoofable header can't trigger it.

**Session cookie `Secure` in `auto` mode:**
- Previously `Secure` only turned on when `CASHPILOT_BASE_URL` started with `https`. On the documented Caddy topology, TLS terminates at the proxy and operators configure the domain *in Caddy*, so `CASHPILOT_BASE_URL` is unset → the 30-day session cookie shipped **non-Secure** over the proxy hop (LAN/MITM interceptable → owner takeover). Now `auto` also turns `Secure` on when `X-Forwarded-Proto: https` behind a trusted proxy. `set_session_cookie` gains an **optional** `request` arg (backward-compatible — callers without it keep the old behavior).

## Tests
New coverage: the three CSP directives; HSTS present/absent by scheme + proxy-trust; cookie `Secure` on/off by `X-Forwarded-Proto` + trust; explicit-override + no-request backward-compat. Full suite **1179 green**, ruff clean.

## Not in scope (tracked)
- Dropping `script-src 'unsafe-inline'` (nonce/delegation) → bead `guw`.
- CSRF Origin-check + POST `/logout` → follow-up (SameSite=Lax + no-CORS already mitigate today).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved session-cookie security when the application runs behind a trusted HTTPS reverse proxy.
  * Added stricter browser security policies, including stronger protection against framing, unsafe form submissions, and unwanted content sources.
  * Improved HSTS behavior so HTTPS enforcement correctly reflects trusted proxy configuration.

* **Bug Fixes**
  * Fixed authentication and registration flows to consistently apply secure session-cookie settings.
  * Preserved existing behavior for deployments that do not use proxy forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->