### PR TITLE
refactor(ui): extract shared action-button icon constants (CashPilot-cyc)

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -425,6 +425,12 @@ const CP = (() => {
     }
   }
 
+  // Action-button icons, extracted so the single-instance row and the per-node sub-row
+  // share one copy each (cyc componentization). Byte-identical to the inline SVGs replaced.
+  const ICON_RESTART = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>';
+  const ICON_STOP = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>';
+  const ICON_LOGS = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>';
+
   function renderServiceRow(svc, bk) {
     const isExternal = svc.container_status === 'external';
     const statusClass = isExternal ? 'external' : (svc.container_status || 'stopped').toLowerCase();
@@ -569,13 +575,13 @@ const CP = (() => {
           ${settingsBtn}
           ${_canWrite ? `
           <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart"${disabledAttr}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+            ${ICON_RESTART}
           </button>
           <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop"${disabledAttr}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
+            ${ICON_STOP}
           </button>
           <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs"${disabledAttr}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+            ${ICON_LOGS}
           </button>` : ''}
         </div>`;
     }
@@ -623,13 +629,13 @@ const CP = (() => {
             <div class="action-btns">
               ${_canWrite ? `
               <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart on ${nodeLabel}"${disabledAttr}>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                ${ICON_RESTART}
               </button>
               <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop on ${nodeLabel}"${disabledAttr}>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
+                ${ICON_STOP}
               </button>
               <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs on ${nodeLabel}"${disabledAttr}>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                ${ICON_LOGS}
               </button>` : ''}
             </div>
           </td>


### PR DESCRIPTION
First safe step of the `cyc` builder componentization, now that browser verification is unblocked.

## What
`renderServiceRow` duplicated the restart/stop/logs SVG icons verbatim — 6 copies (3 icons × single-instance row + per-node sub-row). Extracted to `ICON_RESTART`/`ICON_STOP`/`ICON_LOGS` module consts.

## Why it's provably safe
Per the migration review, "byte-identical" is only guaranteed at the **DOM** level. Verified three ways:
1. **DOM golden-master** — rendered the multi-instance row + expanded per-node sub-rows (via a mocked running service in a headless Chromium harness), dumped the table `innerHTML` before and after: **byte-identical (10346 bytes, zero diff)**.
2. `node --check` clean; the `CP` export surface is unchanged.
3. Playwright harness: the row + all action buttons (stop/restart/logs ×2, credential, expand) render and the expand toggle works, with **0 console/page errors**.

## Scope
Just the icon consts (the truly-identical, single-line strings — zero indentation risk). The env-field / worker-checkbox helpers (which live in the wizard + detail views and differ by indentation/class) follow as separate golden-master-verified PRs, ahead of the `guw` CSP work.

Part of bead CashPilot-cyc.