### PR TITLE
fix: refuse deploying broken/dropped services, not just dead (CashPilot-rp3)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -587,6 +587,14 @@ def _collector_needs_setup(slug: str, config: dict[str, str]) -> bool:
     return False
 
 
+# Catalog statuses a service must never be deployed with. Shared by the catalog
+# listing (which hides them) and the deploy gate (which refuses them) so the two
+# can't drift apart again — previously the listing hid all three but deploy only
+# refused "dead", so a direct link or a stale page could still deploy a broken or
+# dropped service and then silently earn nothing.
+_UNDEPLOYABLE_STATUSES = frozenset({"broken", "dead", "dropped"})
+
+
 def _split_image(ref: str) -> tuple[str, str, str]:
     """Split a Docker image reference into (repository, tag, digest)."""
     digest = ""
@@ -803,7 +811,7 @@ async def api_services_available(request: Request) -> list[dict[str, Any]]:
 
     available = []
     for svc in services:
-        if svc.get("status") in ("broken", "dead", "dropped"):
+        if svc.get("status") in _UNDEPLOYABLE_STATUSES:
             continue  # Known non-functional — hide completely
         docker_conf = svc.get("docker", {})
         has_image = bool(docker_conf and docker_conf.get("image"))
@@ -868,8 +876,15 @@ async def api_deploy(request: Request, slug: str, body: DeployRequest, worker_id
     svc = catalog.get_service(slug)
     if not svc:
         raise HTTPException(status_code=404, detail=f"Service '{slug}' not found")
-    if svc.get("status") == "dead":
-        raise HTTPException(status_code=410, detail=f"Service '{slug}' is no longer available (dead/discontinued)")
+    status = svc.get("status")
+    if status in _UNDEPLOYABLE_STATUSES:
+        # 410 for a service that is permanently gone, 409 for one that is merely
+        # broken right now and may come back. Both are hidden from the catalog
+        # listing, so reaching here means a direct link, a stale page or an API client.
+        raise HTTPException(
+            status_code=409 if status == "broken" else 410,
+            detail=f"Service '{slug}' is no longer available for deployment ({status})",
+        )
 
     docker_conf = svc.get("docker", {})
     image = docker_conf.get("image")

--- a/app/main.py
+++ b/app/main.py
@@ -1858,6 +1858,16 @@ async def api_worker_command(request: Request, worker_id: int, body: WorkerComma
         _require_writer(request)
 
     if body.command == "deploy":
+        # This is a THIRD deploy path. Without the same status gate, a broken or
+        # dropped service could still be deployed here — and this route then runs the
+        # full bookkeeping below, so it would look deployed while earning nothing.
+        # An unknown slug is left alone: this raw route is not catalog-only.
+        deploy_status = (catalog.get_service(body.slug) or {}).get("status")
+        if deploy_status in _UNDEPLOYABLE_STATUSES:
+            raise HTTPException(
+                status_code=409 if deploy_status == "broken" else 410,
+                detail=f"Service '{body.slug}' is no longer available for deployment ({deploy_status})",
+            )
         result = await _proxy_to_worker(worker_id, "POST", f"/api/containers/{body.slug}/deploy", json=body.spec)
     elif body.command in ("stop", "restart", "start"):
         result = await _proxy_to_worker(worker_id, "POST", f"/api/containers/{body.slug}/{body.command}")

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -152,6 +152,30 @@ class TestApiDeploy:
             assert resp.status_code == 410
             assert "no longer available" in resp.json()["detail"]
 
+    def test_deploy_broken_service_refused(self, client):
+        # The catalog listing already hides broken services; the deploy gate used to
+        # let them through, so a direct link or stale page could still deploy one.
+        svc = {"slug": "speedshare", "name": "SpeedShare", "status": "broken", "docker": {"image": "x"}}
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[_online_worker()]),
+            patch("app.main.catalog.get_service", return_value=svc),
+        ):
+            resp = client.post("/api/deploy/speedshare", json={})
+            assert resp.status_code == 409  # broken may come back; not "gone"
+            assert "broken" in resp.json()["detail"]
+
+    def test_deploy_dropped_service_refused(self, client):
+        svc = {"slug": "gone", "name": "Gone", "status": "dropped", "docker": {"image": "x"}}
+        with (
+            _auth_owner(),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[_online_worker()]),
+            patch("app.main.catalog.get_service", return_value=svc),
+        ):
+            resp = client.post("/api/deploy/gone", json={})
+            assert resp.status_code == 410
+            assert "dropped" in resp.json()["detail"]
+
     def test_deploy_no_auth(self, client):
         with _no_auth():
             resp = client.post("/api/deploy/honeygain", json={})

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -690,6 +690,10 @@ class TestWorkerCommand:
         ):
             resp = client.post("/api/workers/1/command", json={"command": "stop", "slug": "speedshare"})
             assert resp.status_code == 200
+        # A 200 alone would also pass if the route silently did nothing, so assert
+        # the stop actually reached the worker at the right path.
+        assert mock_client.post.call_count == 1
+        assert mock_client.post.call_args.args[0].endswith("/api/containers/speedshare/stop")
 
     def test_command_unknown(self, client):
         worker, mock_client = self._setup()

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -651,6 +651,46 @@ class TestWorkerCommand:
             assert resp.status_code == 200
             health_evt.assert_awaited_once()
 
+    def test_command_deploy_refuses_broken_service(self, client):
+        """The raw worker-command route is a THIRD deploy path.
+
+        It proxies straight to the worker and then runs the full bookkeeping, so
+        without the same status gate a broken service would look deployed while
+        earning nothing — the exact drift the shared constant exists to prevent.
+        """
+        worker, mock_client = self._setup()
+        svc = {"slug": "speedshare", "name": "SpeedShare", "status": "broken", "docker": {"image": "x"}}
+        with (
+            _auth_owner(),
+            patch("app.main.catalog.get_service", return_value=svc),
+            patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
+            patch("app.main.httpx.AsyncClient", return_value=mock_client),
+            patch("app.main.FLEET_API_KEY", "test-key"),
+        ):
+            resp = client.post(
+                "/api/workers/1/command",
+                json={"command": "deploy", "slug": "speedshare", "spec": {"image": "x"}},
+            )
+            assert resp.status_code == 409
+        # Refused before the worker was ever contacted.
+        mock_client.post.assert_not_called()
+
+    def test_command_stop_still_allowed_for_broken_service(self, client):
+        # You must still be able to STOP a running service that has since been
+        # marked broken — only deploy is gated.
+        worker, mock_client = self._setup()
+        svc = {"slug": "speedshare", "name": "SpeedShare", "status": "broken", "docker": {"image": "x"}}
+        with (
+            _auth_writer(),
+            patch("app.main.catalog.get_service", return_value=svc),
+            patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
+            patch("app.main.httpx.AsyncClient", return_value=mock_client),
+            patch("app.main.FLEET_API_KEY", "test-key"),
+        ):
+            resp = client.post("/api/workers/1/command", json={"command": "stop", "slug": "speedshare"})
+            assert resp.status_code == 200
+
     def test_command_unknown(self, client):
         worker, mock_client = self._setup()
         with (


### PR DESCRIPTION
The catalog listing (`/api/services/available`) hides services with status `broken`, `dead` or `dropped`, but the deploy gate only refused `dead`. A direct link, a stale page or an API client could therefore still deploy a service the catalog already knows is non-functional — which then silently earns nothing and becomes a support issue.

**Fix:** both paths now share one `_UNDEPLOYABLE_STATUSES` constant, so they cannot drift apart again. `broken` returns **409** (may come back), `dead`/`dropped` return **410** (gone). The existing "no longer available" wording is preserved.

**Tests:** new cases for broken (409) and dropped (410); the existing dead-service test is unchanged. Full suite **1182 passing**, ruff + format clean.

Closes bead CashPilot-rp3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved service availability filtering to exclude services that cannot be deployed.
  - Deployment requests now provide status-specific responses for broken, dead, and dropped services.

- **Bug Fixes**
  - Prevented deployment attempts for broken and dropped services, ensuring unavailable services are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->