### PR TITLE
fix: let operators opt specific volume roots past the block (CashPilot-52w)

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -420,6 +420,31 @@ _BLOCKED_VOLUME_ROOTS = {
 }
 
 
+# System roots that may never be opened up, at ANY depth. An allowlist entry under
+# one of these would hand a third-party container the Docker socket (/run,
+# /var/run), the host's secrets (/etc, /root) or its devices (/dev) — so unlike the
+# data roots below, no subdirectory of these is ever acceptable.
+_NEVER_ALLOWLISTABLE = (
+    "/etc",
+    "/root",
+    "/proc",
+    "/sys",
+    "/dev",
+    "/boot",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/run",
+    "/var",  # covers /var/run (docker.sock) and /var/lib/docker
+)
+
+# How many path components an entry must have below the blocked root it sits under.
+# 2 means /mnt/user/storj is allowed but /mnt/user — the whole Unraid array — is not.
+_MIN_DEPTH_BELOW_ROOT = 2
+
+
 def _parse_allowed_volume_roots(raw: str) -> frozenset[str]:
     """Parse CASHPILOT_ALLOWED_VOLUME_ROOTS into a set of opted-in real paths.
 
@@ -429,22 +454,65 @@ def _parse_allowed_volume_roots(raw: str) -> frozenset[str]:
     the worker on the platform most users run, pushing them to bypass CashPilot
     entirely (strictly worse for security than a scoped exception).
 
-    Deny-by-default is unchanged; the operator must name the exact directories they
-    accept, colon-separated, e.g. CASHPILOT_ALLOWED_VOLUME_ROOTS=/mnt/user/storj.
-    An entry that IS a blocked root (or "/") is refused, so only a specific
-    subdirectory can ever be opted in — this can never re-expose /var/run/docker.sock,
-    /etc or a whole array through a careless value.
+    Deny-by-default is unchanged, and an entry must clear BOTH gates:
+
+    * it may not resolve under a system root (``_NEVER_ALLOWLISTABLE``) at any depth,
+      so /run/docker.sock, /var/lib/docker/... and /etc/shadow are refused; and
+    * it must sit at least ``_MIN_DEPTH_BELOW_ROOT`` components below the blocked
+      root it belongs to, so /mnt/user/storj is accepted but /mnt and /mnt/user
+      (the entire array) are not.
+
+    RESIDUAL RISK, stated plainly rather than papered over: this worker resolves
+    paths in its OWN mount namespace and cannot see the host filesystem, so a
+    symlink created *inside* an allowlisted directory by the service that owns it
+    resolves differently here than in the Docker daemon. Only allowlist a directory
+    whose contents you are willing to treat as trusted.
     """
     allowed: set[str] = set()
     for entry in raw.split(":"):
         entry = entry.strip()
         if not entry:
             continue
+        if not entry.startswith("/"):
+            logger.warning(
+                "Ignoring CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: must be an absolute path",
+                entry,
+            )
+            continue
+        # Check the resolved path AND the lexical one: resolving can move a path out
+        # of a blocked prefix (on macOS /etc -> /private/etc), and a system path must
+        # be refused under either spelling rather than relying on one platform's
+        # symlink layout.
         real = os.path.realpath(entry)
+        lexical = os.path.normpath(entry)
+        if any(
+            candidate == sys_root or candidate.startswith(sys_root + "/")
+            for candidate in (real, lexical)
+            for sys_root in _NEVER_ALLOWLISTABLE
+        ):
+            logger.warning(
+                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: %s is a system path "
+                "and can never be opted in",
+                entry,
+                real,
+            )
+            continue
         if real == "/" or real in _BLOCKED_VOLUME_ROOTS:
             logger.warning(
-                "Ignoring CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: allow a specific "
-                "subdirectory (e.g. /mnt/user/storj), not a whole system root",
+                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: that is a whole root, "
+                "not a service directory",
+                entry,
+            )
+            continue
+        depth_ok = True  # not under any blocked root -> the deny list never applied anyway
+        for blocked in _BLOCKED_VOLUME_ROOTS:
+            if blocked != "/" and real.startswith(blocked + "/"):
+                depth_ok = real[len(blocked) + 1 :].count("/") >= _MIN_DEPTH_BELOW_ROOT - 1
+                break
+        if not depth_ok:
+            logger.warning(
+                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: name a specific service "
+                "directory (e.g. /mnt/user/storj), not a whole root like /mnt or /mnt/user",
                 entry,
             )
             continue

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -418,6 +418,41 @@ _BLOCKED_VOLUME_ROOTS = {
     "/data",  # per-container app data roots, incl. this worker's own /data
     "/tmp",
 }
+
+def _parse_allowed_volume_roots(raw: str) -> frozenset[str]:
+    """Parse CASHPILOT_ALLOWED_VOLUME_ROOTS into a set of opted-in real paths.
+
+    Escape hatch for the blocked roots above. Some legitimate service volumes live
+    under one: Storj needs a large data directory, and on Unraid the only such path
+    is under /mnt/user/... — so a blanket /mnt deny made Storj undeployable through
+    the worker on the platform most users run, pushing them to bypass CashPilot
+    entirely (strictly worse for security than a scoped exception).
+
+    Deny-by-default is unchanged; the operator must name the exact directories they
+    accept, colon-separated, e.g. CASHPILOT_ALLOWED_VOLUME_ROOTS=/mnt/user/storj.
+    An entry that IS a blocked root (or "/") is refused, so only a specific
+    subdirectory can ever be opted in — this can never re-expose /var/run/docker.sock,
+    /etc or a whole array through a careless value.
+    """
+    allowed: set[str] = set()
+    for entry in raw.split(":"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        real = os.path.realpath(entry)
+        if real == "/" or real in _BLOCKED_VOLUME_ROOTS:
+            logger.warning(
+                "Ignoring CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: allow a specific "
+                "subdirectory (e.g. /mnt/user/storj), not a whole system root",
+                entry,
+            )
+            continue
+        allowed.add(real)
+    return frozenset(allowed)
+
+
+_ALLOWED_VOLUME_ROOTS = _parse_allowed_volume_roots(os.getenv("CASHPILOT_ALLOWED_VOLUME_ROOTS", ""))
+
 # Docker memory size syntax: a positive integer with an optional b/k/m/g unit.
 _MEM_LIMIT_RE = re.compile(r"^\d+[bkmgBKMG]?$")
 
@@ -467,6 +502,8 @@ def _validate_deploy_spec(spec: DeploySpec, slug: str | None = None) -> None:
         if not source.startswith("/"):
             continue  # named volume (e.g. "mysterium-data") — always allowed
         real = os.path.realpath(source)
+        if any(real == root or real.startswith(root + "/") for root in _ALLOWED_VOLUME_ROOTS):
+            continue  # explicitly opted in by the operator (see _parse_allowed_volume_roots)
         for blocked in _BLOCKED_VOLUME_ROOTS:
             if real == blocked or real.startswith(blocked + "/"):
                 raise HTTPException(status_code=403, detail=f"Volume mount '{source}' is blocked")

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -419,6 +419,7 @@ _BLOCKED_VOLUME_ROOTS = {
     "/tmp",
 }
 
+
 def _parse_allowed_volume_roots(raw: str) -> frozenset[str]:
     """Parse CASHPILOT_ALLOWED_VOLUME_ROOTS into a set of opted-in real paths.
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -491,16 +491,14 @@ def _parse_allowed_volume_roots(raw: str) -> frozenset[str]:
             for sys_root in _NEVER_ALLOWLISTABLE
         ):
             logger.warning(
-                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: %s is a system path "
-                "and can never be opted in",
+                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: %s is a system path and can never be opted in",
                 entry,
                 real,
             )
             continue
         if real == "/" or real in _BLOCKED_VOLUME_ROOTS:
             logger.warning(
-                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: that is a whole root, "
-                "not a service directory",
+                "Refusing CASHPILOT_ALLOWED_VOLUME_ROOTS entry %r: that is a whole root, not a service directory",
                 entry,
             )
             continue

--- a/docs/AUTOPILOT-WORKLOG.md
+++ b/docs/AUTOPILOT-WORKLOG.md
@@ -33,3 +33,40 @@ Append-only. Newest at the bottom. Every "done" needs evidence (test/CI/commit).
 - US-007: **PR #101 opened** (feat(fleet)!: → v1.0.0), NOT merged (awaits Sergio).
 - Evidence: full pytest **1099 passed**; ruff check+format clean; branch pushed.
 - All 7 PRD stories passes:true. Waiting on #101 CI + CodeRabbit before cancel.
+
+### 2026-07-18 — Bead grind (ralph): security/CI tier shipped, 5wi+ng1 in flight
+- **Merged + released** (v1.0.4→v1.1.x): jia (compose loopback bind), drz (SSRF IP-pin),
+  2zx (metrics bearer token + register race), 4s2 (dead code), 7br (CI SHA-pins + HEALTHCHECK),
+  apm (bcrypt off-loop + earnings index + metrics cardinality), cm6 (coverage floor 90% +
+  fixed CI silently skipping 196 Docker-SDK tests), keb (stricter catalog loader validation).
+- **5wi (PR #117, green, pending CodeRabbit):** detect deployed-image vs catalog-image drift;
+  `_split_image`/`_image_outdated` helpers + `image_outdated` on /api/services/deployed +
+  "update available" badge. TestImageDrift (2). Full suite green.
+- **ng1 (PR #118, green, pending CodeRabbit):** stable worker `client_id` in /data/.worker_id
+  instead of mutable hostname (fixes hostname-collision 401 + rename lockout). Migration
+  preserves an already-enrolled worker's WORKER_NAME identity (else new-UUID → permanent 401).
+  TestClientId (6). Full suite **1168 passed**; ruff clean.
+- CodeRabbit rate-limited all day (PR volume); #117/#118 held green-and-open until its rolling
+  window reopens, then review → merge. NOT bypassing the review gate.
+- **In progress:** 1k5 (main.py god-module refactor + api_worker_command earnings bookkeeping
+  bug) — architect mapping the behavior-preserving plan. Remaining: 1k5, cyc, guw (web) +
+  desktop kca/rrb/ada.
+
+### 2026-07-18 — Bead grind COMPLETE (all safely-verifiable work shipped)
+- **Fully closed + released (14 beads):** web jia/drz/2zx/4s2/7br/apm/cm6/keb/5wi/ng1/1k5
+  (v1.0.4→v1.3.1) + desktop kca/rrb/ada. All merged, CodeRabbit-reviewed, CI-green, released.
+- **1k5** (main.py god-module): fixed the real api_worker_command earnings-bookkeeping bug
+  ($0-forever deploys) + consolidated the 4 worker-proxy blocks / lifecycle trio / entry-meta.
+- **rrb** (desktop): auto-tag.yml (conventional-commit → tag → reusable desktop-release) +
+  build-time version stamping; validated end-to-end (fired on ada's merge).
+- **Partial (open, PRs shipped):**
+  - cyc → PR #120: deploy-flow dedup + the deployServiceToWorkers bug (silent failures + no
+    validation) fixed. REMAINING: HTML-builder componentization + inline-onclick removal.
+  - sux → PR #121: SSRF guard extracted to app/worker_proxy.py (main.py -160L, no new cycle).
+    REMAINING: benign main→routers→main cycle (intentionally left; ~40-seam churn, zero value).
+- **Blocked (need a browser):** cyc componentization + guw (CSP/unsafe-inline). Both change
+  rendered markup / every handler on a LIVE revenue product; the Chrome extension is not
+  connected in this env, so they can't be verified — deferred to a browser-enabled session.
+- Verification: every PR full-suite green (web 1172 pytest; desktop go test -race) + ruff/gofmt
+  + CodeRabbit reviewed. Frontend (cyc) verified statically (node --check + analysis) as browser
+  was unavailable.

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -28,3 +28,6 @@ Keep the shared `CASHPILOT_API_KEY` as the **enrollment/bootstrap** credential o
 - CI runs BOTH `ruff check` and `ruff format --check` — run `ruff format` before every commit.
 - Never manually create tags — the release workflow bumps + tags on push to main.
 - Full `pytest` must stay green.
+
+## 2026-07-18 — continuation
+Test yourself in this mac whatever you need, /research! what to improve, what to unblock... /sergio-loop with ralph then

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -158,7 +158,15 @@ environment:
   - CASHPILOT_ALLOWED_VOLUME_ROOTS=/mnt/user/storj
 ```
 
-Only specific subdirectories can be opted in: an entry that is itself a whole system root (`/`, `/mnt`, `/var/run`, ...) is ignored with a warning, so a careless value can never re-expose the Docker socket or an entire array. Multiple paths are colon-separated.
+Multiple paths are colon-separated. An entry must clear two gates:
+
+- **Never a system path.** Anything resolving under `/etc`, `/root`, `/proc`, `/sys`, `/dev`, `/boot`, `/usr`, `/bin`, `/sbin`, `/lib`, `/run` or `/var` is refused **at any depth** — so `/run/docker.sock`, `/var/lib/docker/...` and `/etc/shadow` cannot be opted in.
+- **Specific enough to be a service directory.** It must sit at least two components below the root it belongs to, so `/mnt/user/storj` is accepted while `/mnt` and `/mnt/user` (the entire Unraid array) are not.
+
+Relative paths are refused, and refusals are logged with the reason.
+
+!!! warning "Residual risk — allowlist only directories you trust"
+    The worker resolves paths in its **own** mount namespace and cannot see the host filesystem, so a symlink created *inside* an allowlisted directory by the service that owns it resolves differently here than in the Docker daemon. Only allowlist a directory whose contents you are willing to treat as trusted, and prefer a dedicated path (`/mnt/user/storj`) over a shared one.
 
 ### Worker URL Validation
 

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -145,6 +145,20 @@ If a worker goes offline (no heartbeat for 180 seconds):
 | `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker in the fleet dashboard |
 | `CASHPILOT_WORKER_URL` | No | *(auto-detected)* | URL the UI uses to reach this worker. Set explicitly for remote/cross-host workers -- auto-detection can report an unreachable address |
 | `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
+| `CASHPILOT_ALLOWED_VOLUME_ROOTS` | No | *(none)* | Colon-separated host directories this worker may bind-mount despite sitting under a blocked system root -- see [Volume mounts](#volume-mounts) |
+
+### Volume mounts
+
+A worker refuses to bind-mount host paths under system roots such as `/`, `/etc`, `/var/run` (which covers the Docker socket), `/var/lib/docker` and `/mnt`, so a fleet-key holder cannot mount the host filesystem or a co-located app's secrets into a service container.
+
+A few services legitimately need a directory under one of those roots -- most notably **Storj**, which wants a large data directory, and on Unraid the only such path is under `/mnt/user/...`. Opt in exactly that directory:
+
+```yaml
+environment:
+  - CASHPILOT_ALLOWED_VOLUME_ROOTS=/mnt/user/storj
+```
+
+Only specific subdirectories can be opted in: an entry that is itself a whole system root (`/`, `/mnt`, `/var/run`, ...) is ignored with a warning, so a careless value can never re-expose the Docker socket or an entire array. Multiple paths are colon-separated.
 
 ### Worker URL Validation
 

--- a/tests/test_worker_api_coverage.py
+++ b/tests/test_worker_api_coverage.py
@@ -219,6 +219,54 @@ class TestValidateDeploySpecRejections:
         spec = DeploySpec(image="x", volumes={"/storage/honeygain": {"bind": "/data", "mode": "rw"}})
         _validate_deploy_spec(spec)  # must not raise
 
+    def test_operator_allowlisted_subdir_permitted(self):
+        # The Storj-on-Unraid case: /mnt is blocked wholesale, but the operator can
+        # opt in the one directory Storj actually needs.
+        spec = DeploySpec(image="x", volumes={"/mnt/user/storj/data": {"bind": "/app/config", "mode": "rw"}})
+        with (
+            patch("app.worker_api.os.path.realpath", side_effect=lambda p: p),
+            patch("app.worker_api._ALLOWED_VOLUME_ROOTS", frozenset({"/mnt/user/storj"})),
+        ):
+            _validate_deploy_spec(spec)  # must not raise
+
+    def test_allowlist_does_not_leak_to_sibling_paths(self):
+        # Opting in /mnt/user/storj must NOT unblock the rest of the array.
+        spec = DeploySpec(image="x", volumes={"/mnt/user/appdata/some-other-app": {"bind": "/x", "mode": "ro"}})
+        with (
+            patch("app.worker_api.os.path.realpath", side_effect=lambda p: p),
+            patch("app.worker_api._ALLOWED_VOLUME_ROOTS", frozenset({"/mnt/user/storj"})),
+            pytest.raises(HTTPException) as ei,
+        ):
+            _validate_deploy_spec(spec)
+        assert ei.value.status_code == 403
+
+    def test_allowlist_prefix_is_path_aware(self):
+        # /mnt/user/storj must not accidentally allow /mnt/user/storjevil.
+        spec = DeploySpec(image="x", volumes={"/mnt/user/storjevil": {"bind": "/x", "mode": "ro"}})
+        with (
+            patch("app.worker_api.os.path.realpath", side_effect=lambda p: p),
+            patch("app.worker_api._ALLOWED_VOLUME_ROOTS", frozenset({"/mnt/user/storj"})),
+            pytest.raises(HTTPException) as ei,
+        ):
+            _validate_deploy_spec(spec)
+        assert ei.value.status_code == 403
+
+    @pytest.mark.parametrize("entry", ["/", "/mnt", "/var/run", "/etc", "/data"])
+    def test_allowlist_refuses_whole_system_roots(self, entry):
+        # Only a specific subdirectory may be opted in, so a careless value can never
+        # re-expose docker.sock, /etc or an entire array.
+        from app.worker_api import _parse_allowed_volume_roots
+
+        with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
+            assert _parse_allowed_volume_roots(entry) == frozenset()
+
+    def test_allowlist_parses_multiple_entries(self):
+        from app.worker_api import _parse_allowed_volume_roots
+
+        with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
+            parsed = _parse_allowed_volume_roots("/mnt/user/storj: /srv/data :")
+        assert parsed == frozenset({"/mnt/user/storj", "/srv/data"})
+
 
 # ---------------------------------------------------------------------------
 # Container command endpoints — success + docker-error paths

--- a/tests/test_worker_api_coverage.py
+++ b/tests/test_worker_api_coverage.py
@@ -251,21 +251,67 @@ class TestValidateDeploySpecRejections:
             _validate_deploy_spec(spec)
         assert ei.value.status_code == 403
 
-    @pytest.mark.parametrize("entry", ["/", "/mnt", "/var/run", "/etc", "/data"])
+    @pytest.mark.parametrize("entry", ["/", "/mnt", "/var/run", "/etc", "/data", "/tmp", "/opt"])
     def test_allowlist_refuses_whole_system_roots(self, entry):
-        # Only a specific subdirectory may be opted in, so a careless value can never
-        # re-expose docker.sock, /etc or an entire array.
         from app.worker_api import _parse_allowed_volume_roots
 
         with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
             assert _parse_allowed_volume_roots(entry) == frozenset()
 
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "/run/docker.sock",  # the Docker socket == host root
+            "/var/run/docker.sock",
+            "/var/lib/docker/volumes",
+            "/etc/shadow",
+            "/root/.ssh",
+            "/dev/sda",
+            "/proc/self",
+            "/usr/bin",
+        ],
+    )
+    def test_allowlist_refuses_system_paths_at_any_depth(self, entry):
+        """A CHILD of a blocked root must not sneak past the guard.
+
+        Regression: the first version tested exact membership only, so
+        `/run/docker.sock` was accepted (only `/run` was in the blocked set) and a
+        deploy mounting `/var/run/docker.sock` then matched the allowlist and skipped
+        the deny list entirely — handing a third-party container host root.
+        """
+        from app.worker_api import _parse_allowed_volume_roots
+
+        with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
+            assert _parse_allowed_volume_roots(entry) == frozenset()
+
+    @pytest.mark.parametrize("entry", ["/mnt/user", "/mnt/disks", "/data/x"])
+    def test_allowlist_refuses_paths_too_shallow_to_be_a_service_dir(self, entry):
+        # /mnt/user IS the whole Unraid array — too broad to be a "specific directory".
+        from app.worker_api import _parse_allowed_volume_roots
+
+        with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
+            assert _parse_allowed_volume_roots(entry) == frozenset()
+
+    @pytest.mark.parametrize("entry", ["/mnt/user/storj", "/mnt/disks/ssd/storj", "/srv/data/storj"])
+    def test_allowlist_accepts_a_specific_service_directory(self, entry):
+        from app.worker_api import _parse_allowed_volume_roots
+
+        with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
+            assert _parse_allowed_volume_roots(entry) == frozenset({entry})
+
+    def test_allowlist_refuses_relative_entries(self):
+        # The natural missing-leading-slash typo would otherwise anchor to the
+        # worker's CWD and be accepted silently.
+        from app.worker_api import _parse_allowed_volume_roots
+
+        assert _parse_allowed_volume_roots("mnt/user/storj") == frozenset()
+
     def test_allowlist_parses_multiple_entries(self):
         from app.worker_api import _parse_allowed_volume_roots
 
         with patch("app.worker_api.os.path.realpath", side_effect=lambda p: p):
-            parsed = _parse_allowed_volume_roots("/mnt/user/storj: /srv/data :")
-        assert parsed == frozenset({"/mnt/user/storj", "/srv/data"})
+            parsed = _parse_allowed_volume_roots("/mnt/user/storj: /srv/data/storj :")
+        assert parsed == frozenset({"/mnt/user/storj", "/srv/data/storj"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

The worker refuses bind mounts under system roots — including `/mnt`, to stop a fleet-key holder mounting a co-located app's secrets off the Unraid array. But **Storj** needs a large data directory, and on Unraid the only such path is `/mnt/user/...`, so its deploy 403s: **Storj is undeployable through the worker on the platform most CashPilot users run**. The practical effect is users deploying it by hand outside CashPilot, which is strictly worse for security than a scoped exception.

## The fix

Deny-by-default is unchanged. `CASHPILOT_ALLOWED_VOLUME_ROOTS` lets the operator name the exact directories they accept, colon-separated:

```
CASHPILOT_ALLOWED_VOLUME_ROOTS=/mnt/user/storj
```

**Only a specific subdirectory can be opted in.** An entry that is itself a whole system root (`/`, `/mnt`, `/var/run`, `/etc`, ...) is ignored with a warning, so a careless value can never re-expose `/var/run/docker.sock`, `/etc` or an entire array. Prefix matching is path-aware, so `/mnt/user/storj` does not allow `/mnt/user/storjevil`.

## Tests

9 new cases: the allowlisted subdir passes; siblings on the array stay blocked; the `storjevil` prefix trap; each whole-system-root entry is refused (parametrised); multi-entry parsing. Full suite **1189 passing**, ruff clean. Documented in `docs/fleet.md`.

Closes bead CashPilot-52w.