### PR TITLE
fix: record the FX rate with each earnings reading (CashPilot-rrr)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -106,11 +106,11 @@ CREATE TABLE IF NOT EXISTS earnings (
     balance    REAL    NOT NULL,
     currency   TEXT    NOT NULL DEFAULT 'USD',
     date       TEXT    NOT NULL,
-    -- Currency -> USD rate at the moment this reading was taken. Rates are only
-    -- cached live, so without storing it here the historical value of a non-USD
-    -- balance (MYST, GRASS, ...) cannot be reconstructed later at any accuracy —
-    -- which is what a net-profit or tax export needs. NULL for USD or when the
-    -- rate was unavailable.
+    -- USD per 1 unit of `currency` when this reading was taken (so USD rows store
+    -- 1.0). Rates are only cached live, so without storing it here the historical
+    -- value of a non-USD balance (MYST, GRASS, ...) cannot be reconstructed later at
+    -- any accuracy — which is what a net-profit or tax export needs. NULL only when
+    -- the rate was genuinely unavailable, never a guess.
     fx_rate_usd REAL,
     created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 );
@@ -404,9 +404,19 @@ async def upsert_earnings(
             ON CONFLICT(platform, date) DO UPDATE SET
                 balance = excluded.balance,
                 currency = excluded.currency,
-                fx_rate_usd = excluded.fx_rate_usd,
+                -- COALESCE, not a plain assignment: if the rate lookup failed this
+                -- cycle (provider outage after a restart cleared the cache) the new
+                -- value is NULL, and overwriting a known-good rate with it would
+                -- destroy the very data this column exists to preserve.
+                fx_rate_usd = COALESCE(excluded.fx_rate_usd, earnings.fx_rate_usd),
                 created_at = datetime('now')
+            -- The balance guard preserves created_at when nothing changed, but it also
+            -- meant a row already stored with a NULL rate (written pre-upgrade, or when
+            -- the rate was briefly unavailable) could never be back-filled: for a
+            -- service whose balance moves once a day, every later run in that day was
+            -- skipped entirely. Allow the update through in that one case.
             WHERE earnings.balance != excluded.balance
+               OR earnings.fx_rate_usd IS NULL
             """,
             (platform, balance, currency, date, fx_rate_usd),
         )

--- a/app/database.py
+++ b/app/database.py
@@ -106,6 +106,12 @@ CREATE TABLE IF NOT EXISTS earnings (
     balance    REAL    NOT NULL,
     currency   TEXT    NOT NULL DEFAULT 'USD',
     date       TEXT    NOT NULL,
+    -- Currency -> USD rate at the moment this reading was taken. Rates are only
+    -- cached live, so without storing it here the historical value of a non-USD
+    -- balance (MYST, GRASS, ...) cannot be reconstructed later at any accuracy —
+    -- which is what a net-profit or tax export needs. NULL for USD or when the
+    -- rate was unavailable.
+    fx_rate_usd REAL,
     created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -351,6 +357,13 @@ async def init_db() -> None:
         if "key_confirmed" not in cols:
             await db.execute("ALTER TABLE workers ADD COLUMN key_confirmed INTEGER NOT NULL DEFAULT 0")
 
+        # Migrate earnings table: add fx_rate_usd so a non-USD balance's value at the
+        # time it was recorded stays reconstructable (rates are only cached live).
+        cursor = await db.execute("PRAGMA table_info(earnings)")
+        earnings_cols = {row["name"] for row in await cursor.fetchall()}
+        if "fx_rate_usd" not in earnings_cols:
+            await db.execute("ALTER TABLE earnings ADD COLUMN fx_rate_usd REAL")
+
         # Migrate users table: add password_changed_at for session invalidation
         cursor = await db.execute("PRAGMA table_info(users)")
         user_cols = {row["name"] for row in await cursor.fetchall()}
@@ -370,8 +383,14 @@ async def upsert_earnings(
     balance: float,
     currency: str = "USD",
     date: str | None = None,
+    fx_rate_usd: float | None = None,
 ) -> None:
-    """Insert or update an earnings record for a platform + date."""
+    """Insert or update an earnings record for a platform + date.
+
+    ``fx_rate_usd`` is the currency -> USD rate at collection time. It is stored
+    alongside the balance because exchange rates are only cached live: without it,
+    the USD value of a historical non-USD reading cannot be reconstructed later.
+    """
     date = date or datetime.now(UTC).strftime("%Y-%m-%d")
     db = await _get_db()
     try:
@@ -380,15 +399,16 @@ async def upsert_earnings(
         # WHERE guard preserves created_at when the balance is unchanged.
         await db.execute(
             """
-            INSERT INTO earnings (platform, balance, currency, date)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(platform, date) DO UPDATE SET
                 balance = excluded.balance,
                 currency = excluded.currency,
+                fx_rate_usd = excluded.fx_rate_usd,
                 created_at = datetime('now')
             WHERE earnings.balance != excluded.balance
             """,
-            (platform, balance, currency, date),
+            (platform, balance, currency, date, fx_rate_usd),
         )
         await db.commit()
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -273,6 +273,11 @@ async def _run_collection() -> None:
                         platform=result.platform,
                         balance=result.balance,
                         currency=result.currency,
+                        # Snapshot the rate now. to_usd(1.0, cur) is the cur -> USD
+                        # rate (1.0 for USD, None if unknown); rates are only cached
+                        # live, so this is the only chance to record what this reading
+                        # was actually worth.
+                        fx_rate_usd=exchange_rates.to_usd(1.0, result.currency),
                     )
                     logger.info("Collected %s: %.4f %s", result.platform, result.balance, result.currency)
                     platforms_ok += 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -112,6 +112,47 @@ class TestEarnings:
 
         asyncio.run(run())
 
+    def test_a_missing_rate_never_overwrites_a_known_one(self, db):
+        """Regression: the UPDATE assigned the new rate unconditionally.
+
+        If the rate lookup failed this cycle (provider outage after a restart cleared
+        the cache) the incoming value is None — and overwriting a good rate with NULL
+        would destroy the only record of what that reading was worth.
+        """
+
+        async def run():
+            await database.upsert_earnings("mysterium", 8.0, "MYST", "2026-01-01", fx_rate_usd=0.25)
+            await database.upsert_earnings("mysterium", 9.0, "MYST", "2026-01-01", fx_rate_usd=None)
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT balance, fx_rate_usd FROM earnings WHERE platform = 'mysterium'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["balance"] == 9.0  # balance still advances
+            assert row["fx_rate_usd"] == 0.25  # rate preserved
+
+        asyncio.run(run())
+
+    def test_a_null_rate_can_still_be_back_filled(self, db):
+        """Regression: the balance guard skipped the whole UPDATE when the balance was
+        unchanged, so a row stored with a NULL rate could never gain one — for a
+        service whose balance moves once a day, that meant never."""
+
+        async def run():
+            await database.upsert_earnings("mysterium", 8.0, "MYST", "2026-01-01", fx_rate_usd=None)
+            # Same balance, rate now available.
+            await database.upsert_earnings("mysterium", 8.0, "MYST", "2026-01-01", fx_rate_usd=0.25)
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT fx_rate_usd FROM earnings WHERE platform = 'mysterium'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["fx_rate_usd"] == 0.25
+
+        asyncio.run(run())
+
     def test_fx_rate_defaults_to_null(self, db):
         # Callers that don't supply a rate (or an unknown currency) store NULL rather
         # than a wrong number.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -78,6 +78,55 @@ class TestEarnings:
 
         asyncio.run(run())
 
+    def test_fx_rate_is_stored_with_the_reading(self, db):
+        # Rates are only cached live, so the rate at collection time must be stored
+        # alongside the balance or the historical USD value is unrecoverable.
+        async def run():
+            await database.upsert_earnings("mysterium", 8.0, "MYST", "2026-01-01", fx_rate_usd=0.25)
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute(
+                    "SELECT balance, currency, fx_rate_usd FROM earnings WHERE platform = 'mysterium'"
+                )
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["balance"] == 8.0
+            assert row["currency"] == "MYST"
+            assert row["fx_rate_usd"] == 0.25
+
+        asyncio.run(run())
+
+    def test_fx_rate_updates_on_conflict(self, db):
+        async def run():
+            await database.upsert_earnings("mysterium", 8.0, "MYST", "2026-01-01", fx_rate_usd=0.25)
+            await database.upsert_earnings("mysterium", 9.0, "MYST", "2026-01-01", fx_rate_usd=0.30)
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT balance, fx_rate_usd FROM earnings WHERE platform = 'mysterium'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["balance"] == 9.0
+            assert row["fx_rate_usd"] == 0.30
+
+        asyncio.run(run())
+
+    def test_fx_rate_defaults_to_null(self, db):
+        # Callers that don't supply a rate (or an unknown currency) store NULL rather
+        # than a wrong number.
+        async def run():
+            await database.upsert_earnings("hg", 1.0, "USD")
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT fx_rate_usd FROM earnings WHERE platform = 'hg'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["fx_rate_usd"] is None
+
+        asyncio.run(run())
+
     def test_get_earnings_history_week(self, db):
         async def run():
             await database.upsert_earnings("hg", 1.0, "USD")
@@ -402,6 +451,66 @@ class TestWorkers:
     def test_get_missing_worker(self, db):
         async def run():
             assert await database.get_worker(9999) is None
+
+        asyncio.run(run())
+
+
+class TestEarningsFxMigration:
+    def test_migration_adds_fx_column_to_existing_db(self, db_dir):
+        """An existing DB predating the column gains it, keeping its rows."""
+
+        async def run():
+            conn = await database._get_db()
+            try:
+                # Recreate the pre-migration shape (no fx_rate_usd) with a row in it.
+                await conn.executescript("""
+                    DROP TABLE IF EXISTS earnings;
+                    CREATE TABLE earnings (
+                        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                        platform   TEXT    NOT NULL,
+                        balance    REAL    NOT NULL,
+                        currency   TEXT    NOT NULL DEFAULT 'USD',
+                        date       TEXT    NOT NULL,
+                        created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+                    );
+                    INSERT INTO earnings (platform, balance, currency, date)
+                    VALUES ('legacy', 4.2, 'USD', '2026-01-01');
+                """)
+                await conn.commit()
+                cur = await conn.execute("PRAGMA table_info(earnings)")
+                before = {row["name"] for row in await cur.fetchall()}
+            finally:
+                await conn.close()
+            assert "fx_rate_usd" not in before
+
+            await database.init_db()
+
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("PRAGMA table_info(earnings)")
+                after = {row["name"] for row in await cur.fetchall()}
+                cur = await conn.execute("SELECT balance, fx_rate_usd FROM earnings WHERE platform = 'legacy'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert "fx_rate_usd" in after
+            # The pre-existing row survives; its unknown historical rate stays NULL
+            # rather than being back-filled with today's (wrong) rate.
+            assert row["balance"] == 4.2
+            assert row["fx_rate_usd"] is None
+
+        asyncio.run(run())
+
+    def test_migration_is_idempotent(self, db):
+        async def run():
+            await database.init_db()  # already migrated by the fixture
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("PRAGMA table_info(earnings)")
+                cols = [row["name"] for row in await cur.fetchall()]
+            finally:
+                await conn.close()
+            assert cols.count("fx_rate_usd") == 1
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Why this is urgent rather than merely missing

The `earnings` table stores `(platform, balance, currency, date)` and **no exchange rate**, while `exchange_rates.py` caches only *current* rates. So the USD value of a historical non-USD reading (MYST, GRASS, ...) cannot be reconstructed afterwards at any accuracy.

Unlike most gaps, **this one cannot be fixed retroactively** — every collection cycle that runs without the column loses that data permanently. That's why it's worth landing before the features that consume it.

## Change

- Nullable `fx_rate_usd` column on `earnings`, plus an idempotent `ALTER TABLE` migration for existing databases (matching the existing `workers`/`users` migration pattern).
- Populated at collection time from `exchange_rates.to_usd(1.0, currency)` — the currency→USD rate, `1.0` for USD, and **`NULL` when the rate is unknown** so a missing rate is never silently stored as a wrong one.
- Existing rows keep `NULL` rather than being back-filled with today's (wrong) rate.

## Tests

5 new: the rate is stored with the reading; it updates on conflict; it defaults to NULL; the migration adds the column to a pre-existing DB **without losing its rows**; and the migration is idempotent. Full suite **1185 passing**, ruff + format clean.

Unblocks the payout ledger (`glc`), power/net-profit (`l01`) and any future tax/CSV export.

Closes bead CashPilot-rrr.