### PR TITLE
feat: weekly catalog liveness check with referral-link guard (CashPilot-owv)

### DIFF
--- a/.github/workflows/catalog-liveness.yml
+++ b/.github/workflows/catalog-liveness.yml
@@ -1,0 +1,64 @@
+name: Catalog Liveness
+
+# Catalog rot is the most common user-facing failure in this project: a provider
+# changes its backend, drops its image or ends its referral programme, and a user
+# finds out before the maintainer does. This checks every service's external
+# references weekly and keeps ONE rollup issue up to date.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays, 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: catalog-liveness
+  cancel-in-progress: false
+
+jobs:
+  check:
+    # Public repo -> GitHub-hosted runners are free and ephemeral.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: pip install httpx pyyaml
+
+      - name: Check catalog liveness
+        # Never fails the run on a dead link — a job that is red every week is a
+        # job nobody reads. Findings go to the summary and the rollup issue.
+        run: python scripts/check_catalog_liveness.py --output report.md
+
+      - name: Open or update the rollup issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if grep -q '^All good' report.md; then
+            echo "No dead references found."
+            exit 0
+          fi
+
+          # Label may not exist yet on a fresh repo.
+          gh label create catalog-liveness \
+            --description "Automated weekly catalog liveness findings" \
+            --color ededed 2>/dev/null || true
+
+          existing=$(gh issue list --state open --label catalog-liveness --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file report.md
+            echo "Updated issue #$existing"
+          else
+            gh issue create \
+              --title "Catalog liveness: dead references detected" \
+              --label catalog-liveness \
+              --body-file report.md
+          fi

--- a/scripts/check_catalog_liveness.py
+++ b/scripts/check_catalog_liveness.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Check that every catalog service's external references are still alive.
+
+Catalog rot is this project's most common user-facing failure: a provider changes
+its backend, drops its image or kills its referral programme, and the first person
+to notice is a user whose service silently stopped earning. This script turns that
+into a scheduled report instead.
+
+For each ``services/**/*.yml`` it checks:
+
+* ``website`` still answers
+* ``referral.signup_url`` still answers **and still carries its referral code** --
+  a dead or code-stripped referral link is direct lost revenue
+* ``docker.image`` still resolves in its registry
+
+Exit code is 0 unless the script itself could not run. A dead link is a *finding
+to report*, not a build failure: a flaky provider must not turn the weekly run red,
+because a job that is red every week is a job nobody reads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+import yaml
+
+# Statuses
+OK = "ok"
+DEAD = "dead"
+UNREACHABLE = "unreachable"
+SKIPPED = "skipped"
+
+# Some providers answer a bare HEAD with a guard rather than the page. These prove
+# the host is alive, which is all this check claims to establish.
+_ALIVE_BUT_GUARDED = frozenset({401, 403, 405, 429})
+
+# A browser-ish UA: several providers 403 the default httpx agent outright.
+_UA = "Mozilla/5.0 (compatible; CashPilot-catalog-check/1.0; +https://github.com/GeiserX/CashPilot)"
+
+
+@dataclass
+class Finding:
+    slug: str
+    kind: str  # "website" | "referral" | "image"
+    target: str
+    status: str
+    detail: str = ""
+
+    @property
+    def is_problem(self) -> bool:
+        return self.status not in (OK, SKIPPED)
+
+
+def classify_status(status_code: int) -> str:
+    """Map an HTTP status onto liveness.
+
+    5xx is deliberately *not* "dead": a provider having a bad afternoon is not a
+    retired service, and calling it dead would churn the catalog on noise.
+    """
+    if 200 <= status_code < 300:
+        return OK
+    if status_code in _ALIVE_BUT_GUARDED:
+        return OK
+    if 300 <= status_code < 400:
+        return OK  # redirect chains are followed; a bare 3xx here is still alive
+    if 400 <= status_code < 500:
+        return DEAD
+    return UNREACHABLE
+
+
+def referral_code_lost(original: str, final: str) -> bool:
+    """True when a referral link redirected to a bare homepage, dropping its code.
+
+    The classic symptom of a retired referral programme: ``…/signup?ref=CODE`` ends
+    up at ``https://provider.com/``. Only that specific collapse is reported -- many
+    healthy links legitimately drop the query after setting a cookie, so anything
+    looser would be noise.
+    """
+    orig = urlparse(original)
+    fin = urlparse(final)
+    had_identity = bool(orig.query) or orig.path.strip("/")
+    landed_bare = not fin.query and not fin.path.strip("/")
+    return bool(had_identity and landed_bare)
+
+
+def check_url(client: httpx.Client, url: str) -> tuple[str, str]:
+    """Return (status, detail) for one URL."""
+    if not url:
+        return SKIPPED, "not set"
+    try:
+        try:
+            resp = client.head(url)
+        except httpx.TooManyRedirects:
+            # Some sites redirect-loop on HEAD but serve GET fine (observed on a live
+            # provider). Retry before calling a working site unreachable.
+            resp = client.get(url)
+        # Some servers simply refuse HEAD; retry once with GET before judging.
+        if resp.status_code in (405, 501):
+            resp = client.get(url)
+        status = classify_status(resp.status_code)
+        detail = f"HTTP {resp.status_code}"
+        if status == OK and str(resp.url) != url:
+            detail += f" -> {resp.url}"
+        return status, detail
+    except httpx.HTTPError as exc:
+        return UNREACHABLE, type(exc).__name__
+
+
+def check_image(image: str) -> tuple[str, str]:
+    """Return (status, detail) for a Docker image reference."""
+    if not image:
+        return SKIPPED, "no image (not Docker-deployable)"
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["docker", "manifest", "inspect", image],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return UNREACHABLE, f"could not run docker: {exc}"
+    if proc.returncode == 0:
+        return OK, "manifest found"
+    stderr = (proc.stderr or "").strip()
+    # A rate-limited or auth-gated registry says nothing about whether the image
+    # still exists — reporting that as "dead" would send us deleting live services.
+    if any(marker in stderr.lower() for marker in ("toomanyrequests", "rate limit", "unauthorized", "denied")):
+        return UNREACHABLE, "registry rate-limited or auth-gated"
+    lines = stderr.splitlines()
+    return DEAD, lines[-1][:160] if lines else "manifest not found"
+
+
+def load_services(services_dir: Path) -> list[dict]:
+    """Load every service YAML, sorted by slug."""
+    services = []
+    for path in sorted(services_dir.rglob("*.y*ml")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            print(f"::warning::could not parse {path}: {exc}", file=sys.stderr)
+            continue
+        if isinstance(data, dict) and data.get("slug"):
+            services.append(data)
+    return sorted(services, key=lambda s: s["slug"])
+
+
+def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> list[Finding]:
+    slug = svc["slug"]
+    findings: list[Finding] = []
+
+    # Services the catalog already marks as gone are expected to be dead; checking
+    # them would just generate noise the maintainer has already acted on.
+    if svc.get("status") in ("dead", "dropped"):
+        return [Finding(slug, "website", svc.get("website", ""), SKIPPED, f"status: {svc['status']}")]
+
+    website = svc.get("website", "") or ""
+    status, detail = check_url(client, website)
+    findings.append(Finding(slug, "website", website, status, detail))
+
+    signup = ((svc.get("referral") or {}).get("signup_url")) or ""
+    if signup:
+        status, detail = check_url(client, signup)
+        if status == OK:
+            try:
+                final = str(client.head(signup).url)
+                if referral_code_lost(signup, final):
+                    status, detail = DEAD, f"referral code lost -> {final}"
+            except httpx.HTTPError:
+                pass
+        findings.append(Finding(slug, "referral", signup, status, detail))
+
+    if check_images:
+        image = ((svc.get("docker") or {}).get("image")) or ""
+        status, detail = check_image(image)
+        findings.append(Finding(slug, "image", image, status, detail))
+
+    return findings
+
+
+def build_report(findings: list[Finding]) -> str:
+    problems = [f for f in findings if f.is_problem]
+    checked = len({f.slug for f in findings})
+    lines = ["# Catalog liveness report", ""]
+    if not problems:
+        lines += [f"All good — {checked} services checked, no dead references."]
+        return "\n".join(lines)
+
+    lines += [f"**{len(problems)} problem(s)** across {checked} services checked.", ""]
+
+    referral = [f for f in problems if f.kind == "referral"]
+    if referral:
+        # Called out first and explicitly: these are lost signups, not just broken links.
+        lines += ["## Referral links (lost revenue)", "", "| Service | Status | Detail | URL |", "|---|---|---|---|"]
+        lines += [f"| `{f.slug}` | {f.status} | {f.detail} | {f.target} |" for f in referral]
+        lines += [""]
+
+    rest = [f for f in problems if f.kind != "referral"]
+    if rest:
+        lines += [
+            "## Websites and images",
+            "",
+            "| Service | What | Status | Detail | Target |",
+            "|---|---|---|---|---|",
+        ]
+        lines += [f"| `{f.slug}` | {f.kind} | {f.status} | {f.detail} | {f.target} |" for f in rest]
+        lines += [""]
+
+    lines += [
+        "_`unreachable` may be a transient provider outage; `dead` means the reference "
+        "answered with a client error or the referral link collapsed to a bare homepage._",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--services-dir", default="services", type=Path)
+    parser.add_argument("--timeout", default=20.0, type=float)
+    parser.add_argument("--skip-images", action="store_true", help="skip registry checks (no docker available)")
+    parser.add_argument("--output", type=Path, help="also write the report here")
+    args = parser.parse_args()
+
+    if not args.services_dir.is_dir():
+        print(f"services dir not found: {args.services_dir}", file=sys.stderr)
+        return 2
+
+    services = load_services(args.services_dir)
+    if not services:
+        print("no services found — refusing to report an empty catalog as healthy", file=sys.stderr)
+        return 2
+
+    findings: list[Finding] = []
+    headers = {"User-Agent": _UA}
+    with httpx.Client(follow_redirects=True, timeout=args.timeout, headers=headers) as client:
+        for svc in services:
+            findings.extend(check_service(client, svc, check_images=not args.skip_images))
+
+    report = build_report(findings)
+    print(report)
+    if args.output:
+        args.output.write_text(report)
+    if summary := os.getenv("GITHUB_STEP_SUMMARY"):
+        with open(summary, "a") as fh:
+            fh.write(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_catalog_liveness.py
+++ b/scripts/check_catalog_liveness.py
@@ -55,7 +55,19 @@ class Finding:
 
     @property
     def is_problem(self) -> bool:
-        return self.status not in (OK, SKIPPED)
+        """Actionable: the catalog itself is wrong and a human should change it.
+
+        UNREACHABLE deliberately does NOT count. It means "we could not tell" —
+        a provider having a bad afternoon, a registry rate-limit, a timeout. If
+        those raised the problem count, the weekly issue would cry wolf most
+        weeks and get ignored, which costs us the one week it is real. They are
+        still reported, just in their own section.
+        """
+        return self.status == DEAD
+
+    @property
+    def is_inconclusive(self) -> bool:
+        return self.status == UNREACHABLE
 
 
 def classify_status(status_code: int) -> str:
@@ -119,7 +131,7 @@ def check_image(image: str) -> tuple[str, str]:
         return SKIPPED, "no image (not Docker-deployable)"
     try:
         proc = subprocess.run(  # noqa: S603
-            ["docker", "manifest", "inspect", image],  # noqa: S607
+            ["docker", "manifest", "inspect", "--", image],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=90,
@@ -137,20 +149,33 @@ def check_image(image: str) -> tuple[str, str]:
     return DEAD, lines[-1][:160] if lines else "manifest not found"
 
 
-def load_services(services_dir: Path) -> list[dict]:
-    """Load every service YAML, sorted by slug."""
+def load_services(services_dir: Path) -> tuple[list[dict], list[Finding]]:
+    """Load every service YAML, sorted by slug.
+
+    Returns the services AND a finding per file that could not be read. A file
+    that fails to parse was previously only a stderr warning, so a catalog with
+    a broken YAML silently checked fewer services and still reported "All good"
+    — the one case where the report is confidently wrong. An unparseable
+    catalog file is a real defect, so it is surfaced as a problem.
+    """
     services = []
+    errors: list[Finding] = []
     for path in sorted(services_dir.rglob("*.y*ml")):
         if path.name.startswith("_"):
             continue
         try:
             data = yaml.safe_load(path.read_text())
-        except yaml.YAMLError as exc:
-            print(f"::warning::could not parse {path}: {exc}", file=sys.stderr)
+        except (yaml.YAMLError, OSError) as exc:
+            # Flattened: a YAML error spans several lines, and a raw newline
+            # inside a markdown table cell breaks the rest of the table.
+            reason = " ".join(str(exc).split())
+            errors.append(Finding(path.stem, "catalog", str(path), DEAD, f"could not parse: {reason[:160]}"))
             continue
         if isinstance(data, dict) and data.get("slug"):
             services.append(data)
-    return sorted(services, key=lambda s: s["slug"])
+        else:
+            errors.append(Finding(path.stem, "catalog", str(path), DEAD, "no slug — not a valid service definition"))
+    return sorted(services, key=lambda s: s["slug"]), errors
 
 
 def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> list[Finding]:
@@ -188,13 +213,38 @@ def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> lis
 
 def build_report(findings: list[Finding]) -> str:
     problems = [f for f in findings if f.is_problem]
+    unknown = [f for f in findings if f.is_inconclusive]
     checked = len({f.slug for f in findings})
     lines = ["# Catalog liveness report", ""]
+
+    def _unknown_section() -> list[str]:
+        if not unknown:
+            return []
+        out = [
+            "## Could not verify (not necessarily broken)",
+            "",
+            "| Service | What | Detail | Target |",
+            "|---|---|---|---|",
+        ]
+        out += [f"| `{f.slug}` | {f.kind} | {f.detail} | {f.target} |" for f in unknown]
+        return out + [""]
+
     if not problems:
         lines += [f"All good — {checked} services checked, no dead references."]
+        if unknown:
+            lines += ["", f"{len(unknown)} check(s) were inconclusive and are listed below.", ""]
+            lines += _unknown_section()
         return "\n".join(lines)
 
     lines += [f"**{len(problems)} problem(s)** across {checked} services checked.", ""]
+
+    broken_yaml = [f for f in problems if f.kind == "catalog"]
+    if broken_yaml:
+        # First: if the catalog itself won't parse, every other number here is
+        # computed over an incomplete set and can't be trusted.
+        lines += ["## Catalog files that could not be read", "", "| File | Detail |", "|---|---|"]
+        lines += [f"| `{f.target}` | {f.detail} |" for f in broken_yaml]
+        lines += [""]
 
     referral = [f for f in problems if f.kind == "referral"]
     if referral:
@@ -203,7 +253,7 @@ def build_report(findings: list[Finding]) -> str:
         lines += [f"| `{f.slug}` | {f.status} | {f.detail} | {f.target} |" for f in referral]
         lines += [""]
 
-    rest = [f for f in problems if f.kind != "referral"]
+    rest = [f for f in problems if f.kind not in ("referral", "catalog")]
     if rest:
         lines += [
             "## Websites and images",
@@ -214,9 +264,12 @@ def build_report(findings: list[Finding]) -> str:
         lines += [f"| `{f.slug}` | {f.kind} | {f.status} | {f.detail} | {f.target} |" for f in rest]
         lines += [""]
 
+    lines += _unknown_section()
+
     lines += [
-        "_`unreachable` may be a transient provider outage; `dead` means the reference "
-        "answered with a client error or the referral link collapsed to a bare homepage._",
+        "_`unreachable` may be a transient provider outage or a registry rate-limit, so it is "
+        "reported but not counted as a problem; `dead` means the reference answered with a "
+        "client error or the referral link collapsed to a bare homepage._",
     ]
     return "\n".join(lines)
 
@@ -233,12 +286,12 @@ def main() -> int:
         print(f"services dir not found: {args.services_dir}", file=sys.stderr)
         return 2
 
-    services = load_services(args.services_dir)
+    services, parse_errors = load_services(args.services_dir)
     if not services:
         print("no services found — refusing to report an empty catalog as healthy", file=sys.stderr)
         return 2
 
-    findings: list[Finding] = []
+    findings: list[Finding] = list(parse_errors)
     headers = {"User-Agent": _UA}
     with httpx.Client(follow_redirects=True, timeout=args.timeout, headers=headers) as client:
         for svc in services:

--- a/tests/test_catalog_liveness.py
+++ b/tests/test_catalog_liveness.py
@@ -1,0 +1,153 @@
+"""Tests for scripts/check_catalog_liveness.py.
+
+Only the pure decision logic is exercised — no network calls and no docker, so
+the suite stays deterministic and offline. What matters here is that the script
+cannot report a *live* service as dead (which would send someone deleting a
+working catalog entry) and cannot report an empty catalog as healthy.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_catalog_liveness.py"
+_spec = importlib.util.spec_from_file_location("check_catalog_liveness", _SCRIPT)
+liveness = importlib.util.module_from_spec(_spec)
+# Register before exec: the module's @dataclass resolves its string annotations
+# (PEP 563) through sys.modules, which fails if the module isn't there yet.
+sys.modules["check_catalog_liveness"] = liveness
+_spec.loader.exec_module(liveness)
+
+
+class TestClassifyStatus:
+    @pytest.mark.parametrize("code", [200, 201, 204, 301, 302])
+    def test_alive_codes(self, code):
+        assert liveness.classify_status(code) == liveness.OK
+
+    @pytest.mark.parametrize("code", [401, 403, 405, 429])
+    def test_guarded_but_alive(self, code):
+        # Cloudflare/bot guards and "HEAD not allowed" prove the host answered.
+        assert liveness.classify_status(code) == liveness.OK
+
+    @pytest.mark.parametrize("code", [400, 404, 410])
+    def test_client_errors_are_dead(self, code):
+        assert liveness.classify_status(code) == liveness.DEAD
+
+    @pytest.mark.parametrize("code", [500, 502, 503])
+    def test_server_errors_are_unreachable_not_dead(self, code):
+        # A provider having a bad afternoon is not a retired service.
+        assert liveness.classify_status(code) == liveness.UNREACHABLE
+
+
+class TestReferralCodeLost:
+    def test_collapse_to_bare_homepage_is_lost(self):
+        assert liveness.referral_code_lost("https://p.com/signup?ref=CODE", "https://p.com/")
+
+    def test_landing_on_a_real_page_is_fine(self):
+        # Plenty of healthy links drop the query after setting a cookie.
+        assert not liveness.referral_code_lost("https://p.com/signup?ref=CODE", "https://p.com/welcome")
+
+    def test_query_preserved_is_fine(self):
+        assert not liveness.referral_code_lost("https://p.com/signup?ref=CODE", "https://p.com/signup?ref=CODE")
+
+    def test_bare_to_bare_is_not_a_loss(self):
+        # Nothing to lose if the configured URL had no path or query to begin with.
+        assert not liveness.referral_code_lost("https://p.com/", "https://p.com/")
+
+
+class TestCheckImage:
+    def test_empty_image_is_skipped(self):
+        status, detail = liveness.check_image("")
+        assert status == liveness.SKIPPED
+        assert "not Docker-deployable" in detail
+
+    def test_manifest_found_is_ok(self):
+        with patch.object(subprocess, "run", return_value=MagicMock(returncode=0, stderr="")):
+            assert liveness.check_image("repo/img:1")[0] == liveness.OK
+
+    @pytest.mark.parametrize("err", ["toomanyrequests: too many requests", "unauthorized: authentication required"])
+    def test_rate_limit_is_unreachable_not_dead(self, err):
+        # Reporting a rate-limited registry as "dead" would send us deleting live services.
+        with patch.object(subprocess, "run", return_value=MagicMock(returncode=1, stderr=err)):
+            assert liveness.check_image("repo/img:1")[0] == liveness.UNREACHABLE
+
+    def test_missing_manifest_is_dead(self):
+        with patch.object(subprocess, "run", return_value=MagicMock(returncode=1, stderr="manifest unknown")):
+            assert liveness.check_image("repo/gone:1")[0] == liveness.DEAD
+
+    def test_docker_missing_is_unreachable(self):
+        with patch.object(subprocess, "run", side_effect=OSError("no docker")):
+            assert liveness.check_image("repo/img:1")[0] == liveness.UNREACHABLE
+
+
+class TestLoadServices:
+    def _write(self, d: Path, name: str, body: str):
+        (d / name).write_text(body)
+
+    def test_loads_and_sorts_skipping_schema(self, tmp_path):
+        self._write(tmp_path, "b.yml", "slug: bravo\nname: B\n")
+        self._write(tmp_path, "a.yml", "slug: alpha\nname: A\n")
+        self._write(tmp_path, "_schema.yml", "slug: schema\nname: S\n")
+        slugs = [s["slug"] for s in liveness.load_services(tmp_path)]
+        assert slugs == ["alpha", "bravo"]
+
+    def test_unparseable_file_is_skipped_not_fatal(self, tmp_path):
+        self._write(tmp_path, "bad.yml", "{{{ not yaml")
+        self._write(tmp_path, "good.yml", "slug: good\nname: G\n")
+        assert [s["slug"] for s in liveness.load_services(tmp_path)] == ["good"]
+
+
+class TestCheckService:
+    def test_dead_status_service_is_skipped(self):
+        client = MagicMock()
+        findings = liveness.check_service(
+            client, {"slug": "gone", "status": "dead", "website": "https://x.com"}, check_images=False
+        )
+        assert all(f.status == liveness.SKIPPED for f in findings)
+        client.head.assert_not_called()  # no network for a service we already retired
+
+    def test_referral_is_checked_separately_from_website(self):
+        client = MagicMock()
+        client.head.return_value = MagicMock(status_code=200, url="https://p.com/signup?ref=CODE")
+        findings = liveness.check_service(
+            client,
+            {
+                "slug": "p",
+                "status": "active",
+                "website": "https://p.com",
+                "referral": {"signup_url": "https://p.com/signup?ref=CODE"},
+            },
+            check_images=False,
+        )
+        kinds = {f.kind for f in findings}
+        assert kinds == {"website", "referral"}
+        assert all(f.status == liveness.OK for f in findings)
+
+
+class TestBuildReport:
+    def test_clean_report_says_all_good(self):
+        findings = [liveness.Finding("a", "website", "u", liveness.OK, "HTTP 200")]
+        assert build_starts_ok(liveness.build_report(findings))
+
+    def test_referral_problems_get_their_own_revenue_section(self):
+        findings = [
+            liveness.Finding("a", "website", "u", liveness.OK, "HTTP 200"),
+            liveness.Finding("a", "referral", "https://p.com/s?ref=X", liveness.DEAD, "referral code lost"),
+        ]
+        report = liveness.build_report(findings)
+        assert "lost revenue" in report
+        assert "referral code lost" in report
+
+    def test_skipped_entries_are_not_problems(self):
+        findings = [liveness.Finding("a", "image", "", liveness.SKIPPED, "no image")]
+        assert build_starts_ok(liveness.build_report(findings))
+
+
+def build_starts_ok(report: str) -> bool:
+    return "All good" in report

--- a/tests/test_catalog_liveness.py
+++ b/tests/test_catalog_liveness.py
@@ -94,13 +94,36 @@ class TestLoadServices:
         self._write(tmp_path, "b.yml", "slug: bravo\nname: B\n")
         self._write(tmp_path, "a.yml", "slug: alpha\nname: A\n")
         self._write(tmp_path, "_schema.yml", "slug: schema\nname: S\n")
-        slugs = [s["slug"] for s in liveness.load_services(tmp_path)]
-        assert slugs == ["alpha", "bravo"]
+        services, errors = liveness.load_services(tmp_path)
+        assert [s["slug"] for s in services] == ["alpha", "bravo"]
+        assert errors == []
 
-    def test_unparseable_file_is_skipped_not_fatal(self, tmp_path):
+    def test_unparseable_file_is_reported_not_silently_skipped(self, tmp_path):
+        """A broken YAML must not let the run claim 'All good'.
+
+        Skipping it quietly means fewer services are checked and the report is
+        confidently wrong — the worst failure mode for a check like this.
+        """
         self._write(tmp_path, "bad.yml", "{{{ not yaml")
         self._write(tmp_path, "good.yml", "slug: good\nname: G\n")
-        assert [s["slug"] for s in liveness.load_services(tmp_path)] == ["good"]
+        services, errors = liveness.load_services(tmp_path)
+        assert [s["slug"] for s in services] == ["good"]
+        assert len(errors) == 1
+        assert errors[0].kind == "catalog"
+        assert errors[0].is_problem
+        assert "bad.yml" in errors[0].target
+        # A raw newline in a markdown table cell breaks the rest of the table.
+        assert "\n" not in errors[0].detail
+        # ...and it must reach the report, which is what the CI gate greps.
+        report = liveness.build_report(errors)
+        assert not report.startswith("# Catalog liveness report\n\nAll good")
+        assert "could not be read" in report
+
+    def test_file_without_slug_is_reported(self, tmp_path):
+        self._write(tmp_path, "nope.yml", "name: no slug here\n")
+        services, errors = liveness.load_services(tmp_path)
+        assert services == []
+        assert len(errors) == 1 and errors[0].is_problem
 
 
 class TestCheckService:
@@ -151,3 +174,44 @@ class TestBuildReport:
 
 def build_starts_ok(report: str) -> bool:
     return "All good" in report
+
+
+class TestInconclusiveIsNotAProblem:
+    """A weekly auto-issue that cries wolf gets ignored — so 'can't tell' != 'broken'."""
+
+    def test_unreachable_does_not_open_an_issue(self):
+        findings = [
+            liveness.Finding("a", "website", "https://a.com", liveness.UNREACHABLE, "ServerError"),
+            liveness.Finding("b", "image", "repo/img", liveness.UNREACHABLE, "registry rate-limited or auth-gated"),
+        ]
+        report = liveness.build_report(findings)
+        # The CI step greps for a leading "All good" to decide whether to file.
+        assert report.splitlines()[2].startswith("All good")
+        # ...but the detail is still visible to a human reading the run.
+        assert "Could not verify" in report
+        assert "rate-limited" in report
+
+    def test_dead_still_opens_an_issue(self):
+        findings = [
+            liveness.Finding("a", "website", "https://a.com", liveness.UNREACHABLE, "ServerError"),
+            liveness.Finding("b", "referral", "https://b.com/?r=X", liveness.DEAD, "referral code lost"),
+        ]
+        report = liveness.build_report(findings)
+        assert not report.splitlines()[2].startswith("All good")
+        assert "**1 problem(s)**" in report
+        # The unreachable one is still shown, just not counted.
+        assert "Could not verify" in report
+
+    def test_image_arg_cannot_be_read_as_a_flag(self):
+        import subprocess
+
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0, stderr="")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            liveness.check_image("repo/img:1")
+        assert "--" in captured["cmd"]
+        assert captured["cmd"].index("--") == captured["cmd"].index("repo/img:1") - 1


### PR DESCRIPTION
## Why

Catalog rot is the most common user-facing failure in this project — a provider changes its backend, drops its image, or ends its referral programme, and **a user finds out before the maintainer does**. Roughly 42% of user-filed issues are stale catalog/collector entries (#103, #82, #59, #44, #24).

## What

`scripts/check_catalog_liveness.py` + a weekly workflow. Per service it checks the **website**, the **referral signup URL**, and the **docker image**, then keeps **one** rollup issue up to date (never a new issue per run).

Referral findings get their own section, called out first: a dead or code-stripped referral link is **direct lost revenue**, not just a broken link. This effectively turns the standing "verify my referral link is correctly set" rule into a scheduled check.

## Deliberately conservative, so the report stays worth reading

A job that is red every week is a job nobody reads. So:

- **5xx → `unreachable`, not `dead`** — a provider having a bad afternoon is not a retired service.
- **Registry rate-limit / auth-gated → `unreachable`** — reporting that as dead would send someone deleting a live service.
- **401/403/405/429 → alive** — bot guards prove the host answered.
- **HEAD redirect-loops retry with GET** — caught a live provider being misreported during testing.
- Services already marked `dead`/`dropped` are skipped (no noise for decisions already made).
- **A dead link never fails the run**; only the script failing to run does.

## Verified against the real catalog, not just mocked

Ran it over all 49 services locally — **11 findings**, including exactly the case it was built for:

> `proxylite` — **referral code lost**: `https://proxylite.ru/?r=KMUPRZIZ` now redirects to a bare `https://proxylite.ru/`.

plus unreachable hosts (`earncc`, `koii`, `teneo`, `wizardgain`, `spide`).

## Tests

32 offline tests covering the decision logic — status classification, the referral-collapse heuristic (including the cases that must **not** fire), rate-limit vs missing-manifest, YAML loading, dead-service skipping, and report shaping. No network or docker in the test suite. Full suite **1212 passing**; repo-wide `ruff check` + `ruff format --check` clean.

Public repo, so `ubuntu-latest` (free, ephemeral) per the CI runner policy.

Closes bead CashPilot-owv.