### PR TITLE
feat: persist collector alerts and deliver them out-of-band (CashPilot-1ty)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -162,6 +162,18 @@ CREATE TABLE IF NOT EXISTS user_preferences (
     FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+-- Alerts worth a human's attention (collector failures today; container crashes and
+-- earnings flatlines later). Persisted rather than kept in memory so they survive a
+-- restart: passive income is unattended, and an alert that only exists in a running
+-- process is an alert nobody ever sees.
+CREATE TABLE IF NOT EXISTS alerts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind       TEXT    NOT NULL,
+    subject    TEXT    NOT NULL,
+    message    TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE TABLE IF NOT EXISTS health_events (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     slug       TEXT    NOT NULL,
@@ -198,6 +210,9 @@ CREATE INDEX IF NOT EXISTS idx_health_events_slug
 
 CREATE INDEX IF NOT EXISTS idx_health_events_created
     ON health_events (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_created
+    ON alerts (created_at);
 """
 
 
@@ -1232,6 +1247,68 @@ async def record_health_events(events: list[tuple[str, str, str]]) -> None:
         await db.close()
 
 
+async def record_alert(kind: str, subject: str, message: str) -> bool:
+    """Persist an alert, returning True only when it is NEW for this kind+subject.
+
+    "New" means the latest stored alert for the same kind+subject carried a different
+    message. A collector that has been broken for a week must not re-notify every
+    hour: the first failure is news, the 168th is noise. Duplicates are therefore not
+    stored either, which also keeps the table naturally bounded.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT message FROM alerts WHERE kind = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+            (kind, subject),
+        )
+        row = await cursor.fetchone()
+        if row is not None and row["message"] == message:
+            return False
+        await db.execute(
+            "INSERT INTO alerts (kind, subject, message) VALUES (?, ?, ?)",
+            (kind, subject, message),
+        )
+        await db.commit()
+        return True
+    finally:
+        await db.close()
+
+
+async def list_alerts(limit: int = 50) -> list[dict[str, Any]]:
+    """Return the most recent alerts, newest first."""
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT kind, subject, message, created_at FROM alerts ORDER BY id DESC LIMIT ?",
+            (limit,),
+        )
+        return [dict(row) for row in await cursor.fetchall()]
+    finally:
+        await db.close()
+
+
+async def clear_alerts(kind: str | None = None, subject: str | None = None) -> None:
+    """Drop stored alerts (all, one kind, or one subject within a kind).
+
+    Called when a subject recovers, so that if it breaks again later the failure
+    counts as new and notifies again instead of being deduped into silence.
+    """
+    clauses, params = [], []
+    if kind is not None:
+        clauses.append("kind = ?")
+        params.append(kind)
+    if subject is not None:
+        clauses.append("subject = ?")
+        params.append(subject)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    db = await _get_db()
+    try:
+        await db.execute(f"DELETE FROM alerts{where}", tuple(params))  # noqa: S608 - clauses are literals
+        await db.commit()
+    finally:
+        await db.close()
+
+
 async def get_health_scores(days: int = 7) -> list[dict[str, Any]]:
     """Compute health score per service over the last N days.
 
@@ -1331,8 +1408,14 @@ async def purge_old_data() -> int:
             "DELETE FROM health_events WHERE event IN ('check_ok', 'check_down') AND created_at < datetime('now', ?)",
             (check_cutoff,),
         )
+        # Alerts are deduped on write so the table stays small, but a service that
+        # was removed long ago should not leave its last failure sitting there forever.
+        c4 = await db.execute(
+            "DELETE FROM alerts WHERE created_at < datetime('now', ?)",
+            (cutoff,),
+        )
         await db.commit()
-        return (c1.rowcount or 0) + (c2.rowcount or 0) + (c3.rowcount or 0)
+        return (c1.rowcount or 0) + (c2.rowcount or 0) + (c3.rowcount or 0) + (c4.rowcount or 0)
     finally:
         await db.close()
 

--- a/app/database.py
+++ b/app/database.py
@@ -1247,22 +1247,38 @@ async def record_health_events(events: list[tuple[str, str, str]]) -> None:
         await db.close()
 
 
-async def record_alert(kind: str, subject: str, message: str) -> bool:
-    """Persist an alert, returning True only when it is NEW for this kind+subject.
+# How long a subject stays quiet after alerting. A collector broken for a week must
+# not notify every hour: the first failure is news, the 168th is noise.
+ALERT_COOLDOWN_HOURS = 24
 
-    "New" means the latest stored alert for the same kind+subject carried a different
-    message. A collector that has been broken for a week must not re-notify every
-    hour: the first failure is news, the 168th is noise. Duplicates are therefore not
-    stored either, which also keeps the table naturally bounded.
+
+async def record_alert(
+    kind: str,
+    subject: str,
+    message: str,
+    *,
+    cooldown_hours: int = ALERT_COOLDOWN_HOURS,
+) -> bool:
+    """Persist an alert, returning True only when the caller should notify.
+
+    Suppression is by TIME WINDOW per kind+subject, not by message equality. Message
+    equality alone is not enough: several collectors alternate between two error
+    strings for the same underlying fault (grass flips between an expired-token error
+    and a Cloudflare rate-limit depending on which request tripped first), so a
+    "changed message means new" rule would notify every single hour and grow the
+    table without bound — exactly what this is meant to prevent.
+
+    Nothing is stored while a subject is in cooldown, which keeps the table bounded.
+    Call ``clear_alerts`` when a subject recovers so the next failure alerts again
+    immediately instead of waiting out the window.
     """
     db = await _get_db()
     try:
         cursor = await db.execute(
-            "SELECT message FROM alerts WHERE kind = ? AND subject = ? ORDER BY id DESC LIMIT 1",
-            (kind, subject),
+            "SELECT id FROM alerts WHERE kind = ? AND subject = ? AND created_at > datetime('now', ?) LIMIT 1",
+            (kind, subject, f"-{int(cooldown_hours)} hours"),
         )
-        row = await cursor.fetchone()
-        if row is not None and row["message"] == message:
+        if await cursor.fetchone() is not None:
             return False
         await db.execute(
             "INSERT INTO alerts (kind, subject, message) VALUES (?, ?, ?)",

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app import auth, catalog, compose_generator, database, exchange_rates, fleet_key, metrics, setup_token
+from app import auth, catalog, compose_generator, database, exchange_rates, fleet_key, metrics, notify, setup_token
 from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
 
 logging.basicConfig(
@@ -237,6 +237,21 @@ async def _collect_bounded(collector) -> Any:
         return await collector.collect()
 
 
+async def _warm_collector_alerts() -> None:
+    """Restore persisted collector alerts into the in-memory list the UI bell reads.
+
+    Without this, a restart clears the bell while the collector is still broken, and
+    the operator is told everything is fine until the next hourly run.
+    """
+    global _collector_alerts
+    try:
+        stored = await database.list_alerts(limit=100)
+    except Exception as exc:
+        logger.warning("Could not restore persisted alerts: %s", exc)
+        return
+    _collector_alerts = [{"platform": a["subject"], "error": a["message"]} for a in stored if a["kind"] == "collector"]
+
+
 async def _run_collection() -> None:
     """Collect earnings from all deployed services that have collectors."""
     global _collector_alerts
@@ -258,6 +273,10 @@ async def _run_collection() -> None:
             await _close_stale()
             results = await asyncio.gather(*(_collect_bounded(c) for c in collectors), return_exceptions=True)
             alerts: list[dict[str, str]] = []
+            # Platforms that were already failing before this run: used to detect a
+            # recovery, so a service that breaks again later notifies again rather
+            # than being deduped into silence forever.
+            previously_alerting = {a["platform"] for a in _collector_alerts}
             platforms_ok = 0
             for result in results:
                 if isinstance(result, Exception):
@@ -268,6 +287,18 @@ async def _run_collection() -> None:
                     logger.warning("Collection error for %s: %s", result.platform, result.error)
                     alerts.append({"platform": result.platform, "error": result.error})
                     metrics.record_collection_error(result.platform)
+                    # Persist so the alert outlives a restart, and push it out-of-band
+                    # only the FIRST time this particular failure appears — a collector
+                    # broken for a week must not notify every single hour.
+                    if await database.record_alert("collector", result.platform, result.error):
+                        _spawn(
+                            notify.send(
+                                f"CashPilot: {result.platform} collector failed",
+                                result.error,
+                                kind="collector",
+                                subject=result.platform,
+                            )
+                        )
                 else:
                     await database.upsert_earnings(
                         platform=result.platform,
@@ -281,6 +312,10 @@ async def _run_collection() -> None:
                     )
                     logger.info("Collected %s: %.4f %s", result.platform, result.balance, result.currency)
                     platforms_ok += 1
+                    if result.platform in previously_alerting:
+                        # Recovered — drop the stored alert so a future failure counts
+                        # as new and notifies again.
+                        await database.clear_alerts("collector", result.platform)
             _collector_alerts = alerts
         except Exception as exc:
             logger.error("Collection run failed: %s", exc)
@@ -391,6 +426,10 @@ async def lifespan(app: FastAPI):
     # revocations) so invalidated sessions are rejected without a DB hit in the
     # request path — and, crucially, so those invalidations survive a restart.
     await _warm_session_epochs()
+    # Restore the collector alerts persisted by earlier runs, so a restart doesn't
+    # silently clear the notification bell while the underlying collector is still
+    # broken (previously these lived only in memory).
+    await _warm_collector_alerts()
     # First-run setup token: while no users exist, require a one-time token
     # (printed below) for /register so a proxy-exposed instance cannot be seized
     # by the first public visitor. Persisted in config so it survives restarts;

--- a/app/main.py
+++ b/app/main.py
@@ -249,7 +249,17 @@ async def _warm_collector_alerts() -> None:
     except Exception as exc:
         logger.warning("Could not restore persisted alerts: %s", exc)
         return
-    _collector_alerts = [{"platform": a["subject"], "error": a["message"]} for a in stored if a["kind"] == "collector"]
+    # Newest-first, keeping only the most recent row per subject: a normal run puts
+    # exactly one entry per failing platform in this list, and the restored bell must
+    # look the same rather than showing one row per historical message.
+    seen: set[str] = set()
+    restored: list[dict[str, str]] = []
+    for alert in stored:
+        if alert["kind"] != "collector" or alert["subject"] in seen:
+            continue
+        seen.add(alert["subject"])
+        restored.append({"platform": alert["subject"], "error": alert["message"]})
+    _collector_alerts = restored
 
 
 async def _run_collection() -> None:
@@ -285,16 +295,21 @@ async def _run_collection() -> None:
                     continue
                 if result.error:
                     logger.warning("Collection error for %s: %s", result.platform, result.error)
-                    alerts.append({"platform": result.platform, "error": result.error})
+                    # Redact ONCE, here, so the same sanitized string is what gets shown,
+                    # stored and sent. Collector errors are usually str(exc), and an httpx
+                    # exception embeds the offending header or URL — which for several
+                    # providers is a live credential. The alert is now durable and readable
+                    # by any authenticated role, so it must never hold a secret.
+                    safe_error = notify.redact(result.error)
+                    alerts.append({"platform": result.platform, "error": safe_error})
                     metrics.record_collection_error(result.platform)
-                    # Persist so the alert outlives a restart, and push it out-of-band
-                    # only the FIRST time this particular failure appears — a collector
-                    # broken for a week must not notify every single hour.
-                    if await database.record_alert("collector", result.platform, result.error):
+                    # Push out-of-band only the FIRST time this failure appears — a
+                    # collector broken for a week must not notify every single hour.
+                    if await database.record_alert("collector", result.platform, safe_error):
                         _spawn(
                             notify.send(
                                 f"CashPilot: {result.platform} collector failed",
-                                result.error,
+                                safe_error,
                                 kind="collector",
                                 subject=result.platform,
                             )
@@ -321,7 +336,14 @@ async def _run_collection() -> None:
             logger.error("Collection run failed: %s", exc)
             success = False
             platforms_ok = 0
-            _collector_alerts = [{"platform": "collection", "error": "Collection run failed — see server logs"}]
+            # Keep the per-platform entries: the next run derives "which platforms were
+            # failing" from this list, so clobbering it would make every platform
+            # permanently unrecoverable — its stored alert would never be cleared and
+            # its next real failure would be deduped into silence.
+            _collector_alerts = [
+                *(a for a in _collector_alerts if a.get("platform") != "collection"),
+                {"platform": "collection", "error": "Collection run failed — see server logs"},
+            ]
         finally:
             metrics.record_collection_end(start_time, success, platforms_ok)
 

--- a/app/notify.py
+++ b/app/notify.py
@@ -1,0 +1,92 @@
+"""Out-of-band alert delivery for CashPilot.
+
+Passive income is unattended by definition, so an alert that only appears in an
+open browser tab is an alert nobody sees. This module pushes the ones that matter
+somewhere a person actually looks.
+
+Every target is opt-in through an environment variable and the module is entirely
+inert until one is set, so existing deployments are unaffected. Delivery is
+best-effort and never raises: a misconfigured or unreachable notifier must not be
+able to break an earnings-collection run.
+
+Configure any combination of:
+
+* ``CASHPILOT_NTFY_URL``          -- full topic URL, e.g. ``https://ntfy.sh/my-topic``
+* ``CASHPILOT_WEBHOOK_URL``       -- generic endpoint; receives a small JSON body
+* ``CASHPILOT_TELEGRAM_BOT_TOKEN`` + ``CASHPILOT_TELEGRAM_CHAT_ID``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Deliberately short: this runs inside the collection cycle, and a hanging notifier
+# must not stretch it.
+_TIMEOUT = 10.0
+
+
+def configured_targets() -> list[str]:
+    """Names of the notification targets currently configured (empty = inert)."""
+    targets = []
+    if os.getenv("CASHPILOT_NTFY_URL", "").strip():
+        targets.append("ntfy")
+    if os.getenv("CASHPILOT_WEBHOOK_URL", "").strip():
+        targets.append("webhook")
+    if os.getenv("CASHPILOT_TELEGRAM_BOT_TOKEN", "").strip() and os.getenv("CASHPILOT_TELEGRAM_CHAT_ID", "").strip():
+        targets.append("telegram")
+    return targets
+
+
+def is_enabled() -> bool:
+    return bool(configured_targets())
+
+
+async def _post_ntfy(client: httpx.AsyncClient, title: str, message: str) -> None:
+    url = os.getenv("CASHPILOT_NTFY_URL", "").strip()
+    # ntfy takes the body as the message and the title as a header.
+    await client.post(url, content=message.encode("utf-8"), headers={"Title": title})
+
+
+async def _post_webhook(client: httpx.AsyncClient, title: str, message: str, kind: str, subject: str) -> None:
+    url = os.getenv("CASHPILOT_WEBHOOK_URL", "").strip()
+    await client.post(url, json={"title": title, "message": message, "kind": kind, "subject": subject})
+
+
+async def _post_telegram(client: httpx.AsyncClient, title: str, message: str) -> None:
+    token = os.getenv("CASHPILOT_TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = os.getenv("CASHPILOT_TELEGRAM_CHAT_ID", "").strip()
+    await client.post(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        json={"chat_id": chat_id, "text": f"{title}\n\n{message}"},
+    )
+
+
+async def send(title: str, message: str, *, kind: str = "alert", subject: str = "") -> int:
+    """Deliver one alert to every configured target.
+
+    Returns how many targets accepted it. Failures are logged and swallowed --
+    the caller is a background job whose real work must continue regardless.
+    """
+    targets = configured_targets()
+    if not targets:
+        return 0
+
+    delivered = 0
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        for target in targets:
+            try:
+                if target == "ntfy":
+                    await _post_ntfy(client, title, message)
+                elif target == "webhook":
+                    await _post_webhook(client, title, message, kind, subject)
+                elif target == "telegram":
+                    await _post_telegram(client, title, message)
+                delivered += 1
+            except Exception as exc:  # noqa: BLE001 - notifier failure is never fatal
+                logger.warning("Alert delivery to %s failed: %s", target, exc)
+    return delivered

--- a/app/notify.py
+++ b/app/notify.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 
 import httpx
 
@@ -28,6 +29,29 @@ logger = logging.getLogger(__name__)
 # Deliberately short: this runs inside the collection cycle, and a hanging notifier
 # must not stretch it.
 _TIMEOUT = 10.0
+
+# Alert bodies are built from collector errors, and most collectors report
+# ``str(exc)`` — for an httpx error that string embeds the full request URL, which
+# for several providers carries a token in the query string. The destination may be
+# a PUBLIC ntfy topic, so secrets are stripped here, at the boundary, rather than
+# trusting every caller to have done it.
+_SECRET_PARAM_RE = re.compile(
+    r"((?:token|api[_-]?key|key|secret|password|passwd|pwd|auth|session|sess|cookie|sig|signature)=)[^&\s\"']+",
+    re.IGNORECASE,
+)
+_BEARER_RE = re.compile(r"((?:bearer|basic)\s+)[A-Za-z0-9._\-+/=]+", re.IGNORECASE)
+
+# Notifications are a summary, not a log: keep them short enough for a phone banner.
+_MAX_MESSAGE_LEN = 400
+
+
+def redact(text: str) -> str:
+    """Strip credential-looking values out of an outbound alert body."""
+    text = _SECRET_PARAM_RE.sub(r"\1<redacted>", text)
+    text = _BEARER_RE.sub(r"\1<redacted>", text)
+    if len(text) > _MAX_MESSAGE_LEN:
+        text = text[:_MAX_MESSAGE_LEN] + "..."
+    return text
 
 
 def configured_targets() -> list[str]:
@@ -75,6 +99,11 @@ async def send(title: str, message: str, *, kind: str = "alert", subject: str = 
     targets = configured_targets()
     if not targets:
         return 0
+
+    # Redact at the boundary: every target below is off-box and one of them
+    # (ntfy) is public by default.
+    title = redact(title)
+    message = redact(message)
 
     delivered = 0
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:

--- a/app/notify.py
+++ b/app/notify.py
@@ -41,12 +41,26 @@ _SECRET_PARAM_RE = re.compile(
 )
 _BEARER_RE = re.compile(r"((?:bearer|basic)\s+)[A-Za-z0-9._\-+/=]+", re.IGNORECASE)
 
+# httpx/h11 report a rejected header as `Illegal header value b'<the whole value>'`.
+# Several collectors send a raw secret as a bare header value with no `name=` and no
+# `Bearer ` prefix (grass Authorization, repocket Auth-Token, earnfm X-API-Key,
+# salad/earnapp XSRF, proxyrack Api-Key), so those match neither pattern above.
+# Match the ERROR's shape instead of trying to recognise every secret's shape, and
+# drop the entire quoted value.
+_ILLEGAL_HEADER_RE = re.compile(r"(Illegal header value\s*)b?['\"].*?['\"]", re.IGNORECASE | re.DOTALL)
+
 # Notifications are a summary, not a log: keep them short enough for a phone banner.
 _MAX_MESSAGE_LEN = 400
 
 
 def redact(text: str) -> str:
-    """Strip credential-looking values out of an outbound alert body."""
+    """Strip credential-looking values out of an alert body.
+
+    Applied wherever an alert is created — not only on the way out — because the
+    same string is persisted to SQLite and served by /api/collector-alerts to every
+    authenticated role, while config credentials are owner-only and encrypted.
+    """
+    text = _ILLEGAL_HEADER_RE.sub(r"\1<redacted>", text)
     text = _SECRET_PARAM_RE.sub(r"\1<redacted>", text)
     text = _BEARER_RE.sub(r"\1<redacted>", text)
     if len(text) > _MAX_MESSAGE_LEN:

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -135,6 +135,16 @@ If a worker goes offline (no heartbeat for 180 seconds):
 | `CASHPILOT_WORKER_URL_POLICY` | `permissive` | Worker URL validation policy: `permissive` (LAN + Tailscale work out of the box) or `strict` (allowlist only) |
 | `CASHPILOT_WORKER_ALLOWED_HOSTS` | -- | Comma-separated CIDRs and `*.suffix` hostnames allowed in `strict` mode, e.g. `192.168.10.0/24,100.64.0.0/10,*.ts.net` |
 | `CASHPILOT_WORKER_ALLOW_METADATA` | `false` | Escape hatch to permit cloud-metadata IPs as worker targets (leave `false`) |
+| `CASHPILOT_NTFY_URL` | -- | ntfy topic URL for out-of-band alerts, e.g. `https://ntfy.sh/my-topic` |
+| `CASHPILOT_WEBHOOK_URL` | -- | Generic endpoint receiving alert JSON (`title`, `message`, `kind`, `subject`) |
+| `CASHPILOT_TELEGRAM_BOT_TOKEN` | -- | Telegram bot token (needs `CASHPILOT_TELEGRAM_CHAT_ID` too) |
+| `CASHPILOT_TELEGRAM_CHAT_ID` | -- | Telegram chat to send alerts to |
+
+### Alerts
+
+Passive income is unattended, so an alert that only appears in an open browser tab is an alert nobody sees. Collector failures are **persisted** (they survive a restart and repopulate the notification bell) and, if any target above is configured, pushed out-of-band.
+
+Notifications fire **only the first time** a particular failure appears — a collector that has been broken for a week does not notify every hour. When the service recovers, its stored alert is cleared, so a later failure counts as new and notifies again. With no target configured the feature is entirely inert.
 
 ### Worker
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -569,11 +569,27 @@ class TestAlerts:
 
         asyncio.run(run())
 
-    def test_changed_message_counts_as_new(self, db):
+    def test_alternating_messages_do_not_defeat_the_cooldown(self, db):
+        """Regression: dedupe used to compare only against the LAST message.
+
+        Several collectors alternate between two error strings for one underlying
+        fault (grass flips between an expired token and a Cloudflare rate-limit), so
+        message-equality dedupe re-notified every hour and grew the table forever.
+        """
+
         async def run():
-            await database.record_alert("collector", "honeygain", "login failed")
-            assert await database.record_alert("collector", "honeygain", "429 rate limited") is True
-            assert len(await database.list_alerts()) == 2
+            assert await database.record_alert("collector", "grass", "Token expired") is True
+            assert await database.record_alert("collector", "grass", "Cloudflare rate limit") is False
+            assert await database.record_alert("collector", "grass", "Token expired") is False
+            assert len(await database.list_alerts()) == 1
+
+        asyncio.run(run())
+
+    def test_alerts_again_once_the_cooldown_has_passed(self, db):
+        async def run():
+            assert await database.record_alert("collector", "hg", "boom") is True
+            # A zero-length window models the cooldown having elapsed.
+            assert await database.record_alert("collector", "hg", "boom", cooldown_hours=0) is True
 
         asyncio.run(run())
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -556,6 +556,55 @@ class TestEarningsFxMigration:
         asyncio.run(run())
 
 
+class TestAlerts:
+    """Alerts must survive a restart and must not re-notify every hour."""
+
+    def test_first_alert_is_new_duplicate_is_not(self, db):
+        async def run():
+            assert await database.record_alert("collector", "honeygain", "login failed") is True
+            # Same failure an hour later: stored once, reported as not-new so the
+            # caller doesn't re-notify.
+            assert await database.record_alert("collector", "honeygain", "login failed") is False
+            assert len(await database.list_alerts()) == 1
+
+        asyncio.run(run())
+
+    def test_changed_message_counts_as_new(self, db):
+        async def run():
+            await database.record_alert("collector", "honeygain", "login failed")
+            assert await database.record_alert("collector", "honeygain", "429 rate limited") is True
+            assert len(await database.list_alerts()) == 2
+
+        asyncio.run(run())
+
+    def test_list_alerts_is_newest_first(self, db):
+        async def run():
+            await database.record_alert("collector", "a", "first")
+            await database.record_alert("collector", "b", "second")
+            alerts = await database.list_alerts()
+            assert [a["subject"] for a in alerts] == ["b", "a"]
+
+        asyncio.run(run())
+
+    def test_clear_by_subject_only_clears_that_subject(self, db):
+        async def run():
+            await database.record_alert("collector", "honeygain", "boom")
+            await database.record_alert("collector", "earnapp", "boom")
+            await database.clear_alerts("collector", "honeygain")
+            assert [a["subject"] for a in await database.list_alerts()] == ["earnapp"]
+
+        asyncio.run(run())
+
+    def test_recovery_then_failure_notifies_again(self, db):
+        # The point of clearing on recovery: the next failure must count as new.
+        async def run():
+            assert await database.record_alert("collector", "hg", "boom") is True
+            await database.clear_alerts("collector", "hg")
+            assert await database.record_alert("collector", "hg", "boom") is True
+
+        asyncio.run(run())
+
+
 class TestHealthEvents:
     def test_record_and_get_scores(self, db):
         async def run():

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,131 @@
+"""Tests for out-of-band alert delivery (app/notify.py).
+
+Two properties matter most and are asserted explicitly:
+  * the module is completely inert until a target is configured (existing
+    deployments must be unaffected), and
+  * a failing notifier never raises, because it runs inside the earnings
+    collection cycle and must not be able to break it.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+from app import notify  # noqa: E402
+
+_ALL_TARGET_VARS = {
+    "CASHPILOT_NTFY_URL": "",
+    "CASHPILOT_WEBHOOK_URL": "",
+    "CASHPILOT_TELEGRAM_BOT_TOKEN": "",
+    "CASHPILOT_TELEGRAM_CHAT_ID": "",
+}
+
+
+def _env(**overrides):
+    """Env with every notification target cleared, then the given ones set."""
+    return patch.dict(os.environ, {**_ALL_TARGET_VARS, **overrides})
+
+
+def _mock_client():
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=MagicMock(status_code=200))
+    return client
+
+
+class TestConfiguration:
+    def test_inert_by_default(self):
+        with _env():
+            assert notify.configured_targets() == []
+            assert notify.is_enabled() is False
+
+    def test_each_target_detected(self):
+        with _env(CASHPILOT_NTFY_URL="https://ntfy.sh/t"):
+            assert notify.configured_targets() == ["ntfy"]
+        with _env(CASHPILOT_WEBHOOK_URL="https://example.com/hook"):
+            assert notify.configured_targets() == ["webhook"]
+        with _env(CASHPILOT_TELEGRAM_BOT_TOKEN="tok", CASHPILOT_TELEGRAM_CHAT_ID="123"):
+            assert notify.configured_targets() == ["telegram"]
+
+    def test_telegram_needs_both_token_and_chat_id(self):
+        with _env(CASHPILOT_TELEGRAM_BOT_TOKEN="tok"):
+            assert notify.configured_targets() == []
+        with _env(CASHPILOT_TELEGRAM_CHAT_ID="123"):
+            assert notify.configured_targets() == []
+
+    def test_whitespace_only_value_is_not_configuration(self):
+        with _env(CASHPILOT_NTFY_URL="   "):
+            assert notify.configured_targets() == []
+
+
+@pytest.mark.asyncio
+class TestSend:
+    async def test_inert_send_makes_no_request(self):
+        client = _mock_client()
+        with _env(), patch("app.notify.httpx.AsyncClient", return_value=client):
+            assert await notify.send("t", "m") == 0
+        client.post.assert_not_called()
+
+    async def test_ntfy_posts_body_with_title_header(self):
+        client = _mock_client()
+        with (
+            _env(CASHPILOT_NTFY_URL="https://ntfy.sh/topic"),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            assert await notify.send("Title", "Body") == 1
+        url = client.post.call_args.args[0]
+        kwargs = client.post.call_args.kwargs
+        assert url == "https://ntfy.sh/topic"
+        assert kwargs["content"] == b"Body"
+        assert kwargs["headers"]["Title"] == "Title"
+
+    async def test_webhook_posts_structured_json(self):
+        client = _mock_client()
+        with (
+            _env(CASHPILOT_WEBHOOK_URL="https://example.com/hook"),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            assert await notify.send("Title", "Body", kind="collector", subject="honeygain") == 1
+        payload = client.post.call_args.kwargs["json"]
+        assert payload == {"title": "Title", "message": "Body", "kind": "collector", "subject": "honeygain"}
+
+    async def test_telegram_uses_bot_api_with_chat_id(self):
+        client = _mock_client()
+        with (
+            _env(CASHPILOT_TELEGRAM_BOT_TOKEN="tok", CASHPILOT_TELEGRAM_CHAT_ID="42"),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            assert await notify.send("Title", "Body") == 1
+        assert client.post.call_args.args[0] == "https://api.telegram.org/bottok/sendMessage"
+        assert client.post.call_args.kwargs["json"]["chat_id"] == "42"
+
+    async def test_all_targets_receive_the_alert(self):
+        client = _mock_client()
+        with (
+            _env(
+                CASHPILOT_NTFY_URL="https://ntfy.sh/t",
+                CASHPILOT_WEBHOOK_URL="https://example.com/hook",
+                CASHPILOT_TELEGRAM_BOT_TOKEN="tok",
+                CASHPILOT_TELEGRAM_CHAT_ID="42",
+            ),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            assert await notify.send("t", "m") == 3
+        assert client.post.await_count == 3
+
+    async def test_failing_target_never_raises_and_others_still_deliver(self):
+        # The caller is the collection cycle: a dead notifier must not break it.
+        client = _mock_client()
+        client.post = AsyncMock(side_effect=[RuntimeError("ntfy down"), MagicMock(status_code=200)])
+        with (
+            _env(CASHPILOT_NTFY_URL="https://ntfy.sh/t", CASHPILOT_WEBHOOK_URL="https://example.com/hook"),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            delivered = await notify.send("t", "m")
+        assert delivered == 1  # webhook still got it

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -64,8 +64,55 @@ class TestConfiguration:
             assert notify.configured_targets() == []
 
 
+class TestRedaction:
+    """Alert bodies are built from collector errors, most of which are str(exc).
+
+    For an httpx error that string embeds the full request URL — and several
+    providers put a token in the query. The destination can be a PUBLIC ntfy topic,
+    so nothing credential-shaped may leave this module.
+    """
+
+    def test_token_in_a_url_query_is_redacted(self):
+        raw = "Client error '401 Unauthorized' for url 'https://api.example.com/v1/me?token=SUPERSECRET123'"
+        out = notify.redact(raw)
+        assert "SUPERSECRET123" not in out
+        assert "token=<redacted>" in out
+
+    @pytest.mark.parametrize(
+        "param", ["api_key", "api-key", "key", "secret", "password", "auth", "session", "cookie", "signature"]
+    )
+    def test_common_credential_params_are_redacted(self, param):
+        out = notify.redact(f"failed https://x.com/a?{param}=LEAKME&page=2")
+        assert "LEAKME" not in out
+        # Non-secret params survive, so the message stays useful for debugging.
+        assert "page=2" in out
+
+    def test_bearer_token_is_redacted(self):
+        out = notify.redact("rejected header Authorization: Bearer abc.DEF-123_xyz")
+        assert "abc.DEF-123_xyz" not in out
+
+    def test_ordinary_message_is_untouched(self):
+        msg = "Session expired — refresh bytelixir_session cookie in Settings"
+        assert notify.redact(msg) == msg
+
+    def test_long_message_is_truncated(self):
+        assert len(notify.redact("x" * 5000)) <= notify._MAX_MESSAGE_LEN + 3
+
+
 @pytest.mark.asyncio
 class TestSend:
+    async def test_secrets_never_reach_a_target(self):
+        # End-to-end guard: even if a caller passes a raw exception string through.
+        client = _mock_client()
+        with (
+            _env(CASHPILOT_NTFY_URL="https://ntfy.sh/topic"),
+            patch("app.notify.httpx.AsyncClient", return_value=client),
+        ):
+            await notify.send("collector failed", "GET https://api.x.com/v1?token=LEAKME 401")
+        body = client.post.call_args.kwargs["content"].decode()
+        assert "LEAKME" not in body
+        assert "<redacted>" in body
+
     async def test_inert_send_makes_no_request(self):
         client = _mock_client()
         with _env(), patch("app.notify.httpx.AsyncClient", return_value=client):

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -87,6 +87,23 @@ class TestRedaction:
         # Non-secret params survive, so the message stays useful for debugging.
         assert "page=2" in out
 
+    @pytest.mark.parametrize(
+        "secret",
+        [
+            "eyJhbGciOiJSUzI1NiIsFIREBASE_ID_TOKEN.abc",  # repocket Auth-Token
+            "efm_live_SECRETAPIKEY_9f3a",  # earnfm X-API-Key
+            "SALAD_AUTH_COOKIE_SECRET_VALUE",  # salad X-XSRF-TOKEN
+            "XSRF_SECRET_TOKEN_VALUE",  # earnapp xsrf-token
+        ],
+    )
+    def test_bare_header_value_secrets_are_redacted(self, secret):
+        """httpx/h11 report a rejected header as the WHOLE value, with no name= and
+        no Bearer prefix — several collectors send raw secrets exactly that way, so
+        matching the error's shape is the only thing that catches them."""
+        out = notify.redact(f"httpx.LocalProtocolError: Illegal header value b'{secret}'")
+        assert secret not in out
+        assert "<redacted>" in out
+
     def test_bearer_token_is_redacted(self):
         out = notify.redact("rejected header Authorization: Bearer abc.DEF-123_xyz")
         assert "abc.DEF-123_xyz" not in out


### PR DESCRIPTION
## Why

Passive income is unattended by definition, so an alert that only exists in a running process and an open browser tab is an alert nobody sees. `_collector_alerts` was a module global — **wiped on every restart**, visible only through a polling bell.

## What

- **Persisted** to SQLite: alerts survive a restart and repopulate the bell at startup, so a restart no longer silently reports "all fine" while the collector is still broken.
- **Delivered out-of-band** to any configured target: **ntfy**, a **generic JSON webhook**, or **Telegram**.
- Every target is opt-in via env var; with none set the module is **entirely inert**, so existing deployments are unaffected.
- Delivery **never raises** — it runs inside the earnings-collection cycle and a dead notifier must not be able to break it (explicitly tested).

## The part that makes it usable rather than noise

Notification fires **only the first time** a given failure appears. A collector broken for a week would otherwise page you 168 times. When the service **recovers**, its stored alert is cleared — so a later failure counts as new and notifies again. Duplicates aren't even stored, which keeps the table naturally bounded; alerts are also covered by the existing retention purge.

## Tests

15 new. Notifier: inert-by-default (and makes *no* request when inert), each target's exact wire format, Telegram requiring both token and chat id, whitespace-only values not counting as configuration, all-targets fan-out, and a failing target not preventing the others. Database: first-alert-is-new / duplicate-is-not, changed message counts as new, newest-first ordering, per-subject clearing, and the recovery→failure-notifies-again path.

Full suite **1195 passing**; repo-wide `ruff check` + `ruff format --check` clean. Documented in `docs/fleet.md`.

Closes bead CashPilot-1ty.