### PR TITLE
fix: stop reporting a session-capture referral link as dead

### DIFF
--- a/scripts/check_catalog_liveness.py
+++ b/scripts/check_catalog_liveness.py
@@ -91,9 +91,15 @@ def referral_code_lost(original: str, final: str) -> bool:
     """True when a referral link redirected to a bare homepage, dropping its code.
 
     The classic symptom of a retired referral programme: ``…/signup?ref=CODE`` ends
-    up at ``https://provider.com/``. Only that specific collapse is reported -- many
-    healthy links legitimately drop the query after setting a cookie, so anything
-    looser would be noise.
+    up at ``https://provider.com/``.
+
+    This detects the *collapse*, which is NOT the same as proving the code was
+    lost. A very common healthy pattern looks identical from outside: the site
+    reads ``?ref=CODE``, stores it in the session, sets a cookie and 302s to a
+    clean URL. ProxyLite does exactly that -- ``?r=CODE`` returns 302 + a
+    PHPSESSID cookie while the bare homepage returns 200. Telling the two apart
+    needs an account, so callers must report this as inconclusive, never as a
+    confirmed dead link.
     """
     orig = urlparse(original)
     fin = urlparse(final)
@@ -198,7 +204,14 @@ def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> lis
             try:
                 final = str(client.head(signup).url)
                 if referral_code_lost(signup, final):
-                    status, detail = DEAD, f"referral code lost -> {final}"
+                    # Inconclusive, not dead: a site that captures the code into
+                    # the session and redirects to a clean URL is indistinguishable
+                    # from one that dropped it. Verified against ProxyLite, where
+                    # this exact shape is a WORKING referral link.
+                    status, detail = (
+                        UNREACHABLE,
+                        f"referral code not visible after redirect -> {final} (verify manually)",
+                    )
             except httpx.HTTPError:
                 pass
         findings.append(Finding(slug, "referral", signup, status, detail))

--- a/scripts/check_catalog_liveness.py
+++ b/scripts/check_catalog_liveness.py
@@ -224,6 +224,10 @@ def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> lis
     return findings
 
 
+# One legend, rendered by every report shape so the two can never drift apart.
+_LEGEND = "_`unreachable` means we could not tell -- a transient provider outage, a registry rate-limit, or a referral link that redirected somewhere its code is no longer visible (which is also what a working session-capture link looks like). Reported, but not counted as a problem. `dead` means the reference answered with a client error, or a catalog file could not be read._"
+
+
 def build_report(findings: list[Finding]) -> str:
     problems = [f for f in findings if f.is_problem]
     unknown = [f for f in findings if f.is_inconclusive]
@@ -247,6 +251,9 @@ def build_report(findings: list[Finding]) -> str:
         if unknown:
             lines += ["", f"{len(unknown)} check(s) were inconclusive and are listed below.", ""]
             lines += _unknown_section()
+            # The legend belongs here too: an all-inconclusive run is exactly when
+            # a reader needs to know that "unreachable" is not "broken".
+            lines += [_LEGEND]
         return "\n".join(lines)
 
     lines += [f"**{len(problems)} problem(s)** across {checked} services checked.", ""]
@@ -279,11 +286,7 @@ def build_report(findings: list[Finding]) -> str:
 
     lines += _unknown_section()
 
-    lines += [
-        "_`unreachable` may be a transient provider outage or a registry rate-limit, so it is "
-        "reported but not counted as a problem; `dead` means the reference answered with a "
-        "client error or the referral link collapsed to a bare homepage._",
-    ]
+    lines += [_LEGEND]
     return "\n".join(lines)
 
 

--- a/tests/test_catalog_liveness.py
+++ b/tests/test_catalog_liveness.py
@@ -215,3 +215,33 @@ class TestInconclusiveIsNotAProblem:
             liveness.check_image("repo/img:1")
         assert "--" in captured["cmd"]
         assert captured["cmd"].index("--") == captured["cmd"].index("repo/img:1") - 1
+
+
+class TestReferralCollapseIsInconclusive:
+    """A collapsed referral URL must not be reported as a confirmed dead link.
+
+    Regression for a real false positive: ProxyLite's `?r=CODE` returns 302 +
+    a session cookie and lands on the bare homepage, which is a WORKING referral
+    capture. Calling that "dead" sent us to retire a live, earning service.
+    """
+
+    def test_collapse_is_reported_but_not_counted_as_a_problem(self):
+        client = MagicMock()
+        client.head.return_value = MagicMock(status_code=200, url="https://p.com/")
+        findings = liveness.check_service(
+            client,
+            {
+                "slug": "p",
+                "status": "active",
+                "website": "https://p.com",
+                "referral": {"signup_url": "https://p.com/?r=CODE"},
+            },
+            check_images=False,
+        )
+        ref = [f for f in findings if f.kind == "referral"][0]
+        assert ref.status == liveness.UNREACHABLE
+        assert not ref.is_problem, "a session-capture referral must not be called dead"
+        assert ref.is_inconclusive
+        report = liveness.build_report(findings)
+        assert report.splitlines()[2].startswith("All good")
+        assert "verify manually" in report

--- a/tests/test_catalog_liveness.py
+++ b/tests/test_catalog_liveness.py
@@ -245,3 +245,11 @@ class TestReferralCollapseIsInconclusive:
         report = liveness.build_report(findings)
         assert report.splitlines()[2].startswith("All good")
         assert "verify manually" in report
+
+    def test_footer_does_not_call_a_collapse_dead(self):
+        """The footer must match the classification, or it teaches the wrong lesson."""
+        findings = [liveness.Finding("a", "referral", "https://p.com/?r=X", liveness.UNREACHABLE, "not visible")]
+        report = liveness.build_report(findings)
+        tail = report.rsplit("_`unreachable`", 1)[-1]
+        assert "referral link collapsed" not in tail
+        assert "no longer visible" in tail


### PR DESCRIPTION
The weekly catalog-liveness check reported ProxyLite's referral link as `referral code lost` and counted it as a problem. Verified against the live site — that is wrong:

| Request | Response |
|---|---|
| bare homepage | `200` |
| `?r=KMUPRZIZ` | `302` + `Set-Cookie: PHPSESSID` → `/` |
| `?r=ZZZZNOPE9` (bogus) | `302` → `/` |

The site special-cases `?r=`, captures the code into the PHP session and redirects to a clean URL. That is a **working** referral link, and the ProxyLite node is live (container relaying traffic continuously, `restarts=0`).

Distinguishing capture-and-redirect from a genuinely dropped code requires an account, so this is now reported as **inconclusive** rather than dead: still listed under 'Could not verify', but not counted in the problem tally that opens the weekly issue.

Against the live catalog the report goes from **1 problem** to **All good — 50 services checked** with 11 inconclusive. The single 'problem' was this false positive.

Adds a regression test pinning the behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Referral links that redirect to a clean homepage are no longer incorrectly reported as dead.
  * These cases now appear as requiring manual verification while preserving the overall “All good” status.

* **Tests**
  * Added coverage to ensure collapsed referral URLs remain visible in reports without being counted as problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->