### PR TITLE
fix(worker): do not use an ephemeral container ID as the worker identity

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -64,6 +64,11 @@ _ui_connected = False
 _last_heartbeat: str = "never"
 _last_error: str = ""
 
+# Consecutive 401s while holding our own per-worker key. One is unremarkable (the UI
+# may be restarting); a run of them means our identity no longer matches our key.
+_consecutive_auth_failures = 0
+_AUTH_FAILURE_ALARM_AFTER = 3
+
 # Per-worker fleet key. On first contact the UI enrolls this worker and hands back
 # a key unique to us, which we persist here (in our own private /data, never the
 # shared /fleet volume) and use for all subsequent auth in both directions. Until
@@ -110,13 +115,37 @@ _worker_key: str | None = _load_worker_key()
 _WORKER_ID_FILE = Path(os.getenv("CASHPILOT_DATA_DIR", "/data")) / ".worker_id"
 
 
+_DOCKER_CONTAINER_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+
+
+def _name_is_ephemeral(name: str) -> bool:
+    """True when WORKER_NAME is really a Docker-assigned container ID.
+
+    Docker defaults a container's hostname to the first 12 hex characters of its
+    ID, and that ID changes every time the container is recreated -- which is
+    exactly what an image bump does. Treating such a name as a durable identity
+    mints a new client_id on every upgrade; the UI then sees a still-valid
+    per-worker key arriving from an unknown client and correctly refuses it, so
+    every heartbeat 401s while the service containers keep earning. The outage
+    is silent. Observed in production upgrading 1.0.0 -> 1.4.1.
+
+    A real host name (bare metal, a VM, or an explicit `hostname:`/
+    CASHPILOT_WORKER_NAME) stays stable across restarts and remains a perfectly
+    good identity, so only the container-ID shape is rejected, and only when we
+    are actually inside a container.
+    """
+    return bool(_DOCKER_CONTAINER_ID_RE.match(name)) and Path("/.dockerenv").exists()
+
+
 def _load_or_create_client_id() -> str:
     """Return this worker's stable client_id, generating and persisting one on first run.
 
     Migration: a worker already enrolled under the pre-client_id scheme has a persisted
     per-worker key but no id file. It keeps the identity the UI already knows it by --
-    its WORKER_NAME -- so upgrading never orphans its row or forces a re-enrollment that
-    its own (already cut-over) key could not complete. A brand-new worker gets a random id.
+    its WORKER_NAME -- so upgrading never orphans its row. The one exception is a name
+    that is really a Docker container ID: that is regenerated on every recreate, so
+    reusing it would mint a new identity and lock the worker out (see _name_is_ephemeral).
+    A brand-new worker gets a random id.
     """
     try:
         existing = _WORKER_ID_FILE.read_text().strip()
@@ -124,7 +153,24 @@ def _load_or_create_client_id() -> str:
             return existing
     except OSError:
         pass
-    cid = WORKER_NAME if _worker_key else uuid.uuid4().hex
+    if _worker_key and not _name_is_ephemeral(WORKER_NAME):
+        cid = WORKER_NAME
+    else:
+        cid = uuid.uuid4().hex
+        if _worker_key:
+            # Enrolled already, but our only clue to which row is ours was an
+            # ephemeral container ID. Say so loudly: the symptom (401 on every
+            # heartbeat) is otherwise very hard to trace back to this decision.
+            logger.warning(
+                "This worker holds a per-worker key but no persisted client_id, and its "
+                "name (%s) is a container ID that changes on every recreate. It will "
+                "enroll as a NEW worker (%s). To keep its existing identity instead, stop "
+                "it, write the client_id the UI shows for this worker into %s, start it "
+                "again, and set CASHPILOT_WORKER_NAME so this cannot recur.",
+                WORKER_NAME,
+                cid,
+                _WORKER_ID_FILE,
+            )
     try:
         _WORKER_ID_FILE.parent.mkdir(parents=True, exist_ok=True)
         _WORKER_ID_FILE.write_text(cid)
@@ -169,7 +215,7 @@ def _verify_api_key(request: Request) -> None:
 
 async def _send_heartbeat() -> None:
     """Send a single heartbeat to the UI."""
-    global _ui_connected, _last_heartbeat, _last_error
+    global _ui_connected, _last_heartbeat, _last_error, _consecutive_auth_failures
 
     containers = []
     try:
@@ -210,12 +256,30 @@ async def _send_heartbeat() -> None:
             _ui_connected = True
             _last_heartbeat = datetime.now(UTC).strftime("%H:%M:%S UTC")
             _last_error = ""
+            _consecutive_auth_failures = 0
             logger.debug("Heartbeat sent to %s", UI_URL)
     except httpx.HTTPStatusError as exc:
         _ui_connected = False
         status = exc.response.status_code
         _last_error = f"authentication rejected ({status})" if status in (401, 403) else "connection failed"
         logger.warning("Heartbeat failed: %s", exc)
+        if status == 401 and _worker_key:
+            _consecutive_auth_failures += 1
+            if _consecutive_auth_failures == _AUTH_FAILURE_ALARM_AFTER:
+                # A per-worker key rejected repeatedly almost always means our
+                # client_id no longer matches the row the UI enrolled — usually
+                # because the id was derived from a container hostname that
+                # changed on recreate. Service containers keep earning through
+                # this, so nothing else surfaces the problem: say it plainly once.
+                logger.error(
+                    "Rejected %d times with this worker's own key. The UI does not "
+                    "recognise client_id %r. If the UI still lists this worker under a "
+                    "different id, stop this container, write that id into %s, and start "
+                    "it again to reclaim the existing row.",
+                    _consecutive_auth_failures,
+                    CLIENT_ID,
+                    _WORKER_ID_FILE,
+                )
     except Exception as exc:
         _ui_connected = False
         _last_error = "connection failed"

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -159,14 +159,18 @@ def _load_or_create_client_id() -> str:
         cid = uuid.uuid4().hex
         if _worker_key:
             # Enrolled already, but our only clue to which row is ours was an
-            # ephemeral container ID. Say so loudly: the symptom (401 on every
-            # heartbeat) is otherwise very hard to trace back to this decision.
-            logger.warning(
+            # ephemeral container ID. This is NOT recoverable by re-enrolling:
+            # we still send our own per-worker key (see _active_key), and the UI
+            # refuses it under an id it never enrolled, so every heartbeat 401s
+            # until the id is restored by hand. Say exactly that -- the symptom
+            # is otherwise very hard to trace back to this decision.
+            logger.error(
                 "This worker holds a per-worker key but no persisted client_id, and its "
-                "name (%s) is a container ID that changes on every recreate. It will "
-                "enroll as a NEW worker (%s). To keep its existing identity instead, stop "
-                "it, write the client_id the UI shows for this worker into %s, start it "
-                "again, and set CASHPILOT_WORKER_NAME so this cannot recur.",
+                "name (%s) is a container ID that changes on every recreate. Heartbeats "
+                "will be REJECTED (401) under the generated id %s, because we authenticate "
+                "with our existing key and the UI does not know that id. To recover: stop "
+                "this container, write the client_id the UI lists for this worker into %s, "
+                "start it again, and set CASHPILOT_WORKER_NAME so this cannot recur.",
                 WORKER_NAME,
                 cid,
                 _WORKER_ID_FILE,
@@ -265,6 +269,11 @@ async def _send_heartbeat() -> None:
         logger.warning("Heartbeat failed: %s", exc)
         if status == 401 and _worker_key:
             _consecutive_auth_failures += 1
+        else:
+            # Any other outcome breaks the run. "Consecutive" has to mean it:
+            # 401 -> timeout -> 401 -> 500 -> 401 is a flaky link, not an
+            # identity mismatch, and must not raise the alarm.
+            _consecutive_auth_failures = 0
             if _consecutive_auth_failures == _AUTH_FAILURE_ALARM_AFTER:
                 # A per-worker key rejected repeatedly almost always means our
                 # client_id no longer matches the row the UI enrolled — usually
@@ -283,6 +292,8 @@ async def _send_heartbeat() -> None:
     except Exception as exc:
         _ui_connected = False
         _last_error = "connection failed"
+        # A network failure is not an auth rejection, so it breaks the run too.
+        _consecutive_auth_failures = 0
         logger.warning("Heartbeat failed: %s", exc)
 
 

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -152,7 +152,7 @@ Notifications fire **only the first time** a particular failure appears — a co
 |----------|:--------:|---------|-------------|
 | `CASHPILOT_UI_URL` | Yes | -- | URL of the CashPilot UI (e.g. `http://192.168.10.100:8080`) |
 | `CASHPILOT_API_KEY` | Yes | -- | Must match the UI's API key |
-| `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker in the fleet dashboard |
+| `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker. **Set this on Docker workers.** Without it the worker's identity falls back to the container hostname, which Docker regenerates on every recreate -- see [Worker identity](#worker-identity) |
 | `CASHPILOT_WORKER_URL` | No | *(auto-detected)* | URL the UI uses to reach this worker. Set explicitly for remote/cross-host workers -- auto-detection can report an unreachable address |
 | `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
 | `CASHPILOT_ALLOWED_VOLUME_ROOTS` | No | *(none)* | Colon-separated host directories this worker may bind-mount despite sitting under a blocked system root -- see [Volume mounts](#volume-mounts) |
@@ -184,6 +184,29 @@ Relative paths are refused, and refusals are logged with the reason.
 Service containers are third-party and closed-source, so the worker deploys them with the minimum kernel surface: **all capabilities dropped**, then only the ones that service's own catalog entry declares added back. They also get `no-new-privileges`, a PID limit, and are **never** privileged — `privileged` is refused by spec validation and is not an accepted argument in the deploy path at all.
 
 If you add a service that genuinely needs a capability, declare it in that service's YAML (`docker.cap_add`). The check is **per service**: a slug may only request the capabilities its own catalog entry declares, so adding one to one service grants nothing to the others. Today that is Mysterium's `NET_ADMIN` and Bitping's `NET_RAW`.
+
+### Worker identity
+
+The UI keys each worker's row -- and its per-worker fleet key -- on a `client_id`,
+persisted at `/data/.worker_id`. That file is written on first run and reused forever,
+so a worker keeps its row across restarts and upgrades.
+
+Set **`CASHPILOT_WORKER_NAME`** on every Docker worker. Without it the name defaults to
+`socket.gethostname()`, which inside a container is the first 12 hex characters of the
+container ID -- regenerated every time the container is recreated, which is exactly what
+an image bump does. A worker that first enrolled under such a name has no durable identity
+to fall back on if `/data/.worker_id` is missing.
+
+!!! warning "Symptom: heartbeats 401 after an upgrade"
+    If a worker's identity changes, it keeps its valid per-worker key but presents it
+    under an unknown `client_id`, and the UI correctly refuses it. Every heartbeat then
+    returns `401 Unauthorized` and the worker drops out of the fleet -- while its service
+    containers keep running and earning, so nothing else looks wrong.
+
+    To reclaim the existing row: stop the worker, write the `client_id` the UI lists for
+    it into `/data/.worker_id` (owned/readable by the container user), start it again,
+    and set `CASHPILOT_WORKER_NAME` so it cannot recur. The worker logs this remediation
+    itself after three consecutive rejections.
 
 ### Worker URL Validation
 

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -152,7 +152,7 @@ Notifications fire **only the first time** a particular failure appears — a co
 |----------|:--------:|---------|-------------|
 | `CASHPILOT_UI_URL` | Yes | -- | URL of the CashPilot UI (e.g. `http://192.168.10.100:8080`) |
 | `CASHPILOT_API_KEY` | Yes | -- | Must match the UI's API key |
-| `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker. **Set this on Docker workers.** Without it the worker's identity falls back to the container hostname, which Docker regenerates on every recreate -- see [Worker identity](#worker-identity) |
+| `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker. Recommended on Docker workers: without it the name is the container hostname, so it changes on every recreate and the dashboard label churns -- see [Worker identity](#worker-identity) |
 | `CASHPILOT_WORKER_URL` | No | *(auto-detected)* | URL the UI uses to reach this worker. Set explicitly for remote/cross-host workers -- auto-detection can report an unreachable address |
 | `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
 | `CASHPILOT_ALLOWED_VOLUME_ROOTS` | No | *(none)* | Colon-separated host directories this worker may bind-mount despite sitting under a blocked system root -- see [Volume mounts](#volume-mounts) |
@@ -191,11 +191,14 @@ The UI keys each worker's row -- and its per-worker fleet key -- on a `client_id
 persisted at `/data/.worker_id`. That file is written on first run and reused forever,
 so a worker keeps its row across restarts and upgrades.
 
-Set **`CASHPILOT_WORKER_NAME`** on every Docker worker. Without it the name defaults to
-`socket.gethostname()`, which inside a container is the first 12 hex characters of the
-container ID -- regenerated every time the container is recreated, which is exactly what
-an image bump does. A worker that first enrolled under such a name has no durable identity
-to fall back on if `/data/.worker_id` is missing.
+Inside a container `socket.gethostname()` is the first 12 hex characters of the container
+ID, regenerated every time the container is recreated -- which is exactly what an image
+bump does. A name of that shape is therefore never adopted as an identity: a worker that
+finds no `/data/.worker_id` generates and persists a random one instead.
+
+Setting **`CASHPILOT_WORKER_NAME`** keeps the dashboard label stable across recreates
+(otherwise it follows the container hostname and churns on every upgrade), and gives a
+worker enrolled before `/data/.worker_id` existed a durable identity to migrate on.
 
 !!! warning "Symptom: heartbeats 401 after an upgrade"
     If a worker's identity changes, it keeps its valid per-worker key but presents it

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -337,3 +337,46 @@ class TestClientIdIsNotTheContainerHostname:
             assert not w._name_is_ephemeral("watchtower")
             assert not w._name_is_ephemeral("515CCBC46CD9")
             assert not w._name_is_ephemeral("515ccbc46cd")
+
+
+class TestAuthFailureAlarmCounter:
+    """ "Consecutive" must mean consecutive, or the alarm fires on a flaky link."""
+
+    def _run(self, statuses):
+        """Drive _send_heartbeat once per status. None = network failure."""
+        w._consecutive_auth_failures = 0
+        for st in statuses:
+            if st is None:
+                client = MagicMock()
+                client.__aenter__ = AsyncMock(return_value=client)
+                client.__aexit__ = AsyncMock(return_value=False)
+                client.post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+            else:
+                request = httpx.Request("POST", "http://ui:8080/api/workers/heartbeat")
+                response = httpx.Response(st, request=request, json={})
+                client = MagicMock()
+                client.__aenter__ = AsyncMock(return_value=client)
+                client.__aexit__ = AsyncMock(return_value=False)
+                client.post = AsyncMock(return_value=response)
+            with (
+                patch.object(w, "_worker_key", "own"),
+                patch.object(w, "UI_URL", "http://ui:8080"),
+                patch("app.worker_api.orchestrator.get_status", return_value=[]),
+                patch("app.worker_api.orchestrator.docker_available", return_value=True),
+                patch("app.worker_api.httpx.AsyncClient", return_value=client),
+            ):
+                asyncio.run(w._send_heartbeat())
+        return w._consecutive_auth_failures
+
+    def test_three_straight_401s_reach_the_alarm(self):
+        assert self._run([401, 401, 401]) == w._AUTH_FAILURE_ALARM_AFTER
+
+    def test_a_timeout_between_401s_breaks_the_run(self):
+        # 401 -> timeout -> 401 -> 500 -> 401 is a flaky link, not an identity mismatch.
+        assert self._run([401, None, 401, 500, 401]) == 1
+
+    def test_a_non_401_status_breaks_the_run(self):
+        assert self._run([401, 401, 503, 401]) == 1
+
+    def test_success_resets(self):
+        assert self._run([401, 401, 200]) == 0

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -263,3 +263,77 @@ class TestClientId:
         # Identity travels as client_id; name remains present but display-only.
         assert captured.get("client_id") == "cid-abc"
         assert captured.get("name") == w.WORKER_NAME
+
+
+class TestClientIdIsNotTheContainerHostname:
+    """Regression: a worker's identity must survive a container recreate.
+
+    Docker names a container after the first 12 hex chars of its ID, and that
+    changes on every recreate — which is what an image bump does. Reusing it as
+    the identity minted a new client_id each upgrade; the UI then refused the
+    worker's still-valid per-worker key as coming from an unknown client, so
+    every heartbeat 401'd while the service containers kept earning — a silent
+    fleet outage. Hit in production upgrading 1.0.0 -> 1.4.1.
+    """
+
+    def test_container_id_name_is_rejected_as_identity(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "_worker_key", "already-enrolled-key"),
+            patch.object(w, "WORKER_NAME", "515ccbc46cd9"),
+            patch.object(w.Path, "exists", lambda self: True),
+        ):
+            cid = w._load_or_create_client_id()
+        assert cid != "515ccbc46cd9", "must not adopt an ephemeral container ID"
+        assert len(cid) == 32
+
+    def test_real_hostname_still_migrates(self, tmp_path):
+        # Bare metal / VM: gethostname() is stable, so the migration is correct
+        # and must keep working — this is the row-preserving path.
+        f = tmp_path / ".worker_id"
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "_worker_key", "already-enrolled-key"),
+            patch.object(w, "WORKER_NAME", "watchtower"),
+        ):
+            assert w._load_or_create_client_id() == "watchtower"
+
+    def test_container_id_shape_outside_docker_still_migrates(self, tmp_path):
+        # A host legitimately named like a hex string is not a container.
+        f = tmp_path / ".worker_id"
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "_worker_key", "already-enrolled-key"),
+            patch.object(w, "WORKER_NAME", "515ccbc46cd9"),
+            patch.object(w.Path, "exists", lambda self: False),
+        ):
+            assert w._load_or_create_client_id() == "515ccbc46cd9"
+
+    def test_persisted_id_wins_over_everything(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        f.write_text("159d39365879")
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "WORKER_NAME", "something-else"),
+        ):
+            assert w._load_or_create_client_id() == "159d39365879"
+
+    def test_first_run_persists_id_so_next_recreate_reuses_it(self, tmp_path):
+        f = tmp_path / ".worker_id"
+        with (
+            patch.object(w, "_WORKER_ID_FILE", f),
+            patch.object(w, "_worker_key", None),
+            patch.object(w, "WORKER_NAME", "aaaaaaaaaaaa"),
+            patch.object(w.Path, "exists", lambda self: True),
+        ):
+            first = w._load_or_create_client_id()
+            assert f.read_text() == first
+            assert w._load_or_create_client_id() == first
+
+    def test_ephemeral_detection(self):
+        with patch.object(w.Path, "exists", lambda self: True):
+            assert w._name_is_ephemeral("515ccbc46cd9")
+            assert not w._name_is_ephemeral("watchtower")
+            assert not w._name_is_ephemeral("515CCBC46CD9")
+            assert not w._name_is_ephemeral("515ccbc46cd")


### PR DESCRIPTION
## The bug

A worker keys its UI row — and its per-worker fleet key — on a `client_id`. When none was persisted yet, an already-enrolled worker fell back to `WORKER_NAME`, which defaults to `socket.gethostname()`. **Inside Docker that is the first 12 hex chars of the container ID, regenerated on every recreate.**

So every image bump minted a new identity. The worker presented its still-valid per-worker key under a `client_id` the UI had never enrolled, the UI correctly refused it, and every heartbeat returned `401 Unauthorized`.

**The failure is silent.** Service containers keep running and earning, so nothing looks broken — the fleet just loses the worker. Hit in production upgrading a live 3-worker fleet from 1.0.0 to 1.4.1:

```
POST http://cashpilot-ui:8080/api/workers/heartbeat "HTTP/1.1 401 Unauthorized"
```

The UI listed the worker as `159d39365879`; the recreated container had invented `515ccbc46cd9`.

## The fix

Narrow deliberately. The migration is worth keeping — on bare metal or a VM the hostname **is** stable, and reusing it preserves the row. Only the Docker container-ID shape is rejected, and only when `/.dockerenv` confirms we are in a container, so existing non-container workers migrate exactly as before (their test still passes unchanged).

Also: after three consecutive 401s while holding our own key, log the concrete remediation — which `client_id` we are sending and the file to write the expected one into — instead of repeating a generic warning forever.

## Verification

- 1317 tests pass; `ruff check` + `ruff format --check` clean
- New regression tests cover: container-ID rejected, real hostname still migrates, hex-shaped hostname **outside** Docker still migrates, persisted id always wins, first run persists for the next recreate
- Fix applied by hand to the live fleet first: all 3 workers recovered to `200 OK` with `key_confirmed=1`, and pre-seeding `/data/.worker_id` on the other two servers upgraded them with **zero** 401s

Docs: new *Worker identity* section in `docs/fleet.md` with the symptom and the recovery steps, and `CASHPILOT_WORKER_NAME` now flagged as one to set on Docker workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker identity handling in Docker environments to prevent unstable container names from causing authentication failures.
  * Added alerts after repeated authentication failures, including recovery guidance.
  * Successful heartbeats now clear authentication failure alerts.

* **Documentation**
  * Expanded worker configuration guidance for Docker deployments.
  * Documented persistent worker identities, authentication errors caused by identity changes, and recovery steps.

* **Tests**
  * Added coverage for stable identity persistence, migration scenarios, and ephemeral container-name detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->