### PR TITLE
docs(agents): record what actually resisted the container hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,48 @@ The durable fix is to make deployed storage and catalog agree — either redeplo
 service deliberately once, where an identity reset is acceptable, or keep the bind
 mount and never redeploy that slug from the catalog.
 
+### Applying the hardening: two services fight back
+
+Verified by hardening a live 40-container fleet in place.
+
+**anyone-protocol crash-loops under `cap_drop: ALL`.** Its entrypoint chowns
+`/var/lib/anon` before dropping privileges, which needs capabilities the blanket drop
+removes:
+
+```
+chown: cannot read directory '/var/lib/anon': Permission denied
+failed to change ownership of '/var/lib/anon' to anond:anond
+```
+
+Add back the minimum set — `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID` —
+which is still far stricter than Docker's ~14 defaults. Confirm recovery by the OR
+listener returning on port 9001; that is the part that earns.
+
+**honeygain restart-loops after ANY recreate, and it is not the hardening.** The log
+is:
+
+```
+Please choose a different device name. Device with this name is already active.
+```
+
+Honeygain's server still holds the previous container's session for that device name.
+It clears itself once the session expires — roughly ten restarts, then "Honeygain
+service is connected and running". Do **not** add capabilities to "fix" this: it runs
+correctly on plain `cap_drop: ALL` with no `cap_add`, and capabilities granted during
+a panic tend to stick, because a sensible recreate tool preserves the existing
+`CapAdd` on every later run.
+
+That stickiness is worth designing for: give any such tool a way to *ignore* the
+current `CapAdd` so capabilities added during one bad diagnosis can be taken back.
+
+Two more details that matter when recreating containers by hand:
+
+- `docker rm -f` is SIGKILL. Storage nodes then log `unclean shutdown detected:
+  reconciling logs` on the way back up. Stop with a timeout first.
+- `Config.User` usually comes from the image's `USER` directive, not a `--user` flag,
+  so it survives a recreate without being passed explicitly — a container that ran as
+  a non-root user still does.
+
 ### A recreated worker can lose its identity (fixed in 1.4.2)
 
 **Symptom:** after an image bump, every heartbeat returns `401 Unauthorized` and the


### PR DESCRIPTION
Follow-up to #135, written from actually doing it: hardened a live 40-container fleet (`cap_drop ALL` + `no-new-privileges` + `pids-limit`) in place across three servers. 40/40 hardened, 40/40 running, every mount identical before and after.

Two services resisted, and the distinction between them is the useful part:

**anyone-protocol** genuinely needs capabilities back. Its entrypoint chowns `/var/lib/anon` before dropping privileges:
```
chown: cannot read directory '/var/lib/anon': Permission denied
```
Minimum set is `CHOWN, DAC_OVERRIDE, FOWNER, SETUID, SETGID` — still far stricter than Docker's ~14 defaults.

**honeygain** looks identical from the outside (restart loop) but is **not** a capability problem at all — the provider still holds the previous session for that device name, and it resolves itself. Adding capabilities there is a wrong fix that then *sticks*, because a recreate tool preserving `CapAdd` carries them into every later run. Documented, along with the need for an escape hatch to drop them again.

Plus two mechanics worth knowing before recreating containers by hand: `rm -f` is SIGKILL (storage nodes log an unclean shutdown), and `Config.User` comes from the image so a non-root container stays non-root without passing `--user`.

Docs-only; sits above the generated beads blocks, still out of mkdocs nav.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance for configuring service capabilities when dropping all Linux capabilities.
  * Documented troubleshooting steps for restart loops caused by stale server-side sessions.
  * Added container recreation cautions covering graceful shutdown, capability persistence, and preserving image-defined users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->