### PR TITLE
docs(agents): add language identifiers to the log-output code fences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Verified by hardening a live 40-container fleet in place.
 `/var/lib/anon` before dropping privileges, which needs capabilities the blanket drop
 removes:
 
-```
+```text
 chown: cannot read directory '/var/lib/anon': Permission denied
 failed to change ownership of '/var/lib/anon' to anond:anond
 ```
@@ -127,7 +127,7 @@ listener returning on port 9001; that is the part that earns.
 **honeygain restart-loops after ANY recreate, and it is not the hardening.** The log
 is:
 
-```
+```text
 Please choose a different device name. Device with this name is already active.
 ```
 


### PR DESCRIPTION
Addresses the CodeRabbit finding left on #136 (`AGENTS.md:121` — *"Add language identifiers to both fenced code blocks"*).

I merged #136 without reading its review comments, so this lands the fix as a follow-up. The two blocks quoting container log output had bare `````` fences; they are now ````text```, consistent with the ````bash``` command blocks around them.

Checked the rest of the section while here: the other four fences were already labelled, and all six are balanced. The pre-existing fences inside the generated beads blocks are left alone deliberately — not this PR's scope, and that content is regenerated by `bd setup`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added language annotations to diagnostic code examples in the contributor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->