### PR TITLE
fix(packetstream): read the balance from the metric card, not a heading level

### DIFF
--- a/app/collectors/packetstream.py
+++ b/app/collectors/packetstream.py
@@ -52,18 +52,36 @@ class PacketStreamCollector(BaseCollector):
             balance = 0.0
             parsed = False
 
-            # Pattern 1: server-rendered Balance card (current)
-            # <h3>Balance</h3>...<h2 ...>$0.13</h2>
+            # Pattern 1: the Balance metric card (current layout).
+            #   <div class="card metric-card metric-card-balance">
+            #     <h2 class=metric-title>Balance</h2>
+            #     <p class="card-subtitle ...">Available Funds
+            #     <h2 class="default-font fw-600">$2.12</h2>
+            # Anchored on the semantic class, NOT a heading level: the heading has
+            # already moved once (<h3>Balance</h3> -> <h2 class=metric-title>), which
+            # is what silently broke this collector. The markup is also minified with
+            # unquoted attributes, so do not require quotes around class values.
             match = re.search(
-                r"<h3>Balance</h3>.*?<h2[^>]*>\$?([\d.]+)</h2>",
+                r"metric-card-balance.{0,400}?\$\s*([\d,]+(?:\.\d+)?)",
                 html,
                 re.DOTALL,
             )
             if match:
-                balance = float(match.group(1))
+                balance = float(match.group(1).replace(",", ""))
                 parsed = True
 
-            # Pattern 2: window.userData JSON (legacy)
+            # Pattern 2: the older Balance card layout.
+            if not parsed:
+                match = re.search(
+                    r"<h3>Balance</h3>.*?<h2[^>]*>\$?([\d.]+)</h2>",
+                    html,
+                    re.DOTALL,
+                )
+                if match:
+                    balance = float(match.group(1))
+                    parsed = True
+
+            # Pattern 3: window.userData JSON (legacy)
             if not parsed:
                 match = re.search(
                     r"window\.userData\s*=\s*(\{[^}]+\})",
@@ -77,7 +95,7 @@ class PacketStreamCollector(BaseCollector):
                     except (json.JSONDecodeError, ValueError):
                         pass
 
-            # Pattern 3: bare "balance" key in JSON
+            # Pattern 4: bare "balance" key in JSON
             if not parsed:
                 match = re.search(r'"balance"\s*:\s*([\d.]+)', html)
                 if match:

--- a/tests/test_packetstream_parser.py
+++ b/tests/test_packetstream_parser.py
@@ -1,0 +1,74 @@
+"""PacketStream dashboard parsing.
+
+The balance is scraped from server-rendered HTML, so a layout change silently
+zeroes the collector. It has already happened twice: the heading moved from
+<h3>Balance</h3> to <h2 class=metric-title>Balance</h2>, and window.userData
+disappeared. These tests pin the shapes we have actually seen in the wild.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.collectors.base import EarningsResult
+from app.collectors.packetstream import PacketStreamCollector
+
+# Captured from the live dashboard: minified, attributes unquoted, and the
+# referral strip further down also contains a $ amount that must NOT be picked.
+LIVE_HTML = (
+    '<div class="card metric-card metric-card-balance"><h2 class=metric-title>Balance</h2>'
+    '<p class="card-subtitle mb-4 text-muted">Available Funds'
+    '<h2 class="default-font fw-600">$2.12</h2></div>'
+    '<div class="card metric-card metric-card-sold"><h2 class=metric-title>Sold</h2></div>'
+    "<div class=referral-strip-earned><p class=referral-strip-label>Earned to date"
+    "<p class=referral-strip-value>$0.00</div>"
+)
+
+
+def _collect(html: str) -> EarningsResult:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.url = "https://app.packetstream.io/dashboard"
+    resp.text = html
+    resp.raise_for_status = MagicMock()
+    client = MagicMock()
+    client.__aenter__ = MagicMock(return_value=client)
+
+    async def _get(*a, **k):
+        return resp
+
+    client.get = _get
+    with patch("app.collectors.packetstream.httpx.AsyncClient", return_value=client):
+        return asyncio.run(PacketStreamCollector(auth_token="jwt").collect())
+
+
+class TestPacketStreamBalanceParsing:
+    def test_current_layout(self):
+        r = _collect(LIVE_HTML)
+        assert r.error is None, r.error
+        assert r.balance == 2.12, "must read the Balance card, not the referral strip"
+
+    def test_does_not_grab_the_referral_amount(self):
+        # Referral strip first in the document; the balance card still wins.
+        html = "<div class=referral-strip-earned><p class=referral-strip-value>$99.99</div>" + LIVE_HTML
+        assert _collect(html).balance == 2.12
+
+    def test_thousands_separator(self):
+        html = LIVE_HTML.replace("$2.12", "$1,234.56")
+        assert _collect(html).balance == 1234.56
+
+    def test_previous_layout_still_parses(self):
+        # Older card: <h3>Balance</h3> ... <h2>$0.13</h2>
+        assert _collect("<h3>Balance</h3><div><h2 class=x>$0.13</h2></div>").balance == 0.13
+
+    def test_legacy_window_userdata(self):
+        assert _collect('window.userData = {"balance": 7.5}').balance == 7.5
+
+    @pytest.mark.parametrize("html", ["<html><body>nothing here</body></html>", ""])
+    def test_unparseable_reports_an_error_rather_than_zero_earnings(self, html):
+        r = _collect(html)
+        assert r.error is not None
+        assert "page structure" in r.error


### PR DESCRIPTION
PacketStream rebuilt its dashboard, so the collector could not find a balance and reported `Could not parse balance from dashboard — page structure may have changed`. Confirmed against the live dashboard (auth is fine — `/dashboard` returns 200; it was purely parsing).

**What changed on their side:** `window.userData` is gone entirely, and the balance moved into a metric card:

```html
<div class="card metric-card metric-card-balance"><h2 class=metric-title>Balance</h2>
<p class="card-subtitle mb-4 text-muted">Available Funds
<h2 class="default-font fw-600">$2.12</h2></div>
```

**The fix** anchors on the `metric-card-balance` class instead of a heading level. That matters: the heading has already moved once (`<h3>Balance</h3>` → `<h2 class=metric-title>`), which is what broke it, so the class is the more stable anchor. The markup is minified with unquoted attributes, so the pattern cannot require quotes, and the match is length-bounded so it cannot run past the card into the referral strip — which contains its own `$0.00` further down.

Older layouts stay as fallbacks.

**Verification:** extracts `2.12` from the real captured page, and a test puts a $99.99 referral amount *before* the balance card to prove the card still wins. 1330 tests pass, ruff clean.