### PR TITLE
docs: render the feature icons and redraw the header logo

### DIFF
--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,42 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="CashPilot">
+  <!--
+    Header logo. Deliberately NOT the same artwork as icon.svg (the favicon):
+    this one is drawn to survive being scaled to ~24px on the theme's coloured
+    header bar. That means no background plate (it would read as a dark blob
+    against the purple), no sub-pixel strokes, and no fine detail that turns to
+    mud. Bold shapes and high contrast only.
+  -->
   <defs>
-    <linearGradient id="bg" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#0A0A1A"/>
-      <stop offset="50%" style="stop-color:#12082A"/>
-      <stop offset="100%" style="stop-color:#0E0520"/>
+    <linearGradient id="cpSun" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFD54F"/>
+      <stop offset="40%" stop-color="#FF9800"/>
+      <stop offset="72%" stop-color="#E91E63"/>
+      <stop offset="100%" stop-color="#AB47BC"/>
     </linearGradient>
-    <linearGradient id="sun" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#FFD54F"/>
-      <stop offset="35%" style="stop-color:#FF9800"/>
-      <stop offset="65%" style="stop-color:#E91E63"/>
-      <stop offset="100%" style="stop-color:#7B1FA2"/>
-    </linearGradient>
-    <clipPath id="sunClip">
-      <circle cx="128" cy="128" r="72"/>
-    </clipPath>
+    <mask id="cpBands">
+      <rect width="256" height="256" fill="#fff"/>
+      <!-- Horizon bands cut straight out of the disc, thick enough to stay
+           visible when the whole mark is 24px wide. -->
+      <rect x="16" y="150" width="224" height="10" fill="#000"/>
+      <rect x="16" y="172" width="224" height="13" fill="#000"/>
+      <rect x="16" y="197" width="224" height="16" fill="#000"/>
+    </mask>
   </defs>
-  <rect width="256" height="256" rx="32" fill="url(#bg)"/>
-  <circle cx="128" cy="128" r="72" fill="url(#sun)"/>
-  <g clip-path="url(#sunClip)">
-    <rect x="40" y="128" width="176" height="5" fill="#0A0A1A" opacity="0.85"/>
-    <rect x="40" y="140" width="176" height="5" fill="#0A0A1A" opacity="0.85"/>
-    <rect x="40" y="152" width="176" height="6" fill="#0A0A1A" opacity="0.85"/>
-    <rect x="40" y="165" width="176" height="7" fill="#0A0A1A" opacity="0.85"/>
-    <rect x="40" y="179" width="176" height="8" fill="#0A0A1A" opacity="0.85"/>
-    <!-- Airplane: long wings, thin fuselage, small tail -->
-    <g transform="translate(128,96) rotate(30)">
-      <path d="M0,-28 L2.5,-6 L30,2 L3,5 L4,12 L0,8 L-4,12 L-3,5 L-30,2 L-2.5,-6 Z"
-            fill="#0A0A1A" opacity="0.65"/>
-    </g>
-  </g>
-  <g opacity="0.12" stroke="#8E24AA" stroke-width="0.8" fill="none">
-    <line x1="128" y1="200" x2="0" y2="256"/>
-    <line x1="128" y1="200" x2="256" y2="256"/>
-    <line x1="128" y1="200" x2="60" y2="256"/>
-    <line x1="128" y1="200" x2="196" y2="256"/>
-    <line x1="128" y1="200" x2="128" y2="256"/>
-    <line x1="20" y1="216" x2="236" y2="216"/>
-    <line x1="10" y1="236" x2="246" y2="236"/>
-    <line x1="0" y1="252" x2="256" y2="252"/>
+
+  <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+
+  <!-- Plane: solid, single colour, sized to still be recognisable when small. -->
+  <g transform="translate(128,104) rotate(28)">
+    <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+          fill="#FFFFFF"/>
   </g>
 </svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,11 @@ markdown_extensions:
   - pymdownx.mark
   - attr_list
   - md_in_html
+  # Renders :material-xxx: shortcodes as real icons. Without this the feature
+  # cards on the home page print the literal shortcode text instead.
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - tables
   - toc:
       permalink: true


### PR DESCRIPTION
Two separate problems on the published site.

### The feature cards were printing raw shortcodes

Every card on the home page showed its icon shortcode as literal text:

```
:material-wizard-hat: Web-Based Setup Wizard
:material-rocket-launch: One-Click Container Deployment
```

…and six more. The grid itself rendered because `attr_list` and `md_in_html` were configured — but `pymdownx.emoji` was not, and that extension is what maps a `:material-xxx:` shortcode onto an icon. This is a bug rather than a style preference.

**Verified in the built HTML**, not just assumed:

| | before | after |
|---|---|---|
| literal `:material-…:` in `index.html` | 8 | **0** |
| rendered icon SVGs | 0 | **8** |

### The header logo was the wrong artwork for the size

`logo.svg` was the full 256×256 illustration including its dark rounded background plate. At the ~24px the theme renders it on the coloured header bar, the plate reads as a black blob against the purple, and the detail inside it — 0.8px strokes at 12% opacity, 5px horizon stripes, a small rotated plane — is simply not resolvable.

Redrawn for the size it is actually displayed at: no background plate (transparent, so it sits on the header colour), thick masked horizon bands, one solid plane, same sunset gradient identity. A comment in the file explains why it deliberately differs from `icon.svg`.

`icon.svg` is untouched — a favicon *does* want its background plate.

Built locally with `mkdocs build --strict`; site builds clean.