### PR TITLE
fix: clamp earnings per platform so a payout can't erase real earnings (CashPilot-glc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to CashPilot are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A payout on one platform no longer erases earnings on another** (CashPilot-glc). Daily and summary earnings were computed by summing every platform's balance delta and only then clamping the total at zero. On a day a payout landed, that platform's balance fell, and the drop cancelled real earnings on other platforms before the clamp ever ran — so a day you actually earned could report zero. Each platform's delta is now clamped at zero *before* summing, so a payout counts as 'nothing earned there today' and never eats into the rest. A pure payout day reads as zero, never negative. The remaining half of the ledger work — a payouts table, drop detection, a lifetime-earned vs current-balance split, and a projected payout date — is tracked as a follow-on
 - **ProxyBase migrated to the current client** (#103). ProxyBase retired its Docker Hub image and old GHCR org and moved to `proxybase.org`, so the catalog entry no longer worked. The image is now `ghcr.io/proxybaseorg/peer-cli` (digest-pinned, multi-arch amd64/arm64/armv7 — arm64/Raspberry Pi now supported), credentials are the client's current `ID` (relabelled **Access Token**, masked) and `NAME` env vars, every URL points at `proxybase.org`, and datacenter IPs are now marked as accepted (residential still earns most). Existing ProxyBase deployments must be re-deployed with a fresh Access Token — see the [updated guide](docs/guides/proxybase.md)
 
 ### Security

--- a/app/database.py
+++ b/app/database.py
@@ -519,7 +519,10 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
         # Today's earnings: delta from yesterday per platform
         cursor = await db.execute(
             """
-            SELECT COALESCE(SUM(t.balance - COALESCE(y.balance, 0)), 0) as earned
+            -- MAX(delta, 0) per platform BEFORE summing: a payout on one
+            -- platform drops its balance, and without the per-platform clamp
+            -- that drop cancels real earnings on another platform in the sum.
+            SELECT COALESCE(SUM(MAX(t.balance - COALESCE(y.balance, 0), 0)), 0) as earned
             FROM (
                 SELECT platform, balance FROM earnings
                 WHERE date = ? AND currency = 'USD'
@@ -538,7 +541,7 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
         cursor = await db.execute(
             """
             SELECT COALESCE(SUM(
-                latest.balance - COALESCE(month_start.balance, 0)
+                MAX(latest.balance - COALESCE(month_start.balance, 0), 0)
             ), 0) as earned
             FROM (
                 SELECT e.platform, e.balance
@@ -571,7 +574,7 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
         day_before = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
         cursor = await db.execute(
             """
-            SELECT COALESCE(SUM(y.balance - COALESCE(dy.balance, 0)), 0) as earned
+            SELECT COALESCE(SUM(MAX(y.balance - COALESCE(dy.balance, 0), 0)), 0) as earned
             FROM (
                 SELECT platform, balance FROM earnings
                 WHERE date = ? AND currency = 'USD'
@@ -642,27 +645,28 @@ async def get_daily_earnings(days: int = 7) -> list[dict[str, Any]]:
     """Return daily aggregated earnings for charting (delta per day)."""
     db = await _get_db()
     try:
-        # Get daily total balance (sum across platforms) for the range
-        # Include one extra day before the range so we can compute the first delta
+        # Per-platform balances, not a cross-platform sum. Summing first and
+        # diffing the total lets a payout drop on one platform cancel real
+        # earnings on another (see get_earnings_dashboard_summary). We clamp each
+        # platform's daily delta at zero, then sum - so a payout counts as zero
+        # earned on that platform, never as a negative eating the rest.
+        # One extra day before the range so the first delta has a predecessor.
         cursor = await db.execute(
             """
-            SELECT date, SUM(balance) as total_balance
+            SELECT date, platform, balance
             FROM earnings
             WHERE date >= date('now', ?) AND currency = 'USD'
-            GROUP BY date
             ORDER BY date
             """,
             (f"-{days + 1} days",),
         )
         rows = await cursor.fetchall()
-        data = [dict(r) for r in rows]
 
-        # Build a map of date -> total_balance
-        balance_by_date: dict[str, float] = {}
-        for row in data:
-            balance_by_date[row["date"]] = row["total_balance"]
+        # date -> {platform -> balance}
+        by_date: dict[str, dict[str, float]] = {}
+        for row in rows:
+            by_date.setdefault(row["date"], {})[row["platform"]] = row["balance"]
 
-        # Generate result for exactly `days` days
         now = datetime.now(UTC)
         result = []
         for i in range(days - 1, -1, -1):
@@ -670,14 +674,14 @@ async def get_daily_earnings(days: int = 7) -> list[dict[str, Any]]:
             date_str = d.strftime("%Y-%m-%d")
             prev_str = (d - timedelta(days=1)).strftime("%Y-%m-%d")
 
-            current = balance_by_date.get(date_str, 0.0)
-            previous = balance_by_date.get(prev_str, 0.0)
-            delta = max(0.0, current - previous) if current > 0 else 0.0
+            current = by_date.get(date_str, {})
+            previous = by_date.get(prev_str, {})
+            earned = sum(max(0.0, bal - previous.get(platform, 0.0)) for platform, bal in current.items())
 
             result.append(
                 {
                     "date": d.strftime("%b %d"),
-                    "amount": round(delta, 2),
+                    "amount": round(earned, 2),
                 }
             )
 

--- a/tests/test_payout_earnings.py
+++ b/tests/test_payout_earnings.py
@@ -1,0 +1,99 @@
+"""A payout on one platform must not erase earnings on another (CashPilot-glc).
+
+The earnings table stores balance snapshots. When a payout lands, that platform's
+balance falls. Earnings were computed by summing the per-platform deltas and only
+then clamping the total at zero - so a large payout drop on one platform cancelled
+real earnings on another before the clamp ever ran, understating what was earned.
+
+The fix clamps each platform's delta at zero *before* summing, so a payout is
+treated as "zero earned on that platform today", never as a negative that eats
+into the rest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app import database
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    db_path = tmp_path / "cashpilot.db"
+    with (
+        patch.object(database, "DB_DIR", tmp_path),
+        patch.object(database, "DB_PATH", db_path),
+    ):
+        yield tmp_path
+
+
+@pytest.fixture
+def db(db_dir):
+    asyncio.run(database.init_db())
+    return db_dir
+
+
+def _day(offset: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=offset)).strftime("%Y-%m-%d")
+
+
+class TestPayoutDoesNotMaskEarnings:
+    def test_today_summary_counts_the_earning_platform_through_a_payout(self, db):
+        """Platform A pays out 20 the same day platform B earns 2."""
+
+        async def run():
+            # Yesterday's balances.
+            await database.upsert_earnings("platform_a", 20.0, date=_day(1))
+            await database.upsert_earnings("platform_b", 5.0, date=_day(1))
+            # Today: A paid out (20 -> 0.10), B earned (5 -> 7).
+            await database.upsert_earnings("platform_a", 0.10, date=_day(0))
+            await database.upsert_earnings("platform_b", 7.0, date=_day(0))
+            return await database.get_earnings_dashboard_summary()
+
+        summary = asyncio.run(run())
+        # B genuinely earned 2.00. The old code summed (-19.90 + 2.00) = -17.90,
+        # clamped to 0.00, and reported nothing earned at all.
+        assert summary["today"] == pytest.approx(2.0), (
+            f"expected B's 2.00 to survive A's payout, got {summary['today']}"
+        )
+
+    def test_daily_chart_counts_the_earning_platform_through_a_payout(self, db):
+        async def run():
+            await database.upsert_earnings("platform_a", 20.0, date=_day(1))
+            await database.upsert_earnings("platform_b", 5.0, date=_day(1))
+            await database.upsert_earnings("platform_a", 0.10, date=_day(0))
+            await database.upsert_earnings("platform_b", 7.0, date=_day(0))
+            return await database.get_daily_earnings(days=2)
+
+        chart = asyncio.run(run())
+        today = chart[-1]["amount"]
+        assert today == pytest.approx(2.0), f"chart should show B's 2.00, got {today}"
+
+    def test_a_pure_payout_day_reads_as_zero_not_negative(self, db):
+        """One platform, balance falls: the day reads 0 earned, never negative."""
+
+        async def run():
+            await database.upsert_earnings("solo", 20.0, date=_day(1))
+            await database.upsert_earnings("solo", 0.0, date=_day(0))
+            return await database.get_daily_earnings(days=2)
+
+        chart = asyncio.run(run())
+        assert chart[-1]["amount"] == 0.0
+        assert all(point["amount"] >= 0 for point in chart)
+
+    def test_ordinary_earnings_are_unchanged(self, db):
+        """The fix must not disturb the normal all-platforms-earning case."""
+
+        async def run():
+            await database.upsert_earnings("platform_a", 10.0, date=_day(1))
+            await database.upsert_earnings("platform_b", 5.0, date=_day(1))
+            await database.upsert_earnings("platform_a", 12.0, date=_day(0))
+            await database.upsert_earnings("platform_b", 6.5, date=_day(0))
+            return await database.get_earnings_dashboard_summary()
+
+        summary = asyncio.run(run())
+        assert summary["today"] == pytest.approx(3.5)  # 2.0 + 1.5


### PR DESCRIPTION
> **Independent of the deploy-stack PRs** (#142/#143/#145/#146). Branched off `main`, touches only the earnings math — reviewable and mergeable on its own.

## The bug

Daily and summary earnings were computed by summing every platform's balance delta and clamping the **total** at zero:

```
delta = max(0.0, current_total - previous_total)
```

The earnings table stores balance *snapshots*. When a payout lands, the paying platform's balance falls — and because the sum happens before the clamp, that drop cancels genuine earnings on other platforms:

```
platform A pays out:  20.00 → 0.10   (delta −19.90)
platform B earns:      5.00 → 7.00   (delta  +2.00)
old: max(0, −19.90 + 2.00) = max(0, −17.90) = 0.00   ← B's real $2 vanishes
```

So a day you actually earned could report **zero**, and one large payout hid everything else that day. The bead described this as "renders negative earnings"; the negative was already clamped, but the clamp on the *sum* is exactly what made it lossy.

## The fix

Clamp each platform's delta at zero **before** summing, in both `get_earnings_dashboard_summary` (today/month/yesterday) and `get_daily_earnings` (the chart series):

```
earned = sum(max(0.0, bal - previous.get(platform, 0.0)) for platform, bal in current.items())
```

A payout now counts as "nothing earned on that platform today", never a negative that eats the rest. A pure payout day reads as zero, never negative.

The summary queries do it in SQL (`SUM(MAX(delta, 0))`); the chart builds per-platform balances in Python rather than a cross-platform `SUM(balance) GROUP BY date`.

## Scope

This is the **correctness core** of `CashPilot-glc`. The larger ledger feature the bead also described — a payouts table, drop detection, a lifetime-earned vs current-balance split, and a projected payout date — is filed as **CashPilot-1og**, so this small, verifiable fix lands on its own.

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1339 passed**, coverage 93.93%
- 4 new tests: B's earnings survive A's payout in both the summary and the chart, a pure payout day reads zero (and the whole series stays ≥ 0), and ordinary all-earning days are unchanged.