### PR TITLE
docs: replace the competitor matrix with a comparison that stays true (CashPilot-qkc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,18 +304,17 @@ Services that were evaluated but are no longer listed in the catalog due to bein
 
 ## How CashPilot Compares
 
-| Feature | CashPilot | money4band | CashFactory | income-generator | InternetIncome |
-|---------|:---------:|:----------:|:-----------:|:----------------:|:--------------:|
-| Web UI with guided setup | **Yes** | No (CLI) | Partial (links only) | No (CLI) | No (CLI) |
-| One-click container deploy | **Yes** | No (compose) | No (compose) | No | No (compose) |
-| Earnings dashboard | **Yes** | No | No | No | No |
-| Historical charts | **Yes** | No | No | No | No |
-| Multi-node fleet management | **Yes** | No | No | No | No |
-| Service catalog with guides | **50 services** | 17 | 8 | 14 | 8 |
-| Automated earnings collection | **15 collectors** | 0 | 0 | 0 | 0 |
-| Multi-arch (amd64 + arm64) | **Yes** | Yes | Yes | No | No |
-| Credential encryption | **Yes** | No | No | No | No |
-| Compose export | **Yes** | Yes | Yes | Yes | Yes |
+There are several good open-source projects in this space, and the honest summary is that they overlap more than they differ. [money4band](https://github.com/MRColorR/money4band) is the most mature of them: it supports 20+ apps, ships a web dashboard, and is actively developed. If you want to run a handful of bandwidth-sharing apps on one machine, it is a perfectly good choice and has been doing this longer than CashPilot has.
+
+CashPilot is built around three things that shape its whole design:
+
+- **A fleet, not a machine.** One dashboard holds the state for many servers, each running a worker. Earnings are collected centrally exactly once, so nothing is double-counted, and every figure drills down per server and per service.
+- **Earnings pulled from the providers themselves.** 15 collectors authenticate against provider APIs and dashboards and record real balances into a local history, rather than reporting that a container is running. That is what makes "running but not earning" detectable at all.
+- **Breadth beyond bandwidth.** 50 catalogued services spanning bandwidth sharing, DePIN, storage and GPU compute, each with a setup guide, a payout method, and a status that is re-checked weekly in CI.
+
+If none of those matter to you, use whichever tool you prefer — they will all start the same containers.
+
+> **On this section.** It deliberately avoids a feature matrix claiming what other projects lack. Those tables go stale the moment someone ships a release, and a comparison a reader can falsify in thirty seconds is worse than no comparison at all. If anything above is out of date, please open an issue.
 
 ## License
 


### PR DESCRIPTION
## The problem, verified

The README table claimed money4band has **no web UI** and **no earnings dashboard**. I fetched its README rather than trusting the bead:

> "📊 Web Dashboard for easy monitoring."
> "Enjoy passive Earnings monitoring your performance through the web dashboard."

It also supports 20+ apps, not the 17 we listed. Both of our claims were false and **falsifiable in about thirty seconds** — which damages a reader's trust in everything else on the page.

## The fix

Replaced the matrix with prose comparing on what is *structurally* different — a fleet with central state rather than a single machine, earnings pulled from provider APIs rather than container liveness, breadth beyond bandwidth — and saying plainly that money4band is the more mature project and a good choice for one machine.

Deliberately **not** another feature matrix. A table asserting what other projects lack goes stale the moment someone ships a release, and nothing in CI can catch it. The section says so and invites an issue if it drifts.

## What I did NOT do, and why

The bead's second half says Grass, Teneo and Dawn should be re-verified because "that competitor removed them from its setup flow months ago."

**That premise does not survive checking** — all three are still in money4band's supported-app list today. So the stated evidence for demoting those three does not exist, and I left their catalog status alone rather than flipping it on a bad premise. Marking a service broken is user-facing and needs real evidence: a failing collector run, a dead endpoint, or a provider announcement. The catalog-liveness CI (`owv`, already shipped) is the mechanism that should produce that, as the bead itself notes.

Recorded on the bead so the correction isn't lost.

## Verification

- Referral links: **zero removed** (checked the diff explicitly — referral links are revenue), and the 11 referral-guard tests pass.
- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1335 passed**, coverage 93.91%