### PR TITLE
feat: pre-deploy reality check (CashPilot-w58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to CashPilot are documented here.
 - Prometheus HTTP metrics bound their `path` label: `/api/workers/{id}` collapses per-id paths and unknown/scanner paths fold into a single `/{other}` label, so probe traffic can't grow label cardinality without limit
 
 ### Added
+- **A pre-deploy reality check tells you what a service will actually do for you** (CashPilot-w58). The catalog shows one generic earnings range, so there was no way to tell before deploying whether a service would work in *your* situation — and several will not. Users found out weeks later, when it had earned nothing. `GET /api/services/{slug}/preflight` now answers that in one or two plain sentences with a clear verdict: a duplicate deployment where only one device per IP is allowed says so and warns that some providers forfeit the balance; a storage node states the disk commitment and that part of the balance is held back and forfeited if the node is abandoned early; GPU and residential-IP requirements are named as preconditions. It **never blocks a deploy** — the goal is informed consent, not a nanny — and it lists what it did *not* check (egress IP type, connection speed, free disk) so a clean result is never mistaken for a guarantee about things nobody looked at
 - Self-service password change `POST /api/users/me/password` (all roles, via the avatar menu) and owner reset `POST /api/users/{id}/password`
 - `CASHPILOT_WORKER_URL_POLICY`, `CASHPILOT_WORKER_ALLOWED_HOSTS`, and `CASHPILOT_WORKER_ALLOW_METADATA` env vars for worker-URL validation
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,18 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app import auth, catalog, compose_generator, database, exchange_rates, fleet_key, metrics, notify, setup_token
+from app import (
+    auth,
+    catalog,
+    compose_generator,
+    database,
+    exchange_rates,
+    fleet_key,
+    metrics,
+    notify,
+    preflight,
+    setup_token,
+)
 from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
 
 logging.basicConfig(
@@ -1408,6 +1419,34 @@ async def api_collect(request: Request) -> dict[str, str]:
 
 
 _MAX_ALERT_ERROR_LEN = 200
+
+
+@app.get("/api/services/{slug}/preflight")
+async def api_service_preflight(request: Request, slug: str, worker_id: int | None = None) -> dict[str, Any]:
+    """What this service will realistically do for THIS user, before deploying.
+
+    Never blocks a deploy: the goal is informed consent, not a nanny.
+    """
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+
+    # What is already running on the SAME machine is what makes a per-IP limit
+    # checkable at all, so scope to that worker when we know which one.
+    deployed = await database.get_deployments()
+    if worker_id is not None:
+        worker = await database.get_worker(worker_id)
+        running = {c.get("service") for c in (worker or {}).get("containers", []) if c.get("service")}
+    else:
+        running = {d["slug"] for d in deployed}
+
+    system_info = {}
+    if worker_id is not None:
+        worker = await database.get_worker(worker_id)
+        system_info = (worker or {}).get("system_info") or {}
+
+    return preflight.assess(service, already_deployed_slugs=running, system_info=system_info)
 
 
 @app.get("/api/collector-alerts")

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -1,0 +1,169 @@
+"""Pre-deploy reality check (CashPilot-w58).
+
+The catalog shows one generic earnings range per service. A user cannot tell,
+before deploying, whether a service will work at all *in their situation* — and
+several will not. They find out weeks later, when it has earned nothing.
+
+This turns what we already know into a decision the user can actually make:
+a verdict and one or two plain sentences, not a wall of warnings.
+
+Two rules shape everything here:
+
+* **Informed consent, not a nanny.** Where the answer is "this will earn nothing
+  for you", say so plainly and let them deploy anyway. Nothing here blocks.
+* **Never imply a check we did not run.** We cannot currently detect egress IP
+  type or connection speed (that is CashPilot-5qc). Requirements that depend on
+  those are reported as *unverified preconditions in the user's own words*,
+  never as a pass. Claiming a green light we did not earn is worse than silence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Verdicts, worst first. The caller shows the worst one that applies.
+EARNS_NOTHING = "will_earn_nothing"
+REDUCED = "reduced_earnings"
+CHECK_YOURSELF = "check_these"
+LOOKS_FINE = "looks_fine"
+
+_SEVERITY = {EARNS_NOTHING: 3, REDUCED: 2, CHECK_YOURSELF: 1, LOOKS_FINE: 0}
+
+
+def _worst(verdicts: list[str]) -> str:
+    return max(verdicts, key=lambda v: _SEVERITY[v], default=LOOKS_FINE)
+
+
+def assess(
+    service: dict[str, Any],
+    *,
+    already_deployed_slugs: set[str] | None = None,
+    system_info: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Answer "what will this realistically do for me?" before the deploy runs.
+
+    ``already_deployed_slugs`` is what is already running on the SAME worker,
+    which is what makes a per-IP limit checkable at all.
+    """
+    already_deployed = already_deployed_slugs or set()
+    info = system_info or {}
+    reqs = service.get("requirements") or {}
+    slug = service.get("slug", "")
+
+    findings: list[dict[str, str]] = []
+    verdicts: list[str] = []
+
+    # Already running here. A second instance on one egress IP is the case
+    # several providers forbid outright, and the penalty is a forfeited balance.
+    if slug and slug in already_deployed:
+        devices_per_ip = reqs.get("devices_per_ip")
+        if devices_per_ip == 1:
+            findings.append(
+                {
+                    "verdict": EARNS_NOTHING,
+                    "message": (
+                        f"{service.get('name', slug)} is already running on this machine, and it "
+                        "allows only one device per IP. A second instance normally earns nothing, "
+                        "and some providers forfeit the balance of accounts that do this."
+                    ),
+                }
+            )
+            verdicts.append(EARNS_NOTHING)
+        else:
+            findings.append(
+                {
+                    "verdict": REDUCED,
+                    "message": (
+                        f"{service.get('name', slug)} is already running on this machine. "
+                        "A second instance shares the same connection, so expect the pair to earn "
+                        "roughly what one already does."
+                    ),
+                }
+            )
+            verdicts.append(REDUCED)
+
+    # Hardware the container cannot conjure.
+    if reqs.get("gpu"):
+        findings.append(
+            {
+                "verdict": CHECK_YOURSELF,
+                "message": (
+                    "This needs a supported GPU passed through to the container. Without one it "
+                    "will start and then sit idle, earning nothing."
+                ),
+            }
+        )
+        verdicts.append(CHECK_YOURSELF)
+
+    min_storage = reqs.get("min_storage")
+    if min_storage:
+        findings.append(
+            {
+                "verdict": CHECK_YOURSELF,
+                "message": (
+                    f"Needs at least {min_storage} of disk you can commit for months. Storage "
+                    "payouts accrue slowly and part of the balance is held back and forfeited if "
+                    "the node is abandoned early — running one for a month is worse than not "
+                    "running it at all."
+                ),
+            }
+        )
+        verdicts.append(CHECK_YOURSELF)
+
+    # IP type. We cannot detect this yet, so it is stated as a precondition and
+    # explicitly labelled unverified rather than dressed up as a check.
+    if reqs.get("residential_ip") and reqs.get("vps_ip") is False:
+        findings.append(
+            {
+                "verdict": CHECK_YOURSELF,
+                "message": (
+                    "This needs a residential IP. On a VPS or datacentre connection it typically "
+                    "earns far less, or the account is banned outright. CashPilot cannot check "
+                    "your connection type, so this one is on you."
+                ),
+            }
+        )
+        verdicts.append(CHECK_YOURSELF)
+
+    min_bandwidth = reqs.get("min_bandwidth")
+    if min_bandwidth:
+        findings.append(
+            {
+                "verdict": CHECK_YOURSELF,
+                "message": (
+                    f"Wants at least {min_bandwidth}. Below that it still runs, it just earns "
+                    "proportionally less. CashPilot does not measure your connection."
+                ),
+            }
+        )
+        verdicts.append(CHECK_YOURSELF)
+
+    # A note the catalog author left specifically for this situation.
+    note = reqs.get("note")
+    if note:
+        findings.append({"verdict": CHECK_YOURSELF, "message": str(note)})
+        verdicts.append(CHECK_YOURSELF)
+
+    verdict = _worst(verdicts)
+    return {
+        "slug": slug,
+        "verdict": verdict,
+        "summary": _summary(verdict, service),
+        "findings": findings,
+        # Say what was NOT checked, so a clean result is not mistaken for a
+        # guarantee about things we never looked at.
+        "not_checked": ["egress IP type", "connection speed", "available disk"],
+        "worker_arch": info.get("arch"),
+        "blocking": False,  # informed consent, never a block
+    }
+
+
+def _summary(verdict: str, service: dict[str, Any]) -> str:
+    name = service.get("name") or service.get("slug") or "This service"
+    if verdict == EARNS_NOTHING:
+        return f"{name} will most likely earn nothing here. You can deploy it anyway."
+    if verdict == REDUCED:
+        return f"{name} will probably earn less here than the catalog range suggests."
+    if verdict == CHECK_YOURSELF:
+        return f"{name} should work, provided the points below are true of your setup."
+    return f"Nothing stands out — {name} should work normally here."

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -116,3 +116,48 @@ _SEEN = {
     preflight.REDUCED,
     preflight.EARNS_NOTHING,
 }
+
+
+class TestPreflightEndpoint:
+    def _call(self, slug, worker_id=None, worker=None, deployments=None):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_deployments", AsyncMock(return_value=deployments or [])),
+                patch.object(main.database, "get_worker", AsyncMock(return_value=worker)),
+            ):
+                return await main.api_service_preflight(MagicMock(), slug, worker_id=worker_id)
+
+        return asyncio.run(run())
+
+    def test_an_unknown_service_is_a_404(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._call("no-such-service")
+        assert exc.value.status_code == 404
+
+    def test_it_returns_a_verdict_for_a_real_service(self):
+        result = self._call("storj")
+        assert result["slug"] == "storj"
+        assert result["verdict"] in _SEEN
+        assert result["blocking"] is False
+
+    def test_a_duplicate_on_the_named_worker_is_detected(self):
+        """Scoped to that worker: a per-IP limit is about ONE machine."""
+        worker = {
+            "containers": [{"service": "honeygain"}],
+            "system_info": {"arch": "x86_64"},
+        }
+        result = self._call("honeygain", worker_id=1, worker=worker)
+        assert result["verdict"] in {preflight.REDUCED, preflight.EARNS_NOTHING}
+        assert result["worker_arch"] == "x86_64"
+
+    def test_without_a_worker_it_falls_back_to_all_deployments(self):
+        result = self._call("honeygain", deployments=[{"slug": "honeygain"}])
+        assert result["verdict"] in {preflight.REDUCED, preflight.EARNS_NOTHING}

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,118 @@
+"""Pre-deploy reality check (CashPilot-w58).
+
+The catalog shows one generic earnings range per service, so a user cannot tell
+before deploying whether it will work in *their* situation — and several will
+not. They find out weeks later, when it has earned nothing.
+
+Two properties matter more than the individual verdicts, and both are tested
+below: it never blocks a deploy (informed consent, not a nanny), and it never
+implies a check that was not run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import catalog, preflight
+
+
+def _svc(**reqs):
+    return {"slug": "demo", "name": "Demo", "requirements": reqs}
+
+
+class TestVerdicts:
+    def test_a_clean_service_looks_fine(self):
+        result = preflight.assess(_svc(residential_ip=False, gpu=False))
+        assert result["verdict"] == preflight.LOOKS_FINE
+        assert result["findings"] == []
+
+    def test_a_duplicate_where_only_one_device_is_allowed_earns_nothing(self):
+        result = preflight.assess(_svc(devices_per_ip=1), already_deployed_slugs={"demo"})
+        assert result["verdict"] == preflight.EARNS_NOTHING
+        assert "forfeit" in result["findings"][0]["message"]
+
+    def test_a_duplicate_without_a_declared_limit_is_only_reduced(self):
+        """Absent data must soften the verdict, never invent one."""
+        result = preflight.assess(_svc(), already_deployed_slugs={"demo"})
+        assert result["verdict"] == preflight.REDUCED
+
+    def test_a_gpu_requirement_is_called_out(self):
+        result = preflight.assess(_svc(gpu=True))
+        assert result["verdict"] == preflight.CHECK_YOURSELF
+        assert "idle" in result["findings"][0]["message"]
+
+    def test_storage_commitment_warns_about_the_held_balance(self):
+        """Running a storage node for a month is worse than not running it."""
+        result = preflight.assess(_svc(min_storage="550GB"))
+        message = result["findings"][0]["message"]
+        assert "550GB" in message
+        assert "forfeited" in message
+
+    def test_a_residential_only_service_says_so_plainly(self):
+        result = preflight.assess(_svc(residential_ip=True, vps_ip=False))
+        assert any("residential IP" in f["message"] for f in result["findings"])
+
+    def test_a_catalog_note_is_surfaced(self):
+        result = preflight.assess(_svc(note="Nodes on the same subnet share allocation."))
+        assert any("same subnet" in f["message"] for f in result["findings"])
+
+    def test_the_worst_verdict_wins(self):
+        result = preflight.assess(_svc(devices_per_ip=1, gpu=True), already_deployed_slugs={"demo"})
+        assert result["verdict"] == preflight.EARNS_NOTHING
+
+    def test_empty_requirement_strings_are_not_treated_as_requirements(self):
+        """Most of the catalog stores '' for unknown, which must stay silent."""
+        result = preflight.assess(_svc(min_bandwidth="", min_storage=""))
+        assert result["verdict"] == preflight.LOOKS_FINE
+
+
+class TestItNeverOversteps:
+    def test_it_never_blocks_a_deploy(self):
+        """Informed consent, not a nanny — even in the worst case."""
+        result = preflight.assess(_svc(devices_per_ip=1), already_deployed_slugs={"demo"})
+        assert result["blocking"] is False
+        assert "anyway" in result["summary"]
+
+    def test_it_declares_what_it_did_not_check(self):
+        """A clean result must not read as a guarantee about unexamined things."""
+        result = preflight.assess(_svc())
+        assert "egress IP type" in result["not_checked"]
+        assert "connection speed" in result["not_checked"]
+
+    def test_another_service_running_here_is_not_treated_as_a_duplicate(self):
+        result = preflight.assess(_svc(devices_per_ip=1), already_deployed_slugs={"something-else"})
+        assert result["verdict"] == preflight.LOOKS_FINE
+
+
+class TestAgainstTheRealCatalog:
+    @pytest.mark.parametrize("slug", ["storj", "honeygain", "mysterium"])
+    def test_real_services_produce_a_usable_verdict(self, slug):
+        service = catalog.get_service(slug)
+        assert service, f"{slug} missing from the catalog"
+        result = preflight.assess(service)
+        assert result["verdict"] in {
+            preflight.LOOKS_FINE,
+            preflight.CHECK_YOURSELF,
+            preflight.REDUCED,
+            preflight.EARNS_NOTHING,
+        }
+        assert result["summary"]
+
+    def test_storj_warns_about_the_disk_commitment(self):
+        result = preflight.assess(catalog.get_service("storj"))
+        assert any("forfeited" in f["message"] for f in result["findings"])
+
+    def test_every_catalog_service_can_be_assessed(self):
+        """A malformed requirements block must not break the deploy page."""
+        for service in catalog.get_services():
+            result = preflight.assess(service)
+            assert result["verdict"] in _SEEN
+            assert isinstance(result["findings"], list)
+
+
+_SEEN = {
+    preflight.LOOKS_FINE,
+    preflight.CHECK_YOURSELF,
+    preflight.REDUCED,
+    preflight.EARNS_NOTHING,
+}


### PR DESCRIPTION
## The problem

The catalog shows one generic earnings range per service. A user can't tell **before** deploying whether it will work in *their* situation — and several won't. They find out weeks later, when it has earned nothing.

`GET /api/services/{slug}/preflight` answers "what will this realistically do for me?" from what we already know: the catalog `requirements` block, and what's already running on the same worker.

| Situation | Verdict |
|---|---|
| Same service already here, `devices_per_ip: 1` | **will earn nothing** — and some providers forfeit the balance for this |
| Same service already here, no declared limit | reduced earnings — one connection, shared |
| Storage node | disk commitment named, plus: part of the balance is held back and **forfeited if abandoned early** |
| GPU / residential-IP requirement | named as a precondition CashPilot cannot verify |
| Nothing notable | looks fine |

## Two rules the module is built around

**Informed consent, not a nanny.** Even the worst verdict doesn't block — it says *"this will most likely earn nothing here. You can deploy it anyway."* `blocking` is always `False`, and a test asserts it.

**Never imply a check that wasn't run.** Egress IP type and connection speed can't be detected yet (that's `5qc`), so requirements depending on them are reported as *unverified preconditions in the user's own words*, and every response carries a `not_checked` list. A clean result must never read as a guarantee about things nobody looked at.

Absent catalog data deliberately **softens** the verdict rather than inventing one.

## A real gap this surfaced

Most services **don't declare `devices_per_ip`** — only 3 of 50 — even though the README table lists it as 1 for Honeygain, IPRoyal, EarnApp and others. Verified directly:

```
honeygain requirements -> {residential_ip, devices_per_account: 10, min_bandwidth: '', gpu, min_storage}
```

So the strongest verdict is unavailable for exactly the services where a user is most likely to make the mistake. Filed separately rather than bulk-transcribed from the README — that table is hand-maintained and is the same class of artefact that turned out to be factually wrong in #150. Each value should be confirmed against the provider, and left absent where it can't be.

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1352 passed**, coverage 93.68%
- 17 new tests, including every catalog service assessing without error (a malformed requirements block must not break the deploy page)