### PR TITLE
fix(security): stop logging raw worker error bodies, and 3 review follow-ups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1210,10 +1210,16 @@ async def _proxy_to_worker(
             else:
                 resp = await client.post(f"{url}{path}", json=json, params=params, headers=headers)
             if resp.status_code >= 400:
-                logger.warning("worker proxy error (%s): %s", resp.status_code, resp.text)
+                # NOT resp.text at warning level: withholding the raw body from the
+                # caller (see _safe_worker_detail) is pointless if it goes straight
+                # into the log instead. A deploy failure can echo env values, which
+                # for several providers are live credentials.
+                safe = _safe_worker_detail(resp)
+                logger.warning("worker proxy error (%s): %s", resp.status_code, safe or "unstructured error body")
+                logger.debug("worker proxy error body (%s): %s", resp.status_code, resp.text)
                 raise HTTPException(
                     status_code=resp.status_code,
-                    detail=_safe_worker_detail(resp) or "Worker request failed",
+                    detail=safe or "Worker request failed",
                 )
             return resp.json()
     except httpx.HTTPError as exc:

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -33,9 +33,11 @@
 #   critical_volumes:          (optional) mounts holding state that CANNOT be recovered
 #     - target: "/container/path"   must match the container-side path in `volumes`
 #       holds: "what is lost, in one or two sentences shown to the operator"
-#     Declaring a mount here makes the worker REFUSE to delete that volume, and
-#     refuse a redeploy that would drop it, unless the caller passes an explicit
-#     override. Use it only for genuinely irreplaceable state — node identities,
+#     Declaring a mount here makes the worker REFUSE to delete that volume unless
+#     the caller passes an explicit override (owner role required).
+#     NOTE: redeploy protection — refusing a redeploy that would drop or retype a
+#     critical mount — is NOT implemented yet; only the delete guard is.
+#     Use it only for genuinely irreplaceable state — node identities,
 #     keystores, generated wallets — not for caches or re-downloadable data.
 #   command: "" (optional override)
 #   network_mode: "" (optional, e.g. "host")

--- a/tests/test_critical_volumes.py
+++ b/tests/test_critical_volumes.py
@@ -17,9 +17,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # some other test module happened to be collected first and set it.
 os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
 
-import pytest
+import pytest  # noqa: E402
 
-from app import catalog, orchestrator
+from app import catalog, orchestrator  # noqa: E402
 
 
 def _container(mounts):
@@ -157,7 +157,14 @@ class TestCatalogRobustness:
 class TestWorkerEndpoint:
     """The refusal must reach the caller as a 409 carrying the reason."""
 
-    def _client(self):
+    @pytest.fixture
+    def client(self):
+        """Disable the heartbeat lifespan, then put it back.
+
+        worker_api.app is module-level and shared across the whole session, so
+        replacing its lifespan permanently would leak into every later test that
+        builds a client from it.
+        """
         from contextlib import asynccontextmanager
 
         from fastapi.testclient import TestClient
@@ -168,11 +175,15 @@ class TestWorkerEndpoint:
         async def _noop(app):
             yield
 
+        original = worker_api.app.router.lifespan_context
         worker_api.app.router.lifespan_context = _noop
-        return TestClient(worker_api.app, raise_server_exceptions=False), worker_api
+        try:
+            yield TestClient(worker_api.app, raise_server_exceptions=False), worker_api
+        finally:
+            worker_api.app.router.lifespan_context = original
 
-    def test_blocked_delete_returns_409_with_the_reason(self):
-        client, worker_api = self._client()
+    def test_blocked_delete_returns_409_with_the_reason(self, client):
+        client, worker_api = client
         blocked = [{"volume": "storj-identity", "target": "/app/identity", "holds": "Node identity."}]
         err = orchestrator.CriticalVolumeError("storj", blocked)
 
@@ -188,8 +199,8 @@ class TestWorkerEndpoint:
         assert detail["blocked"] == blocked
         assert "allow_delete_critical" in detail["hint"]
 
-    def test_override_is_forwarded_to_the_orchestrator(self):
-        client, worker_api = self._client()
+    def test_override_is_forwarded_to_the_orchestrator(self, client):
+        client, worker_api = client
         removal = {"container": "cashpilot-storj", "deleted_volumes": [], "failed_volumes": []}
 
         with patch("app.worker_api.orchestrator.remove_service", return_value=removal) as mock:
@@ -329,3 +340,45 @@ class TestSafeWorkerDetailRobustness:
             pytest.raises(orchestrator.CriticalVolumeError),
         ):
             orchestrator.remove_service("s", delete_volumes=True)
+
+
+class TestWorkerErrorsAreNotLeakedToLogs:
+    """Withholding a body from the caller is pointless if it lands in the log."""
+
+    def test_the_raw_worker_body_is_not_logged_at_warning(self, caplog):
+        import asyncio
+        import contextlib
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import httpx
+
+        from app import main
+
+        secret = "AKIA-PRETEND-CREDENTIAL-IN-ENV-ECHO"
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = f"deploy failed: env WALLET={secret} path=/mnt/user/appdata"
+        resp.json.side_effect = ValueError("not json")
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, *a, **k):
+                return resp
+
+        async def run():
+            with (
+                patch.object(main, "_get_verified_worker_url", AsyncMock(return_value=("http://w", {}))),
+                patch.object(main.database, "get_worker", AsyncMock(return_value={"id": 1, "url": "http://w"})),
+                patch.object(httpx, "AsyncClient", lambda **kw: _Client()),
+                caplog.at_level("WARNING"),
+                contextlib.suppress(Exception),
+            ):
+                await main._proxy_to_worker(1, "POST", "/api/containers/x/deploy", json={})
+
+        asyncio.run(run())
+        assert secret not in caplog.text, "a worker error body must not reach the warning log"


### PR DESCRIPTION
CodeRabbit's review of #143 landed **while that PR was merging** and I did not wait for it — my mistake. All four findings were valid. This addresses them on `main`.

## Major — the sanitisation was undone one line above it

`_safe_worker_detail` deliberately withholds unstructured worker error bodies from the caller because they *"can carry internal paths and hostnames"*. The line right above then wrote the full `resp.text` to the **warning log** for every worker error:

```python
logger.warning("worker proxy error (%s): %s", resp.status_code, resp.text)
```

A deploy failure echoes env values, which for several providers **are live credentials**. So the careful sanitisation protected the HTTP response and leaked the same data into the log.

Now: warning logs the status and the *sanitised* detail; the raw body is debug-level. A regression test asserts a credential-shaped value in a worker error body never reaches the warning log.

## The other three

- **`services/_schema.yml` overclaimed.** It said `critical_volumes` also makes the worker refuse a redeploy that would drop the mount. It doesn't — only the delete guard shipped. Corrected, with the gap stated plainly instead of left as a promise the code doesn't keep.
- **Imports after env setup** in the test are intentional (the API key must be set before `worker_api` imports) — now marked `noqa: E402` rather than relying on ruff's current defaults.
- **The worker test client leaked state.** It replaced `worker_api.app.router.lifespan_context` and never restored it. `app` is module-level and shared for the whole session, so that leaked into every later test building a client from it. Now a fixture that restores the original in a `finally`.

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1370 passed**, coverage 94.11%