### PR TITLE
docs(mysterium): document the TUN device failure that looks like a healthy node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ Triggers on version tags (`v*`). Lints with ruff, builds multi-arch (amd64 + arm
 - Node identity lives in Docker volume (`mysterium-data:/var/lib/mysterium-node/keystore/`). Deleting volume = new identity.
 - Registration is blockchain-based (Polygon). Hermes "internal error" = temporary server issue.
 - Image: `mysteriumnetwork/myst` (NOT `mysteriumnet/myst`).
+- **Needs `/dev/net/tun`, not just `NET_ADMIN`.** Without the device the node starts, registers and advertises normally but cannot carry wireguard/dvpn traffic — so it looks healthy, earns nothing, and MystNodes emails "unable to track its status". Diagnose with `curl -s http://127.0.0.1:4050/node/monitoring-agent-statuses` (look for `tun_device_problem`) and `docker exec <container> ls -l /dev/net/tun`. The catalog cannot declare devices yet, so a CashPilot-deployed Mysterium container does not get it automatically. See `docs/guides/mysterium.md` for the full runbook.
+- A container recreate is safe: the identity lives in the mounted data dir, not the container. Always confirm the address is unchanged afterwards via `curl -s http://127.0.0.1:4050/identities`.
 
 ## Collector Implementation Status
 

--- a/docs/guides/mysterium.md
+++ b/docs/guides/mysterium.md
@@ -55,3 +55,78 @@ In the CashPilot web UI, find **MystNodes** in the service catalog and click **D
 ### Environment Variables
 
 No environment variables required.
+
+## Troubleshooting
+
+### "Running but not earning" — monitoring failed, quality 0
+
+**Symptom.** The container is up and its logs look healthy. MystNodes emails you
+*"we're temporarily unable to track its status"*. The dashboard shows no quality
+score, and earnings stay flat.
+
+**Cause.** The node cannot open a TUN device. Mysterium serves `wireguard` and
+`dvpn` through `/dev/net/tun`, and without it the node still starts, still
+registers, and still advertises itself to the network — it simply cannot carry
+any traffic. Everything looks fine from outside, which is what makes this one
+hard to spot.
+
+**Confirm it.** Ask the node itself, on the host running it:
+
+```bash
+curl -s http://127.0.0.1:4050/node/monitoring-agent-statuses
+```
+
+A TUN problem looks like this:
+
+```json
+{"statuses":{"data_transfer":{"tun_device_problem":14},
+             "scraping":{"tun_device_problem":14},
+             "monitoring":{"connect_fail":5,"tun_device_problem":1}}}
+```
+
+And `curl -s http://127.0.0.1:4050/node/monitoring-status` returns
+`{"status":"failed"}`.
+
+**Check whether the device reached the container:**
+
+```bash
+docker exec cashpilot-mysterium ls -l /dev/net/tun
+# "No such file or directory" means it did not
+```
+
+**Fix.** The container needs the device mapped in, alongside `NET_ADMIN`:
+
+```bash
+docker run -d --name cashpilot-mysterium \
+  --network host --restart unless-stopped \
+  --cap-drop ALL --cap-add NET_ADMIN \
+  --device /dev/net/tun \
+  --security-opt no-new-privileges:true \
+  -v /path/to/your/myst/data:/var/lib/mysterium-node \
+  mysteriumnetwork/myst:latest \
+  --ui.address=0.0.0.0 --tequilapi.address=0.0.0.0 service --agreed-terms-and-conditions
+```
+
+Verify it took:
+
+```bash
+docker exec cashpilot-mysterium sh -c 'ip tuntap add dev probe mode tun && echo TUN_OK && ip link del probe'
+docker logs cashpilot-mysterium 2>&1 | grep -i wireguard | tail -3   # expect "Wireguard: started"
+```
+
+**Your identity is safe.** It lives in the mounted data directory
+(`/var/lib/mysterium-node/keystore/`), not in the container, so recreating the
+container keeps the same node identity and its accumulated reputation. Confirm
+with `curl -s http://127.0.0.1:4050/identities` — the address must be unchanged.
+
+**On the host**, `/dev/net/tun` must exist (`ls -l /dev/net/tun`). If it does
+not, load the module with `modprobe tun`.
+
+MystNodes' own monitoring takes a while to re-score a node after the fix — allow
+several hours before judging it by the dashboard rather than by the node's own
+`monitoring-agent-statuses`.
+
+> **Note.** CashPilot cannot yet declare a device in the service catalog, so a
+> Mysterium container it deploys does not get `/dev/net/tun` automatically. Until
+> that lands you have to add `--device /dev/net/tun` yourself, as above.
+


### PR DESCRIPTION
Hit in production on my own fleet, and worth writing down because the failure is genuinely hard to spot.

## The failure

A Mysterium node without `/dev/net/tun` **starts, registers, and advertises itself to the network** — and carries no traffic. The container is up, the logs look normal, the collector authenticates. The balance just never moves.

The first the user hears of it is MystNodes emailing *"we're temporarily unable to track its status."*

## What the docs now cover

In `docs/guides/mysterium.md`, written for someone who has just received that email:

- the symptom in the provider's own wording
- confirming it from the node itself — `/node/monitoring-agent-statuses` returning `tun_device_problem`
- checking whether the device actually reached the container
- the fix (`--device /dev/net/tun` alongside `NET_ADMIN`)
- verifying it took: `ip tuntap add` inside the container, `Wireguard: started` in the logs
- that **the identity is safe** across a recreate, because it lives in the mounted data dir — with the command to confirm the address is unchanged
- that the provider's monitoring takes hours to re-score, so don't judge the fix by the dashboard

`CLAUDE.md` gets the short maintainer version in its existing Mysterium section.

## Stated honestly rather than glossed

The docs say plainly that **CashPilot cannot declare a device in the catalog yet**, so this is a manual step today. The alternative was leaving a reader to assume a normal deploy handles it — which is how this took a provider email to surface in the first place.

That gap is filed as its own P1 bug: the catalog supports `cap_add` but has no device support at all, and the design note insists on an allow-list rather than free-form passthrough, scoped per-slug the way `cap_add` already is.

## Verification

Docs-only; full suite still green (**1437 passed**). Every command in the runbook was run against the live node while fixing it — including `TUN_CREATE_OK` and the identity check.