### PR TITLE
fix(ci): detect release changes since the last tag, not the last commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,21 @@ jobs:
       - name: Detect what changed
         id: changes
         run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          # Diff across everything since the last RELEASE, not just the last
+          # commit. A release contains every commit since the previous tag, and
+          # HEAD~1 only sees the newest one -- so a release whose app changes
+          # landed in earlier commits (anything merged with [skip ci], or a
+          # workflow_dispatch run) detected "nothing to build", skipped the
+          # version step, and silently produced no tag and no image while the
+          # run still reported success.
+          LAST_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | head -1)
+          if [ -n "$LAST_TAG" ]; then
+            CHANGED=$(git diff --name-only "$LAST_TAG"..HEAD 2>/dev/null || echo "")
+            echo "Comparing $LAST_TAG..HEAD"
+          else
+            CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+            echo "No previous tag; comparing HEAD~1..HEAD"
+          fi
           echo "Changed files: $CHANGED"
 
           BUILD_UI=false


### PR DESCRIPTION
## The bug

The release job decided whether to build from:

```bash
CHANGED=$(git diff --name-only HEAD~1 HEAD)
```

That only ever sees the **newest commit**. But a release contains every commit since the previous tag.

**The failure is silent.** When the app changes landed in earlier commits — anything merged with `[skip ci]`, or any `workflow_dispatch` run — the detection concluded there was nothing to build, skipped the version step, and produced **no tag and no image** while the workflow still reported ✅ success.

That is exactly what just happened cutting 1.5.0: nine merges of `app/` changes, then a final compose-only commit, and a green run with no release.

## The fix

Diff from the latest `v*.*.*` tag to HEAD, falling back to `HEAD~1` only when no tag exists yet. `checkout` already uses `fetch-depth: 0`, so the tags are present.

## Verified against the real range

```
$ git diff --name-only v1.4.4..HEAD | grep -E '^(app/|services/)'
app/catalog.py
app/collectors/__init__.py
app/database.py
app/main.py
app/orchestrator.py
app/preflight.py
app/worker_api.py
services/_schema.yml
```

which resolves to **build UI: YES** — where the old logic said nothing to build.

This is what unblocks the v1.5.0 release.