### PR TITLE
docs: match the site theme to the product it documents

### DIFF
--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -1,0 +1,42 @@
+/* Match the docs to the product.
+ *
+ * The app ships a dark UI (#0f1117 background, #1a1d26 cards, #3b82f6 accent).
+ * The docs shipped mkdocs-material's "deep purple + pink", so the site and the
+ * thing it documents looked like two different products — and the warm sunset
+ * logo, drawn for a dark backdrop, clashed with the purple header on top of it.
+ *
+ * These are the app's own values, so the header the logo sits on is the same
+ * colour as the dashboard behind it.
+ */
+:root {
+  --md-primary-fg-color:        #0f1117;  /* app background */
+  --md-primary-fg-color--light: #1a1d26;  /* app card       */
+  --md-primary-fg-color--dark:  #08090d;
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: #ffffffb3;
+
+  --md-accent-fg-color:         #3b82f6;  /* app accent */
+  --md-accent-fg-color--transparent: #3b82f61a;
+}
+
+/* Dark scheme: keep the body close to the app rather than material's default
+   slate, so scrolling from the header into the page is continuous. */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:        #0f1117;
+  --md-code-bg-color:           #1a1d26;
+  --md-typeset-a-color:         #3b82f6;
+}
+
+/* Light scheme keeps a light page, but links pick up the app accent so the two
+   schemes still read as the same product. */
+[data-md-color-scheme="default"] {
+  --md-typeset-a-color:         #2563eb;
+}
+
+/* The header logo is a warm mark on a near-black bar; give it a touch of room
+   so it does not crowd the wordmark at small sizes. */
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg {
+  height: 1.6rem;
+  width: 1.6rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,14 +15,14 @@ theme:
   favicon: icon.svg
   palette:
     - scheme: slate
-      primary: deep purple
-      accent: pink
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
     - scheme: default
-      primary: deep purple
-      accent: pink
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -74,6 +74,9 @@ extra:
       link: https://github.com/GeiserX/CashPilot
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/drumsergio/cashpilot
+
+extra_css:
+  - stylesheets/theme.css
 
 nav:
   - Home: index.md


### PR DESCRIPTION
The docs shipped mkdocs-material's **deep purple + pink** while the app runs a dark UI (`#0f1117` background, `#1a1d26` cards, `#3b82f6` accent). The site and the thing it documents looked like two different products — and the warm sunset logo, drawn for a dark backdrop, clashed with the purple header on top of that.

Now uses the app's own values, so the header the logo sits on is the same colour as the dashboard behind it, and the dark scheme's body no longer jumps from material's slate to the app's near-black.

**No logo redraw needed** — the mark was already drawn for dark; it was the bar underneath it that was wrong.

Verified with `mkdocs build`: clean, and `theme.css` ships into `site/`.