### PR TITLE
fix: charge power per worker, not once for the whole fleet (CashPilot-yh5)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1816,30 +1816,55 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
         logger.warning("Worker status unavailable for the power estimate: %s", exc)
         statuses = []
     # Only RUNNING containers. A stopped one draws nothing, and counting it
-    # inflates container_count, which shrinks every running service's share of
-    # the idle floor and understates the fleet's real cost.
+    # inflates a worker's container count, which shrinks every running service's
+    # share of that host's idle floor and understates the fleet's real cost.
     running = [c for c in statuses if c.get("service") and str(c.get("status", "")).lower() == "running"]
-    count = max(1, len(running))
-    cpu_by_service: dict[str, float] = {}
+
+    # Group by WORKER and keep it that way through the watt calculation. Each
+    # host pays its own idle draw, so collapsing a multi-host fleet into one
+    # count charges a single idle floor for the whole estate. Keeping the group
+    # is also the only way power.is_metered can be applied: a VPS bill does not
+    # move with CPU, and billing it like a home server invents a cost.
+    by_worker: dict[Any, list[dict[str, Any]]] = {}
     for c in running:
-        cpu_by_service[c["service"]] = cpu_by_service.get(c["service"], 0.0) + float(c.get("cpu_percent") or 0.0)
+        by_worker.setdefault(c.get("_worker_id"), []).append(c)
+
+    worker_meta = {w.get("id"): w for w in await database.list_workers()}
 
     hours = max(1, int(days)) * 24.0
     # Earned OVER THE WINDOW, not the latest balance: subtracting a window's
     # electricity from a running total would be meaningless arithmetic.
     earned = await database.get_earned_by_platform(max(1, int(days)))
+
+    watts_by_service: dict[str, float] = {}
+    unmetered_services: set[str] = set()
+    for wid, containers in by_worker.items():
+        meta = worker_meta.get(wid) or {}
+        info = _safe_json(meta.get("system_info", "{}"), {})
+        metered = power.is_metered(info)
+        try:
+            tdp = float(info.get("host_tdp_watts") or host_tdp)
+        except (TypeError, ValueError):
+            tdp = host_tdp
+        count = max(1, len(containers))
+        for c in containers:
+            svc = c["service"]
+            if not metered:
+                # No marginal power cost to the user on this host, so charge
+                # nothing rather than computing watts and multiplying by zero.
+                unmetered_services.add(svc)
+                continue
+            watts_by_service[svc] = watts_by_service.get(svc, 0.0) + power.estimate_watts(
+                float(c.get("cpu_percent") or 0.0), host_tdp_watts=tdp, container_count=count
+            )
+
     rows = []
     for platform, gross in earned.items():
-        watts = (
-            power.estimate_watts(cpu_by_service.get(platform, 0.0), host_tdp_watts=host_tdp, container_count=count)
-            if platform in cpu_by_service
-            else 0.0
-        )
         rows.append(
             {
                 "platform": platform,
                 "gross": float(gross),
-                "watts": watts,
+                "watts": watts_by_service.get(platform, 0.0),
                 "hours": hours,
                 "cost_quality": power.ESTIMATED,
             }

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -209,7 +209,7 @@ class TestEarnedOverTheWindow:
 class TestNetEndpoint:
     """The endpoint wiring: config parsing, windowing, and the honesty rules end to end."""
 
-    def _call(self, cfg, earned, containers, days=30):
+    def _call(self, cfg, earned, containers, days=30, workers=None):
         import asyncio
         from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -221,6 +221,7 @@ class TestNetEndpoint:
                 patch.object(main.database, "get_config", AsyncMock(return_value=cfg)),
                 patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value=earned)),
                 patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=workers or [])),
             ):
                 return await main.api_earnings_net(MagicMock(), days=days)
 
@@ -272,6 +273,7 @@ class TestNetEndpoint:
                 patch.object(main.database, "get_config", AsyncMock(return_value={"power_price_per_kwh": "0.30"})),
                 patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"svc": 7.0})),
                 patch.object(main, "_get_all_worker_containers", AsyncMock(side_effect=RuntimeError("worker down"))),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=[])),
             ):
                 return await main.api_earnings_net(MagicMock(), days=30)
 
@@ -281,3 +283,97 @@ class TestNetEndpoint:
     def test_a_malformed_tariff_is_treated_as_unset_rather_than_crashing(self):
         out = self._call({"power_price_per_kwh": "not-a-number"}, {"svc": 1.0}, [])
         assert out["cost_known"] is False
+
+
+class TestPerWorkerAttribution:
+    """Each host pays its own idle draw (CashPilot-yh5).
+
+    Collapsing a fleet into one count charged a single idle floor for the whole
+    estate, and left no per-worker context for power.is_metered — so a VPS was
+    billed like a home server.
+    """
+
+    def _call(self, containers, workers, price="0.30"):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value={"power_price_per_kwh": price})),
+                patch.object(
+                    main.database,
+                    "get_earned_by_platform",
+                    AsyncMock(return_value={c["service"]: 10.0 for c in containers}),
+                ),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=workers)),
+            ):
+                return await main.api_earnings_net(MagicMock(), days=30)
+
+        return asyncio.run(run())
+
+    def test_two_hosts_are_charged_two_idle_floors(self):
+        """One container on each of two hosts costs more than two on one host."""
+        two_hosts = self._call(
+            [
+                {"service": "a", "status": "running", "cpu_percent": 0.0, "_worker_id": 1},
+                {"service": "b", "status": "running", "cpu_percent": 0.0, "_worker_id": 2},
+            ],
+            [{"id": 1, "system_info": "{}"}, {"id": 2, "system_info": "{}"}],
+        )
+        one_host = self._call(
+            [
+                {"service": "a", "status": "running", "cpu_percent": 0.0, "_worker_id": 1},
+                {"service": "b", "status": "running", "cpu_percent": 0.0, "_worker_id": 1},
+            ],
+            [{"id": 1, "system_info": "{}"}],
+        )
+        assert two_hosts["total_cost"] > one_host["total_cost"], (
+            "two machines burn two idle floors; collapsing them charged only one"
+        )
+        assert two_hosts["total_cost"] == pytest.approx(one_host["total_cost"] * 2, rel=0.01)
+
+    def test_an_unmetered_host_contributes_no_cost(self):
+        """A VPS bill does not move with CPU."""
+        out = self._call(
+            [
+                {"service": "home", "status": "running", "cpu_percent": 10.0, "_worker_id": 1},
+                {"service": "vps", "status": "running", "cpu_percent": 10.0, "_worker_id": 2},
+            ],
+            [
+                {"id": 1, "system_info": "{}"},
+                {"id": 2, "system_info": '{"metered": false}'},
+            ],
+        )
+        rows = {r["platform"]: r for r in out["services"]}
+        assert rows["vps"]["cost"] == 0.0, "an unmetered host must not be charged"
+        assert rows["home"]["cost"] > 0.0
+
+    def test_a_per_worker_tdp_is_honoured(self):
+        """A 200W server must not be costed as a 65W mini PC."""
+        big = self._call(
+            [{"service": "a", "status": "running", "cpu_percent": 50.0, "_worker_id": 1}],
+            [{"id": 1, "system_info": '{"host_tdp_watts": 200}'}],
+        )
+        small = self._call(
+            [{"service": "a", "status": "running", "cpu_percent": 50.0, "_worker_id": 1}],
+            [{"id": 1, "system_info": '{"host_tdp_watts": 65}'}],
+        )
+        assert big["total_cost"] > small["total_cost"]
+
+    def test_a_service_spread_over_two_hosts_accumulates_both(self):
+        one = self._call(
+            [{"service": "a", "status": "running", "cpu_percent": 20.0, "_worker_id": 1}],
+            [{"id": 1, "system_info": "{}"}],
+        )
+        two = self._call(
+            [
+                {"service": "a", "status": "running", "cpu_percent": 20.0, "_worker_id": 1},
+                {"service": "a", "status": "running", "cpu_percent": 20.0, "_worker_id": 2},
+            ],
+            [{"id": 1, "system_info": "{}"}, {"id": 2, "system_info": "{}"}],
+        )
+        assert two["services"][0]["cost"] > one["services"][0]["cost"]


### PR DESCRIPTION
The deferred half of `f5u`, now closed.

## The bug

The net-profit endpoint collapsed **every online worker** into a single container count and a single host TDP. On any multi-host fleet:

- **A three-host fleet was charged one machine's idle floor.** Each host pays its own idle draw, so total cost was understated roughly in proportion to the number of hosts.
- **`power.is_metered` could not be applied at all.** It exists so a VPS — whose bill doesn't move with CPU — is charged nothing. With one global count there was no per-worker context to apply it to, so a mixed fleet of home servers and VPSes was billed as though every machine were metered.

`_get_all_worker_containers` already grouped by worker; the endpoint threw that grouping away before the watt calculation.

## The fix

The grouping is kept. Each worker contributes its own container count, its own host TDP (from `system_info`, falling back to the configured default) and its own metered flag. An unmetered host is **skipped** rather than costed and multiplied by zero, and a service running on several hosts accumulates cost from each.

## Tests assert the fleet arithmetic

- two hosts cost **twice** one host for the same containers
- an unmetered host contributes **zero** while a metered one does not
- a 200W server is not costed as a 65W mini PC
- a service spread over two hosts costs more than on one

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1529 passed**, coverage 94.30%