### PR TITLE
fix(ci): publish both images on every release, and fail if a tag is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,48 @@ jobs:
           cache-from: type=gha,scope=ui
           cache-to: type=gha,mode=max,scope=ui
 
+  # A release must publish BOTH images even when only one changed. The compose
+  # files pin them to the same tag, so a version that exists for one and not the
+  # other makes the documented quickstart reference a tag that is not there —
+  # `docker compose pull` then fails for anyone following the README.
+  #
+  # This is a manifest re-point, not a rebuild: imagetools copies the existing
+  # multi-arch descriptor to the new tags in seconds, so an unchanged image is
+  # never rebuilt just to satisfy a naming convention.
+  retag-ui:
+    needs: [lint, resolve-tags]
+    if: ${{ !inputs.build_ui && inputs.version != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-point the unchanged UI image at this release's tags
+        run: |
+          for tag in ${{ needs.resolve-tags.outputs.ui_tags }}; do
+            echo "retagging -> $tag"
+            docker buildx imagetools create -t "$tag" drumsergio/cashpilot:latest
+          done
+
+  retag-worker:
+    needs: [lint, resolve-tags]
+    if: ${{ !inputs.build_worker && inputs.version != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-point the unchanged worker image at this release's tags
+        run: |
+          for tag in ${{ needs.resolve-tags.outputs.worker_tags }}; do
+            echo "retagging -> $tag"
+            docker buildx imagetools create -t "$tag" drumsergio/cashpilot-worker:latest
+          done
+
   build-worker:
     needs: [lint, resolve-tags]
     if: inputs.build_worker
@@ -126,3 +168,27 @@ jobs:
           tags: ${{ needs.resolve-tags.outputs.worker_tags }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
+
+  # CI passed happily while cashpilot:1.7.0 existed and cashpilot-worker:1.7.0
+  # did not — the gap was only found by deploying. This closes that: if a tag
+  # this release claims to have published does not resolve, the run fails.
+  verify-tags:
+    needs: [resolve-tags, build-ui, build-worker, retag-ui, retag-worker]
+    if: ${{ always() && inputs.version != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Every published tag must resolve
+        run: |
+          missing=0
+          for tag in ${{ needs.resolve-tags.outputs.ui_tags }} ${{ needs.resolve-tags.outputs.worker_tags }}; do
+            if docker manifest inspect "$tag" >/dev/null 2>&1; then
+              echo "ok      $tag"
+            else
+              echo "MISSING $tag"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::A release tag is missing. The compose files pin both images to the same tag, so a partial release breaks the documented quickstart."
+            exit 1
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,8 +124,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Re-point the unchanged UI image at this release's tags
+        # Tags derive from inputs.version, which workflow_dispatch lets a caller
+        # set freely. Interpolating that straight into `for tag in ...` would let
+        # a malformed value break Bash parsing in a step that runs AFTER the
+        # registry login, so it goes through the environment and is read as data.
+        env:
+          TAGS: ${{ needs.resolve-tags.outputs.ui_tags }}
         run: |
-          for tag in ${{ needs.resolve-tags.outputs.ui_tags }}; do
+          printf '%s\n' "$TAGS" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
             echo "retagging -> $tag"
             docker buildx imagetools create -t "$tag" drumsergio/cashpilot:latest
           done
@@ -141,8 +148,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Re-point the unchanged worker image at this release's tags
+        env:
+          TAGS: ${{ needs.resolve-tags.outputs.worker_tags }}
         run: |
-          for tag in ${{ needs.resolve-tags.outputs.worker_tags }}; do
+          printf '%s\n' "$TAGS" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
             echo "retagging -> $tag"
             docker buildx imagetools create -t "$tag" drumsergio/cashpilot-worker:latest
           done
@@ -178,16 +188,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Every published tag must resolve
+        env:
+          UI_TAGS: ${{ needs.resolve-tags.outputs.ui_tags }}
+          WORKER_TAGS: ${{ needs.resolve-tags.outputs.worker_tags }}
         run: |
+          # Written to a file and read WITHOUT a pipe: a `while` on the right of
+          # a pipe runs in a subshell, so a counter set inside it is lost. And
+          # the step runs under `bash -e`, where a plain `[ -s f ] && x=1` fails
+          # the whole step on the happy path when the file is absent.
+          printf '%s\n%s\n' "$UI_TAGS" "$WORKER_TAGS" > /tmp/tags.txt
           missing=0
-          for tag in ${{ needs.resolve-tags.outputs.ui_tags }} ${{ needs.resolve-tags.outputs.worker_tags }}; do
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
             if docker manifest inspect "$tag" >/dev/null 2>&1; then
               echo "ok      $tag"
             else
               echo "MISSING $tag"
               missing=1
             fi
-          done
+          done < /tmp/tags.txt
           if [ "$missing" -ne 0 ]; then
             echo "::error::A release tag is missing. The compose files pin both images to the same tag, so a partial release breaks the documented quickstart."
             exit 1


### PR DESCRIPTION
Releasing v1.7.0 exposed this, and it breaks the **documented quickstart** for anyone following the README.

## What happened

The build only rebuilds an image whose source changed — which is right. Nothing under `Dockerfile.worker` or `app/{worker_api,orchestrator,constants,catalog,fleet_key}.py` had changed, so `build-worker` was correctly skipped. The result:

```
drumsergio/cashpilot:1.7.0         EXISTS
drumsergio/cashpilot-worker:1.7.0  MISSING
```

But the compose files pin **both** images to the same major.minor tag (`jz3`), and `tests/test_compose_image_pins.py` **enforces** that they match. So on any release where one image is rebuilt and the other isn't, following our own documented pinning yields a compose file referencing a tag that doesn't exist — and `docker compose pull` fails.

The build contract and the pinning rule contradicted each other, and the test enforced the broken side.

## The fix

**`retag-ui` / `retag-worker`** re-point an unchanged image at the new release's tags via `buildx imagetools create`. That's a **manifest operation, not a rebuild** — an unchanged multi-arch artefact is never rebuilt merely to satisfy a naming convention, which would trade minutes of QEMU for nothing.

**`verify-tags`** then asserts every tag the release claims actually resolves, and fails the run otherwise.

## Why the gate matters more than the fix

CI passed happily while v1.7.0 was half-published. It was found only by deploying and running `docker manifest inspect` by hand. That is exactly what a release gate should catch, and now does.

This is the third bug this session that CI could not see and running the thing could.

## Verification

- `ruff check . && ruff format --check .` — clean
- full pytest green; the 6 compose-pin tests still pass, and with retagging their same-tag rule becomes genuinely valid rather than a trap
- workflow parses; jobs: `resolve-tags, lint, build-ui, retag-ui, retag-worker, build-worker, verify-tags`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release image tagging so unchanged UI and worker images remain available across all release tags.
  * Added automated validation to confirm that every expected UI and worker release tag is present.
  * Release builds now provide more consistent image availability and fail early when tags are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->