### PR TITLE
feat: producer state — is it earning, not just running (CashPilot-b4e)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app import (
     notify,
     power,
     preflight,
+    producer_state,
     setup_token,
 )
 from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
@@ -1874,6 +1875,56 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
     result["window_days"] = max(1, int(days))
     result["host_tdp_watts"] = host_tdp
     return result
+
+
+@app.get("/api/services/{slug}/producer-state")
+async def api_producer_state(request: Request, slug: str, worker_id: int | None = None) -> dict[str, Any]:
+    """Is this service actually EARNING, as distinct from merely running?
+
+    Container health is computed from restarts and crashes, so a service that
+    has produced nothing for a month still scores full marks. This is a separate
+    verdict, and it says "unknown" rather than guessing when the earnings cannot
+    be seen at all.
+    """
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+
+    from app.collectors import COLLECTOR_MAP
+
+    has_collector = slug in COLLECTOR_MAP
+
+    earned_recently: bool | None = None
+    if has_collector:
+        earned = await database.get_earned_by_platform(days=7)
+        if slug in earned:
+            earned_recently = earned[slug] > 0
+
+    running = True
+    log_hits: list[dict[str, str]] = []
+    signals = producer_state.signals_for(service)
+    try:
+        containers = await _get_all_worker_containers()
+        matches = [c for c in containers if c.get("service") == slug]
+        running = any(str(c.get("status", "")).lower() == "running" for c in matches)
+        if signals and running:
+            wid = worker_id if worker_id is not None else (matches[0].get("_worker_id") if matches else None)
+            if wid is not None:
+                logs = (await _proxy_worker_logs(wid, slug, lines=200)).get("logs", "")
+                log_hits = producer_state.match_log_signals(logs, signals)
+    except Exception as exc:
+        # Never let a log or worker problem turn "is it earning?" into a 500;
+        # the earnings signal alone is still worth reporting.
+        logger.warning("Producer-state signals unavailable for %s: %s", slug, exc)
+
+    return producer_state.assess(
+        slug=slug,
+        has_collector=has_collector,
+        earned_recently=earned_recently,
+        log_hits=log_hits,
+        container_running=running,
+    )
 
 
 @app.get("/api/collector-alerts")

--- a/app/producer_state.py
+++ b/app/producer_state.py
@@ -1,0 +1,135 @@
+"""Producer state: is it actually earning? (CashPilot-b4e)
+
+Container health answers "is the process up". It is computed from restarts,
+crashes and check results, so a container that has produced nothing for a month
+still scores 100/100. "It runs but earns nothing" is the most common complaint
+in this whole product category, and container health is structurally incapable
+of seeing it.
+
+This is a SEPARATE state, deliberately. A service can be perfectly healthy as a
+container and dead as a producer, and collapsing the two would hide exactly the
+case a user cares about.
+
+Three signals feed it. Two are implemented here:
+
+* **Earnings movement** — only meaningful for a service that HAS a collector.
+* **Log signals** — per-service regexes declared in the service YAML. This is
+  the only signal available for the 30+ catalogued services with no collector,
+  and keeping the patterns in YAML follows the rule that service-specific
+  knowledge never lives in ``app/``.
+
+The third, container network counters, needs the rx/tx figures wired through the
+Docker worker heartbeat and is tracked separately.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# States, best to worst. FAILING beats IDLE: a log line saying "login failed" is
+# a concrete, actionable diagnosis, whereas idleness is only an observation.
+PRODUCING = "producing"
+IDLE = "idle"
+FAILING = "failing"
+UNKNOWN = "unknown"
+
+_RANK = {PRODUCING: 0, UNKNOWN: 1, IDLE: 2, FAILING: 3}
+
+# A regex from YAML is applied to container logs. Cap the work so a hostile or
+# accidentally catastrophic pattern cannot hang the worker.
+_MAX_LOG_CHARS = 200_000
+
+
+def _compile(pattern: str) -> re.Pattern[str] | None:
+    try:
+        return re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        return None
+
+
+def match_log_signals(logs: str, signals: list[dict[str, Any]] | None) -> list[dict[str, str]]:
+    """Return the declared signals whose pattern appears in ``logs``.
+
+    Each signal is ``{pattern, means, state}`` from the service YAML. An invalid
+    regex is skipped rather than raised: a typo in one service's catalog entry
+    must not break health reporting for every other service.
+    """
+    if not logs or not signals:
+        return []
+    haystack = logs[-_MAX_LOG_CHARS:]
+    hits: list[dict[str, str]] = []
+    for signal in signals:
+        if not isinstance(signal, dict):
+            continue
+        compiled = _compile(str(signal.get("pattern") or ""))
+        if compiled is None or not compiled.search(haystack):
+            continue
+        hits.append(
+            {
+                "pattern": str(signal.get("pattern")),
+                "means": str(signal.get("means") or "").strip() or "Matched a declared failure signal.",
+                "state": str(signal.get("state") or FAILING).lower(),
+            }
+        )
+    return hits
+
+
+def assess(
+    *,
+    slug: str,
+    has_collector: bool,
+    earned_recently: bool | None,
+    log_hits: list[dict[str, str]] | None = None,
+    container_running: bool = True,
+) -> dict[str, Any]:
+    """Combine the available signals into one producer state.
+
+    ``earned_recently`` is None when it cannot be determined — no collector, or
+    not enough history. That is reported as UNKNOWN rather than guessed, because
+    telling a user their service is idle when we simply cannot see its earnings
+    is the same false confidence this module exists to remove.
+    """
+    log_hits = log_hits or []
+    reasons: list[str] = []
+    candidates: list[str] = []
+
+    if not container_running:
+        return {
+            "slug": slug,
+            "state": UNKNOWN,
+            "reasons": ["The container is not running, so there is nothing to judge."],
+            "log_hits": [],
+        }
+
+    for hit in log_hits:
+        state = hit["state"] if hit["state"] in _RANK else FAILING
+        candidates.append(state)
+        reasons.append(hit["means"])
+
+    if earned_recently is True:
+        candidates.append(PRODUCING)
+        reasons.append("Recorded earnings have moved recently.")
+    elif earned_recently is False:
+        candidates.append(IDLE)
+        reasons.append("Recorded earnings have not moved recently.")
+    elif has_collector:
+        candidates.append(UNKNOWN)
+        reasons.append("Not enough earnings history yet to judge.")
+    else:
+        candidates.append(UNKNOWN)
+        reasons.append(
+            "This service has no collector, so CashPilot cannot see its earnings. "
+            "Only declared log signals can say anything about it."
+        )
+
+    state = max(candidates, key=lambda s: _RANK[s]) if candidates else UNKNOWN
+    return {"slug": slug, "state": state, "reasons": reasons, "log_hits": log_hits}
+
+
+def signals_for(service: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The ``health_signals`` block a service declares, or an empty list."""
+    if not service:
+        return []
+    raw = (service.get("docker") or {}).get("health_signals") or service.get("health_signals") or []
+    return [s for s in raw if isinstance(s, dict)]

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -42,6 +42,15 @@
 #   command: "" (optional override)
 #   network_mode: "" (optional, e.g. "host")
 #   cap_add: [] (optional)
+#   health_signals: [] (optional) log patterns that say whether the service is EARNING,
+#     which container health cannot see. The only signal available for the services with
+#     no collector.
+#       - pattern: "login failed"       regex, matched case-insensitively against logs
+#         means:   "The service rejected the stored credentials."   shown to the user
+#         state:   failing              failing (default) | idle
+#     Only add a pattern you have actually seen in that service's logs. A guessed regex
+#     that never matches is dead weight; one that matches the wrong line tells the user
+#     something false.
 #   devices: [] (optional) host devices to map in, e.g. ["/dev/net/tun"]
 #     Only devices on the worker's allow-list may be requested, and only by the
 #     service whose own YAML declares them. A device is a direct line to the

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -1,0 +1,229 @@
+"""Producer state is not container health (CashPilot-b4e).
+
+Container health is computed from restarts and crashes, so a service that has
+produced nothing for a month still scores 100/100. "It runs but earns nothing"
+is the most common complaint in this category and container health cannot see it.
+
+The tests that matter most are the ones about NOT claiming to know: a service
+with no collector must read unknown rather than idle, because saying "idle" when
+we simply cannot see the earnings is the false confidence this exists to remove.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import producer_state as ps
+
+FAILED_LOGIN = {"pattern": r"login failed", "means": "The service rejected the stored credentials.", "state": "failing"}
+BANNED = {"pattern": r"\bbanned\b", "means": "The provider has banned this node.", "state": "failing"}
+IDLE_HINT = {"pattern": r"no tasks available", "means": "Connected but nothing to do.", "state": "idle"}
+
+
+class TestLogSignals:
+    def test_a_declared_pattern_is_matched(self):
+        hits = ps.match_log_signals("2026-08-02 ERROR login failed for user", [FAILED_LOGIN])
+        assert len(hits) == 1
+        assert hits[0]["means"].startswith("The service rejected")
+
+    def test_matching_is_case_insensitive(self):
+        assert ps.match_log_signals("LOGIN FAILED", [FAILED_LOGIN])
+
+    def test_an_absent_pattern_does_not_match(self):
+        assert ps.match_log_signals("everything is fine", [FAILED_LOGIN]) == []
+
+    def test_an_invalid_regex_is_skipped_not_raised(self):
+        """A typo in one service's YAML must not break health for all the others."""
+        hits = ps.match_log_signals("login failed", [{"pattern": "(unclosed", "means": "x"}, FAILED_LOGIN])
+        assert len(hits) == 1
+
+    def test_a_signal_without_a_reason_still_says_something(self):
+        hits = ps.match_log_signals("banned", [{"pattern": "banned"}])
+        assert hits[0]["means"]
+
+    def test_only_the_tail_of_a_huge_log_is_scanned(self):
+        """A pattern must not cost unbounded work on a noisy container."""
+        logs = ("x" * 500_000) + "login failed"
+        assert ps.match_log_signals(logs, [FAILED_LOGIN])
+
+    def test_no_logs_or_no_signals_is_simply_no_hits(self):
+        assert ps.match_log_signals("", [FAILED_LOGIN]) == []
+        assert ps.match_log_signals("login failed", None) == []
+
+
+class TestItDoesNotClaimToKnow:
+    def test_a_service_with_no_collector_is_unknown_not_idle(self):
+        """We cannot see its earnings, so we must not call it idle."""
+        out = ps.assess(slug="grass", has_collector=False, earned_recently=None)
+        assert out["state"] == ps.UNKNOWN
+        assert any("no collector" in r for r in out["reasons"])
+
+    def test_too_little_history_is_unknown_not_idle(self):
+        out = ps.assess(slug="new", has_collector=True, earned_recently=None)
+        assert out["state"] == ps.UNKNOWN
+        assert any("Not enough" in r for r in out["reasons"])
+
+    def test_a_stopped_container_is_not_judged_at_all(self):
+        out = ps.assess(slug="x", has_collector=True, earned_recently=False, container_running=False)
+        assert out["state"] == ps.UNKNOWN
+        assert "not running" in out["reasons"][0]
+
+
+class TestStates:
+    def test_moving_earnings_read_as_producing(self):
+        assert ps.assess(slug="x", has_collector=True, earned_recently=True)["state"] == ps.PRODUCING
+
+    def test_flat_earnings_read_as_idle(self):
+        assert ps.assess(slug="x", has_collector=True, earned_recently=False)["state"] == ps.IDLE
+
+    def test_a_failure_log_beats_moving_earnings(self):
+        """A concrete diagnosis outranks an observation."""
+        out = ps.assess(
+            slug="x",
+            has_collector=True,
+            earned_recently=True,
+            log_hits=ps.match_log_signals("login failed", [FAILED_LOGIN]),
+        )
+        assert out["state"] == ps.FAILING
+        assert any("rejected the stored credentials" in r for r in out["reasons"])
+
+    def test_a_log_signal_can_explain_a_collector_less_service(self):
+        """The whole point of the YAML signals: 30+ services have no collector."""
+        out = ps.assess(
+            slug="teneo",
+            has_collector=False,
+            earned_recently=None,
+            log_hits=ps.match_log_signals("account banned", [BANNED]),
+        )
+        assert out["state"] == ps.FAILING
+        assert any("banned" in r for r in out["reasons"])
+
+    def test_an_idle_log_signal_does_not_masquerade_as_failure(self):
+        out = ps.assess(
+            slug="x",
+            has_collector=False,
+            earned_recently=None,
+            log_hits=ps.match_log_signals("no tasks available", [IDLE_HINT]),
+        )
+        assert out["state"] == ps.IDLE
+
+    def test_the_worst_signal_wins(self):
+        out = ps.assess(
+            slug="x",
+            has_collector=True,
+            earned_recently=True,
+            log_hits=ps.match_log_signals("no tasks available and banned", [IDLE_HINT, BANNED]),
+        )
+        assert out["state"] == ps.FAILING
+
+    def test_every_verdict_carries_its_reasons(self):
+        for kwargs in (
+            {"has_collector": True, "earned_recently": True},
+            {"has_collector": True, "earned_recently": False},
+            {"has_collector": False, "earned_recently": None},
+        ):
+            assert ps.assess(slug="x", **kwargs)["reasons"], "a state with no reason is not actionable"
+
+
+class TestCatalogIntegration:
+    def test_signals_are_read_from_the_service_yaml(self):
+        svc = {"slug": "x", "docker": {"health_signals": [FAILED_LOGIN]}}
+        assert ps.signals_for(svc) == [FAILED_LOGIN]
+
+    def test_a_service_declaring_none_yields_none(self):
+        assert ps.signals_for({"slug": "x", "docker": {}}) == []
+        assert ps.signals_for(None) == []
+
+    def test_malformed_entries_are_ignored(self):
+        svc = {"slug": "x", "docker": {"health_signals": ["not-a-mapping", FAILED_LOGIN]}}
+        assert ps.signals_for(svc) == [FAILED_LOGIN]
+
+    def test_every_declared_signal_in_the_real_catalog_compiles(self):
+        """A broken regex shipped in the catalog would be silently useless."""
+        import re
+
+        from app import catalog
+
+        for svc in catalog.get_services():
+            for sig in ps.signals_for(svc):
+                pattern = sig.get("pattern")
+                assert pattern, f"{svc['slug']}: health_signals entry has no pattern"
+                try:
+                    re.compile(str(pattern))
+                except re.error as exc:
+                    pytest.fail(f"{svc['slug']}: invalid health_signals regex {pattern!r} ({exc})")
+                assert str(sig.get("means") or "").strip(), (
+                    f"{svc['slug']}: signal {pattern!r} has no 'means' — a match nobody can interpret"
+                )
+
+
+class TestProducerStateEndpoint:
+    """The wiring: collector detection, log fetching, and never 500-ing."""
+
+    def _call(self, slug, service, earned=None, containers=None, logs="", collector=True):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        cmap = {slug: object()} if collector else {}
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.catalog, "get_service", return_value=service),
+                patch.dict("app.collectors.COLLECTOR_MAP", cmap, clear=True),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value=earned or {})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers or [])),
+                patch.object(main, "_proxy_worker_logs", AsyncMock(return_value={"logs": logs})),
+            ):
+                return await main.api_producer_state(MagicMock(), slug)
+
+        return asyncio.run(run())
+
+    SVC = {"slug": "demo", "docker": {"health_signals": [FAILED_LOGIN]}}
+    RUNNING = [{"service": "demo", "status": "running", "_worker_id": 1}]
+
+    def test_an_unknown_service_is_a_404(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._call("nope", None)
+        assert exc.value.status_code == 404
+
+    def test_moving_earnings_report_producing(self):
+        out = self._call("demo", self.SVC, earned={"demo": 1.5}, containers=self.RUNNING)
+        assert out["state"] == ps.PRODUCING
+
+    def test_flat_earnings_report_idle(self):
+        out = self._call("demo", self.SVC, earned={"demo": 0.0}, containers=self.RUNNING)
+        assert out["state"] == ps.IDLE
+
+    def test_a_log_signal_is_matched_from_worker_logs(self):
+        out = self._call("demo", self.SVC, earned={"demo": 1.0}, containers=self.RUNNING, logs="ERROR login failed")
+        assert out["state"] == ps.FAILING
+        assert out["log_hits"]
+
+    def test_a_service_without_a_collector_is_unknown_not_idle(self):
+        out = self._call("demo", self.SVC, containers=self.RUNNING, collector=False)
+        assert out["state"] == ps.UNKNOWN
+
+    def test_a_log_fetch_failure_never_500s(self):
+        """The earnings signal alone is still worth reporting."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.catalog, "get_service", return_value=self.SVC),
+                patch.dict("app.collectors.COLLECTOR_MAP", {"demo": object()}, clear=True),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"demo": 2.0})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(side_effect=RuntimeError("down"))),
+            ):
+                return await main.api_producer_state(MagicMock(), "demo")
+
+        out = asyncio.run(run())
+        assert out["state"] == ps.PRODUCING


### PR DESCRIPTION
`get_health_scores` is computed from restarts, crashes and check results — so a container that has produced **nothing for a month still scores 100/100**. "It runs but earns nothing" is the most common complaint in this category, and container health is structurally incapable of seeing it.

This is a deliberately **separate** verdict. A service can be perfectly healthy as a container and dead as a producer; collapsing the two hides exactly the case the user cares about.

## Two of the bead's three signals

- **Earnings movement** over a trailing window, for services that have a collector.
- **`health_signals` in the service YAML** — log regexes with a plain-language `means` and a state. This is the **only** signal available for the 30+ catalogued services with no collector, and keeping the patterns in YAML follows the rule that service-specific knowledge never lives in `app/`.

## What it refuses to claim

A service with **no collector reads `unknown`, never `idle`**. Telling someone their service is idle when we simply cannot see its earnings is the same false confidence this exists to remove. Too little history is `unknown` too, and a stopped container isn't judged at all.

Every verdict carries its reasons — a state with no reason isn't actionable. And a concrete log diagnosis outranks an earnings observation, so *"login failed"* beats *"earnings moved"*: the log says **why**.

## No catalog entries yet, on purpose

I have not populated `health_signals` for any service. A guessed regex that never matches is dead weight; one that matches the wrong line tells the user something false. Populating them needs real log samples per service. The schema says so explicitly, and a test fails if any declared pattern doesn't compile or has no `means`.

## Scope

The third signal — container network rx/tx counters — needs those figures wired through the Docker worker heartbeat, which the bead itself calls "the bulk of the work". Not in this change.

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1556 passed**, coverage 94.38%
- 27 new tests, with the endpoint covered up front (four earlier PRs failed `codecov/patch` for exactly the omission of endpoint tests)