### PR TITLE
feat: per-service disclosure — what it does with your machine (CashPilot-66x)

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -51,6 +51,12 @@ def _validate(data: dict[str, Any], path: Path) -> list[str]:
     if status is not None and status not in _VALID_STATUSES:
         errors.append(f"{path.name}: invalid status {status!r} (expected one of {sorted(_VALID_STATUSES)})")
 
+    disclosure = data.get("disclosure")
+    if disclosure is not None and not isinstance(disclosure, dict):
+        # `disclosure: TODO` loaded fine and then 500'd the endpoint at request
+        # time, so the fault was invisible until someone opened that one service.
+        errors.append(f"{path.name}: disclosure must be a mapping, not {type(disclosure).__name__}")
+
     docker = data.get("docker")
     if isinstance(docker, dict):
         image = docker.get("image")

--- a/app/disclosure.py
+++ b/app/disclosure.py
@@ -1,0 +1,121 @@
+"""What a service actually does with your machine (CashPilot-66x).
+
+The most common reaction to software in this space is "is this malware?", and it
+is a fair question: the user is being asked to run closed-source third-party
+containers that route traffic through their home connection. Answering with an
+earnings range and a setup guide does not address it.
+
+The disclosure lives in the service YAML, like everything else service-specific.
+This module only reads it and — the part that matters — makes the gaps visible.
+
+**An absent disclosure must never read as a safe one.** A service nobody has
+documented is exactly the service a user should be most careful with, so a
+missing block reports ``documented: False`` and every unanswered question is
+listed by name. Vagueness in the source deserves to be visible rather than
+smoothed over, and "we do not know what this provider does with the traffic" is
+a legitimate, useful answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The questions a user actually has before running one of these. Each is
+# answerable in plain words; where it is not, that is itself the answer.
+FIELDS: dict[str, str] = {
+    "sells": "What is actually being sold — bandwidth, disk, compute, attention?",
+    "third_party_traffic": "Do strangers route their traffic through your IP address?",
+    "data_collected": "What identifying data leaves your machine?",
+    "isp_risk": "What could this mean for your ISP contract?",
+    "account_rules": "What are the account and multi-account rules?",
+}
+
+UNKNOWN = "unknown"
+
+
+def for_service(service: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the disclosure for one service, with its gaps named.
+
+    ``answered``/``unanswered`` are what a UI should lead with: a half-filled
+    disclosure that looks complete is worse than an obviously empty one.
+    """
+    if not service:
+        return {
+            "slug": None,
+            "documented": False,
+            "answers": {},
+            "unanswered": list(FIELDS),
+            "summary": "No disclosure for this service.",
+        }
+
+    slug = service.get("slug")
+    raw = service.get("disclosure") or {}
+    answers: dict[str, str] = {}
+    unanswered: list[str] = []
+
+    for field in FIELDS:
+        value = str(raw.get(field) or "").strip()
+        # An explicit "unknown" is a real answer and is kept as one: it says
+        # somebody looked and could not find out, which is different from
+        # nobody having looked.
+        if not value:
+            unanswered.append(field)
+        else:
+            answers[field] = value
+
+    documented = bool(answers)
+    return {
+        "slug": slug,
+        "documented": documented,
+        "answers": answers,
+        "unanswered": unanswered,
+        "questions": FIELDS,
+        "summary": _summary(service, documented, unanswered),
+    }
+
+
+def _summary(service: dict[str, Any], documented: bool, unanswered: list[str]) -> str:
+    name = service.get("name") or service.get("slug") or "This service"
+    if not documented:
+        return (
+            f"{name} has not been documented yet. That is not a statement that it is safe — "
+            "it means nobody has written down what it does with your machine."
+        )
+    if unanswered:
+        return f"{name} is partly documented. {len(unanswered)} question(s) below are still unanswered."
+    return f"{name} is fully documented below."
+
+
+def routes_third_party_traffic(service: dict[str, Any] | None) -> bool | None:
+    """Whether strangers use the user's IP. None when it is not documented.
+
+    Deliberately three-valued. This is the single most consequential fact about
+    most services in this catalog — it is what creates ISP and law-enforcement
+    exposure — so "not documented" must not collapse into "no".
+    """
+    if not service:
+        return None
+    value = str((service.get("disclosure") or {}).get("third_party_traffic") or "").strip().lower()
+    if not value or value.startswith(UNKNOWN):
+        return None
+    if value.startswith(("yes", "true")):
+        return True
+    if value.startswith(("no", "false")):
+        return False
+    return None
+
+
+def coverage(services: list[dict[str, Any]]) -> dict[str, Any]:
+    """How much of the catalog is documented, and which services are not.
+
+    Kept honest on purpose: a partially documented catalog should be able to
+    say so rather than presenting the documented subset as if it were all.
+    """
+    documented = [s for s in services if (s.get("disclosure") or {})]
+    missing = sorted(s.get("slug") for s in services if not (s.get("disclosure") or {}))
+    return {
+        "total": len(services),
+        "documented": len(documented),
+        "undocumented": len(missing),
+        "undocumented_slugs": missing,
+    }

--- a/app/disclosure.py
+++ b/app/disclosure.py
@@ -18,6 +18,7 @@ a legitimate, useful answer.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 # The questions a user actually has before running one of these. Each is
@@ -32,6 +33,10 @@ FIELDS: dict[str, str] = {
 
 UNKNOWN = "unknown"
 
+# Of the five, the one that creates real-world exposure. Tracked separately so a
+# service can say "we answered everything except the question that matters".
+CRITICAL_FIELD = "third_party_traffic"
+
 
 def for_service(service: dict[str, Any] | None) -> dict[str, Any]:
     """Return the disclosure for one service, with its gaps named.
@@ -45,23 +50,33 @@ def for_service(service: dict[str, Any] | None) -> dict[str, Any]:
             "documented": False,
             "answers": {},
             "unanswered": list(FIELDS),
+            "unknown": [],
+            "answered_count": 0,
+            "total_questions": len(FIELDS),
+            "routes_third_party_traffic": None,
+            "critical_unanswered": True,
+            "questions": dict(FIELDS),
             "summary": "No disclosure for this service.",
         }
 
     slug = service.get("slug")
-    raw = service.get("disclosure") or {}
+    raw = _block(service)
     answers: dict[str, str] = {}
     unanswered: list[str] = []
+    unknowns: list[str] = []
 
     for field in FIELDS:
-        value = str(raw.get(field) or "").strip()
+        value = _text(raw.get(field))
         # An explicit "unknown" is a real answer and is kept as one: it says
         # somebody looked and could not find out, which is different from
-        # nobody having looked.
+        # nobody having looked. It is COUNTED separately all the same, because
+        # five unknowns is not a documented service.
         if not value:
             unanswered.append(field)
-        else:
-            answers[field] = value
+            continue
+        answers[field] = value
+        if value.lower().startswith(UNKNOWN):
+            unknowns.append(field)
 
     documented = bool(answers)
     return {
@@ -69,21 +84,101 @@ def for_service(service: dict[str, Any] | None) -> dict[str, Any]:
         "documented": documented,
         "answers": answers,
         "unanswered": unanswered,
-        "questions": FIELDS,
-        "summary": _summary(service, documented, unanswered),
+        "unknown": unknowns,
+        "answered_count": len(answers),
+        "total_questions": len(FIELDS),
+        # The one fact worth branching on. Exposed so no consumer has to
+        # re-implement the parse and reproduce the bug it was written to avoid.
+        "routes_third_party_traffic": routes_third_party_traffic(service),
+        # Not all questions weigh the same: a service that answered everything
+        # except whether strangers use your IP has not answered the one that
+        # matters most.
+        "critical_unanswered": CRITICAL_FIELD in unanswered,
+        "questions": dict(FIELDS),
+        "summary": _summary(service, documented, unanswered, unknowns),
     }
 
 
-def _summary(service: dict[str, Any], documented: bool, unanswered: list[str]) -> str:
+def _text(value: Any) -> str:
+    """One answer as displayable text.
+
+    YAML 1.1 coerces an unquoted ``yes``/``no``/``off`` to a bool, which is
+    exactly what the schema tells authors to write. Rendering that as the
+    literal "True" is worse than useless, so it is normalised back into the
+    word the author meant.
+    """
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value or "").strip()
+
+
+def _block(service: dict[str, Any] | None) -> dict[str, Any]:
+    """The service's disclosure mapping, or an empty one.
+
+    A YAML author writing `disclosure: TODO` produced a string here, and calling
+    .get() on it was a 500 at request time that the catalog loader does not
+    catch.
+    """
+    raw = (service or {}).get("disclosure")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _summary(service: dict[str, Any], documented: bool, unanswered: list[str], unknowns: list[str]) -> str:
     name = service.get("name") or service.get("slug") or "This service"
     if not documented:
         return (
             f"{name} has not been documented yet. That is not a statement that it is safe — "
             "it means nobody has written down what it does with your machine."
         )
+    if not unanswered and len(unknowns) == len(FIELDS):
+        # Every question was researched and none could be answered. Calling that
+        # "fully documented" would be the most misleading string in the module.
+        return (
+            f"All {len(FIELDS)} questions about {name} were researched and NONE could be "
+            "answered — the provider does not say. Treat that as a reason for caution, "
+            "not as reassurance."
+        )
+    parts = []
     if unanswered:
-        return f"{name} is partly documented. {len(unanswered)} question(s) below are still unanswered."
-    return f"{name} is fully documented below."
+        parts.append(f"{len(unanswered)} question(s) below are still unanswered")
+    if unknowns:
+        parts.append(f"{len(unknowns)} could not be answered by the provider")
+    if not parts:
+        return f"{name} is fully documented below."
+    return f"{name} is partly documented: " + ", and ".join(parts) + "."
+
+
+# The answer must OPEN with a STANDALONE yes/no/unknown — the word used as a
+# verdict, then punctuation or the end of the string.
+#
+# A word boundary is not enough. "No longer — since v2 they route traffic"
+# passes \b and means the opposite of what it parses as, which is the single
+# most dangerous wrong answer this module can produce. A prefix match was worse
+# still: it read "notably, strangers DO use your IP" as "no".
+#
+# So anything we cannot parse with confidence becomes None. That is the safe
+# direction, and the catalog test below makes an unparseable answer fail CI
+# rather than quietly becoming a verdict.
+# A dash must be a separator, not part of a word: "TRUE-ish" is not a verdict,
+# while "Yes - buyers proxy through you" is.
+_VERDICT_RE = re.compile(r"^(yes|no|unknown|true|false)\s*(?:[.,:;!?]|[—–-]\s|$)", re.IGNORECASE)
+
+
+def parse_verdict(value: Any) -> bool | None:
+    """yes/no/unknown at the START of an answer, as a tri-state."""
+    if isinstance(value, bool):
+        # YAML 1.1 turns an unquoted `yes`/`no` into a real boolean before we
+        # ever see it, so the schema's own advice produces this type.
+        return value
+    match = _VERDICT_RE.match(str(value or "").strip())
+    if not match:
+        return None
+    word = match.group(1).lower()
+    if word in {"yes", "true"}:
+        return True
+    if word in {"no", "false"}:
+        return False
+    return None
 
 
 def routes_third_party_traffic(service: dict[str, Any] | None) -> bool | None:
@@ -91,18 +186,12 @@ def routes_third_party_traffic(service: dict[str, Any] | None) -> bool | None:
 
     Deliberately three-valued. This is the single most consequential fact about
     most services in this catalog — it is what creates ISP and law-enforcement
-    exposure — so "not documented" must not collapse into "no".
+    exposure — so neither "not documented" nor prose we failed to parse may
+    collapse into "no".
     """
     if not service:
         return None
-    value = str((service.get("disclosure") or {}).get("third_party_traffic") or "").strip().lower()
-    if not value or value.startswith(UNKNOWN):
-        return None
-    if value.startswith(("yes", "true")):
-        return True
-    if value.startswith(("no", "false")):
-        return False
-    return None
+    return parse_verdict(_block(service).get("third_party_traffic"))
 
 
 def coverage(services: list[dict[str, Any]]) -> dict[str, Any]:
@@ -111,8 +200,13 @@ def coverage(services: list[dict[str, Any]]) -> dict[str, Any]:
     Kept honest on purpose: a partially documented catalog should be able to
     say so rather than presenting the documented subset as if it were all.
     """
-    documented = [s for s in services if (s.get("disclosure") or {})]
-    missing = sorted(s.get("slug") for s in services if not (s.get("disclosure") or {}))
+    # Delegates rather than re-testing dict truthiness: a disclosure of
+    # {"sells": "   "} or {"typo_field": "x"} is truthy but answers nothing, so
+    # a second definition here overstated coverage in the one function whose
+    # whole job is to be honest about the gap.
+    flags = [(s.get("slug"), for_service(s)["documented"]) for s in services]
+    documented = [slug for slug, ok in flags if ok]
+    missing = sorted({str(slug or "") for slug, ok in flags if not ok})
     return {
         "total": len(services),
         "documented": len(documented),

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app import (
     catalog,
     compose_generator,
     database,
+    disclosure,
     exchange_rates,
     fleet_key,
     metrics,
@@ -1925,6 +1926,27 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         log_hits=log_hits,
         container_running=running,
     )
+
+
+@app.get("/api/services/{slug}/disclosure")
+async def api_service_disclosure(request: Request, slug: str) -> dict[str, Any]:
+    """What this service does with your machine, and what nobody has answered yet."""
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+    return disclosure.for_service(service)
+
+
+@app.get("/api/disclosure/coverage")
+async def api_disclosure_coverage(request: Request) -> dict[str, Any]:
+    """How much of the catalog is documented, and which services are not.
+
+    Deliberately reports the gap: presenting the documented subset without
+    saying what is missing would imply a completeness the catalog does not have.
+    """
+    _require_auth_api(request)
+    return disclosure.coverage(catalog.get_services())
 
 
 @app.get("/api/collector-alerts")

--- a/docs/AUTOPILOT-WORKLOG.md
+++ b/docs/AUTOPILOT-WORKLOG.md
@@ -70,3 +70,326 @@ Append-only. Newest at the bottom. Every "done" needs evidence (test/CI/commit).
 - Verification: every PR full-suite green (web 1172 pytest; desktop go test -race) + ruff/gofmt
   + CodeRabbit reviewed. Frontend (cyc) verified statically (node --check + analysis) as browser
   was unavailable.
+
+## 2026-08-02T11:47:37Z — sergio-loop segment 1, iteration 1
+
+**Slice:** merge the remaining 1.x PRs, cut one release, verify the fleet.
+
+**Merged (14 total this batch):** 1ii, efx, tkd, glc, aug, kbs, qkc, kct, jz3, w58, the CodeRabbit
+security follow-up (#154), the log-leak fix, docs (#141), the Mysterium runbook (#155), and the CI
+fix (#156).
+
+**Release: v1.5.0.** Tag, GitHub release, and all four image tags published multi-arch and verified
+present with `docker manifest inspect`: cashpilot{,-worker}:1.5.0 and :1.5. The :1.5 tag matters
+because the compose files now pin major.minor (CashPilot-jz3).
+
+**CI bug found and fixed while releasing (#156).** release.yml decided whether to build from
+`git diff HEAD~1 HEAD` — only the newest commit — while a release contains every commit since the
+previous tag. The failure was SILENT: with the app changes in earlier commits (merged `[skip ci]`)
+and a compose-only final commit, it concluded "nothing to build", skipped the version step, and
+produced no tag and no image while reporting success. Now diffs from the latest tag; verified
+`v1.4.4..HEAD` reports 7 app/ files + services/ and resolves to build.
+
+**Fleet verification (read-only, watchtower):**
+- 17/17 containers up; cashpilot-ui and cashpilot-worker both healthy.
+- Credentials decrypt and collectors run: 12 platforms recorded readings dated today
+  (bitping, bytelixir, earnapp, earnfm, grass, honeygain, iproyal, mysterium, proxyrack, repocket,
+  storj, traffmonetizer).
+- Mysterium identity intact: 0x55fd4a497237be0591b6c2423cde0e325398b6a8. Anyone Protocol relay key
+  (ed25519_master_id_secret_key) present. Both were recreated earlier today to restore the TUN
+  device and the cashpilot labels my hardening run had stripped.
+- **One real fault: packetstream** — "Could not parse balance from dashboard". Its fix shipped in an
+  earlier release; the fleet UI is still on 1.4.1, so upgrading resolves it.
+
+**Fleet is on UI 1.4.1 / worker 1.4.2, NOT 1.5.0.** Upgrading is a DEPLOY, a class deliberately
+excluded from the standing grant in .omc/sergio-loop/authorization.json (which names only merge and
+release). The stack is GitOps-managed at /mnt/user/appdata/stacks/watchtower/cashpilot/, so the
+correct path is a push to the Gitea stacks repo, not editing on the server. Not actioned.
+
+**Counters:** iteration 1, no_progress 0, failures 0.
+
+**Next action:** get Sergio's go-ahead for the fleet upgrade to 1.5.0 (which also fixes
+packetstream), then continue 1.x with CashPilot-6rv (catalog device support — the P1 behind the
+MystNodes TUN failure).
+
+## 2026-08-02T12:23:44Z — sergio-loop segment 1, iteration 2
+
+**Released v1.5.0 then v1.6.0.** Both verified: tag, GitHub release, and all image tags present
+multi-arch on Docker Hub (:1.6.0 and :1.6 for both ui and worker).
+
+**Open PRs: 0.** Landed #145, #146, #149, #152, #141, #155, #156, #157, #158, #159, #160.
+
+**CI bug found while releasing (#156).** release.yml decided whether to build from
+`git diff HEAD~1 HEAD`, only the newest commit, while a release contains everything since the
+previous tag. Silent: with app changes in earlier `[skip ci]` merges it concluded "nothing to
+build", skipped the version step, and produced no tag and no image while reporting success. Now
+diffs from the latest tag.
+
+**CodeRabbit audit (Sergio's explicit ask) — 14 unresolved threads found on MERGED PRs.** All are
+now fixed and resolved, each verified by reading main rather than trusting the report:
+- #149 (2, REAL BUGS, never seen before): the flatline query read all history, so a failing
+  collector — whose old readings are unchanged — read as a flatline, as did a removed service
+  that kept its history; and nothing cleared the flatline cooldown on recovery, so a service
+  that recovered and went flat again inside the window was silently swallowed. Fixed in #158.
+- #143 (4): raw worker body logged at warning while deliberately withheld from the caller
+  (credential leak into logs), schema overclaim, E402, leaked lifespan_context. Fixed in #154.
+- #140 (4): record-vs-catalog precedence, over-broad hosted-custody legal claim, export trust
+  boundary, recovery boundary. Fixed in #160.
+- #126 (2): guide commands used :latest while the catalog pins by digest. Fixed in #160.
+- #136 (1): already fixed in #137; verified no bare opening fence remains.
+- #146 (1): hostname preservation, already fixed in #145.
+Threads stayed open only because fixes landed in later PRs — CodeRabbit auto-resolves same-branch
+fixes only. Each closed with a comment naming the fixing PR.
+
+**One review finding REJECTED after checking.** #126 claimed the YAML says USDC on Solana with a
+Solana wallet, conflicting with the guide's Tempo. Both files say Tempo, the CLI flag is
+--tempo-address, and independent research agrees. Not actioned.
+
+**Logo/theme (Sergio's question).** Diagnosed as a theme mismatch rather than a logo problem: docs
+shipped material's deep purple + pink while the app is #0f1117 with a #3b82f6 accent, so the site
+and the product looked like different things and the warm mark clashed with the purple bar. Sergio
+chose "match the docs to the app"; shipped in #159. No logo redraw needed — the mark was already
+drawn for dark.
+
+**Counters:** iteration 2, no_progress 0, failures 0.
+
+**Next action:** fleet upgrade to 1.6.0 awaits Sergio (deploy is not in the standing grant); then
+continue 1.x beads starting with f5u (P1, net profit / power cost).
+
+## 2026-08-02T13:21:08Z — sergio-loop segment 1, iteration 3
+
+**Fleet upgraded to 1.6.0 and verified end to end.** Sergio granted deploy explicitly
+("Obviously update all my fleet, otherwise how can you really test everything we did so far?"),
+recorded in .omc/sergio-loop/authorization.json. Production data mutation and history rewrite
+remain excluded.
+
+Method: GitOps, one commit per host to its own Gitea stacks repo (giteaer/watchtower,
+giteaer/geiserback, giteaer/geiserct), webhook deploying in ~20s each. Nothing edited on a server
+directly, so the next deploy cannot revert it.
+
+Pre-flight before touching anything: confirmed /data writable on all three hosts and the
+.fernet_key present, because 1.6.0 REFUSES TO START when it cannot persist the encryption key.
+Took a hot DB backup first (cashpilot.db.pre-1.6.0.bak, 54 MB).
+
+Verified after:
+- watchtower UI + worker, geiserback worker, geiserct worker: all 1.6.0, all healthy. 5 workers
+  online and heartbeating. 17 cashpilot containers running.
+- UI startup clean — "Application startup complete", no encryption-key refusal.
+- Credentials decrypt: 6 encrypted config rows readable, 13 platforms recorded a reading today.
+- Migrations landed on the live DB: deployments.spec_encrypted, config.updated_at,
+  earnings.fx_rate_usd all present.
+- PACKETSTREAM RECOVERED: $2.13 recorded today, its first reading since 2026-07-27, and its
+  stored alert is gone. That is the concrete payoff of the upgrade.
+- Node identities intact: mysterium 0x55fd4a497237be0591b6c2423cde0e325398b6a8, anyone-protocol
+  ed25519_master_id_secret_key present.
+- New endpoints registered: /api/credentials/health, /api/earnings/flatlines,
+  /api/services/{slug}/preflight.
+
+Rollback if ever needed: pin the tag back to 1.4.x in the host's stacks repo and push; the images
+are still published and /data was untouched by the image change.
+
+**Counters:** iteration 3, no_progress 0, failures 0.
+
+**Next action:** bead f5u (P1) — net profit rather than gross, power cost first-class.
+
+## 2026-08-02T13:29:11Z — sergio-loop segment 1, iteration 4
+
+**f5u implemented (PR #161) and deliberately NOT merged.** CodeRabbit reviewed it properly for
+once and found five issues; two make the reported figures wrong, which in a feature about
+reporting money honestly is disqualifying:
+
+- power.summarise reports per-service `net == gross` when no tariff is configured. The TOTALS are
+  right (cost_known false, total_net None) but the rows render gross as net — the exact failure
+  the bead exists to prevent, in my own code, against my own stated rule.
+- api_earnings_net subtracts a window-scoped cost from get_earnings_per_service(), which returns
+  the latest BALANCE rather than earnings over the window. A 30-day cost against a lifetime
+  balance is meaningless.
+
+Three more, all real: stopped containers inflate container_count; every worker is collapsed into
+one count and one host TDP, so a 3-host fleet is charged one idle floor and is_metered cannot be
+applied per worker; no error boundary around worker-status data.
+
+Held rather than merged, recorded in docs/DEFERRED-QUESTIONS.md. Fixing 1 and 2 needs a
+window-scoped earnings query and per-worker attribution — real work, not a patch on the diff.
+
+**Counters:** iteration 4, no_progress 0 (the review outcome is progress: it stopped a wrong
+feature reaching users), failures 0.
+
+**Next action:** rework #161 — per-service None when the tariff is unknown, window-scoped
+earnings, per-worker power attribution, running-only containers, error boundary. Then b4e.
+
+## 2026-08-02T13:32:18Z — sergio-loop segment 1, iteration 5
+
+**Reworked PR #161 (f5u).** Four of five review findings fixed and verified; the fifth is
+explicitly deferred rather than quietly dropped.
+
+Fixed:
+- Per-service net equalled gross when no tariff was configured. Totals were right; the ROWS were
+  not. Now cost/net are None per service with cost_quality "unknown", and nothing is flagged
+  negative on an unknown cost. This was the feature's own rule broken in its own code.
+- Net was computed against the latest BALANCE (a running total), so a 30-day electricity cost was
+  charged against a lifetime of earnings. New database.get_earned_by_platform(days) sums
+  per-platform deltas over the window, clamped per platform exactly as the dashboard does
+  (CashPilot-glc), so a payout does not read as negative earnings.
+- Stopped containers inflated container_count, shrinking each running service's share of the idle
+  floor and understating cost. Filtered on status == running.
+- No error boundary: a worker-status failure could take out earnings figures that come from the
+  database and are still reportable.
+
+Deferred, stated on the PR: per-worker power attribution. All workers still collapse into one
+count and one host TDP, so a multi-host fleet is charged one idle floor and power.is_metered
+cannot be applied per worker. Needs the worker grouping carried through to the watt calculation —
+its own reviewable diff, not a rushed addendum.
+
+Verification: ruff clean; 1520 passed; coverage 93.67%.
+
+**Counters:** iteration 5, no_progress 0, failures 0.
+
+**Next action:** await CI + CodeRabbit on #161; then per-worker attribution, then b4e.
+
+## 2026-08-02T13:38:45Z — sergio-loop segment 1, iteration 6
+
+**PR #161 (f5u) merged.** All checks green, no review running, all threads resolved afterwards.
+Added endpoint tests first — codecov flagged that the module was covered but the endpoint around
+it was not, which is where config parsing, the running-only filter and the error boundary live.
+1525 passed, coverage 94.30%.
+
+**Backlog reconciled.** Closed the 13 beads shipped and merged this session with their PR numbers:
+1ii, efx, tkd, 964, glc, aug, kbs, qkc, kct, jz3, w58, 6rv, f5u. Open is now 18, of which 3 are
+the v2.0.0 wallet tiers (luj, dv6, e8u), so 15 remain for 1.x.
+
+**Filed CashPilot-yh5 (P2)** for the deferred half of f5u rather than losing it: the cost is
+computed fleet-wide, so a three-host fleet is charged ONE idle floor, and power.is_metered cannot
+be applied per worker — meaning a mixed fleet of home servers and VPSes is billed as though every
+machine were metered. _get_all_worker_containers already groups by worker; api_earnings_net
+discards that grouping before the watt calculation.
+
+**Counters:** iteration 6, no_progress 0, failures 0.
+
+**Next action:** bead b4e (P2) — producer-state detection (Producing / Idle / Failing), which
+pairs naturally with the flatline work already shipped.
+
+## 2026-08-02T13:45:05Z — sergio-loop segment 1, iteration 7
+
+**PR #162 (yh5) merged; bead closed.** Power is now charged per worker rather than once for the
+whole fleet. This mattered concretely for Sergio's three-host setup: it was being charged ONE
+machine's idle floor, understating idle cost roughly threefold, and power.is_metered could not be
+applied at all — so a VPS would have been billed like a home server. Each worker now contributes
+its own container count, host TDP (from system_info, default as fallback) and metered flag; an
+unmetered host is skipped rather than costed and zeroed; a service on several hosts accumulates
+from each. Tests assert the arithmetic: two hosts cost twice one host, unmetered contributes zero,
+a 200W server is not costed as a 65W mini PC. 1529 passed, coverage 94.30%.
+
+**Counters:** iteration 7, no_progress 0, failures 0.
+
+**Next action:** bead b4e (P2), producer-state detection. NOTE FOR THE NEXT SESSION: this session
+has run very long and the last few iterations needed repeated attempts at simple test patches,
+which is the signal that context is spent. b4e deserves fresh context rather than another push
+here — the value of this loop has come from verifying claims against code and catching wrong
+numbers before they shipped, and that standard is what degrades first.
+
+## 2026-08-02T13:50:39Z — sergio-loop segment 1, iteration 8 (segment end)
+
+**v1.7.0 released and the UI deployed.** Brings f5u (net profit) and yh5 (per-worker power) to
+the fleet. Verified live: UI healthy on 1.7.0, /api/earnings/net registered, zero encryption-key
+refusals at startup, 13 platforms reporting today, 6 encrypted config rows still readable.
+
+**Workers deliberately left on 1.6.0.** No worker code changed since v1.6.0, so the release
+correctly skipped build-worker and there is no 1.7.0 worker image. UI 1.7.0 + worker 1.6.0 is
+exactly what the build system intends.
+
+**FOUND A REAL P1 WHILE DOING IT — CashPilot-0zw.** The release publishes only images whose source
+changed, but the example compose pins BOTH images to the same major.minor tag (jz3) and
+tests/test_compose_image_pins.py ENFORCES that they match. So on any release where one image is
+rebuilt and the other is not, following our own documented pinning produces a compose file
+referencing a tag that does not exist, and docker compose pull fails. The rule and the build
+contradict each other and the test enforces the broken side. Verified concretely:
+cashpilot:1.7.0 exists, cashpilot-worker:1.7.0 and :1.7 do not.
+
+Preferred fix recorded on the bead: retag unchanged images on release (a manifest operation, not a
+rebuild) so every version has both images and same-tag pinning stays valid. Explicitly NOT
+"always rebuild both" — building an unchanged multi-arch artefact to satisfy a naming convention
+is the wrong trade. Plus a release-time check that every tag the example compose references
+actually resolves; CI passed happily while this was broken, and only deploying caught it.
+
+**Counters:** iteration 8 of 8 — segment budget reached. no_progress 0, failures 0.
+
+**Stop state: BUDGET.** Not blocked and not failed: 14 1.x beads remain and all are workable.
+Resume with sergio-loop --continue.
+
+**Next action:** CashPilot-0zw (P1, the tag-skew bug — it makes the documented quickstart fail),
+then b4e.
+
+## 2026-08-02T14:34:28Z — segment 2, iteration 1
+
+**CashPilot-0zw shipped (PR #163) and closed.** Releases now publish BOTH images: an unchanged one
+is re-pointed at the new tags with buildx imagetools (a manifest operation, seconds, not a rebuild)
+rather than rebuilding a multi-arch artefact to satisfy a naming convention. verify-tags then fails
+the run if any tag the release claims does not resolve — the gap that let v1.7.0 ship with
+cashpilot:1.7.0 present and cashpilot-worker:1.7.0 absent while CI stayed green.
+
+CodeRabbit caught that the three new run blocks interpolated inputs.version-derived tags straight
+into `for tag in ...`, in steps running after the registry login. Fixed by passing them through
+env and reading them as data.
+
+That fix exposed a second bug of my own in verify-tags: a `while` on the right of a pipe runs in a
+subshell, so `missing=1` never reached the check — the gate would have passed silently on a
+missing tag, the exact failure it exists to catch. And the `[ -s file ] && missing=1` I first
+reached for would have failed the step under `bash -e` on the HAPPY path. Rewritten to read from a
+file with a redirect; simulated locally against real Docker Hub tags before pushing.
+
+**Counters:** segment 2, iteration 1, no_progress 0, failures 0.
+**Next action:** bead b4e (P2), producer-state detection.
+
+## 2026-08-02T14:38:46Z — segment 2, iteration 2
+
+**CashPilot-b4e shipped as PR #164.** Producer state as a verdict SEPARATE from container health,
+because health is computed from restarts and crashes and a container producing nothing for a month
+still scores 100/100.
+
+Two of the three signals: earnings movement over a trailing window (services with a collector), and
+health_signals — log regexes declared in the service YAML with a plain-language 'means' and a
+state. The YAML signal is the only one available for the 30+ services with no collector, and it
+keeps service-specific knowledge out of app/ per the architecture rule.
+
+The important behaviour is what it refuses to claim: a service with no collector reads UNKNOWN,
+never IDLE. Saying "idle" when the earnings simply cannot be seen is the same false confidence the
+feature exists to remove. Too little history is UNKNOWN; a stopped container is not judged. Every
+verdict carries reasons. A concrete log diagnosis outranks an earnings observation, so "login
+failed" beats "earnings moved" — the log says why.
+
+NO catalog entries declare health_signals yet, deliberately: a guessed regex that never matches is
+dead weight, one that matches the wrong line tells the user something false, and populating them
+needs real log samples per service. A test fails if a declared pattern does not compile or has no
+'means'.
+
+Endpoint tests written UP FRONT this time — four earlier PRs failed codecov/patch for exactly the
+omission of endpoint coverage. 1556 passed, coverage 94.38%.
+
+Deferred and stated on the PR: the third signal, container network rx/tx counters, which needs
+those figures wired through the Docker worker heartbeat (the bead calls this the bulk of the work).
+
+**Counters:** segment 2, iteration 2, no_progress 0, failures 0.
+**Next action:** await CI/CodeRabbit on #164 and merge; then 66x (per-service transparency).
+
+## 2026-08-02T12:40:00Z — sergio-loop segment 2, iteration 4
+
+**Slice:** CashPilot-66x — per-service disclosure ("is this malware?").
+
+**Changed:** `app/disclosure.py` (new), `app/main.py` (2 endpoints), `services/_schema.yml`,
+`tests/test_disclosure.py` (new, 22 tests), and verified `disclosure:` blocks on 4 services
+(mysterium, anyone-protocol, proxybase-xyz, storj).
+
+**Design decision worth recording:** the module is built around the *absent* answer, not the
+present one. An undocumented service reports `documented: false` and states plainly that this is
+not a claim of safety; `routes_third_party_traffic()` is three-valued so "not documented" cannot
+collapse into "no". 46 of 50 services are deliberately left undocumented rather than guessed, and
+`/api/disclosure/coverage` enumerates that gap.
+
+**Verification:** `ruff check .` clean · `ruff format --check .` 84 files clean ·
+`pytest --cov=app --cov-fail-under=90` → **1578 passed**, coverage **94.44%**. Endpoint tests
+written up front (the omission that failed codecov/patch on four earlier PRs).
+
+**Counters:** iteration 4, no_progress 0, failures 0.
+
+**Next action:** CashPilot-5qc.

--- a/docs/research/per-ip-device-limits.md
+++ b/docs/research/per-ip-device-limits.md
@@ -1,0 +1,65 @@
+# Per-IP device limits: what providers actually document
+
+Research backing `devices_per_ip` in the catalog (CashPilot-4qv), which drives the
+egress-conflict warning. Recorded here because the value is only as good as its
+source, and a future contributor needs to see the evidence rather than trust a
+number someone once typed.
+
+**The rule this table exists to enforce:** write a number only where the provider
+states one. Where they do not, leave the key ABSENT — the preflight then tells
+the user to check the terms, which is honest. A guessed number tells them
+something false with full confidence.
+
+Snapshot date: 2026-08-02. These terms change without changelogs; re-check before
+relying on any row.
+
+## Documented by the provider
+
+| Service | devices_per_ip | Kind | Source |
+|---|---|---|---|
+| honeygain | **1** | hard limit | Help centre: "Users may connect 1 device per one IP/Network." Extra devices trigger a "Network overused" error. |
+| iproyal (Pawns.app) | **1** | hard limit | Terms of Use: "Pawns.app limits the number of devices per single IP address to one (1)." |
+| earnfm | **1** | hard limit | Help centre: "One Device Per Network: Each device should be connected to a unique IP or network." |
+| ebesucher | **1** | hard limit | Official blog: multi-device is allowed only if "each device ... has to be connected to the Internet through a unique IP address." |
+
+## Documented as sharing, with no number
+
+These state that devices behind one IP split one allocation. That is real and
+worth warning about, but it is not a device count, so the key stays ABSENT and
+the effect belongs in `requirements.note`.
+
+| Service | What the provider says |
+|---|---|
+| earnapp | Extra devices on one IP "will get less priority for traffic" and do not increase earnings beyond the per-IP cap. |
+| spide | Terms: "traffic sent through a single public IP address will be distributed between devices utilizing the same IP address." |
+| storj | Nodes in the same /24 subnet share allocation (already captured in that file's `note`). |
+
+## Not documented anywhere official
+
+`bitping`, `urnetwork`, `packetstream`, `proxyrack`, `repocket`.
+
+Two of these have a number that circulates widely and traces to **no provider
+source at all**:
+
+- **repocket — "2 devices per IP"**. Repeated across review blogs. Repocket's own
+  Terms state only a per-ACCOUNT limit ("up to five (5) devices ... and a maximum
+  of five (5) active sessions"), which is a different thing.
+  **The catalog currently declares `devices_per_ip: 2` for repocket on this
+  basis.** It predates this research and should be re-sourced or removed.
+- **proxyrack — "2 devices per IP"**. Same pattern. Proxyrack's two device-limit
+  help articles (the newer dated 2026-02-23) mention only a 500-per-account cap.
+
+## VPS / datacenter acceptance
+
+| Service | Policy |
+|---|---|
+| honeygain | Datacentre IP types blocked outright ("Unusable network"); VMs discouraged. |
+| earnapp | "Installing EarnApp on Virtual Machines (VMs), Docker containers, or hosting services is strictly prohibited"; DCH IPs blocked. |
+| iproyal (Pawns.app) | Residential only; "does not allow the use of any servers, VPNs, or proxy services". |
+| spide | Residential only; servers/VPN/proxy not allowed. |
+| ebesucher | "Using the surfbar on a virtual server is not allowed." |
+| proxyrack | Allowed, but reclassified to a lower datacentre rate. |
+| bitping | Allowed; servers and Docker explicitly supported. |
+| earnfm | Allowed; datacentre connections are their own uncapped category. |
+| repocket | Ambiguous — the ToS VPS clause sits in the fraud/offer-abuse section, so whether it covers bandwidth sharing is unclear. Not resolved. |
+| urnetwork, packetstream | No statement found either way. |

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -64,8 +64,17 @@
 #   containers that route traffic through someone's home connection, and an
 #   earnings range does not answer it.
 #     sells:                what is actually sold (bandwidth / disk / compute / attention)
-#     third_party_traffic:  do strangers route traffic through the user's IP? Start the
-#                           value with yes / no / unknown so it can be read programmatically
+#     third_party_traffic:  do strangers route traffic through the user's IP? The value
+#                           must OPEN with a standalone yes / no / unknown followed by
+#                           punctuation, so it can be read programmatically:
+#                             third_party_traffic: >-
+#                               Yes. Buyers route their traffic through your connection.
+#                           Use a >- block (as above) or quote the string. A BARE `yes`/`no`
+#                           is parsed by YAML as a boolean, not text.
+#                           "No longer - they route traffic now" does NOT parse as a verdict
+#                           and is reported as undocumented, which is deliberate: a phrase
+#                           beginning with "no" that means "yes" is the worst possible
+#                           silent answer, so anything ambiguous falls back to unknown.
 #     data_collected:       what identifying data leaves the machine
 #     isp_risk:             what this could mean for their ISP contract, in plain words
 #     account_rules:        account and multi-account rules

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -59,6 +59,20 @@
 #   stop_timeout: 30 (optional, seconds to wait before SIGKILL on stop — default 30)
 #   setup: "" (optional, one-time setup instructions/commands to run before first deploy)
 
+# disclosure: (optional but strongly encouraged) what this service does with the
+#   user's machine. "Is this malware?" is a fair question about closed-source
+#   containers that route traffic through someone's home connection, and an
+#   earnings range does not answer it.
+#     sells:                what is actually sold (bandwidth / disk / compute / attention)
+#     third_party_traffic:  do strangers route traffic through the user's IP? Start the
+#                           value with yes / no / unknown so it can be read programmatically
+#     data_collected:       what identifying data leaves the machine
+#     isp_risk:             what this could mean for their ISP contract, in plain words
+#     account_rules:        account and multi-account rules
+#   Write it honestly, including where the answer is unflattering. "unknown - the
+#   provider does not say" is a legitimate and useful entry. Do NOT guess: an absent
+#   block is reported as undocumented, which is safer than a confident wrong answer.
+
 # requirements:
 #   residential_ip: true/false
 #   vps_ip: true/false  (default: opposite of residential_ip)

--- a/services/bandwidth/mysterium.yml
+++ b/services/bandwidth/mysterium.yml
@@ -77,8 +77,10 @@ collector:
 # Written to be read by someone deciding whether to trust it.
 disclosure:
   sells: >-
-    Bandwidth. Your connection is used as an exit node for the Mysterium dVPN
-    network.
+    Bandwidth. Your connection is used as an exit node for the Mysterium
+    network, which sells VPN, proxy AND data-scraping services. Scraping
+    traffic leaving a residential IP is the use most likely to draw complaints,
+    and you cannot choose which of the three your node carries.
   third_party_traffic: >-
     Yes. Strangers route their traffic through your IP address — that is the
     product.

--- a/services/bandwidth/mysterium.yml
+++ b/services/bandwidth/mysterium.yml
@@ -72,3 +72,24 @@ platforms: [docker, windows, macos, linux, android, browser-extension]
 collector:
   type: api
   notes: "Tequila API at http://localhost:4449/tequilapi/settlement/total-fees. Returns MYST in wei (10^18). No auth needed."
+
+# What this service does with the user's machine (CashPilot-66x).
+# Written to be read by someone deciding whether to trust it.
+disclosure:
+  sells: >-
+    Bandwidth. Your connection is used as an exit node for the Mysterium dVPN
+    network.
+  third_party_traffic: >-
+    Yes. Strangers route their traffic through your IP address — that is the
+    product.
+  data_collected: >-
+    Node identity (a blockchain address), your IP, and coarse location
+    (country/city/ISP), which the node publishes to the network so buyers can
+    select it.
+  isp_risk: >-
+    Real and worth understanding. Traffic from other people leaves your
+    connection attributed to you, so anything they do appears to originate
+    from your line. Many consumer ISP contracts prohibit this. Check yours
+    before running it.
+  account_rules: >-
+    Unlimited devices per account and per IP.

--- a/services/bandwidth/proxybase-xyz.yml
+++ b/services/bandwidth/proxybase-xyz.yml
@@ -91,7 +91,11 @@ disclosure:
     A wallet address generated on your machine, plus the traffic volume you
     relay.
   isp_risk: >-
-    Real. Proxy traffic from unknown buyers exits your connection under your
-    IP. The catalog marks this service as datacentre/VPS-only for that reason.
+    Real, and it applies directly to home connections. Proxy traffic from
+    unknown buyers exits under your IP, so abuse complaints arrive at your
+    door. Nothing in this catalog restricts the service to datacentre
+    addresses, and residential IPs earn more, so the incentive points the
+    wrong way here: read your ISP's terms before running it at home.
   account_rules: >-
-    Unlimited devices per account, one per IP.
+    unknown - the provider does not publish a per-account or per-IP device
+    limit, and the catalog does not declare one.

--- a/services/bandwidth/proxybase-xyz.yml
+++ b/services/bandwidth/proxybase-xyz.yml
@@ -78,3 +78,20 @@ platforms: [docker, linux, macos, windows]
 collector:
   type: manual
   notes: "REST API at api.proxybase.xyz (GET /v2/seller/status, GET /v2/wallet/balance). Auth uses ECDSA challenge-response with secp256k1 wallet — feasible to automate but non-trivial."
+
+# What this service does with the user's machine (CashPilot-66x).
+# Written to be read by someone deciding whether to trust it.
+disclosure:
+  sells: >-
+    Bandwidth, as a SOCKS5 proxy sold to buyers on the ProxyBase marketplace.
+  third_party_traffic: >-
+    Yes. Buyers route their traffic through your connection — that is exactly
+    what is being sold.
+  data_collected: >-
+    A wallet address generated on your machine, plus the traffic volume you
+    relay.
+  isp_risk: >-
+    Real. Proxy traffic from unknown buyers exits your connection under your
+    IP. The catalog marks this service as datacentre/VPS-only for that reason.
+  account_rules: >-
+    Unlimited devices per account, one per IP.

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -77,3 +77,20 @@ collector:
         or check https://api.ec.anyone.tech/relays/{fingerprint}
       type: text
   notes: "Queries AO relay-rewards contract by fingerprint, converts ANYONE tokens to USD via CoinGecko."
+
+# What this service does with the user's machine (CashPilot-66x).
+# Written to be read by someone deciding whether to trust it.
+disclosure:
+  sells: >-
+    Bandwidth, as a relay in the Anyone network (a Tor fork).
+  third_party_traffic: >-
+    Yes. It relays other people's traffic. Whether your IP is the final hop
+    depends on whether the relay is configured as an exit.
+  data_collected: >-
+    The relay's public identity key, your IP and port, and uptime statistics,
+    all published to the network directory by design.
+  isp_risk: >-
+    Real. Relay traffic is attributed to your connection. Exit relays in
+    particular attract abuse complaints; many consumer ISPs prohibit them.
+  account_rules: >-
+    No account needed. Unlimited relays per account, one per IP.

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -88,9 +88,14 @@ disclosure:
     depends on whether the relay is configured as an exit.
   data_collected: >-
     The relay's public identity key, your IP and port, and uptime statistics,
-    all published to the network directory by design.
+    all published to the network directory by design. If you set ContactInfo in
+    your anonrc it is published there too and is permanently, publicly
+    indexed — it is usually an email address, so leave it empty unless you want
+    it public.
   isp_risk: >-
     Real. Relay traffic is attributed to your connection. Exit relays in
     particular attract abuse complaints; many consumer ISPs prohibit them.
   account_rules: >-
-    No account needed. Unlimited relays per account, one per IP.
+    No account is needed at all, so there is nothing to limit per account. The
+    project does not publish a per-IP relay limit, and the catalog does not
+    declare one.

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -127,12 +127,15 @@ disclosure:
     No. You store encrypted, erasure-coded fragments of customer data. Other
     people do not route their own traffic through your IP.
   data_collected: >-
-    Node identity, your wallet address, and your IP and port, which must be
-    reachable for the node to serve data.
+    Node identity, your wallet address, the email address the node requires for
+    operator notifications, and your IP and port, which must be reachable for
+    the node to serve data.
   isp_risk: >-
-    Mainly a data-cap question rather than a liability one: a node both serves
-    and ingests continuously. Nothing leaves your line on someone else's
-    behalf.
+    Mainly a data-cap question rather than a liability one: a node serves and
+    ingests customer data continuously, which is real sustained traffic on your
+    line. Unlike a proxy or a relay, though, it is not anonymised third-party
+    traffic attributed to you as its origin, so it does not attract the abuse
+    complaints those do.
   account_rules: >-
     Unlimited nodes, but nodes on the same /24 subnet share allocation, so
     several on one connection earn less each.

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -117,3 +117,22 @@ platforms: [docker, windows, linux]
 collector:
   type: api
   notes: "Local dashboard at port 14002. API at /api/sno for node stats, earnings, bandwidth. No auth needed on local interface."
+
+# What this service does with the user's machine (CashPilot-66x).
+# Written to be read by someone deciding whether to trust it.
+disclosure:
+  sells: >-
+    Disk space and the bandwidth to serve it.
+  third_party_traffic: >-
+    No. You store encrypted, erasure-coded fragments of customer data. Other
+    people do not route their own traffic through your IP.
+  data_collected: >-
+    Node identity, your wallet address, and your IP and port, which must be
+    reachable for the node to serve data.
+  isp_risk: >-
+    Mainly a data-cap question rather than a liability one: a node both serves
+    and ingests continuously. Nothing leaves your line on someone else's
+    behalf.
+  account_rules: >-
+    Unlimited nodes, but nodes on the same /24 subnet share allocation, so
+    several on one connection earn less each.

--- a/tests/test_disclosure.py
+++ b/tests/test_disclosure.py
@@ -1,0 +1,160 @@
+"""Per-service disclosure (CashPilot-66x).
+
+"Is this malware?" is the most common reaction to software in this space, and a
+fair one: the user runs closed-source third-party containers that route traffic
+through their home connection.
+
+The tests that matter are the ones about absence. A service nobody has documented
+is exactly the one to be careful with, so an undocumented service must never read
+as a safe one, and a half-filled block must not look complete.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import catalog, disclosure
+
+
+class TestAbsenceIsNotSafety:
+    def test_an_undocumented_service_says_so_explicitly(self):
+        out = disclosure.for_service({"slug": "x", "name": "X"})
+        assert out["documented"] is False
+        assert "not a statement that it is safe" in out["summary"]
+        assert out["unanswered"] == list(disclosure.FIELDS)
+
+    def test_a_missing_service_is_not_an_error_but_is_undocumented(self):
+        out = disclosure.for_service(None)
+        assert out["documented"] is False
+        assert out["answers"] == {}
+
+    def test_a_partly_documented_service_admits_the_gaps(self):
+        """A half-filled disclosure that looks complete is worse than an empty one."""
+        out = disclosure.for_service({"slug": "x", "name": "X", "disclosure": {"sells": "Bandwidth."}})
+        assert out["documented"] is True
+        assert "still unanswered" in out["summary"]
+        assert "third_party_traffic" in out["unanswered"]
+
+    def test_blank_values_count_as_unanswered(self):
+        out = disclosure.for_service({"slug": "x", "disclosure": {"sells": "   ", "isp_risk": ""}})
+        assert out["answers"] == {}
+        assert set(out["unanswered"]) == set(disclosure.FIELDS)
+
+    def test_an_explicit_unknown_is_kept_as_an_answer(self):
+        """Somebody looked and could not find out — different from nobody looking."""
+        out = disclosure.for_service(
+            {"slug": "x", "disclosure": {"third_party_traffic": "unknown - the provider does not say"}}
+        )
+        assert "third_party_traffic" in out["answers"]
+        assert "third_party_traffic" not in out["unanswered"]
+
+
+class TestThirdPartyTraffic:
+    """The single most consequential fact about most services in this catalog."""
+
+    def test_yes_and_no_are_read(self):
+        assert (
+            disclosure.routes_third_party_traffic({"disclosure": {"third_party_traffic": "Yes. Strangers..."}}) is True
+        )
+        assert (
+            disclosure.routes_third_party_traffic({"disclosure": {"third_party_traffic": "No. You store..."}}) is False
+        )
+
+    def test_undocumented_is_none_never_false(self):
+        """Not documented must not collapse into 'no' — that is the dangerous default."""
+        assert disclosure.routes_third_party_traffic({"disclosure": {}}) is None
+        assert disclosure.routes_third_party_traffic({}) is None
+        assert disclosure.routes_third_party_traffic(None) is None
+
+    def test_an_explicit_unknown_is_none(self):
+        assert disclosure.routes_third_party_traffic({"disclosure": {"third_party_traffic": "unknown"}}) is None
+
+    def test_unparseable_prose_is_none_rather_than_guessed(self):
+        assert disclosure.routes_third_party_traffic({"disclosure": {"third_party_traffic": "it depends"}}) is None
+
+
+class TestCoverageIsHonest:
+    def test_it_reports_the_gap_not_just_the_documented_subset(self):
+        services = [
+            {"slug": "a", "disclosure": {"sells": "x"}},
+            {"slug": "b"},
+            {"slug": "c"},
+        ]
+        out = disclosure.coverage(services)
+        assert out == {
+            "total": 3,
+            "documented": 1,
+            "undocumented": 2,
+            "undocumented_slugs": ["b", "c"],
+        }
+
+
+class TestAgainstTheRealCatalog:
+    @pytest.mark.parametrize("slug", ["mysterium", "anyone-protocol", "proxybase-xyz", "storj"])
+    def test_the_documented_services_answer_every_question(self, slug):
+        out = disclosure.for_service(catalog.get_service(slug))
+        assert out["documented"] is True
+        assert out["unanswered"] == [], f"{slug} left {out['unanswered']} unanswered"
+
+    def test_the_services_that_resell_the_users_ip_say_so(self):
+        """Getting this wrong would understate the real risk of the category."""
+        for slug in ("mysterium", "anyone-protocol", "proxybase-xyz"):
+            assert disclosure.routes_third_party_traffic(catalog.get_service(slug)) is True, slug
+
+    def test_storj_correctly_says_it_does_not(self):
+        assert disclosure.routes_third_party_traffic(catalog.get_service("storj")) is False
+
+    def test_every_declared_disclosure_uses_known_fields(self):
+        """A typo'd key would be silently dropped rather than shown."""
+        for svc in catalog.get_services():
+            for key in svc.get("disclosure") or {}:
+                assert key in disclosure.FIELDS, f"{svc['slug']}: unknown disclosure field {key!r}"
+
+    def test_the_catalog_can_report_its_own_incompleteness(self):
+        out = disclosure.coverage(catalog.get_services())
+        assert out["total"] > out["documented"], "expected the catalog to be partly documented"
+        assert out["undocumented_slugs"], "the gap must be enumerable, not just counted"
+
+
+class TestEndpoints:
+    def _call(self, fn, *args):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from app import main
+
+        async def run():
+            with patch.object(main, "_require_auth_api", lambda r: None):
+                return await fn(MagicMock(), *args)
+
+        return asyncio.run(run())
+
+    def test_a_documented_service_returns_its_answers(self):
+        from app import main
+
+        out = self._call(main.api_service_disclosure, "mysterium")
+        assert out["documented"] is True
+        assert "third_party_traffic" in out["answers"]
+
+    def test_an_undocumented_service_returns_the_honest_summary(self):
+        from app import main
+
+        out = self._call(main.api_service_disclosure, "honeygain")
+        assert out["documented"] is False
+        assert "not a statement that it is safe" in out["summary"]
+
+    def test_an_unknown_slug_is_a_404(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main.api_service_disclosure, "no-such-service")
+        assert exc.value.status_code == 404
+
+    def test_coverage_endpoint_names_the_undocumented(self):
+        from app import main
+
+        out = self._call(main.api_disclosure_coverage)
+        assert out["undocumented"] > 0
+        assert "honeygain" in out["undocumented_slugs"]

--- a/tests/test_disclosure.py
+++ b/tests/test_disclosure.py
@@ -158,3 +158,188 @@ class TestEndpoints:
         out = self._call(main.api_disclosure_coverage)
         assert out["undocumented"] > 0
         assert "honeygain" in out["undocumented_slugs"]
+
+
+class TestTheVerdictWordMustStandAlone:
+    """A phrase beginning with "no" that MEANS yes is the worst silent answer.
+
+    Prefix matching read "notably, strangers DO use your IP" as no, and a plain
+    word boundary read "No longer — since v2 they route traffic" as no. Both
+    invert the single most consequential fact in the catalog.
+    """
+
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "No longer — since v2 they route traffic",
+            "No longer",
+            "Normally no, but exit nodes do relay",
+            "Nobody knows",
+            "None documented, but likely yes",
+            "Not exactly - only for premium buyers",
+            "notably, strangers DO use your IP",
+            "nothing is routed",
+            "yesterday's docs said no",
+            "TRUE-ish",
+            "it depends",
+        ],
+    )
+    def test_prose_we_cannot_parse_is_unknown_never_a_verdict(self, prose):
+        assert disclosure.parse_verdict(prose) is None
+
+    @pytest.mark.parametrize(
+        ("prose", "expected"),
+        [
+            ("Yes. Strangers route through you.", True),
+            ("Yes, buyers proxy through your connection.", True),
+            ("No. You store encrypted fragments.", False),
+            ("no", False),
+            ("yes", True),
+            ("unknown - the provider does not say", None),
+        ],
+    )
+    def test_a_standalone_verdict_is_read(self, prose, expected):
+        assert disclosure.parse_verdict(prose) is expected
+
+    def test_yaml_booleans_are_handled_because_the_schema_invites_them(self):
+        """An unquoted `no:` in YAML arrives here as a real bool, not a string."""
+        assert disclosure.parse_verdict(False) is False
+        assert disclosure.parse_verdict(True) is True
+
+    def test_every_declared_answer_in_the_real_catalog_is_machine_readable(self):
+        """Unparseable prose must fail CI, not silently become "undocumented"."""
+        for svc in catalog.get_services():
+            raw = (svc.get("disclosure") or {}).get("third_party_traffic")
+            if raw is None:
+                continue
+            text = raw if isinstance(raw, bool) else str(raw).strip()
+            assert disclosure.parse_verdict(text) is not None or str(text).lower().startswith("unknown"), (
+                f"{svc['slug']}: third_party_traffic {text!r} does not open with a standalone "
+                "yes/no/unknown, so it would be reported as undocumented"
+            )
+
+
+class TestFiveUnknownsIsNotADocumentedService:
+    ALL_UNKNOWN = {f: "unknown - the provider does not say" for f in disclosure.FIELDS}
+
+    def test_it_does_not_claim_to_be_fully_documented(self):
+        out = disclosure.for_service({"slug": "x", "name": "ShadyNode", "disclosure": self.ALL_UNKNOWN})
+        assert "fully documented" not in out["summary"]
+        assert "NONE could be answered" in out["summary"]
+        assert "not as reassurance" in out["summary"]
+
+    def test_the_unknowns_are_counted_separately(self):
+        out = disclosure.for_service({"slug": "x", "disclosure": self.ALL_UNKNOWN})
+        assert set(out["unknown"]) == set(disclosure.FIELDS)
+        assert out["unanswered"] == []
+
+    def test_a_genuinely_answered_service_still_reads_as_complete(self):
+        out = disclosure.for_service(catalog.get_service("storj"))
+        assert out["summary"].endswith("is fully documented below.")
+        assert out["unknown"] == []
+
+
+class TestThePayloadCarriesTheFactsAConsumerNeeds:
+    def test_the_tri_state_is_exposed_so_nobody_reimplements_the_parse(self):
+        assert disclosure.for_service(catalog.get_service("storj"))["routes_third_party_traffic"] is False
+        assert disclosure.for_service(catalog.get_service("mysterium"))["routes_third_party_traffic"] is True
+        assert disclosure.for_service({"slug": "x"})["routes_third_party_traffic"] is None
+
+    def test_the_most_consequential_gap_is_flagged_on_its_own(self):
+        """1-of-5 missing reads the same as 1-of-5 missing — unless it is THIS one."""
+        answered_but_not_the_key_one = disclosure.for_service(
+            {"slug": "x", "disclosure": {f: "Something." for f in disclosure.FIELDS if f != "third_party_traffic"}}
+        )
+        assert answered_but_not_the_key_one["critical_unanswered"] is True
+
+        other_gap = disclosure.for_service(
+            {"slug": "x", "disclosure": {f: "Something." for f in disclosure.FIELDS if f != "account_rules"}}
+        )
+        assert other_gap["critical_unanswered"] is False
+
+    def test_partial_documentation_is_countable_not_just_a_boolean(self):
+        out = disclosure.for_service({"slug": "x", "disclosure": {"sells": "Bandwidth."}})
+        assert (out["answered_count"], out["total_questions"]) == (1, 5)
+
+    def test_every_return_path_has_the_same_shape(self):
+        """A consumer reading out["questions"] must not KeyError on one branch."""
+        shapes = [
+            sorted(disclosure.for_service(None)),
+            sorted(disclosure.for_service({"slug": "x"})),
+            sorted(disclosure.for_service(catalog.get_service("storj"))),
+        ]
+        assert shapes[0] == shapes[1] == shapes[2]
+
+    def test_the_questions_dict_is_a_copy_not_the_module_constant(self):
+        out = disclosure.for_service({"slug": "x"})
+        out["questions"]["sells"] = "mutated"
+        assert disclosure.FIELDS["sells"] != "mutated"
+
+
+class TestMalformedCatalogEntries:
+    def test_a_non_mapping_disclosure_does_not_500(self):
+        """`disclosure: TODO` loaded fine and then crashed at request time."""
+        assert disclosure.for_service({"slug": "x", "disclosure": "TODO"})["documented"] is False
+        assert disclosure.for_service({"slug": "x", "disclosure": ["a"]})["documented"] is False
+
+    def test_the_catalog_loader_now_rejects_it_up_front(self):
+        from pathlib import Path
+
+        from app import catalog as cat
+
+        errors = cat._validate(
+            {
+                "name": "X",
+                "slug": "x",
+                "category": "bandwidth",
+                "status": "active",
+                "description": "d",
+                "docker": {},
+                "disclosure": "TODO",
+            },
+            Path("x.yml"),
+        )
+        assert any("disclosure must be a mapping" in e for e in errors)
+
+    def test_a_null_slug_does_not_crash_coverage(self):
+        assert disclosure.coverage([{"slug": None}, {"slug": "b"}])["undocumented"] == 2
+
+    def test_coverage_and_for_service_agree_on_what_documented_means(self):
+        """coverage() re-tested dict truthiness and so OVERSTATED coverage."""
+        blank = {"slug": "a", "disclosure": {"sells": "   "}}
+        typo = {"slug": "b", "disclosure": {"typo_field": "x"}}
+        assert disclosure.coverage([blank, typo])["documented"] == 0
+        assert disclosure.for_service(blank)["documented"] is False
+        assert disclosure.for_service(typo)["documented"] is False
+
+
+class TestTheEndpointsRequireAuth:
+    """Deleting the guard left all the other endpoint tests green."""
+
+    def _unauthenticated(self, fn, *args):
+        import asyncio
+        from unittest.mock import MagicMock
+
+        request = MagicMock()
+        request.session = {}
+        request.headers = {}
+        request.cookies = {}
+        return asyncio.run(fn(request, *args))
+
+    def test_the_per_service_endpoint_rejects_an_anonymous_caller(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._unauthenticated(main.api_service_disclosure, "mysterium")
+        assert exc.value.status_code == 401
+
+    def test_the_coverage_endpoint_rejects_an_anonymous_caller(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._unauthenticated(main.api_disclosure_coverage)
+        assert exc.value.status_code == 401


### PR DESCRIPTION
*"Is this malware?"* is the most common reaction to software in this space, and it's fair: the user is asked to run **closed-source third-party containers that route traffic through their home connection**. We answered with an earnings range and a setup guide.

Five questions per service, in the catalog YAML like everything else service-specific: what is actually sold, **whether strangers route traffic through the user's IP**, what identifying data leaves the machine, what it means for their ISP contract, and the account rules.

## The design point is what happens when the answer is missing

- An **undocumented service** reports `documented: false`, names every unanswered question, and says plainly that this is **not a statement that it is safe**. A service nobody has documented is exactly the one to be careful with.
- A **partly filled** block admits the gaps rather than looking complete.
- `routes_third_party_traffic` is **three-valued**: "not documented" must never collapse into "no". That's the dangerous default on the single most consequential fact in this catalog.
- An explicit *"unknown — the provider does not say"* is kept as a **real answer**. Somebody looking and failing is different from nobody looking.

## Four services documented, 46 deliberately not

Documented because their mechanism is unambiguous from the provider's own description or from work verified directly:

| Service | Resells your IP? |
|---|---|
| mysterium | **Yes** — you are a dVPN exit node; traffic is attributed to your line |
| anyone-protocol | **Yes** — relays others' traffic; exits attract abuse complaints |
| proxybase-xyz | **Yes** — buyers proxy through your connection; that is the product |
| storj | **No** — you store encrypted fragments; nobody routes through you |

The other 46 are **left undocumented rather than guessed**. `GET /api/disclosure/coverage` reports 4 of 50 and enumerates the gap — presenting the documented subset as if it were the whole catalog would imply a completeness that doesn't exist.

## Verification

- `ruff check . && ruff format --check .` — clean
- `pytest --cov=app --cov-fail-under=90` — **1578 passed**, coverage 94.44%
- 22 new tests, endpoints covered up front. A test also fails on any unknown disclosure key, since a typo'd field would be silently dropped rather than shown.