### PR TITLE
feat: see the fleet the way providers do — by IP, not by machine (CashPilot-5qc)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,8 @@ Three invariants that must not be "simplified" away:
   the tailnet range every reference-fleet worker uses; grouping on it would put
   the whole fleet into one fabricated conflict.
 - **An absent `devices_per_ip` is undocumented, not unlimited.** `0` is a
-  verified no-limit and suppresses the warning; only write it when the provider
-  actually says so.
+  verified no-limit and *downgrades* the warning to a shared-bandwidth note (it
+  does not silence it); only write it when the provider actually says so.
 
 Note that heartbeat container entries key the service as **`slug`**; code that
 filtered on `service` silently matched nothing in production. Use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,34 @@ Two separate Docker images:
 | `CASHPILOT_UI_URL` | Yes | -- | URL of the CashPilot UI |
 | `CASHPILOT_API_KEY` | Yes | -- | Shared API key for worker-to-UI auth |
 | `CASHPILOT_WORKER_NAME` | No | hostname | Human-readable name for this worker |
+| `CASHPILOT_WORKER_NETWORK` | No | detected | `residential`/`hosting`; overrides the DMI-vendor guess |
+| `CASHPILOT_EGRESS_DETECT` | No | on | `off` disables the hourly public-IP lookup |
+| `CASHPILOT_EGRESS_IP` | No | -- | State the public IP directly (validated; a LAN/tailnet address is rejected) |
+| `CASHPILOT_EGRESS_IP_URL` | No | -- | Custom IP-echo endpoint returning a bare IP |
+
+### Egress IP awareness (CashPilot-5qc)
+
+Providers cap per **IP**, not per device, so two workers behind one home
+connection are one customer to the provider and the second earns nothing. Each
+worker reports its public egress IP (`system_info.egress_ip`) and a
+hosting/residential hint (`system_info.egress_network_type`); `app/egress.py`
+groups the fleet by exit and `app/preflight.py` warns before a conflicting
+deploy.
+
+Three invariants that must not be "simplified" away:
+
+- **Undetected is not shared.** A worker with no detected IP produces no
+  conflict finding and is bucketed as undetermined.
+- **Private addresses are detection failures.** `100.64/10` is both CGNAT and
+  the tailnet range every reference-fleet worker uses; grouping on it would put
+  the whole fleet into one fabricated conflict.
+- **An absent `devices_per_ip` is undocumented, not unlimited.** `0` is a
+  verified no-limit and suppresses the warning; only write it when the provider
+  actually says so.
+
+Note that heartbeat container entries key the service as **`slug`**; code that
+filtered on `service` silently matched nothing in production. Use
+`egress.container_slug()`.
 
 ### Dashboard UI Features
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -40,6 +40,9 @@ COPY --from=builder /build/.venv ./.venv
 COPY --chown=cashpilot:root app/__init__.py ./app/
 COPY --chown=cashpilot:root app/constants.py ./app/
 COPY --chown=cashpilot:root app/fleet_key.py ./app/
+# Egress identity: pure helpers, deliberately free of app-level imports so
+# the worker image stays minimal.
+COPY --chown=cashpilot:root app/egress.py ./app/
 COPY --chown=cashpilot:root app/worker_api.py ./app/
 COPY --chown=cashpilot:root app/orchestrator.py ./app/
 COPY --chown=cashpilot:root app/catalog.py ./app/

--- a/README.md
+++ b/README.md
@@ -180,6 +180,30 @@ The UI's web port inside the container is fixed at `8080` (set via the container
 | `CASHPILOT_WORKER_URL` | *(auto-detected)* | URL the UI uses to reach this worker, e.g. `http://192.168.10.50:8081`. Set explicitly for remote/cross-host workers |
 | `CASHPILOT_WORKER_BIND_ADDR` | `127.0.0.1` | Host interface the worker's Docker-socket API port is published on. Loopback by default — for a remote worker set a private/VPN interface, **never** a public IP |
 | `CASHPILOT_PORT` | `8081` | Mini-UI/API port the worker listens on |
+| `CASHPILOT_WORKER_NETWORK` | *(detected)* | `residential` or `hosting`. Overrides the hardware-based guess used to warn about residential-only services |
+| `CASHPILOT_EGRESS_DETECT` | on | Set to `off` to stop this worker looking up its own public IP (see below) |
+| `CASHPILOT_EGRESS_IP` | -- | State this worker's public IP directly instead of looking it up. Must be a public address |
+| `CASHPILOT_EGRESS_IP_URL` | -- | Use your own IP-echo endpoint (returning a bare IP) instead of the public ones. Used **exclusively** — no fallback |
+
+#### Why the worker looks up its public IP
+
+Bandwidth providers cap earnings **per IP address, not per machine**. Two
+workers behind one home connection are two rows on your dashboard and *one*
+customer to the provider, so the second one usually earns nothing. To warn you
+before that happens, each worker asks a public IP-echo service what address it
+comes from — one request per hour.
+
+That is the only outbound call CashPilot makes purely to learn about your setup.
+Turn it off with `CASHPILOT_EGRESS_DETECT=off`, point it at your own endpoint
+with `CASHPILOT_EGRESS_IP_URL`, or skip the lookup entirely by stating the
+address with `CASHPILOT_EGRESS_IP`. With detection off, the fleet simply reports
+that worker's exit as undetermined and raises no conflict warnings for it.
+
+Known limitation: grouping matches on the exact address, so on a **native-IPv6**
+connection each machine has its own global address and no conflict is detected.
+The check is therefore best-effort — it can miss a conflict, but it will not
+invent one.
+
 
 ## Multi-Node Fleet Management
 

--- a/app/egress.py
+++ b/app/egress.py
@@ -1,0 +1,235 @@
+"""Egress-IP awareness across the fleet (CashPilot-5qc).
+
+Providers cap per **IP address**, not per device. Honeygain treats more than one
+active device on a network as "network overused"; EarnApp documents that extra
+devices behind one IP share the same daily cap without increasing earnings.
+
+CashPilot's whole fleet model encourages deploying one service to several
+machines — and until now it warned about none of this. Two workers in the same
+house are two machines to us and one customer to the provider, so the second
+one earns nothing and can get the account flagged.
+
+This is the one check a single-host tool structurally cannot perform, because
+seeing it requires knowing about the *other* machines.
+
+Three rules hold this together, and each exists because the opposite is worse
+than saying nothing:
+
+* **An undetected egress IP is not a shared one, and not a distinct one.** Two
+  workers whose IP we could not determine must never be grouped as if they
+  matched, nor reported as separate as if we had checked. They go to a bucket
+  that says exactly that.
+* **An absent ``devices_per_ip`` means nobody documented it — not "unlimited".**
+  The schema uses ``0`` for unlimited, which is a real, deliberate answer. A
+  missing key is not. Only ~4 of 50 services declare it today, so reading
+  absence as permission would silently bless the exact mistake this module was
+  written to catch.
+* **A private address is a detection failure.** A worker reporting 192.168.x,
+  or a tailnet 100.64/10 address, has told us about its LAN, not its egress.
+  Grouping on it would invent a shared IP that does not exist — and on a
+  tailnet, would group the *entire* fleet into one false conflict.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
+# What kind of connection the worker sits on. UNKNOWN is the default and is
+# never upgraded by guesswork: "we could not tell" and "we checked, it is
+# residential" lead to different advice and must not be confused.
+RESIDENTIAL = "residential"
+HOSTING = "hosting"
+UNKNOWN = "unknown"
+
+_NETWORK_TYPES = {RESIDENTIAL, HOSTING, UNKNOWN}
+
+# Vendor strings that appear in DMI/product identifiers on hosted machines.
+# Deliberately a *local* signal: no third party is asked to profile the user's
+# address, and nothing breaks when the machine is offline.
+HOSTING_VENDOR_HINTS = (
+    "amazon ec2",
+    "digitalocean",
+    "google compute engine",
+    "hetzner",
+    "linode",
+    "microsoft corporation",  # Azure reports this as the chassis vendor
+    "openstack",
+    "oracle",
+    "ovh",
+    "scaleway",
+    "vultr",
+)
+
+
+def classify_vendor(vendor: str | None) -> str:
+    """Map a DMI vendor/product string to a network type.
+
+    Returns UNKNOWN for anything unrecognised, including bare hypervisors like
+    QEMU or VMware: a VM on a home server is a residential connection, and a
+    home lab is this project's most common deployment. Calling that "hosting"
+    would fire a ban warning at precisely the users who are fine.
+    """
+    text = (vendor or "").strip().lower()
+    if not text:
+        return UNKNOWN
+    return HOSTING if any(hint in text for hint in HOSTING_VENDOR_HINTS) else UNKNOWN
+
+
+def normalise_network_type(value: Any) -> str:
+    """Accept only the three known values; anything else is UNKNOWN."""
+    text = str(value or "").strip().lower()
+    return text if text in _NETWORK_TYPES else UNKNOWN
+
+
+def public_ip(value: Any) -> str | None:
+    """Return ``value`` only if it is a usable public egress address.
+
+    Private, loopback, link-local, multicast, reserved and shared-CGNAT
+    (100.64/10 — which is also the tailnet range) addresses all mean the
+    detection failed and we are looking at an interface, not an exit.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        addr = ipaddress.ip_address(text)
+    except ValueError:
+        return None
+    if not addr.is_global or addr.is_multicast:
+        return None
+    return str(addr)
+
+
+def egress_of(worker: dict[str, Any] | None) -> str | None:
+    """The worker's public egress IP, or None when it is not known."""
+    if not worker:
+        return None
+    info = worker.get("system_info") or {}
+    if not isinstance(info, dict):
+        return None
+    return public_ip(info.get("egress_ip"))
+
+
+def network_type_of(worker: dict[str, Any] | None) -> str:
+    """The worker's connection type, defaulting to UNKNOWN."""
+    if not worker:
+        return UNKNOWN
+    info = worker.get("system_info") or {}
+    if not isinstance(info, dict):
+        return UNKNOWN
+    return normalise_network_type(info.get("egress_network_type"))
+
+
+def devices_per_ip_limit(service: dict[str, Any] | None) -> int | None:
+    """How many devices this service allows per IP.
+
+    ``None`` means *not documented*, which is different from ``0`` (documented
+    as unlimited). Callers must keep them apart; collapsing them is how a
+    warning becomes wrong.
+    """
+    if not service:
+        return None
+    raw = (service.get("requirements") or {}).get("devices_per_ip")
+    if raw is None:
+        return None
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return limit if limit >= 0 else None
+
+
+def group_by_egress(workers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group workers by the IP the provider actually sees.
+
+    The fleet view is by machine; providers count by exit. A group of two is the
+    thing worth showing, so groups are returned largest first.
+
+    Workers with no detected egress IP are collected into a single group flagged
+    ``known: False``. That group is NOT a claim that they share an address — it
+    is the list of machines whose exit we could not determine, and every caller
+    has to treat it as unchecked rather than as a conflict.
+    """
+    groups: dict[str, list[dict[str, Any]]] = {}
+    unknown: list[dict[str, Any]] = []
+
+    for worker in workers or []:
+        ip = egress_of(worker)
+        if ip is None:
+            unknown.append(worker)
+        else:
+            groups.setdefault(ip, []).append(worker)
+
+    out = [
+        {
+            "egress_ip": ip,
+            "known": True,
+            "network_type": _group_network_type(members),
+            "workers": members,
+            "worker_count": len(members),
+            "shared": len(members) > 1,
+        }
+        for ip, members in groups.items()
+    ]
+    out.sort(key=lambda g: (-g["worker_count"], g["egress_ip"]))
+
+    if unknown:
+        out.append(
+            {
+                "egress_ip": None,
+                "known": False,
+                "network_type": UNKNOWN,
+                "workers": unknown,
+                "worker_count": len(unknown),
+                # Not "shared": we have no idea whether these share anything.
+                "shared": False,
+            }
+        )
+    return out
+
+
+def _group_network_type(members: list[dict[str, Any]]) -> str:
+    """One address has one connection type; disagreement means we trust none."""
+    seen = {network_type_of(m) for m in members} - {UNKNOWN}
+    return seen.pop() if len(seen) == 1 else UNKNOWN
+
+
+def peers_sharing_egress(worker: dict[str, Any], workers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Other workers behind the same public IP as ``worker``.
+
+    Empty when the IP is unknown — an unchecked worker has no *known* peers, and
+    reporting one would be a fabrication.
+    """
+    ip = egress_of(worker)
+    if ip is None:
+        return []
+    own_id = worker.get("client_id")
+    return [w for w in workers or [] if w.get("client_id") != own_id and egress_of(w) == ip]
+
+
+def container_slug(container: dict[str, Any] | None) -> str:
+    """The service slug of one heartbeat container entry.
+
+    Worth a named function: ``orchestrator.get_status`` emits ``slug`` and so
+    does the UI's aggregation, but hand-written fixtures kept using ``service``
+    — and code that read ``service`` therefore matched nothing in production
+    while its tests passed. Both keys are accepted so neither shape can silently
+    match zero containers again.
+    """
+    if not isinstance(container, dict):
+        return ""
+    return str(container.get("slug") or container.get("service") or "")
+
+
+def running_slugs(worker: dict[str, Any] | None) -> set[str]:
+    """Slugs of the containers a worker reports as running."""
+    if not worker:
+        return set()
+    containers = worker.get("containers")
+    if not isinstance(containers, list):
+        return set()
+    found = {
+        container_slug(c) for c in containers if isinstance(c, dict) and str(c.get("status", "")).lower() == "running"
+    }
+    return found - {""}

--- a/app/egress.py
+++ b/app/egress.py
@@ -28,6 +28,13 @@ than saying nothing:
   or a tailnet 100.64/10 address, has told us about its LAN, not its egress.
   Grouping on it would invent a shared IP that does not exist — and on a
   tailnet, would group the *entire* fleet into one false conflict.
+
+Known limitation, stated rather than hidden: grouping is exact-address equality,
+so on a **native-IPv6** connection every machine has its own global /128 and two
+hosts on one physical line never match. Detecting that properly means grouping
+on the delegated prefix, which is a separate design decision. The consequence is
+a missed conflict, never a fabricated one — which is the right way round for
+this to fail, and the reason it ships as-is.
 """
 
 from __future__ import annotations
@@ -47,13 +54,17 @@ _NETWORK_TYPES = {RESIDENTIAL, HOSTING, UNKNOWN}
 # Vendor strings that appear in DMI/product identifiers on hosted machines.
 # Deliberately a *local* signal: no third party is asked to profile the user's
 # address, and nothing breaks when the machine is offline.
+# Deliberately NOT here: "microsoft corporation". Azure guests do report it,
+# but so do Surface hardware and Hyper-V guests — including Hyper-V on a home
+# Windows desktop. A false "hosting" verdict escalates a residential-IP note
+# into a ban warning, fired at a user who is fine, which is the exact failure
+# classify_vendor exists to avoid. A missed VPS costs far less than that.
 HOSTING_VENDOR_HINTS = (
     "amazon ec2",
     "digitalocean",
     "google compute engine",
     "hetzner",
     "linode",
-    "microsoft corporation",  # Azure reports this as the chassis vendor
     "openstack",
     "oracle",
     "ovh",
@@ -82,12 +93,27 @@ def normalise_network_type(value: Any) -> str:
     return text if text in _NETWORK_TYPES else UNKNOWN
 
 
+# Address families that Python reports as global but that carry, or translate,
+# an address belonging to someone else. NAT64 (64:ff9b::/96) embeds an arbitrary
+# IPv4 address in its low bits — including a private one — and 6to4 (2002::/16)
+# embeds one likewise, so both can smuggle a LAN address past an is_global check.
+_TRANSLATION_PREFIXES = tuple(ipaddress.ip_network(n) for n in ("64:ff9b::/96", "64:ff9b:1::/48", "2002::/16"))
+
+
 def public_ip(value: Any) -> str | None:
     """Return ``value`` only if it is a usable public egress address.
 
     Private, loopback, link-local, multicast, reserved and shared-CGNAT
     (100.64/10 — which is also the tailnet range) addresses all mean the
     detection failed and we are looking at an interface, not an exit.
+
+    An IPv4-mapped IPv6 address is unwrapped to its IPv4 form rather than
+    returned verbatim. Two things depend on that: grouping is string equality,
+    so the same host reported as ``81.61.1.9`` and ``::ffff:81.61.1.9`` would
+    never match itself; and older 3.12 patch releases — which this project's
+    ``requires-python`` still permits for a source install — got ``is_global``
+    wrong for the mapped form, so unwrapping first makes the check correct
+    independently of the interpreter version.
     """
     text = str(value or "").strip()
     if not text:
@@ -95,6 +121,11 @@ def public_ip(value: Any) -> str | None:
     try:
         addr = ipaddress.ip_address(text)
     except ValueError:
+        return None
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
+    if any(addr in net for net in _TRANSLATION_PREFIXES if net.version == addr.version):
         return None
     if not addr.is_global or addr.is_multicast:
         return None
@@ -172,7 +203,7 @@ def group_by_egress(workers: list[dict[str, Any]]) -> list[dict[str, Any]]:
         }
         for ip, members in groups.items()
     ]
-    out.sort(key=lambda g: (-g["worker_count"], g["egress_ip"]))
+    out.sort(key=lambda g: (-g["worker_count"], g["egress_ip"] or ""))
 
     if unknown:
         out.append(
@@ -204,8 +235,17 @@ def peers_sharing_egress(worker: dict[str, Any], workers: list[dict[str, Any]]) 
     ip = egress_of(worker)
     if ip is None:
         return []
-    own_id = worker.get("client_id")
-    return [w for w in workers or [] if w.get("client_id") != own_id and egress_of(w) == ip]
+    # Identity on the primary key, not client_id: two legacy rows can both hold
+    # a NULL client_id, and `None != None` is False, so they would silently
+    # exclude each other and under-report a real conflict.
+    own = (worker.get("id"), worker.get("client_id"))
+
+    def _same(w: dict[str, Any]) -> bool:
+        if own[0] is not None and w.get("id") is not None:
+            return w.get("id") == own[0]
+        return own[1] is not None and w.get("client_id") == own[1]
+
+    return [w for w in workers or [] if not _same(w) and egress_of(w) == ip]
 
 
 def container_slug(container: dict[str, Any] | None) -> str:
@@ -223,7 +263,7 @@ def container_slug(container: dict[str, Any] | None) -> str:
 
 
 def running_slugs(worker: dict[str, Any] | None) -> set[str]:
-    """Slugs of the containers a worker reports as running."""
+    """Slugs a worker reports as running, from Docker containers AND Android apps."""
     if not worker:
         return set()
     containers = worker.get("containers")
@@ -232,4 +272,11 @@ def running_slugs(worker: dict[str, Any] | None) -> set[str]:
     found = {
         container_slug(c) for c in containers if isinstance(c, dict) and str(c.get("status", "")).lower() == "running"
     }
+    # Android workers report `apps` with a boolean `running` instead of Docker
+    # containers. A phone on the home WiFi plus a server is two devices on ONE
+    # public IP — the canonical case for this whole feature — so leaving them
+    # out would blind it to the very conflict it exists to catch.
+    apps = worker.get("apps")
+    if isinstance(apps, list):
+        found |= {container_slug(a) for a in apps if isinstance(a, dict) and a.get("running")}
     return found - {""}

--- a/app/egress.py
+++ b/app/egress.py
@@ -97,7 +97,15 @@ def normalise_network_type(value: Any) -> str:
 # an address belonging to someone else. NAT64 (64:ff9b::/96) embeds an arbitrary
 # IPv4 address in its low bits — including a private one — and 6to4 (2002::/16)
 # embeds one likewise, so both can smuggle a LAN address past an is_global check.
-_TRANSLATION_PREFIXES = tuple(ipaddress.ip_network(n) for n in ("64:ff9b::/96", "64:ff9b:1::/48", "2002::/16"))
+_TRANSLATION_PREFIXES = tuple(
+    ipaddress.ip_network(n)
+    for n in (
+        "64:ff9b::/96",  # NAT64
+        "64:ff9b:1::/48",  # NAT64, local-use prefix
+        "2002::/16",  # 6to4
+        "fec0::/10",  # deprecated site-local — a LAN address Python calls global
+    )
+)
 
 
 def public_ip(value: Any) -> str | None:
@@ -107,8 +115,9 @@ def public_ip(value: Any) -> str | None:
     (100.64/10 — which is also the tailnet range) addresses all mean the
     detection failed and we are looking at an interface, not an exit.
 
-    An IPv4-mapped IPv6 address is unwrapped to its IPv4 form rather than
-    returned verbatim. Two things depend on that: grouping is string equality,
+    An IPv6 address carrying an IPv4 one — mapped ``::ffff:a.b.c.d`` or the
+    deprecated compatible ``::a.b.c.d`` — is unwrapped to that IPv4 form rather
+    than returned verbatim. Two things depend on that: grouping is string equality,
     so the same host reported as ``81.61.1.9`` and ``::ffff:81.61.1.9`` would
     never match itself; and older 3.12 patch releases — which this project's
     ``requires-python`` still permits for a source install — got ``is_global``
@@ -122,14 +131,29 @@ def public_ip(value: Any) -> str | None:
         addr = ipaddress.ip_address(text)
     except ValueError:
         return None
-    mapped = getattr(addr, "ipv4_mapped", None)
-    if mapped is not None:
-        addr = mapped
+    addr = _unwrap_v4(addr)
     if any(addr in net for net in _TRANSLATION_PREFIXES if net.version == addr.version):
         return None
     if not addr.is_global or addr.is_multicast:
         return None
     return str(addr)
+
+
+def _unwrap_v4(addr: Any) -> Any:
+    """Reduce an IPv6 form that carries an IPv4 address to that IPv4 address.
+
+    Covers BOTH ``::ffff:a.b.c.d`` (mapped) and the deprecated ``::a.b.c.d``
+    (compatible). Python exposes a helper only for the first, and the second is
+    just as dangerous: ``::192.168.1.5`` is reported global, so an unwrapped LAN
+    address would become a grouping key. It also breaks self-matching, since a
+    host seen once as 81.61.1.9 and once as ::81.61.1.9 would never match.
+    """
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        return mapped
+    if getattr(addr, "version", None) == 6 and int(addr) >> 32 == 0 and int(addr) > 1:
+        return ipaddress.ip_address(int(addr) & 0xFFFFFFFF)
+    return addr
 
 
 def egress_of(worker: dict[str, Any] | None) -> str | None:
@@ -235,12 +259,16 @@ def peers_sharing_egress(worker: dict[str, Any], workers: list[dict[str, Any]]) 
     ip = egress_of(worker)
     if ip is None:
         return []
-    # Identity on the primary key, not client_id: two legacy rows can both hold
-    # a NULL client_id, and `None != None` is False, so they would silently
-    # exclude each other and under-report a real conflict.
+    # Identity on the primary key. client_id is a secondary key (NOT NULL in the
+    # schema, but backfilled from the display name by an old migration, so it is
+    # the weaker identity of the two); `id` is what the row actually is.
     own = (worker.get("id"), worker.get("client_id"))
 
     def _same(w: dict[str, Any]) -> bool:
+        if own == (None, None):
+            # No identity to compare on; only object identity can exclude it,
+            # and without this a caller's worker becomes its own peer.
+            return w is worker
         if own[0] is not None and w.get("id") is not None:
             return w.get("id") == own[0]
         return own[1] is not None and w.get("client_id") == own[1]
@@ -268,7 +296,7 @@ def running_slugs(worker: dict[str, Any] | None) -> set[str]:
         return set()
     containers = worker.get("containers")
     if not isinstance(containers, list):
-        return set()
+        containers = []
     found = {
         container_slug(c) for c in containers if isinstance(c, dict) and str(c.get("status", "")).lower() == "running"
     }

--- a/app/main.py
+++ b/app/main.py
@@ -1793,8 +1793,16 @@ async def api_service_preflight(request: Request, slug: str, worker_id: int | No
         deployed = await database.get_deployments()
         return preflight.assess(service, already_deployed_slugs={d["slug"] for d in deployed})
 
-    workers = [_decoded_worker(w) for w in await database.list_workers()]
-    worker = next((w for w in workers if w.get("id") == worker_id), None)
+    # Only ONLINE workers count as peers. A worker that is merely switched off
+    # keeps its row forever once enrolled (the purge spares enrolled rows), and
+    # its last heartbeat still lists every container as running — so a retired
+    # machine would fabricate a conflict against a live one. This module
+    # promises the opposite failure direction: a missed conflict, never an
+    # invented one. The worker being deployed to is looked up separately so a
+    # freshly-restarted one can still be assessed.
+    all_workers = [_decoded_worker(w) for w in await database.list_workers()]
+    workers = [w for w in all_workers if w.get("status") == "online"]
+    worker = next((w for w in all_workers if w.get("id") == worker_id), None)
     if worker is None:
         raise HTTPException(status_code=404, detail=f"Unknown worker {worker_id}")
 

--- a/app/main.py
+++ b/app/main.py
@@ -123,9 +123,9 @@ def _decoded_worker(worker: dict[str, Any]) -> dict[str, Any]:
     that reads inside them goes through here.
     """
     decoded = dict(worker)
-    decoded["containers"] = _safe_json(worker.get("containers", "[]"), [])
-    decoded["apps"] = _safe_json(worker.get("apps", "[]"), [])
-    decoded["system_info"] = _safe_json(worker.get("system_info", "{}"), {})
+    # Deliberately delegates rather than repeating the three _safe_json calls:
+    # a second copy of the decoding is how one caller ends up forgetting it.
+    _parse_worker_json(decoded)
     return decoded
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app import (
     compose_generator,
     database,
     disclosure,
+    egress,
     exchange_rates,
     fleet_key,
     metrics,
@@ -111,6 +112,21 @@ def _safe_json(raw: str, fallback: Any = None) -> Any:
         return json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return fallback if fallback is not None else []
+
+
+def _decoded_worker(worker: dict[str, Any]) -> dict[str, Any]:
+    """A worker row with its JSON-TEXT columns decoded into real structures.
+
+    ``list_workers``/``get_worker`` return raw rows, so ``containers`` and
+    ``system_info`` arrive as strings. Passing one of those straight to code
+    expecting a mapping is an AttributeError at request time, so every caller
+    that reads inside them goes through here.
+    """
+    decoded = dict(worker)
+    decoded["containers"] = _safe_json(worker.get("containers", "[]"), [])
+    decoded["apps"] = _safe_json(worker.get("apps", "[]"), [])
+    decoded["system_info"] = _safe_json(worker.get("system_info", "{}"), {})
+    return decoded
 
 
 async def _get_all_worker_containers() -> list[dict[str, Any]]:
@@ -1773,19 +1789,56 @@ async def api_service_preflight(request: Request, slug: str, worker_id: int | No
 
     # What is already running on the SAME machine is what makes a per-IP limit
     # checkable at all, so scope to that worker when we know which one.
-    deployed = await database.get_deployments()
-    if worker_id is not None:
-        worker = await database.get_worker(worker_id)
-        running = {c.get("service") for c in (worker or {}).get("containers", []) if c.get("service")}
-    else:
-        running = {d["slug"] for d in deployed}
+    if worker_id is None:
+        deployed = await database.get_deployments()
+        return preflight.assess(service, already_deployed_slugs={d["slug"] for d in deployed})
 
-    system_info = {}
-    if worker_id is not None:
-        worker = await database.get_worker(worker_id)
-        system_info = (worker or {}).get("system_info") or {}
+    workers = [_decoded_worker(w) for w in await database.list_workers()]
+    worker = next((w for w in workers if w.get("id") == worker_id), None)
+    if worker is None:
+        raise HTTPException(status_code=404, detail=f"Unknown worker {worker_id}")
 
-    return preflight.assess(service, already_deployed_slugs=running, system_info=system_info)
+    return preflight.assess(
+        service,
+        already_deployed_slugs=egress.running_slugs(worker),
+        system_info=worker.get("system_info") or {},
+        # The cross-machine half: providers cap per IP, so a sibling worker
+        # behind the same public address is the case a single-host tool cannot
+        # see at all.
+        worker=worker,
+        fleet_workers=workers,
+    )
+
+
+@app.get("/api/fleet/egress-groups")
+async def api_fleet_egress_groups(request: Request) -> dict[str, Any]:
+    """The fleet grouped by the public address providers actually see.
+
+    The normal fleet view is by machine, which is the wrong unit: two machines
+    in one house are two rows here and one customer to every provider.
+    """
+    _require_auth_api(request)
+    workers = [_decoded_worker(w) for w in await database.list_workers()]
+    groups = egress.group_by_egress(workers)
+    return {
+        "groups": [
+            {
+                "egress_ip": g["egress_ip"],
+                "known": g["known"],
+                "network_type": g["network_type"],
+                "shared": g["shared"],
+                "worker_count": g["worker_count"],
+                "workers": [
+                    {"id": w.get("id"), "name": w.get("name"), "client_id": w.get("client_id")} for w in g["workers"]
+                ],
+            }
+            for g in groups
+        ],
+        "shared_groups": sum(1 for g in groups if g["shared"]),
+        # Reported separately and never folded into the groups above: these are
+        # machines whose exit we could not determine, not machines we checked.
+        "undetermined": sum(g["worker_count"] for g in groups if not g["known"]),
+    }
 
 
 @app.get("/api/earnings/net")
@@ -1907,7 +1960,10 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
     signals = producer_state.signals_for(service)
     try:
         containers = await _get_all_worker_containers()
-        matches = [c for c in containers if c.get("service") == slug]
+        # Heartbeat entries key the service as "slug"; matching on "service"
+        # here found nothing in production while the tests, which hand-fed
+        # the wrong shape, passed.
+        matches = [c for c in containers if egress.container_slug(c) == slug]
         running = any(str(c.get("status", "")).lower() == "running" for c in matches)
         if signals and running:
             wid = worker_id if worker_id is not None else (matches[0].get("_worker_id") if matches else None)

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -55,7 +55,13 @@ def assess(
     single-machine checks and keeps saying that the egress IP was not examined.
     """
     already_deployed = already_deployed_slugs or set()
-    info = system_info or {}
+    # Derived from the worker when not passed explicitly. Reading this from a
+    # separate kwarg while the fleet half read worker["system_info"] meant the
+    # SAME worker produced different verdicts depending on whether the caller
+    # remembered a redundant argument.
+    info = system_info if system_info is not None else ((worker or {}).get("system_info") or {})
+    if not isinstance(info, dict):
+        info = {}
     reqs = service.get("requirements") or {}
     slug = service.get("slug", "")
 
@@ -175,7 +181,11 @@ def assess(
 
     verdict = _worst(verdicts)
     not_checked = ["connection speed", "available disk"]
-    if egress.egress_of(worker) is None:
+    # Gated on the connection TYPE, not on the address. Knowing the IP says
+    # nothing about whether it is residential, and dropping the label because we
+    # learned the address produced a response that claimed the type was checked
+    # while a finding in the same payload said it could not be.
+    if egress.network_type_of(worker) == egress.UNKNOWN:
         not_checked.insert(0, "egress IP type")
     return {
         "slug": slug,
@@ -234,8 +244,9 @@ def _fleet_findings(
     if not peers:
         return findings
 
+    conflicting = [w for w in peers if slug in egress.running_slugs(w)]
     running_elsewhere = sorted(
-        w.get("name") or w.get("client_id") or "another machine" for w in peers if slug in egress.running_slugs(w)
+        {w.get("name") or w.get("client_id") or f"machine {w.get('id', '?')}" for w in conflicting}
     )
     if not running_elsewhere:
         return findings
@@ -281,7 +292,10 @@ def _fleet_findings(
             }
         )
     else:
-        instances = len(running_elsewhere) + 1
+        # Peers + the one already running here + the prospective deploy. Omitting
+        # the local one under-counts by exactly the case the feature is for.
+        local = 1 if slug in egress.running_slugs(worker) else 0
+        instances = len(running_elsewhere) + local + 1
         verdict = EARNS_NOTHING if instances > limit else REDUCED
         findings.append(
             {

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app import egress
+
 # Verdicts, worst first. The caller shows the worst one that applies.
 EARNS_NOTHING = "will_earn_nothing"
 REDUCED = "reduced_earnings"
@@ -39,11 +41,18 @@ def assess(
     *,
     already_deployed_slugs: set[str] | None = None,
     system_info: dict[str, Any] | None = None,
+    worker: dict[str, Any] | None = None,
+    fleet_workers: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Answer "what will this realistically do for me?" before the deploy runs.
 
     ``already_deployed_slugs`` is what is already running on the SAME worker,
     which is what makes a per-IP limit checkable at all.
+
+    ``worker`` and ``fleet_workers`` add the cross-machine half (CashPilot-5qc):
+    providers cap per IP, so a sibling worker behind the same public address
+    counts against the same limit. Omit them and the assessment degrades to the
+    single-machine checks and keeps saying that the egress IP was not examined.
     """
     already_deployed = already_deployed_slugs or set()
     info = system_info or {}
@@ -110,20 +119,35 @@ def assess(
         )
         verdicts.append(CHECK_YOURSELF)
 
-    # IP type. We cannot detect this yet, so it is stated as a precondition and
-    # explicitly labelled unverified rather than dressed up as a check.
+    # IP type. Since CashPilot-5qc a worker can sometimes identify itself as a
+    # hosted machine, which turns a precondition into a real finding. When it
+    # cannot, this stays an explicitly unverified precondition rather than being
+    # dressed up as a check.
     if reqs.get("residential_ip") and reqs.get("vps_ip") is False:
-        findings.append(
-            {
-                "verdict": CHECK_YOURSELF,
-                "message": (
-                    "This needs a residential IP. On a VPS or datacentre connection it typically "
-                    "earns far less, or the account is banned outright. CashPilot cannot check "
-                    "your connection type, so this one is on you."
-                ),
-            }
-        )
-        verdicts.append(CHECK_YOURSELF)
+        if str(info.get("egress_network_type") or "").lower() == "hosting":
+            findings.append(
+                {
+                    "verdict": EARNS_NOTHING,
+                    "message": (
+                        "This machine identifies itself as a hosted/VPS server, and this service "
+                        "requires a residential IP. Datacentre addresses are usually detected and "
+                        "rejected — expect little or nothing, and possibly a banned account."
+                    ),
+                }
+            )
+            verdicts.append(EARNS_NOTHING)
+        else:
+            findings.append(
+                {
+                    "verdict": CHECK_YOURSELF,
+                    "message": (
+                        "This needs a residential IP. On a VPS or datacentre connection it typically "
+                        "earns far less, or the account is banned outright. CashPilot cannot check "
+                        "your connection type, so this one is on you."
+                    ),
+                }
+            )
+            verdicts.append(CHECK_YOURSELF)
 
     min_bandwidth = reqs.get("min_bandwidth")
     if min_bandwidth:
@@ -144,7 +168,15 @@ def assess(
         findings.append({"verdict": CHECK_YOURSELF, "message": str(note)})
         verdicts.append(CHECK_YOURSELF)
 
+    # The cross-machine half: what the REST of the fleet implies about this.
+    for finding in _fleet_findings(service, worker=worker, fleet_workers=fleet_workers):
+        findings.append(finding)
+        verdicts.append(finding["verdict"])
+
     verdict = _worst(verdicts)
+    not_checked = ["connection speed", "available disk"]
+    if egress.egress_of(worker) is None:
+        not_checked.insert(0, "egress IP type")
     return {
         "slug": slug,
         "verdict": verdict,
@@ -152,7 +184,7 @@ def assess(
         "findings": findings,
         # Say what was NOT checked, so a clean result is not mistaken for a
         # guarantee about things we never looked at.
-        "not_checked": ["egress IP type", "connection speed", "available disk"],
+        "not_checked": not_checked,
         "worker_arch": info.get("arch"),
         "blocking": False,  # informed consent, never a block
     }
@@ -167,3 +199,98 @@ def _summary(verdict: str, service: dict[str, Any]) -> str:
     if verdict == CHECK_YOURSELF:
         return f"{name} should work, provided the points below are true of your setup."
     return f"Nothing stands out — {name} should work normally here."
+
+
+def _fleet_findings(
+    service: dict[str, Any],
+    *,
+    worker: dict[str, Any] | None,
+    fleet_workers: list[dict[str, Any]] | None,
+) -> list[dict[str, str]]:
+    """What the *rest of the fleet* implies about deploying this here.
+
+    Returns findings in the preflight shape (``verdict``/``message``). Only the
+    cross-machine facts live here; same-machine checks stay in ``preflight``.
+
+    Verdicts are deliberately asymmetric. A documented one-device-per-IP service
+    already running behind this exact address is a concrete, provider-documented
+    loss, so it is stated as one. Everything resting on an undetected IP or an
+    undocumented limit is a "check this" — a warning nobody can act on, fired at
+    users who are fine, is how a safety feature gets ignored.
+
+    The connection *type* is not handled here: ``preflight`` already reads it
+    from the same ``system_info`` and owns that finding, so stating it twice
+    would double-count one fact.
+    """
+    if not worker:
+        return []
+
+    name = service.get("name") or service.get("slug") or "This service"
+    slug = str(service.get("slug") or "")
+    limit = egress.devices_per_ip_limit(service)
+    findings: list[dict[str, str]] = []
+
+    peers = egress.peers_sharing_egress(worker, fleet_workers or [])
+    if not peers:
+        return findings
+
+    running_elsewhere = sorted(
+        w.get("name") or w.get("client_id") or "another machine" for w in peers if slug in egress.running_slugs(w)
+    )
+    if not running_elsewhere:
+        return findings
+
+    where = ", ".join(running_elsewhere)
+    shared_ip = egress.egress_of(worker)
+
+    if limit == 1:
+        findings.append(
+            {
+                "verdict": EARNS_NOTHING,
+                "message": (
+                    f"{name} is already running on {where}, which leaves the internet through the "
+                    f"same public address ({shared_ip}) as this machine. It allows one device per "
+                    "IP, so the provider sees one connection either way: the second instance "
+                    "normally earns nothing, and some providers forfeit the balance of accounts "
+                    "that do this."
+                ),
+            }
+        )
+    elif limit is None:
+        findings.append(
+            {
+                "verdict": CHECK_YOURSELF,
+                "message": (
+                    f"{name} is already running on {where}, behind the same public address "
+                    f"({shared_ip}) as this machine. Nobody has documented how many devices this "
+                    "service allows per IP, so CashPilot cannot tell you whether that is fine or "
+                    "wasted — check the provider's terms before relying on the second one."
+                ),
+            }
+        )
+    elif limit == 0:
+        findings.append(
+            {
+                "verdict": REDUCED,
+                "message": (
+                    f"{name} is already running on {where}, behind the same public address "
+                    f"({shared_ip}). This service documents no per-IP device limit, but both "
+                    "instances still share one connection, so expect the pair to earn roughly "
+                    "what one already does rather than double."
+                ),
+            }
+        )
+    else:
+        instances = len(running_elsewhere) + 1
+        verdict = EARNS_NOTHING if instances > limit else REDUCED
+        findings.append(
+            {
+                "verdict": verdict,
+                "message": (
+                    f"{name} is already running on {where}, behind the same public address "
+                    f"({shared_ip}). It allows {limit} devices per IP and this would be number "
+                    f"{instances}."
+                ),
+            }
+        )
+    return findings

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -130,7 +130,7 @@ def assess(
     # cannot, this stays an explicitly unverified precondition rather than being
     # dressed up as a check.
     if reqs.get("residential_ip") and reqs.get("vps_ip") is False:
-        if str(info.get("egress_network_type") or "").lower() == "hosting":
+        if egress.normalise_network_type(info.get("egress_network_type")) == egress.HOSTING:
             findings.append(
                 {
                     "verdict": EARNS_NOTHING,
@@ -185,7 +185,10 @@ def assess(
     # nothing about whether it is residential, and dropping the label because we
     # learned the address produced a response that claimed the type was checked
     # while a finding in the same payload said it could not be.
-    if egress.network_type_of(worker) == egress.UNKNOWN:
+    # Read from `info`, the same source the residential finding uses. Gating this
+    # on the worker while that finding reads the kwarg is exactly the two-source
+    # divergence this function was just fixed to remove, mirrored.
+    if egress.normalise_network_type(info.get("egress_network_type")) == egress.UNKNOWN:
         not_checked.insert(0, "egress IP type")
     return {
         "slug": slug,
@@ -245,8 +248,13 @@ def _fleet_findings(
         return findings
 
     conflicting = [w for w in peers if slug in egress.running_slugs(w)]
+    # Deduplicated for DISPLAY ONLY. Two different machines can share a display
+    # name — WORKER_NAME defaults to the hostname, and duplicate hostnames in a
+    # home fleet are ordinary — so counting the deduplicated names would merge
+    # two real instances into one and under-warn, which is the failure this
+    # whole module exists to remove. The arithmetic below uses `conflicting`.
     running_elsewhere = sorted(
-        {w.get("name") or w.get("client_id") or f"machine {w.get('id', '?')}" for w in conflicting}
+        {w.get("name") or w.get("client_id") or f"machine {w.get('id') or '?'}" for w in conflicting}
     )
     if not running_elsewhere:
         return findings
@@ -295,7 +303,7 @@ def _fleet_findings(
         # Peers + the one already running here + the prospective deploy. Omitting
         # the local one under-counts by exactly the case the feature is for.
         local = 1 if slug in egress.running_slugs(worker) else 0
-        instances = len(running_elsewhere) + local + 1
+        instances = len(conflicting) + local + 1
         verdict = EARNS_NOTHING if instances > limit else REDUCED
         findings.append(
             {

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -32,7 +32,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from app import fleet_key, orchestrator
+from app import egress, fleet_key, orchestrator
 
 try:
     from app.catalog import get_services as _catalog_get_services
@@ -217,6 +217,94 @@ def _verify_api_key(request: Request) -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Egress identity (CashPilot-5qc)
+# ---------------------------------------------------------------------------
+
+# Every provider in the catalog caps per IP address, so the UI cannot warn about
+# two workers behind one connection unless each worker knows its own exit.
+#
+# This is the one outbound call CashPilot makes purely to learn about the user,
+# so it is opt-outable and endpoint-overridable. The privacy cost is genuinely
+# small — a worker's whole purpose is to route traffic for these providers, all
+# of whom already see this address — but "small" is not "none", and defaults
+# that quietly phone somewhere are how trust is lost in this category.
+_EGRESS_ENDPOINTS = ("https://api.ipify.org", "https://ifconfig.me/ip", "https://icanhazip.com")
+
+# Local, network-free hosting hint. Read from DMI rather than an ASN lookup so
+# nothing is disclosed to a third party and it still works offline.
+_DMI_PATHS = ("/sys/class/dmi/id/sys_vendor", "/sys/class/dmi/id/product_name", "/sys/class/dmi/id/chassis_vendor")
+
+_egress_cache: tuple[str | None, float] = (None, 0.0)
+_EGRESS_TTL_SECONDS = 3600.0
+
+
+def _detect_network_type() -> str:
+    """residential / hosting / unknown, from local hardware identifiers only.
+
+    An explicit ``CASHPILOT_WORKER_NETWORK`` always wins: the user knows their
+    own connection better than any heuristic, and a wrong "hosting" verdict
+    fires ban warnings at people who are fine.
+    """
+    declared = egress.normalise_network_type(os.getenv("CASHPILOT_WORKER_NETWORK"))
+    if declared != egress.UNKNOWN:
+        return declared
+    for path in _DMI_PATHS:
+        try:
+            vendor = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        detected = egress.classify_vendor(vendor)
+        if detected != egress.UNKNOWN:
+            return detected
+    return egress.UNKNOWN
+
+
+async def _detect_egress_ip() -> str | None:
+    """This worker's public IP, cached for an hour, or None.
+
+    Every failure mode returns None rather than a guess: a wrong address would
+    group unrelated machines together, which is worse than the fleet view simply
+    saying it does not know.
+    """
+    global _egress_cache
+
+    if os.getenv("CASHPILOT_EGRESS_DETECT", "").strip().lower() in {"0", "off", "false", "no"}:
+        return None
+
+    cached, fetched_at = _egress_cache
+    now = asyncio.get_running_loop().time()
+    if cached and (now - fetched_at) < _EGRESS_TTL_SECONDS:
+        return cached
+
+    override = os.getenv("CASHPILOT_EGRESS_IP", "").strip()
+    if override:
+        # A user behind a proxy or split tunnel can state the truth directly.
+        confirmed = egress.public_ip(override)
+        if confirmed:
+            _egress_cache = (confirmed, now)
+        return confirmed
+
+    endpoints = [os.getenv("CASHPILOT_EGRESS_IP_URL", "").strip()] if os.getenv("CASHPILOT_EGRESS_IP_URL") else []
+    endpoints.extend(_EGRESS_ENDPOINTS)
+
+    for url in endpoints:
+        if not url:
+            continue
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(url)
+            if resp.status_code != 200:
+                continue
+            found = egress.public_ip(resp.text.strip()[:64])
+            if found:
+                _egress_cache = (found, now)
+                return found
+        except Exception as exc:  # noqa: BLE001 — never let this break a heartbeat
+            logger.debug("Egress IP lookup via %s failed: %s", url, exc)
+    return None
+
+
 async def _send_heartbeat() -> None:
     """Send a single heartbeat to the UI."""
     global _ui_connected, _last_heartbeat, _last_error, _consecutive_auth_failures
@@ -237,6 +325,10 @@ async def _send_heartbeat() -> None:
             "arch": platform.machine(),
             "hostname": socket.gethostname(),
             "docker_available": await asyncio.to_thread(orchestrator.docker_available),
+            # Providers count devices per public IP, so the UI needs the address
+            # the provider sees — not this container's LAN or tailnet address.
+            "egress_ip": await _detect_egress_ip(),
+            "egress_network_type": _detect_network_type(),
         },
     }
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -20,6 +20,7 @@ import os
 import platform
 import re
 import socket
+import time
 import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -237,6 +238,19 @@ _DMI_PATHS = ("/sys/class/dmi/id/sys_vendor", "/sys/class/dmi/id/product_name", 
 
 _egress_cache: tuple[str | None, float] = (None, 0.0)
 _EGRESS_TTL_SECONDS = 3600.0
+# A failed lookup is cached too, and briefly. Without it a blackholed network
+# (DROP, not REJECT) costs the full timeout on EVERY heartbeat, forever.
+_EGRESS_FAILURE_TTL_SECONDS = 300.0
+# Total wall-clock budget for the whole attempt. httpx's timeout is PER
+# OPERATION — its read timeout is the maximum gap between chunks, not a deadline
+# — so an endpoint dribbling one byte every few seconds would hold the request
+# open indefinitely. That matters here because the heartbeat loop is serial: a
+# stalled lookup stops heartbeats entirely and the UI marks this worker offline
+# after 180s, so deploys and restarts for this host start failing. A diagnostic
+# nicety must never be able to take the control plane down.
+_EGRESS_TOTAL_TIMEOUT = 10.0
+# Enough for any textual IP form; the body is never read past this.
+_EGRESS_MAX_BYTES = 128
 
 
 def _detect_network_type() -> str:
@@ -260,6 +274,19 @@ def _detect_network_type() -> str:
     return egress.UNKNOWN
 
 
+async def _fetch_egress_ip(url: str) -> str | None:
+    """One IP-echo request, with the response body capped while streaming."""
+    async with httpx.AsyncClient(timeout=5) as client, client.stream("GET", url) as resp:
+        if resp.status_code != 200:
+            return None
+        body = b""
+        async for chunk in resp.aiter_bytes():
+            body += chunk
+            if len(body) >= _EGRESS_MAX_BYTES:
+                break
+    return egress.public_ip(body[:_EGRESS_MAX_BYTES].decode("utf-8", "replace").strip())
+
+
 async def _detect_egress_ip() -> str | None:
     """This worker's public IP, cached for an hour, or None.
 
@@ -273,9 +300,15 @@ async def _detect_egress_ip() -> str | None:
         return None
 
     cached, fetched_at = _egress_cache
-    now = asyncio.get_running_loop().time()
-    if cached and (now - fetched_at) < _EGRESS_TTL_SECONDS:
+    # time.monotonic(), not the event loop's clock: the loop's epoch is
+    # unspecified, and one starting near zero would make this difference
+    # negative — always under the TTL — pinning a stale address forever.
+    now = time.monotonic()
+    age = now - fetched_at
+    if cached and age < _EGRESS_TTL_SECONDS:
         return cached
+    if not cached and fetched_at and age < _EGRESS_FAILURE_TTL_SECONDS:
+        return None
 
     override = os.getenv("CASHPILOT_EGRESS_IP", "").strip()
     if override:
@@ -283,25 +316,32 @@ async def _detect_egress_ip() -> str | None:
         confirmed = egress.public_ip(override)
         if confirmed:
             _egress_cache = (confirmed, now)
-        return confirmed
+            return confirmed
+        # Ignoring this silently would be cruel: "192.168.1.5" is what most
+        # people would call their IP, and the only symptom is nothing happening.
+        logger.warning(
+            "CASHPILOT_EGRESS_IP=%r is not a public address, so it cannot be this worker's "
+            "egress IP — ignoring it and looking the address up instead.",
+            override,
+        )
 
-    endpoints = [os.getenv("CASHPILOT_EGRESS_IP_URL", "").strip()] if os.getenv("CASHPILOT_EGRESS_IP_URL") else []
-    endpoints.extend(_EGRESS_ENDPOINTS)
+    custom = os.getenv("CASHPILOT_EGRESS_IP_URL", "").strip()
+    # An operator who names their own endpoint did so to avoid disclosing to a
+    # third party. Falling back to the public ones on a transient failure would
+    # quietly undo exactly that choice, so a custom endpoint is used ALONE.
+    endpoints = [custom] if custom else list(_EGRESS_ENDPOINTS)
 
     for url in endpoints:
-        if not url:
-            continue
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                resp = await client.get(url)
-            if resp.status_code != 200:
-                continue
-            found = egress.public_ip(resp.text.strip()[:64])
-            if found:
-                _egress_cache = (found, now)
-                return found
+            found = await asyncio.wait_for(_fetch_egress_ip(url), timeout=_EGRESS_TOTAL_TIMEOUT)
         except Exception as exc:  # noqa: BLE001 — never let this break a heartbeat
             logger.debug("Egress IP lookup via %s failed: %s", url, exc)
+            continue
+        if found:
+            _egress_cache = (found, now)
+            return found
+
+    _egress_cache = (None, now)
     return None
 
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -241,7 +241,11 @@ _EGRESS_TTL_SECONDS = 3600.0
 # A failed lookup is cached too, and briefly. Without it a blackholed network
 # (DROP, not REJECT) costs the full timeout on EVERY heartbeat, forever.
 _EGRESS_FAILURE_TTL_SECONDS = 300.0
-# Total wall-clock budget for the whole attempt. httpx's timeout is PER
+# Wall-clock budget for the WHOLE attempt, shared across every endpoint tried
+# (see the deadline in _detect_egress_ip). Per-endpoint would multiply by the
+# endpoint count: at 3 endpoints plus the 15s heartbeat POST that is already 45s
+# on a 60s serial cycle, and a longer list would breach the 180s offline
+# threshold — the exact failure this bound exists to prevent. httpx's timeout is PER
 # OPERATION — its read timeout is the maximum gap between chunks, not a deadline
 # — so an endpoint dribbling one byte every few seconds would hold the request
 # open indefinitely. That matters here because the heartbeat loop is serial: a
@@ -331,9 +335,14 @@ async def _detect_egress_ip() -> str | None:
     # quietly undo exactly that choice, so a custom endpoint is used ALONE.
     endpoints = [custom] if custom else list(_EGRESS_ENDPOINTS)
 
+    deadline = time.monotonic() + _EGRESS_TOTAL_TIMEOUT
     for url in endpoints:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.debug("Egress IP lookup budget exhausted before trying %s", url)
+            break
         try:
-            found = await asyncio.wait_for(_fetch_egress_ip(url), timeout=_EGRESS_TOTAL_TIMEOUT)
+            found = await asyncio.wait_for(_fetch_egress_ip(url), timeout=remaining)
         except Exception as exc:  # noqa: BLE001 — never let this break a heartbeat
             logger.debug("Egress IP lookup via %s failed: %s", url, exc)
             continue
@@ -430,12 +439,25 @@ async def _send_heartbeat() -> None:
 
 
 async def _heartbeat_loop() -> None:
-    """Send heartbeats to the UI at regular intervals."""
-    # Send first heartbeat immediately
-    await _send_heartbeat()
+    """Send heartbeats to the UI at regular intervals.
+
+    Every cycle is guarded. _send_heartbeat builds its payload OUTSIDE its own
+    try (docker_available, the egress lookup and the network-type probe all run
+    while the dict literal is evaluated), so an exception there would otherwise
+    propagate out of this loop and kill the task silently and permanently.
+    That is strictly worse than any single failed heartbeat: a missed cycle
+    costs one 180s offline window and self-heals, whereas a dead task means
+    offline until someone restarts the container — while the service containers
+    keep earning and nothing surfaces the problem.
+    """
     while True:
+        try:
+            await _send_heartbeat()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Heartbeat cycle failed — continuing")
         await asyncio.sleep(HEARTBEAT_INTERVAL)
-        await _send_heartbeat()
 
 
 def _get_local_ip() -> str:

--- a/docs/AUTOPILOT-WORKLOG.md
+++ b/docs/AUTOPILOT-WORKLOG.md
@@ -393,3 +393,50 @@ written up front (the omission that failed codecov/patch on four earlier PRs).
 **Counters:** iteration 4, no_progress 0, failures 0.
 
 **Next action:** CashPilot-5qc.
+
+## 2026-08-02T17:35:00Z — sergio-loop segment 2, iteration 5
+
+**Slice:** CashPilot-5qc — egress-IP conflict detection, on `feat/egress-conflicts`.
+
+**Changed:** `app/egress.py` (new), `app/preflight.py` (fleet half + hosting verdict),
+`app/main.py` (`_decoded_worker`, rewritten preflight endpoint, `/api/fleet/egress-groups`),
+`app/worker_api.py` (egress + hosting detection in the heartbeat), `Dockerfile.worker`,
+`services/_schema.yml`, `README.md`, `docs/fleet.md`, `CLAUDE.md`, and three test files.
+
+**Two defects found while wiring it, both with passing tests:**
+
+1. `/api/services/{slug}/preflight?worker_id=N` returned **500 in production**. Confirmed on the
+   live 1.7.0 UI on watchtower against its own worker rows: `AttributeError 'str' object has no
+   attribute 'get'`. `list_workers` returns raw rows, so `containers`/`system_info` arrive as JSON
+   TEXT. Every reader now goes through `_decoded_worker`, which delegates to the pre-existing
+   `_parse_worker_json` so there is exactly one decode path.
+2. `/api/services/{slug}/producer-state` (b4e, merged yesterday) filtered on `c["service"]` while
+   heartbeats emit `slug`, so `container_running` was always false and every service reported
+   UNKNOWN — the feature was inert. Not yet released, so it never reached the fleet.
+
+Both fixtures hand-fed a shape production never produces. That is the transferable lesson and it
+is now recorded in `CLAUDE.md`.
+
+**Independent review:** 22 findings, 2 HIGH. Every finding acted on was reproduced by execution
+first. The serious ones: a stalled IP lookup could stall the serial heartbeat loop and take a
+worker offline (httpx's timeout is per-operation, not a deadline), and `not_checked` claimed the
+connection type was checked while a finding in the same payload said it could not be. Also fixed:
+an off-by-one that under-warned, Android workers invisible to the check, a custom IP endpoint
+silently falling back to third parties, and a unit test making a **real network request**.
+
+**Verified against real hardware:** watchtower and geiserback both report `ASUSTeK COMPUTER INC.`
+and classify as *not* hosting (no false ban warnings on home servers); the DMI path is readable
+from inside the worker container; the two hosts have genuinely different public IPs (ER605
+dual-WAN), so no conflict is reported between them — correct.
+
+**Verification:** `ruff check .` + `ruff format --check .` clean · `pytest --cov=app
+--cov-fail-under=90` → **1671 passed**, coverage **94.59%** · worker image module set simulated to
+prove `app/egress.py` adds no import the worker lacks.
+
+**Counters:** iteration 5, no_progress 0, failures 0.
+
+**Blocker worth naming:** CodeRabbit rate-limited on #165 and now returns "review finished" with
+zero comments — the failed attempt marked the commit reviewed, so re-triggering is a no-op. Its
+green check is a SKIPPED review, not a pass. Independent reviews substituted; not merging on it.
+
+**Next action:** merge #165 once its review returns, then open the 5qc PR off main.

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -157,6 +157,44 @@ Notifications fire **only the first time** a particular failure appears — a co
 | `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
 | `CASHPILOT_ALLOWED_VOLUME_ROOTS` | No | *(none)* | Colon-separated host directories this worker may bind-mount despite sitting under a blocked system root -- see [Volume mounts](#volume-mounts) |
 | `CASHPILOT_PIDS_LIMIT` | No | `512` | Max processes a deployed service container may create. Raise only if a service legitimately needs more. An unparseable or non-positive value falls back to the default |
+| `CASHPILOT_WORKER_NETWORK` | No | *(detected)* | `residential` or `hosting`. Overrides the hardware-based guess -- see [Egress IP and per-IP limits](#egress-ip-and-per-ip-limits) |
+| `CASHPILOT_EGRESS_DETECT` | No | on | Set to `off` to stop this worker looking up its own public IP. The fleet then reports its exit as undetermined |
+| `CASHPILOT_EGRESS_IP` | No | -- | State this worker's public IP directly instead of looking it up. Must be a public address; a LAN or tailnet address is rejected |
+| `CASHPILOT_EGRESS_IP_URL` | No | -- | Use your own IP-echo endpoint (must return a bare IP) instead of the public ones |
+
+### Egress IP and per-IP limits
+
+Providers count devices per **IP address**, not per machine. Honeygain treats a
+second active device on a network as "network overused", and EarnApp documents
+that extra devices behind one IP share a single daily cap. Two workers in one
+house are two machines on your dashboard and **one customer** to the provider,
+so the second one usually earns nothing.
+
+Each worker therefore reports the public address it leaves the internet through,
+and the UI can group the fleet by that address (`/api/fleet/egress-groups`)
+rather than by host. Deploying a service to a machine that shares an address
+with one already running it is called out before the deploy, by name.
+
+Three things worth knowing about how this behaves:
+
+- **A worker whose exit could not be determined is reported as undetermined,
+  never as sharing.** No warning is produced for it at all. That is deliberate:
+  a wrong conflict warning is worse than none.
+- **Private addresses are ignored.** A LAN or tailnet (`100.64/10`) address means
+  detection failed, not that the machine exits there.
+- **A service with no documented per-IP limit is treated as unknown, not
+  unlimited.** You are told to check the provider's terms rather than reassured.
+
+Detection is local where it can be. The "is this a hosted machine?" hint comes
+from the machine's own hardware identifiers, so nothing is sent anywhere and it
+works offline; a plain hypervisor such as QEMU or VMware is **not** treated as
+hosting, because a VM on a home server is a residential connection.
+
+The public-IP lookup is the one outbound call CashPilot makes purely to learn
+about your setup. It is a single request per hour to a public IP-echo service.
+Turn it off with `CASHPILOT_EGRESS_DETECT=off`, point it at your own endpoint
+with `CASHPILOT_EGRESS_IP_URL`, or skip it entirely by stating the address with
+`CASHPILOT_EGRESS_IP`.
 
 ### Volume mounts
 

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -87,6 +87,15 @@
 #   vps_ip: true/false  (default: opposite of residential_ip)
 #   devices_per_account: 0  (0 = unlimited)
 #   devices_per_ip: 1  (0 = unlimited)
+#
+#   devices_per_ip drives the egress-conflict warning (app/egress.py), so the
+#   distinction between OMITTING it and setting it to 0 is load-bearing:
+#     - omitted -> "nobody has documented this", and the user is told to check
+#       the provider's terms before running a second instance behind one IP;
+#     - 0       -> a verified statement that the provider imposes no per-IP
+#       limit, which suppresses that warning.
+#   Only write 0 when the provider actually says so. Writing it to silence a
+#   warning turns a cautious message into a wrong one.
 #   note: ""  (footnote text for special cases in README table)
 #   note_column: ""  (which column footnote applies to: vps_ip, devices_per_ip)
 #   min_bandwidth: ""

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -93,8 +93,11 @@
 #     - omitted -> "nobody has documented this", and the user is told to check
 #       the provider's terms before running a second instance behind one IP;
 #     - 0       -> a verified statement that the provider imposes no per-IP
-#       limit, which suppresses that warning.
-#   Only write 0 when the provider actually says so. Writing it to silence a
+#       limit. The "check the terms" warning is then replaced by a milder note
+#       that two instances still share one connection, so the pair earns roughly
+#       what one does. It is downgraded, NOT silenced -- shared bandwidth is a
+#       real effect regardless of what the provider permits.
+#   Only write 0 when the provider actually says so. Writing it to quieten a
 #   warning turns a cautious message into a wrong one.
 #   note: ""  (footnote text for special cases in README table)
 #   note_column: ""  (which column footnote applies to: vps_ip, devices_per_ip)

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -20,7 +20,7 @@ import pytest
 from app import egress, preflight
 
 
-def worker(wid, name, ip=None, network=None, running=(), status="running"):
+def worker(wid, name, ip=None, network=None, running=(), status="running", worker_status="online"):
     info = {"arch": "x86_64"}
     if ip is not None:
         info["egress_ip"] = ip
@@ -30,6 +30,7 @@ def worker(wid, name, ip=None, network=None, running=(), status="running"):
         "id": wid,
         "client_id": f"cid-{wid}",
         "name": name,
+        "status": worker_status,
         "system_info": info,
         "containers": [{"service": s, "status": status} for s in running],
     }
@@ -615,3 +616,115 @@ def main_groups():
     from app import main
 
     return main.api_fleet_egress_groups
+
+
+class TestARetiredMachineMustNotFabricateAConflict:
+    """An enrolled worker's row survives being switched off, forever.
+
+    The stale-worker purge deliberately spares enrolled rows, and the last
+    heartbeat it left behind still lists every container as running with its
+    last-known egress IP. Counting those as peers would invent a conflict
+    against a live machine — the opposite of this module's stated failure
+    direction, which is to miss a conflict and never to invent one.
+    """
+
+    OFFLINE_PEER = worker(50, "old-server", "81.61.1.9", running=["honeygain"], worker_status="offline")
+    LIVE = worker(51, "survivor", "81.61.1.9")
+
+    def _preflight(self, workers, worker_id):
+        import asyncio
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        rows = [
+            {**w, "containers": json.dumps(w["containers"]), "system_info": json.dumps(w["system_info"])}
+            for w in workers
+        ]
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=rows)),
+                patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
+                patch.object(main.catalog, "get_service", return_value=ONE_PER_IP),
+            ):
+                return await main.api_service_preflight(MagicMock(), "honeygain", worker_id)
+
+        return asyncio.run(run())
+
+    def test_an_offline_peer_raises_no_conflict(self):
+        out = self._preflight([self.OFFLINE_PEER, self.LIVE], 51)
+        assert out["findings"] == [], "a machine that is switched off is not competing for the IP"
+
+    def test_the_same_peer_online_does_raise_one(self):
+        online = {**self.OFFLINE_PEER, "status": "online"}
+        out = self._preflight([online, self.LIVE], 51)
+        assert out["verdict"] == "will_earn_nothing"
+
+    def test_an_offline_worker_can_still_be_assessed_itself(self):
+        """A worker that just restarted must not 404 while its status catches up."""
+        out = self._preflight([self.OFFLINE_PEER, self.LIVE], 50)
+        assert out["blocking"] is False
+
+
+class TestTheInstanceCountUsesMachinesNotNames:
+    def test_two_distinct_peers_sharing_a_hostname_both_count(self):
+        """WORKER_NAME defaults to the hostname; duplicate hostnames are ordinary."""
+        two = {"slug": "honeygain", "name": "Honeygain", "requirements": {"devices_per_ip": 2}}
+        me = worker(60, "me", "81.61.1.9")
+        peers = [
+            worker(61, "raspberrypi", "81.61.1.9", running=["honeygain"]),
+            worker(62, "raspberrypi", "81.61.1.9", running=["honeygain"]),
+        ]
+        out = preflight.assess(two, worker=me, fleet_workers=[me, *peers])
+        assert out["verdict"] == preflight.EARNS_NOTHING, "3 instances against a limit of 2"
+
+    def test_the_message_still_names_each_machine_once(self):
+        me = worker(63, "me", "81.61.1.9")
+        peers = [
+            worker(64, "pi", "81.61.1.9", running=["honeygain"]),
+            worker(65, "pi", "81.61.1.9", running=["honeygain"]),
+        ]
+        out = preflight.assess(ONE_PER_IP, worker=me, fleet_workers=[me, *peers])
+        message = " ".join(f["message"] for f in out["findings"])
+        assert "pi, pi" not in message, "the display list should collapse duplicate names"
+
+
+class TestAddressFormsThatCarrySomeoneElsesAddress:
+    @pytest.mark.parametrize(
+        "addr", ["::192.168.1.5", "::10.0.0.1", "fec0::1", "2002:c0a8:101::1", "64:ff9b::c0a8:101"]
+    )
+    def test_they_are_all_rejected(self, addr):
+        assert egress.public_ip(addr) is None
+
+    def test_the_compatible_form_of_a_public_address_matches_itself(self):
+        """Grouping is string equality, so both forms must reduce to one key."""
+        assert egress.public_ip("::81.61.1.9") == egress.public_ip("81.61.1.9") == "81.61.1.9"
+
+
+class TestTheHeartbeatSurvivesABadCycle:
+    @pytest.mark.asyncio
+    async def test_one_failing_cycle_does_not_end_the_loop(self, monkeypatch):
+        """A dead task means offline until someone restarts the container."""
+        import asyncio
+
+        from app import worker_api
+
+        calls = []
+
+        async def flaky():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("docker_available blew up")
+
+        monkeypatch.setattr(worker_api, "_send_heartbeat", flaky)
+        monkeypatch.setattr(worker_api, "HEARTBEAT_INTERVAL", 0)
+        task = asyncio.create_task(worker_api._heartbeat_loop())
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if len(calls) >= 3:
+                break
+        task.cancel()
+        assert len(calls) >= 3, "the loop stopped after the first exception"

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -220,10 +220,46 @@ class TestPreflightSeesTheRestOfTheFleet:
         out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[stopped, HOME_B])
         assert out["findings"] == []
 
-    def test_a_known_egress_ip_stops_advertising_it_as_unchecked(self):
+    def test_knowing_the_address_does_not_mean_knowing_the_type(self):
+        """The label is about the connection TYPE. An IP says nothing about it.
+
+        Dropping it because the address was found produced a response that
+        claimed the type was checked while a finding beside it said it could not
+        be — the exact self-contradiction the module forbids.
+        """
         out = preflight.assess(UNLIMITED, worker=HOME_B, fleet_workers=[HOME_B])
+        assert "egress IP type" in out["not_checked"]
+
+    def test_a_known_connection_type_stops_advertising_it_as_unchecked(self):
+        out = preflight.assess(UNLIMITED, worker=REMOTE, fleet_workers=[REMOTE])
         assert "egress IP type" not in out["not_checked"]
         assert "connection speed" in out["not_checked"]
+
+    def test_the_local_instance_counts_towards_a_documented_limit(self):
+        """Peers + the one already here + the new one. Omitting the local one
+        under-warns in exactly the situation this feature exists for."""
+        two = {"slug": "honeygain", "name": "Honeygain", "requirements": {"devices_per_ip": 2}}
+        here = worker(7, "here", "81.61.1.9", running=["honeygain"])
+        out = preflight.assess(
+            two,
+            already_deployed_slugs=egress.running_slugs(here),
+            worker=here,
+            fleet_workers=[here, HOME_A],
+        )
+        assert out["verdict"] == preflight.EARNS_NOTHING
+
+    def test_two_unnamed_peers_do_not_render_as_a_repeated_phrase(self):
+        anon = [
+            {
+                "id": i,
+                "system_info": {"egress_ip": "81.61.1.9"},
+                "containers": [{"slug": "honeygain", "status": "running"}],
+            }
+            for i in (20, 21)
+        ]
+        out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[*anon, HOME_B])
+        joined = " ".join(f["message"] for f in out["findings"])
+        assert "machine 20" in joined and "machine 21" in joined
 
     def test_it_still_never_blocks(self):
         out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
@@ -233,6 +269,61 @@ class TestPreflightSeesTheRestOfTheFleet:
         out = preflight.assess(ONE_PER_IP)
         assert out["verdict"] == preflight.LOOKS_FINE
         assert "egress IP type" in out["not_checked"]
+
+
+class TestOneFactOneSource:
+    """The hosting verdict must not depend on a redundant kwarg."""
+
+    RESI = {"slug": "honeygain", "name": "Honeygain", "requirements": {"residential_ip": True, "vps_ip": False}}
+
+    def test_the_verdict_is_the_same_with_and_without_system_info(self):
+        with_kwarg = preflight.assess(
+            self.RESI, worker=REMOTE, fleet_workers=[REMOTE], system_info=REMOTE["system_info"]
+        )
+        without = preflight.assess(self.RESI, worker=REMOTE, fleet_workers=[REMOTE])
+        assert with_kwarg["verdict"] == without["verdict"] == preflight.EARNS_NOTHING
+
+    def test_an_explicit_system_info_still_wins(self):
+        out = preflight.assess(self.RESI, worker=REMOTE, fleet_workers=[REMOTE], system_info={})
+        assert out["verdict"] == preflight.CHECK_YOURSELF
+
+    def test_a_malformed_system_info_does_not_raise(self):
+        assert preflight.assess(self.RESI, worker={"system_info": "junk"})["blocking"] is False
+
+
+class TestAndroidWorkersAreCounted:
+    """A phone on the home WiFi plus a server is two devices on ONE public IP."""
+
+    PHONE = {
+        "id": 30,
+        "client_id": "cid-30",
+        "name": "phone",
+        "system_info": {"egress_ip": "81.61.1.9", "device_type": "android"},
+        "containers": [],
+        "apps": [{"slug": "honeygain", "running": True}, {"slug": "grass", "running": False}],
+    }
+
+    def test_a_running_android_app_counts_as_a_device(self):
+        assert egress.running_slugs(self.PHONE) == {"honeygain"}
+
+    def test_a_phone_behind_the_same_ip_is_a_conflict(self):
+        out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[self.PHONE, HOME_B])
+        assert out["verdict"] == preflight.EARNS_NOTHING
+        assert "phone" in " ".join(f["message"] for f in out["findings"])
+
+
+class TestSelfExclusion:
+    def test_two_legacy_rows_with_no_client_id_do_not_cancel_each_other(self):
+        """`None != None` is False, so keying on client_id hid real conflicts."""
+        a = {
+            "id": 40,
+            "client_id": None,
+            "name": "a",
+            "system_info": {"egress_ip": "81.61.1.9"},
+            "containers": [{"slug": "honeygain", "status": "running"}],
+        }
+        b = {"id": 41, "client_id": None, "name": "b", "system_info": {"egress_ip": "81.61.1.9"}, "containers": []}
+        assert [w["id"] for w in egress.peers_sharing_egress(b, [a, b])] == [40]
 
 
 class TestResidentialOnlyOnAHostedMachine:
@@ -255,6 +346,62 @@ class TestResidentialOnlyOnAHostedMachine:
     def test_it_is_stated_once_not_twice(self):
         out = preflight.assess(self.RESI, worker=REMOTE, fleet_workers=[REMOTE], system_info=REMOTE["system_info"])
         assert len([f for f in out["findings"] if "residential" in f["message"].lower()]) == 1
+
+
+class _FakeStream:
+    """Stands in for httpx's streaming response so no test touches the network."""
+
+    def __init__(self, body=b"", status=200, exc=None):
+        self.body, self.status_code, self.exc = body, status, exc
+
+    async def __aenter__(self):
+        if self.exc:
+            raise self.exc
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def aiter_bytes(self):
+        yield self.body
+
+
+class _FakeClient:
+    def __init__(self, resp, seen):
+        self._resp, self._seen = resp, seen
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def stream(self, method, url):
+        self._seen.append(url)
+        return self._resp
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Fail loudly if anything here would really reach the internet."""
+    from app import worker_api
+
+    for var in (
+        "CASHPILOT_EGRESS_DETECT",
+        "CASHPILOT_EGRESS_IP",
+        "CASHPILOT_EGRESS_IP_URL",
+        "CASHPILOT_WORKER_NETWORK",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+    seen: list[str] = []
+
+    def install(resp):
+        monkeypatch.setattr(worker_api.httpx, "AsyncClient", lambda **kw: _FakeClient(resp, seen))
+        return seen
+
+    install(_FakeStream(exc=AssertionError("a test tried to reach the network")))
+    return install, seen
 
 
 class TestWorkerSideDetection:
@@ -280,71 +427,125 @@ class TestWorkerSideDetection:
         monkeypatch.setattr(worker_api, "_DMI_PATHS", (str(tmp_path / "missing"), str(vendor)))
         assert worker_api._detect_network_type() == egress.HOSTING
 
+    def test_a_home_server_vendor_is_not_flagged_as_hosting(self, monkeypatch, tmp_path):
+        """Verified against the real reference fleet, which reports this string."""
+        from app import worker_api
+
+        monkeypatch.delenv("CASHPILOT_WORKER_NETWORK", raising=False)
+        vendor = tmp_path / "sys_vendor"
+        vendor.write_text("ASUSTeK COMPUTER INC.\n")
+        monkeypatch.setattr(worker_api, "_DMI_PATHS", (str(vendor),))
+        assert worker_api._detect_network_type() == egress.UNKNOWN
+
     @pytest.mark.asyncio
-    async def test_detection_can_be_switched_off(self, monkeypatch):
+    async def test_detection_can_be_switched_off(self, monkeypatch, no_network):
         from app import worker_api
 
         monkeypatch.setenv("CASHPILOT_EGRESS_DETECT", "off")
         assert await worker_api._detect_egress_ip() is None
 
     @pytest.mark.asyncio
-    async def test_an_override_is_honoured_and_still_validated(self, monkeypatch):
+    async def test_a_valid_override_skips_the_lookup_entirely(self, monkeypatch, no_network):
         from app import worker_api
 
-        monkeypatch.delenv("CASHPILOT_EGRESS_DETECT", raising=False)
-        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
         monkeypatch.setenv("CASHPILOT_EGRESS_IP", "81.61.1.9")
         assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        assert no_network[1] == [], "an override must not cause any request"
 
-        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+    @pytest.mark.asyncio
+    async def test_an_invalid_override_warns_and_falls_back_to_lookup(self, monkeypatch, no_network, caplog):
+        """192.168.x is what most people would call 'my IP'; silence is cruel."""
+        from app import worker_api
+
+        install, seen = no_network
+        install(_FakeStream(b"81.61.1.9\n"))
         monkeypatch.setenv("CASHPILOT_EGRESS_IP", "192.168.1.5")
-        assert await worker_api._detect_egress_ip() is None, "a LAN override is still a LAN address"
+        with caplog.at_level("WARNING"):
+            assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        assert "not a public address" in caplog.text
+        assert seen, "it should still look the address up"
 
     @pytest.mark.asyncio
-    async def test_every_endpoint_failing_yields_none_not_a_guess(self, monkeypatch):
+    async def test_a_custom_endpoint_is_used_alone_and_never_falls_back(self, monkeypatch, no_network):
+        """Naming your own endpoint IS the opt-out; a quiet fallback undoes it."""
         from app import worker_api
 
-        for var in ("CASHPILOT_EGRESS_DETECT", "CASHPILOT_EGRESS_IP", "CASHPILOT_EGRESS_IP_URL"):
-            monkeypatch.delenv(var, raising=False)
-        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+        install, seen = no_network
+        install(_FakeStream(b"not-an-ip"))
+        monkeypatch.setenv("CASHPILOT_EGRESS_IP_URL", "https://my-own.example/ip")
+        assert await worker_api._detect_egress_ip() is None
+        assert seen == ["https://my-own.example/ip"], f"leaked to a third party: {seen}"
 
-        class Boom:
-            async def __aenter__(self):
-                return self
+    @pytest.mark.asyncio
+    async def test_a_response_is_validated_before_it_is_trusted(self, monkeypatch, no_network):
+        from app import worker_api
 
-            async def __aexit__(self, *a):
-                return False
-
-            async def get(self, url):
-                raise OSError("no network")
-
-        monkeypatch.setattr(worker_api.httpx, "AsyncClient", lambda **kw: Boom())
+        install, _ = no_network
+        install(_FakeStream(b"<html>error page</html>"))
         assert await worker_api._detect_egress_ip() is None
 
     @pytest.mark.asyncio
-    async def test_a_lookup_response_is_validated_before_it_is_trusted(self, monkeypatch):
+    async def test_a_non_200_is_not_parsed(self, monkeypatch, no_network):
         from app import worker_api
 
-        for var in ("CASHPILOT_EGRESS_DETECT", "CASHPILOT_EGRESS_IP", "CASHPILOT_EGRESS_IP_URL"):
-            monkeypatch.delenv(var, raising=False)
-        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
-
-        class Resp:
-            status_code = 200
-            text = "<html>error page</html>"
-
-        class Client:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *a):
-                return False
-
-            async def get(self, url):
-                return Resp()
-
-        monkeypatch.setattr(worker_api.httpx, "AsyncClient", lambda **kw: Client())
+        install, _ = no_network
+        install(_FakeStream(b"81.61.1.9", status=503))
         assert await worker_api._detect_egress_ip() is None
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_body_cannot_exhaust_memory(self, monkeypatch, no_network):
+        from app import worker_api
+
+        install, _ = no_network
+        install(_FakeStream(b"81.61.1.9" + b"x" * 10_000_000))
+        assert await worker_api._detect_egress_ip() is None, "truncated garbage is not an IP"
+
+    @pytest.mark.asyncio
+    async def test_a_stalled_endpoint_cannot_hang_the_heartbeat(self, monkeypatch, no_network):
+        """A serial heartbeat loop means a hung lookup takes the worker offline."""
+        import asyncio
+
+        from app import worker_api
+
+        async def never_returns(url):
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(worker_api, "_fetch_egress_ip", never_returns)
+        monkeypatch.setattr(worker_api, "_EGRESS_TOTAL_TIMEOUT", 0.05)
+        assert await worker_api._detect_egress_ip() is None
+
+    @pytest.mark.asyncio
+    async def test_a_successful_lookup_is_cached(self, monkeypatch, no_network):
+        from app import worker_api
+
+        install, seen = no_network
+        install(_FakeStream(b"81.61.1.9"))
+        assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        assert len(seen) == 1, "the second call must come from cache"
+
+    @pytest.mark.asyncio
+    async def test_a_failure_is_cached_too_so_a_blackhole_is_not_retried_every_minute(self, monkeypatch, no_network):
+        from app import worker_api
+
+        install, seen = no_network
+        install(_FakeStream(b"nope"))
+        assert await worker_api._detect_egress_ip() is None
+        tried = len(seen)
+        assert tried == len(worker_api._EGRESS_ENDPOINTS), "the first attempt should try each fallback"
+        assert await worker_api._detect_egress_ip() is None
+        assert len(seen) == tried, "a DROPped network would otherwise cost the timeout every heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_the_cache_expires(self, monkeypatch, no_network):
+        from app import worker_api
+
+        install, seen = no_network
+        install(_FakeStream(b"81.61.1.9"))
+        assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        monkeypatch.setattr(worker_api, "_EGRESS_TTL_SECONDS", -1.0)
+        assert await worker_api._detect_egress_ip() == "81.61.1.9"
+        assert len(seen) == 2
 
 
 class TestEndpoints:

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -1,0 +1,416 @@
+"""Egress-IP conflict detection (CashPilot-5qc).
+
+Providers cap per IP, not per device, and CashPilot's fleet model actively
+encourages deploying one service to several machines that may all sit behind one
+home connection. The tests that matter are the ones that keep the warning from
+being *wrong*, because a warning that cries wolf gets switched off:
+
+* an egress IP we could not detect must never look like a shared one;
+* a tailnet or LAN address must never be mistaken for an exit — every worker in
+  this project's own reference fleet has one, so the false-conflict blast radius
+  is the entire fleet;
+* an undocumented per-IP limit must not read as "unlimited"; only 4 of 50
+  services declare one today.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import egress, preflight
+
+
+def worker(wid, name, ip=None, network=None, running=(), status="running"):
+    info = {"arch": "x86_64"}
+    if ip is not None:
+        info["egress_ip"] = ip
+    if network is not None:
+        info["egress_network_type"] = network
+    return {
+        "id": wid,
+        "client_id": f"cid-{wid}",
+        "name": name,
+        "system_info": info,
+        "containers": [{"service": s, "status": status} for s in running],
+    }
+
+
+HOME_A = worker(1, "watchtower", "81.61.1.9", running=["honeygain"])
+HOME_B = worker(2, "geiserback", "81.61.1.9")
+REMOTE = worker(3, "vps", "95.216.4.7", network="hosting")
+UNSEEN = worker(4, "pi")
+
+ONE_PER_IP = {"slug": "honeygain", "name": "Honeygain", "requirements": {"devices_per_ip": 1}}
+UNDOCUMENTED = {"slug": "honeygain", "name": "Honeygain", "requirements": {}}
+UNLIMITED = {"slug": "honeygain", "name": "Honeygain", "requirements": {"devices_per_ip": 0}}
+
+
+class TestOnlyRealPublicAddressesCount:
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "192.168.10.100",  # LAN
+            "10.0.0.5",
+            "172.16.4.1",
+            "127.0.0.1",
+            "169.254.1.1",  # link-local
+            "100.101.102.103",  # CGNAT — and the tailnet range this fleet uses
+            "fd00::1",  # unique-local v6
+            "::1",
+            "224.0.0.1",  # multicast
+            "0.0.0.0",
+            "",
+            "not-an-ip",
+            None,
+        ],
+    )
+    def test_a_non_public_address_is_a_detection_failure(self, addr):
+        assert egress.public_ip(addr) is None
+
+    def test_a_real_public_address_is_kept(self):
+        assert egress.public_ip("81.61.1.9") == "81.61.1.9"
+        assert egress.public_ip("2606:4700::1111") == "2606:4700::1111"
+
+    @pytest.mark.parametrize("addr", ["203.0.113.9", "198.51.100.4", "192.0.2.1", "2001:db8:1::1"])
+    def test_reserved_documentation_ranges_are_rejected_too(self, addr):
+        """Not pedantry: a stub or fixture leaking into production must not group hosts."""
+        assert egress.public_ip(addr) is None
+
+    def test_a_tailnet_address_never_groups_the_fleet(self):
+        """Every worker here has a 100.x tailnet IP; grouping on it would be catastrophic."""
+        tailnet = [worker(i, f"w{i}", f"100.64.0.{i}") for i in range(1, 4)]
+        groups = egress.group_by_egress(tailnet)
+        assert len(groups) == 1
+        assert groups[0]["known"] is False
+        assert groups[0]["shared"] is False
+
+
+class TestUndetectedIsNotShared:
+    def test_workers_with_no_ip_are_not_reported_as_sharing_one(self):
+        groups = egress.group_by_egress([UNSEEN, worker(5, "other")])
+        assert len(groups) == 1
+        assert groups[0]["known"] is False
+        assert groups[0]["shared"] is False, "two unchecked machines are not a conflict"
+
+    def test_an_unchecked_worker_has_no_known_peers(self):
+        assert egress.peers_sharing_egress(UNSEEN, [HOME_A, HOME_B, UNSEEN]) == []
+
+    def test_a_shared_address_is_reported_as_shared(self):
+        groups = egress.group_by_egress([HOME_A, HOME_B, REMOTE, UNSEEN])
+        shared = [g for g in groups if g["shared"]]
+        assert len(shared) == 1
+        assert shared[0]["egress_ip"] == "81.61.1.9"
+        assert shared[0]["worker_count"] == 2
+
+    def test_groups_are_largest_first_and_unknown_goes_last(self):
+        groups = egress.group_by_egress([UNSEEN, REMOTE, HOME_A, HOME_B])
+        assert [g["worker_count"] for g in groups] == [2, 1, 1]
+        assert groups[-1]["known"] is False
+
+    def test_a_worker_is_not_its_own_peer(self):
+        assert [w["id"] for w in egress.peers_sharing_egress(HOME_A, [HOME_A, HOME_B])] == [2]
+
+
+class TestNetworkType:
+    @pytest.mark.parametrize(
+        "vendor",
+        ["DigitalOcean", "Amazon EC2", "Hetzner", "  vultr  ", "Google Compute Engine", "OVH SAS"],
+    )
+    def test_hosting_vendors_are_recognised(self, vendor):
+        assert egress.classify_vendor(vendor) == egress.HOSTING
+
+    @pytest.mark.parametrize("vendor", ["QEMU", "VMware, Inc.", "ASUSTeK COMPUTER INC.", "", None, "Innotek GmbH"])
+    def test_a_home_lab_hypervisor_is_not_hosting(self, vendor):
+        """A VM on a home server is a residential connection — the common case here."""
+        assert egress.classify_vendor(vendor) == egress.UNKNOWN
+
+    def test_unrecognised_values_normalise_to_unknown(self):
+        assert egress.normalise_network_type("datacenter") == egress.UNKNOWN
+        assert egress.normalise_network_type(None) == egress.UNKNOWN
+        assert egress.normalise_network_type("HOSTING") == egress.HOSTING
+
+    def test_a_group_with_disagreeing_members_claims_nothing(self):
+        a = worker(1, "a", "81.61.1.9", network="hosting")
+        b = worker(2, "b", "81.61.1.9", network="residential")
+        assert egress.group_by_egress([a, b])[0]["network_type"] == egress.UNKNOWN
+
+    def test_a_group_agrees_when_its_members_do(self):
+        a = worker(1, "a", "81.61.1.9", network="hosting")
+        b = worker(2, "b", "81.61.1.9")
+        assert egress.group_by_egress([a, b])[0]["network_type"] == egress.HOSTING
+
+    def test_malformed_system_info_does_not_raise(self):
+        assert egress.egress_of({"system_info": "not-a-dict"}) is None
+        assert egress.network_type_of({"system_info": None}) == egress.UNKNOWN
+        assert egress.egress_of(None) is None
+
+
+class TestDevicesPerIpLimit:
+    def test_absent_means_undocumented_not_unlimited(self):
+        assert egress.devices_per_ip_limit({"requirements": {}}) is None
+        assert egress.devices_per_ip_limit({}) is None
+        assert egress.devices_per_ip_limit(None) is None
+
+    def test_zero_means_documented_as_unlimited(self):
+        assert egress.devices_per_ip_limit(UNLIMITED) == 0
+
+    def test_a_real_limit_is_read(self):
+        assert egress.devices_per_ip_limit(ONE_PER_IP) == 1
+
+    def test_garbage_is_undocumented_rather_than_guessed(self):
+        assert egress.devices_per_ip_limit({"requirements": {"devices_per_ip": "one"}}) is None
+        assert egress.devices_per_ip_limit({"requirements": {"devices_per_ip": -3}}) is None
+
+
+class TestRunningSlugs:
+    def test_only_running_containers_count(self):
+        w = {"containers": [{"service": "a", "status": "running"}, {"service": "b", "status": "exited"}]}
+        assert egress.running_slugs(w) == {"a"}
+
+    def test_malformed_container_lists_are_ignored(self):
+        assert egress.running_slugs({"containers": "[]"}) == set()
+        assert egress.running_slugs({"containers": ["x", {"status": "running"}]}) == set()
+        assert egress.running_slugs(None) == set()
+
+
+class TestPreflightSeesTheRestOfTheFleet:
+    """The differentiator: a single-host tool cannot see any of this."""
+
+    def test_a_one_per_ip_service_on_a_sibling_behind_one_ip_earns_nothing(self):
+        out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
+        assert out["verdict"] == preflight.EARNS_NOTHING
+        joined = " ".join(f["message"] for f in out["findings"])
+        assert "watchtower" in joined, "the user has to know WHICH machine"
+        assert "81.61.1.9" in joined
+
+    def test_an_undocumented_limit_says_it_does_not_know(self):
+        out = preflight.assess(UNDOCUMENTED, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
+        assert out["verdict"] == preflight.CHECK_YOURSELF
+        assert "documented" in " ".join(f["message"] for f in out["findings"])
+
+    def test_a_documented_unlimited_service_is_only_reduced(self):
+        out = preflight.assess(UNLIMITED, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
+        assert out["verdict"] == preflight.REDUCED
+
+    def test_a_documented_multi_device_limit_counts_the_instances(self):
+        three = {"slug": "honeygain", "name": "Honeygain", "requirements": {"devices_per_ip": 3}}
+        out = preflight.assess(three, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
+        assert out["verdict"] == preflight.REDUCED
+
+        crowded = [worker(i, f"w{i}", "81.61.1.9", running=["honeygain"]) for i in range(10, 13)]
+        out = preflight.assess(three, worker=HOME_B, fleet_workers=[*crowded, HOME_B])
+        assert out["verdict"] == preflight.EARNS_NOTHING
+
+    def test_a_different_public_ip_is_not_a_conflict(self):
+        out = preflight.assess(ONE_PER_IP, worker=REMOTE, fleet_workers=[HOME_A, REMOTE])
+        assert out["verdict"] != preflight.EARNS_NOTHING
+
+    def test_an_undetected_ip_produces_no_fleet_finding_at_all(self):
+        """Better silent than inventing a conflict we did not observe."""
+        out = preflight.assess(ONE_PER_IP, worker=UNSEEN, fleet_workers=[HOME_A, UNSEEN])
+        assert out["findings"] == []
+        assert "egress IP type" in out["not_checked"]
+
+    def test_a_sibling_not_running_the_service_is_not_a_conflict(self):
+        out = preflight.assess(ONE_PER_IP, worker=HOME_A, fleet_workers=[HOME_A, worker(9, "idle", "81.61.1.9")])
+        assert out["findings"] == []
+
+    def test_a_stopped_sibling_container_is_not_a_conflict(self):
+        stopped = worker(9, "stopped", "81.61.1.9", running=["honeygain"], status="exited")
+        out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[stopped, HOME_B])
+        assert out["findings"] == []
+
+    def test_a_known_egress_ip_stops_advertising_it_as_unchecked(self):
+        out = preflight.assess(UNLIMITED, worker=HOME_B, fleet_workers=[HOME_B])
+        assert "egress IP type" not in out["not_checked"]
+        assert "connection speed" in out["not_checked"]
+
+    def test_it_still_never_blocks(self):
+        out = preflight.assess(ONE_PER_IP, worker=HOME_B, fleet_workers=[HOME_A, HOME_B])
+        assert out["blocking"] is False
+
+    def test_no_fleet_context_degrades_to_the_old_behaviour(self):
+        out = preflight.assess(ONE_PER_IP)
+        assert out["verdict"] == preflight.LOOKS_FINE
+        assert "egress IP type" in out["not_checked"]
+
+
+class TestResidentialOnlyOnAHostedMachine:
+    RESI = {
+        "slug": "honeygain",
+        "name": "Honeygain",
+        "requirements": {"residential_ip": True, "vps_ip": False},
+    }
+
+    def test_a_hosted_worker_turns_the_precondition_into_a_verdict(self):
+        out = preflight.assess(self.RESI, worker=REMOTE, fleet_workers=[REMOTE], system_info=REMOTE["system_info"])
+        assert out["verdict"] == preflight.EARNS_NOTHING
+        assert "hosted/VPS" in " ".join(f["message"] for f in out["findings"])
+
+    def test_an_unknown_connection_stays_the_users_problem_not_a_false_pass(self):
+        out = preflight.assess(self.RESI, worker=HOME_B, fleet_workers=[HOME_B], system_info=HOME_B["system_info"])
+        assert out["verdict"] == preflight.CHECK_YOURSELF
+        assert "cannot check" in " ".join(f["message"] for f in out["findings"])
+
+    def test_it_is_stated_once_not_twice(self):
+        out = preflight.assess(self.RESI, worker=REMOTE, fleet_workers=[REMOTE], system_info=REMOTE["system_info"])
+        assert len([f for f in out["findings"] if "residential" in f["message"].lower()]) == 1
+
+
+class TestWorkerSideDetection:
+    def test_an_explicit_declaration_beats_the_hardware_guess(self, monkeypatch):
+        from app import worker_api
+
+        monkeypatch.setenv("CASHPILOT_WORKER_NETWORK", "residential")
+        assert worker_api._detect_network_type() == egress.RESIDENTIAL
+
+    def test_a_bad_declaration_falls_through_to_unknown(self, monkeypatch):
+        from app import worker_api
+
+        monkeypatch.setenv("CASHPILOT_WORKER_NETWORK", "datacenter")
+        monkeypatch.setattr(worker_api, "_DMI_PATHS", ())
+        assert worker_api._detect_network_type() == egress.UNKNOWN
+
+    def test_a_hosting_vendor_in_dmi_is_detected(self, monkeypatch, tmp_path):
+        from app import worker_api
+
+        monkeypatch.delenv("CASHPILOT_WORKER_NETWORK", raising=False)
+        vendor = tmp_path / "sys_vendor"
+        vendor.write_text("DigitalOcean\n")
+        monkeypatch.setattr(worker_api, "_DMI_PATHS", (str(tmp_path / "missing"), str(vendor)))
+        assert worker_api._detect_network_type() == egress.HOSTING
+
+    @pytest.mark.asyncio
+    async def test_detection_can_be_switched_off(self, monkeypatch):
+        from app import worker_api
+
+        monkeypatch.setenv("CASHPILOT_EGRESS_DETECT", "off")
+        assert await worker_api._detect_egress_ip() is None
+
+    @pytest.mark.asyncio
+    async def test_an_override_is_honoured_and_still_validated(self, monkeypatch):
+        from app import worker_api
+
+        monkeypatch.delenv("CASHPILOT_EGRESS_DETECT", raising=False)
+        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+        monkeypatch.setenv("CASHPILOT_EGRESS_IP", "81.61.1.9")
+        assert await worker_api._detect_egress_ip() == "81.61.1.9"
+
+        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+        monkeypatch.setenv("CASHPILOT_EGRESS_IP", "192.168.1.5")
+        assert await worker_api._detect_egress_ip() is None, "a LAN override is still a LAN address"
+
+    @pytest.mark.asyncio
+    async def test_every_endpoint_failing_yields_none_not_a_guess(self, monkeypatch):
+        from app import worker_api
+
+        for var in ("CASHPILOT_EGRESS_DETECT", "CASHPILOT_EGRESS_IP", "CASHPILOT_EGRESS_IP_URL"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+
+        class Boom:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url):
+                raise OSError("no network")
+
+        monkeypatch.setattr(worker_api.httpx, "AsyncClient", lambda **kw: Boom())
+        assert await worker_api._detect_egress_ip() is None
+
+    @pytest.mark.asyncio
+    async def test_a_lookup_response_is_validated_before_it_is_trusted(self, monkeypatch):
+        from app import worker_api
+
+        for var in ("CASHPILOT_EGRESS_DETECT", "CASHPILOT_EGRESS_IP", "CASHPILOT_EGRESS_IP_URL"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(worker_api, "_egress_cache", (None, 0.0))
+
+        class Resp:
+            status_code = 200
+            text = "<html>error page</html>"
+
+        class Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url):
+                return Resp()
+
+        monkeypatch.setattr(worker_api.httpx, "AsyncClient", lambda **kw: Client())
+        assert await worker_api._detect_egress_ip() is None
+
+
+class TestEndpoints:
+    """Including the regression: worker rows arrive as JSON TEXT, not dicts."""
+
+    def _call(self, fn, *args, workers=None):
+        import asyncio
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        # Rows exactly as SQLite hands them back: containers/system_info are strings.
+        rows = [
+            {**w, "containers": json.dumps(w["containers"]), "system_info": json.dumps(w["system_info"])}
+            for w in (workers or [])
+        ]
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=rows)),
+                patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
+                patch.object(main.catalog, "get_service", return_value=ONE_PER_IP),
+            ):
+                return await fn(MagicMock(), *args)
+
+        return asyncio.run(run())
+
+    def test_preflight_with_a_worker_id_does_not_500_on_raw_json_columns(self):
+        """Shipped code passed the raw TEXT column to code expecting a mapping."""
+        out = self._call(main_preflight(), "honeygain", 2, workers=[HOME_A, HOME_B])
+        assert out["verdict"] == "will_earn_nothing"
+        assert "watchtower" in " ".join(f["message"] for f in out["findings"])
+
+    def test_preflight_for_an_unknown_worker_is_a_404(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main_preflight(), "honeygain", 99, workers=[HOME_A])
+        assert exc.value.status_code == 404
+
+    def test_preflight_without_a_worker_id_still_works(self):
+        out = self._call(main_preflight(), "honeygain", None, workers=[HOME_A])
+        assert out["blocking"] is False
+
+    def test_egress_groups_reports_sharing_and_the_undetermined_separately(self):
+        out = self._call(main_groups(), workers=[HOME_A, HOME_B, REMOTE, UNSEEN])
+        assert out["shared_groups"] == 1
+        assert out["undetermined"] == 1
+        shared = next(g for g in out["groups"] if g["shared"])
+        assert shared["egress_ip"] == "81.61.1.9"
+        assert {w["name"] for w in shared["workers"]} == {"watchtower", "geiserback"}
+
+    def test_egress_groups_on_an_empty_fleet_is_empty_not_an_error(self):
+        out = self._call(main_groups(), workers=[])
+        assert out == {"groups": [], "shared_groups": 0, "undetermined": 0}
+
+
+def main_preflight():
+    from app import main
+
+    return main.api_service_preflight
+
+
+def main_groups():
+    from app import main
+
+    return main.api_fleet_egress_groups

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -123,7 +123,6 @@ _SEEN = {
 class TestPreflightEndpoint:
     def _call(self, slug, worker_id=None, worker=None, deployments=None):
         import asyncio
-        import json  # noqa: F401 — used by callers building realistic rows
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from app import main

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -11,6 +11,8 @@ implies a check that was not run.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from app import catalog, preflight
@@ -121,6 +123,7 @@ _SEEN = {
 class TestPreflightEndpoint:
     def _call(self, slug, worker_id=None, worker=None, deployments=None):
         import asyncio
+        import json  # noqa: F401 — used by callers building realistic rows
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from app import main
@@ -129,7 +132,7 @@ class TestPreflightEndpoint:
             with (
                 patch.object(main, "_require_auth_api", lambda r: None),
                 patch.object(main.database, "get_deployments", AsyncMock(return_value=deployments or [])),
-                patch.object(main.database, "get_worker", AsyncMock(return_value=worker)),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=[worker] if worker else [])),
             ):
                 return await main.api_service_preflight(MagicMock(), slug, worker_id=worker_id)
 
@@ -149,10 +152,18 @@ class TestPreflightEndpoint:
         assert result["blocking"] is False
 
     def test_a_duplicate_on_the_named_worker_is_detected(self):
-        """Scoped to that worker: a per-IP limit is about ONE machine."""
+        """Scoped to that worker: a per-IP limit is about ONE machine.
+
+        The worker row is built the way SQLite actually returns one — JSON TEXT
+        columns, and the container keyed by ``slug`` as the heartbeat emits it.
+        Fixtures that used dicts and ``service`` are why a 500 and a
+        never-matching filter both shipped green.
+        """
         worker = {
-            "containers": [{"service": "honeygain"}],
-            "system_info": {"arch": "x86_64"},
+            "id": 1,
+            "client_id": "cid-1",
+            "containers": json.dumps([{"slug": "honeygain", "status": "running"}]),
+            "system_info": json.dumps({"arch": "x86_64"}),
         }
         result = self._call("honeygain", worker_id=1, worker=worker)
         assert result["verdict"] in {preflight.REDUCED, preflight.EARNS_NOTHING}

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -227,3 +227,51 @@ class TestProducerStateEndpoint:
 
         out = asyncio.run(run())
         assert out["state"] == ps.PRODUCING
+
+
+class TestItReadsTheShapeWorkersActuallySend:
+    """Regression: this matched on ``service`` while heartbeats emit ``slug``.
+
+    Every service therefore reported "the container is not running" in
+    production — the feature was inert — and the tests above passed because they
+    hand-fed the key the code was looking for rather than the key it would get.
+    """
+
+    def _call(self, containers, logs=""):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        svc = {"slug": "demo", "docker": {"health_signals": [FAILED_LOGIN]}}
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.catalog, "get_service", return_value=svc),
+                patch.dict("app.collectors.COLLECTOR_MAP", {"demo": object()}, clear=True),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"demo": 0.0})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
+                patch.object(main, "_proxy_worker_logs", AsyncMock(return_value={"logs": logs})),
+            ):
+                return await main.api_producer_state(MagicMock(), "demo")
+
+        return asyncio.run(run())
+
+    REAL = [{"slug": "demo", "status": "running", "_worker_id": 1, "name": "cashpilot-demo"}]
+
+    def test_a_container_keyed_by_slug_is_found(self):
+        assert self._call(self.REAL)["state"] == ps.IDLE
+
+    def test_its_logs_are_actually_fetched_and_matched(self):
+        """Not finding the container also meant never reading its logs."""
+        out = self._call(self.REAL, logs="ERROR login failed")
+        assert out["state"] == ps.FAILING
+
+    def test_the_legacy_service_key_still_matches(self):
+        legacy = [{"service": "demo", "status": "running", "_worker_id": 1}]
+        assert self._call(legacy)["state"] == ps.IDLE
+
+    def test_an_unrelated_container_is_not_matched(self):
+        other = [{"slug": "something-else", "status": "running", "_worker_id": 1}]
+        assert self._call(other)["state"] == ps.UNKNOWN


### PR DESCRIPTION
Every bandwidth provider caps **per IP address, not per device**. Honeygain treats a second active device on a network as *"network overused"*; EarnApp documents that extra devices behind one IP share a single daily cap.

CashPilot's whole fleet model encourages deploying a service to several machines, and warned about none of it. Two workers in one house are two rows on the dashboard and **one customer** to the provider — so the second earns nothing.

Seeing this requires knowing about the *other* machines, which is why a single-host tool structurally cannot do it.

## What lands

- Each worker reports its public egress IP and, where it can tell locally, whether it is a hosted machine.
- Deploying to a worker that shares an address with one already running the service is called out **by name**, before the deploy.
- `GET /api/fleet/egress-groups` groups the fleet by exit rather than by host.
- A residential-only service on a machine that identifies itself as a VPS is no longer a polite "check this yourself" — it's a verdict.

## Three rules that keep the warning from being wrong

A warning that cries wolf gets switched off, so:

- **An undetected IP is neither shared nor distinct.** Those workers produce *no finding at all* and are bucketed as undetermined.
- **A private address is a detection failure, not an identity.** Concretely: every worker in the reference fleet has a `100.64/10` tailnet address — grouping on it would collapse the entire fleet into one fabricated conflict.
- **An absent `devices_per_ip` means undocumented, not unlimited.** `0` is a verified no-limit; a missing key is not. Only 4 of 50 services declare one.

Detection is local-first: the hosting hint comes from DMI vendor strings, so nothing is disclosed to a third party and it works offline. A bare hypervisor (QEMU, VMware) is deliberately **not** hosting — a VM on a home server is a residential connection.

## Two defects fixed, one confirmed live in 1.7.0

- **`/api/services/{slug}/preflight?worker_id=N` returned 500.** Confirmed against the deployed UI on real worker rows: `AttributeError: 'str' object has no attribute 'get'`. `list_workers` returns JSON *text* columns; the endpoint treated them as dicts.
- **`/api/services/{slug}/producer-state` never matched a container** — it filtered on `c["service"]` while heartbeats emit `slug`, so every service reported UNKNOWN. Merged after 1.7.0, so it never reached production.

Both had passing tests, because both fixtures hand-fed a shape production never produces. Tests now build rows the way SQLite actually returns them.

## Review

An independent review raised 22 findings; each was reproduced by execution before being acted on. The serious ones: a stalled IP lookup could stall the **serial** heartbeat loop and take a worker offline (httpx's timeout is per-operation, not a deadline), and `not_checked` claimed the connection type was checked while a finding beside it said it couldn't be. Also fixed: an off-by-one that under-warned, Android workers invisible to the check, a custom IP endpoint silently falling back to third parties, and **a unit test making a real network request**.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1704 passed**, coverage 94.60%
- Verified against real hardware: both home servers report `ASUSTeK COMPUTER INC.` and correctly classify as *not* hosting; the DMI path is readable from inside the worker container; the worker image module set was simulated to prove `app/egress.py` adds no import the worker lacks.

Detection is on by default and makes one outbound call per hour, so it is documented in the README (not just `CLAUDE.md`) with `CASHPILOT_EGRESS_DETECT=off` and two ways to avoid the third party entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fleet-wide egress IP grouping and a new endpoint for viewing shared, unknown, and worker-specific egress details.
  - Worker heartbeats now report egress IP and network type.
  - Added configuration for network classification, IP detection, explicit egress addresses, and custom lookup endpoints.
- **Bug Fixes**
  - Preflight checks now detect shared egress conflicts, per-IP limits, duplicate instances, and hosted-network mismatches.
  - Improved worker and service-state handling, including legacy container data compatibility.
  - Heartbeats recover from temporary detection or network failures.
- **Documentation**
  - Documented egress tracking, privacy controls, fleet grouping, limits, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->