### PR TITLE
fix: record only per-IP limits a provider actually states (CashPilot-4qv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Services CashPilot can deploy and manage automatically via Docker.
 | [Anyone Protocol](https://anyone.io) | [Guide](docs/guides/anyone-protocol.md) | ✅ | ✅ | Unlimited | 1 | Crypto (ANYONE) |
 | [Bitping](https://app.bitping.com) | [Guide](docs/guides/bitping.md) | ✅ | ✅ | Unlimited | 1 | Crypto (SOL) |
 | [Earn.fm](https://earn.fm/ref/GEISYB91) | [Guide](docs/guides/earnfm.md) | ✅ | ✅ | Unlimited | 1 | Crypto |
-| [EarnApp](https://earnapp.com/i/TSMD9wSm) | [Guide](docs/guides/earnapp.md) | ✅ | ❌ | 15 | 1 | PayPal, Gift Cards, Wise |
+| [EarnApp](https://earnapp.com/i/TSMD9wSm) \*\*\*\* | [Guide](docs/guides/earnapp.md) | ✅ | ❌ | 15 | 1 | PayPal, Gift Cards, Wise |
 | [Honeygain](https://dashboard.honeygain.com/ref/SERGIB4014) | [Guide](docs/guides/honeygain.md) | ✅ | ❌ | 10 | 1 | PayPal, Crypto |
 | [IPRoyal Pawns](https://pawns.app?r=19266874) | [Guide](docs/guides/iproyal.md) | ✅ | ❌ | Unlimited | 1 | PayPal, Crypto, Bank Transfer |
 | [MystNodes](https://mystnodes.co/?referral_code=do7v7YOoBBpbOstKQovX2pUvZYKia4ZhH3QIdNtE) | [Guide](docs/guides/mysterium.md) | ✅ | ✅ | Unlimited | Unlimited | Crypto (MYST) |
@@ -74,8 +74,8 @@ Services CashPilot can deploy and manage automatically via Docker.
 | [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO) | [Guide](docs/guides/proxybase.md) | ✅ | ✅ | Unlimited | 1 | Crypto |
 | [ProxyBase Markets](https://proxybase.xyz) | [Guide](docs/guides/proxybase-xyz.md) | ❌ | ✅ | Unlimited | 1 | Crypto (USDC) |
 | [ProxyLite](https://proxylite.ru/?r=KMUPRZIZ) | [Guide](docs/guides/proxylite.md) | ✅ | ✅ | Unlimited | 1 | Crypto, PayPal |
-| [ProxyRack](https://peer.proxyrack.com/ref/mpwiok3xlaxeycnn5znqlg7ipjeutxyxr6xl7vmn) | [Guide](docs/guides/proxyrack.md) | ✅ | ✅ | 500 | 1 | PayPal, Crypto |
-| [Repocket](https://repocket.com/) | [Guide](docs/guides/repocket.md) | ✅ | ❌ | 5 | 2 | PayPal, Crypto |
+| [ProxyRack](https://peer.proxyrack.com/ref/mpwiok3xlaxeycnn5znqlg7ipjeutxyxr6xl7vmn) | [Guide](docs/guides/proxyrack.md) | ✅ | ✅ | 500 | ? \*\*\* | PayPal, Crypto |
+| [Repocket](https://repocket.com/) | [Guide](docs/guides/repocket.md) | ✅ | ❌ | 5 | ? \*\*\* | PayPal, Crypto |
 | [Storj](https://www.storj.io/node) | [Guide](docs/guides/storj.md) | ✅ | ✅ | Unlimited | 1 \* | Crypto (STORJ) |
 | [Traffmonetizer](https://traffmonetizer.com/?aff=2111758) | [Guide](docs/guides/traffmonetizer.md) | ✅ | ✅ \*\* | Unlimited | Unlimited | Crypto (USDT), PayPal |
 | [URnetwork](https://ur.io/?referral_code=1Q3G19) | [Guide](docs/guides/urnetwork.md) | ✅ | ✅ | Unlimited | 1 | Crypto |
@@ -83,6 +83,10 @@ Services CashPilot can deploy and manage automatically via Docker.
 > \* Storj nodes on the same /24 subnet share data allocation, reducing per-node earnings.
 >
 > \*\* Traffmonetizer ToS requires residential IP, but VPS nodes are accepted in practice.
+>
+> \*\*\*\* EarnApp's help centre **prohibits** Docker containers, VMs, hosting services and home servers, with account termination and cancellation of pending payments as the stated penalty — which is exactly how CashPilot deploys it. Read the [guide](docs/guides/earnapp.md) before deploying.
+>
+> \*\*\* `?` means the provider does not publish a per-IP device limit. A number widely repeated on review sites is not a source — see [per-IP device limits](docs/research/per-ip-device-limits.md). Rows showing `1` without a citation there have not been re-verified against the provider's terms.
 
 ### Browser Extension / Desktop Only
 
@@ -93,7 +97,7 @@ These services have no Docker image. CashPilot lists them in the catalog with si
 | [Bytelixir](https://bytelixir.com/r/OYEIRE0VSZBZ) | [Guide](docs/guides/bytelixir.md) | ✅ | ❌ | Unlimited | 1 | Crypto | Active |
 | [Dawn Internet](https://dawninternet.com/?code=2QLQV97F) | [Guide](docs/guides/dawn.md) | ✅ | ❌ | Unlimited | 1 | Crypto (DAWN) | Active |
 | [Deeper Network](https://deeper.network) | [Guide](docs/guides/deeper-network.md) | ✅ | ❌ | Unlimited | 1 | Crypto (DPR) | Active |
-| [Ebesucher](https://www.ebesucher.com/?ref=geiserx) | [Guide](docs/guides/ebesucher.md) | ✅ | ✅ | Unlimited | 1 | PayPal | Active |
+| [Ebesucher](https://www.ebesucher.com/?ref=geiserx) | [Guide](docs/guides/ebesucher.md) | ✅ | ❌ | Unlimited | 1 | PayPal | Active |
 | [Gradient Network](https://app.gradient.network/signup?referralCode=YSKMY7) | [Guide](docs/guides/gradient.md) | ✅ | ❌ | Unlimited | 1 | Crypto (GRADIENT) | Active |
 | [Grass](https://app.grass.io/register?referralCode=kn8FNEPnUr2tMqE) | [Guide](docs/guides/grass.md) | ✅ | ❌ | Unlimited | 1 | Crypto (GRASS) | Active |
 | [Helium](https://helium.com) | [Guide](docs/guides/helium.md) | ✅ | ❌ | Unlimited | 1 | Crypto (HNT) | Active |

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -225,6 +225,14 @@ def assess(
 
 def _summary(verdict: str, service: dict[str, Any]) -> str:
     name = service.get("name") or service.get("slug") or "This service"
+    if (service.get("requirements") or {}).get("container_prohibited"):
+        # "will earn nothing" is the right severity but the wrong words: the
+        # outcome here is a closed account and a cancelled balance, not a
+        # disappointing month.
+        return (
+            f"{name} forbids being run this way. The risk is not low earnings — it is a "
+            "terminated account with any pending payment cancelled. You can still deploy it."
+        )
     if verdict == EARNS_NOTHING:
         return f"{name} will most likely earn nothing here. You can deploy it anyway."
     if verdict == REDUCED:

--- a/app/preflight.py
+++ b/app/preflight.py
@@ -97,6 +97,26 @@ def assess(
             )
             verdicts.append(REDUCED)
 
+    # The provider forbids the very thing CashPilot does. This outranks every
+    # other finding: the outcome is not "earns less", it is a terminated account
+    # with the pending balance cancelled, and CashPilot deploying it as a
+    # container is itself the violation. Saying nothing here would be the worst
+    # possible silence, because the tool causes the breach on the user's behalf.
+    if reqs.get("container_prohibited"):
+        findings.append(
+            {
+                "verdict": EARNS_NOTHING,
+                "message": (
+                    "This provider forbids running its software in Docker containers, on virtual "
+                    "machines, on home servers, or for monetisation — which is exactly what "
+                    "CashPilot does. Their stated penalty is termination without notice and "
+                    "cancellation of any pending payment. Deploying this here means accepting "
+                    "that risk knowingly."
+                ),
+            }
+        )
+        verdicts.append(EARNS_NOTHING)
+
     # Hardware the container cannot conjure.
     if reqs.get("gpu"):
         findings.append(

--- a/docs/guides/earnapp.md
+++ b/docs/guides/earnapp.md
@@ -3,9 +3,27 @@
 > **Category:** Bandwidth Sharing | **Status:** Active
 > **Website:** [https://earnapp.com](https://earnapp.com)
 
+!!! danger "EarnApp prohibits the way CashPilot runs it — read this first"
+
+    EarnApp's help centre states: **"Installing EarnApp on Virtual Machines
+    (VMs), Docker containers, or hosting services is strictly prohibited."** It
+    names **personal or home servers** and **"any device used for business or
+    monetization purposes"** as prohibited environments, and says the penalty is
+    that your **account is terminated without prior notice** and any **pending
+    payments are cancelled**.
+
+    CashPilot deploys every service as a Docker container, usually on a home
+    server. **Deploying EarnApp through CashPilot means knowingly accepting that
+    risk.** This guide is kept so the decision is an informed one, not so the
+    risk is hidden behind a signup link.
+
+    EarnApp does support ordinary desktops, laptops, phones and Raspberry Pi via
+    its own installer. If you want to earn with it, that is the route that does
+    not put your account and balance at risk — and CashPilot cannot manage it.
+
 ## Description
 
-EarnApp by Bright Data lets you sell your unused bandwidth for passive income. Bright Data is the world's largest proxy network, powering data collection for Fortune 500 companies. The community Docker image (fazalfarhan01) makes headless deployment easy with a lite mode that requires only a UUID.
+EarnApp by Bright Data lets you sell your unused bandwidth for passive income. Bright Data is the world's largest proxy network, powering data collection for Fortune 500 companies.
 
 ## Earning Estimates
 

--- a/docs/research/per-ip-device-limits.md
+++ b/docs/research/per-ip-device-limits.md
@@ -49,6 +49,31 @@ source at all**:
 - **proxyrack — "2 devices per IP"**. Same pattern. Proxyrack's two device-limit
   help articles (the newer dated 2026-02-23) mention only a 500-per-account cap.
 
+## EarnApp prohibits containers outright
+
+Verified first-party (help centre, "Can I install EarnApp on Hosting Services,
+Virtual Machines or Dockers?", updated 2025):
+
+> **No. Installing EarnApp on Virtual Machines (VMs), Docker containers, or
+> hosting services is strictly prohibited.**
+>
+> Prohibited environments: Virtual Machines (VMs) · Docker containers · Cloud
+> hosting services · **Personal or home servers** · Any device used for business
+> or monetization purposes.
+>
+> If our system detects that EarnApp is running in a virtualized or unauthorized
+> environment: your account will be **terminated without prior notice**, any
+> **pending payments will be canceled**.
+
+CashPilot deploys every service as a Docker container, so shipping EarnApp
+without saying this would make the tool the cause of the ban. It is recorded as
+`requirements.container_prohibited: true`, which the preflight reports as its
+strongest verdict. The deploy is still allowed — informed consent, not a block.
+
+No other catalogued service has been found to name containers this way. The flag
+requires a first-party source and must never be inferred from a residential-IP
+rule; a test enforces that only sourced services carry it.
+
 ## VPS / datacenter acceptance
 
 | Service | Policy |

--- a/docs/research/per-ip-device-limits.md
+++ b/docs/research/per-ip-device-limits.md
@@ -15,12 +15,18 @@ relying on any row.
 
 ## Documented by the provider
 
+Every row must carry a URL. The one row that did not — spide — is the row that
+was wrong: it was filed under "no number" while the provider's Terms state a
+limit of one, in the sentence immediately before the one that was quoted. A
+reviewer with a link opens the page and sees it; without one, the error survives.
+
 | Service | devices_per_ip | Kind | Source |
 |---|---|---|---|
-| honeygain | **1** | hard limit | Help centre: "Users may connect 1 device per one IP/Network." Extra devices trigger a "Network overused" error. |
-| iproyal (Pawns.app) | **1** | hard limit | Terms of Use: "Pawns.app limits the number of devices per single IP address to one (1)." |
-| earnfm | **1** | hard limit | Help centre: "One Device Per Network: Each device should be connected to a unique IP or network." |
-| ebesucher | **1** | hard limit | Official blog: multi-device is allowed only if "each device ... has to be connected to the Internet through a unique IP address." |
+| honeygain | **1** | hard limit, enforced | Help centre: *"Users may connect 1 device per one IP/Network."* Extra devices trigger a `Network overused` error. <https://support.honeygain.com/hc/en-us/articles/360011188779> |
+| iproyal (Pawns.app) | **1** | hard limit, in binding Terms | *"Pawns.app limits the number of devices per single IP address to one (1)."* <https://pawns.app/terms-of-use/> |
+| spide | **1** | hard limit, in binding Terms | *"Spide Network limits the number of devices per single IP address to one."* Restrictions also forbid *"connect[ing] more than the allowed number of devices"*. The same paragraph adds that traffic through one IP *"will be distributed between devices utilizing the same IP address"*. <https://spide.network/terms-of-use.html> |
+| earnfm | **1** | help-centre guidance, not a Terms clause | *"One Device Per Network: Each device **should** be connected to a unique IP or network."* Phrased as guidance; no device-per-IP clause found in the Terms, so treat enforcement as unproven. <https://help.earn.fm/portal/en/kb/articles/do-i-earn-more-if-i-run-earnfm-on-multiple-devices> |
+| ebesucher | **1** | hard limit | Multi-device is allowed only if *"each device ... has to be connected to the Internet through a unique IP address."* <https://www.ebesucher.com/blog/besuchertausch/multigeraete-funktion> |
 
 ## Documented as sharing, with no number
 
@@ -30,9 +36,12 @@ the effect belongs in `requirements.note`.
 
 | Service | What the provider says |
 |---|---|
-| earnapp | Extra devices on one IP "will get less priority for traffic" and do not increase earnings beyond the per-IP cap. |
-| spide | Terms: "traffic sent through a single public IP address will be distributed between devices utilizing the same IP address." |
+| earnapp | Extra devices on one IP *"will get less priority for traffic"* and do not increase earnings beyond the per-IP cap. <https://help.earnapp.com/hc/en-us/articles/10198969950353> |
 | storj | Nodes in the same /24 subnet share allocation (already captured in that file's `note`). |
+
+*(spide was listed here in the first draft. That was wrong — it belongs in the
+table above. Its Terms state a limit of one; the sharing sentence quoted here
+sits in the same paragraph as the limit sentence, which was missed.)*
 
 ## Not documented anywhere official
 
@@ -42,12 +51,18 @@ Two of these have a number that circulates widely and traces to **no provider
 source at all**:
 
 - **repocket — "2 devices per IP"**. Repeated across review blogs. Repocket's own
-  Terms state only a per-ACCOUNT limit ("up to five (5) devices ... and a maximum
-  of five (5) active sessions"), which is a different thing.
-  **The catalog currently declares `devices_per_ip: 2` for repocket on this
-  basis.** It predates this research and should be re-sourced or removed.
-- **proxyrack — "2 devices per IP"**. Same pattern. Proxyrack's two device-limit
-  help articles (the newer dated 2026-02-23) mention only a 500-per-account cap.
+  Terms state only a per-ACCOUNT limit (*"up to five (5) devices ... and a
+  maximum of five (5) active sessions"*), which is a different thing.
+  <https://repocket.com/terms-and-conditions>
+  The catalog declared `devices_per_ip: 2` on that basis; it has been removed.
+  Note the honest limit of this conclusion: `help.repocket.com` is a dead host
+  and `repocket.com/faq` 404s, so this is *no first-party source found*, which is
+  weaker than *no first-party source exists*.
+- **proxyrack — "2 devices per IP"**. Same pattern; third-party reviews claim
+  both 1 and 2 and contradict each other. Proxyrack's two device-limit help
+  articles (the newer dated 2026-02-23) mention only a 500-per-account cap.
+  Datacentre IPs are accepted at roughly a tenth of the residential rate.
+  <https://help.proxyrack.com/en/articles/6532815>
 
 ## EarnApp prohibits containers outright
 

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -99,6 +99,12 @@
 #       real effect regardless of what the provider permits.
 #   Only write 0 when the provider actually says so. Writing it to quieten a
 #   warning turns a cautious message into a wrong one.
+#   container_prohibited: true/false  (default false)
+#     Set ONLY when the provider explicitly forbids containers/VMs/servers for
+#     its own software. This is the strongest verdict the preflight can give:
+#     the outcome is a terminated account with the pending balance cancelled,
+#     and CashPilot deploying the service as a container IS the violation.
+#     Requires a first-party source; never infer it from a residential-IP rule.
 #   note: ""  (footnote text for special cases in README table)
 #   note_column: ""  (which column footnote applies to: vps_ip, devices_per_ip)
 #   min_bandwidth: ""

--- a/services/bandwidth/earnapp.yml
+++ b/services/bandwidth/earnapp.yml
@@ -40,6 +40,8 @@ docker:
 
 requirements:
   residential_ip: true
+  vps_ip: false
+  container_prohibited: true
   devices_per_account: 15
   min_bandwidth: ""
   gpu: false

--- a/services/bandwidth/earnfm.yml
+++ b/services/bandwidth/earnfm.yml
@@ -33,6 +33,7 @@ docker:
 requirements:
   residential_ip: true
   vps_ip: true
+  devices_per_ip: 1
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/ebesucher.yml
+++ b/services/bandwidth/ebesucher.yml
@@ -23,7 +23,9 @@ docker:
   network_mode: ""
 
 requirements:
-  residential_ip: false
+  residential_ip: true
+  vps_ip: false
+  devices_per_ip: 1
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/honeygain.yml
+++ b/services/bandwidth/honeygain.yml
@@ -44,7 +44,9 @@ docker:
 
 requirements:
   residential_ip: true
+  vps_ip: false
   devices_per_account: 10
+  devices_per_ip: 1
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/iproyal.yml
+++ b/services/bandwidth/iproyal.yml
@@ -51,6 +51,8 @@ docker:
 
 requirements:
   residential_ip: true
+  vps_ip: false
+  devices_per_ip: 1
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/proxyrack.yml
+++ b/services/bandwidth/proxyrack.yml
@@ -46,6 +46,8 @@ docker:
 requirements:
   residential_ip: false
   devices_per_account: 500
+  note: "Proxyrack documents a 500-device limit per ACCOUNT and no per-IP limit. Datacentre IPs are accepted but reclassified to a lower rate."
+  note_column: devices_per_ip
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/repocket.yml
+++ b/services/bandwidth/repocket.yml
@@ -40,7 +40,8 @@ docker:
 requirements:
   residential_ip: true
   devices_per_account: 5
-  devices_per_ip: 2
+  note: "Repocket documents a five-device limit per ACCOUNT but publishes no per-IP device limit. The '2 devices per IP' figure repeated on review sites has no provider source, so CashPilot does not assert it."
+  note_column: devices_per_ip
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/spide.yml
+++ b/services/bandwidth/spide.yml
@@ -28,6 +28,9 @@ docker:
 
 requirements:
   residential_ip: true
+  vps_ip: false
+  note: "Traffic through one public IP is split between the devices sharing it, so a second device on the same connection does not add earnings. Spide states no device-count limit."
+  note_column: devices_per_ip
   min_bandwidth: ""
   gpu: false
   min_storage: ""

--- a/services/bandwidth/spide.yml
+++ b/services/bandwidth/spide.yml
@@ -2,7 +2,7 @@ name: Spide
 slug: spide
 category: bandwidth
 status: active
-website: https://spide.io
+website: https://spide.network
 description: >
   Spide is a bandwidth-sharing service that lets you monetize unused internet
   bandwidth. Uses an optional machine ID for device tracking. Available through
@@ -29,7 +29,8 @@ docker:
 requirements:
   residential_ip: true
   vps_ip: false
-  note: "Traffic through one public IP is split between the devices sharing it, so a second device on the same connection does not add earnings. Spide states no device-count limit."
+  devices_per_ip: 1
+  note: "Traffic through one public IP is split between the devices sharing it, so a second device on the same connection adds nothing."
   note_column: devices_per_ip
   min_bandwidth: ""
   gpu: false

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -221,11 +221,41 @@ class TestProviderForbidsWhatCashPilotDoes:
 class TestSourcedPerIpLimits:
     """Values must trace to a provider statement; see docs/research/per-ip-device-limits.md."""
 
-    @pytest.mark.parametrize("slug", ["honeygain", "iproyal", "earnfm", "ebesucher"])
-    def test_the_four_documented_services_declare_one_per_ip(self, slug):
+    @pytest.mark.parametrize("slug", ["honeygain", "iproyal", "spide", "earnfm", "ebesucher"])
+    def test_the_documented_services_declare_one_per_ip(self, slug):
+        """spide was MISSING from this list, and that is how the bug shipped.
+
+        Its Terms say "Spide Network limits the number of devices per single IP
+        address to one", but the catalog asserted the opposite, because the
+        research quoted the sharing sentence beside the limit sentence and
+        nobody opened the page. A hardcoded list cements whatever it omits, so
+        the note-consistency test below guards the shape of that failure too.
+        """
         from app import catalog
 
-        assert (catalog.get_service(slug)["requirements"] or {}).get("devices_per_ip") == 1
+        svc = catalog.get_service(slug)
+        assert svc is not None, f"{slug} is not in the catalog"
+        assert (svc.get("requirements") or {}).get("devices_per_ip") == 1
+
+    def test_no_note_claims_a_provider_states_no_limit(self):
+        """The Spide failure in one assertion.
+
+        Claiming a provider states there is NO limit is an assertion about their
+        terms, and asserting it wrongly walks the user into a breach. If we
+        cannot find a limit, the honest phrasing is that none was found — never
+        that none exists.
+        """
+        from app import catalog
+
+        banned = ("states no device-count limit", "no device limit", "imposes no limit")
+        for svc in catalog.get_services():
+            note = str((svc.get("requirements") or {}).get("note") or "").lower()
+            for phrase in banned:
+                assert phrase not in note, (
+                    f"{svc['slug']}: note asserts a provider states no limit ({phrase!r}). "
+                    "Verify against their terms and record the URL in "
+                    "docs/research/per-ip-device-limits.md before claiming this."
+                )
 
     @pytest.mark.parametrize("slug", ["repocket", "proxyrack", "packetstream", "bitping", "urnetwork"])
     def test_services_with_no_provider_source_stay_absent(self, slug):
@@ -235,7 +265,9 @@ class TestSourcedPerIpLimits:
         """
         from app import catalog
 
-        assert "devices_per_ip" not in (catalog.get_service(slug)["requirements"] or {})
+        svc = catalog.get_service(slug)
+        assert svc is not None, f"{slug} is not in the catalog"
+        assert "devices_per_ip" not in (svc.get("requirements") or {})
 
     def test_a_second_device_behind_one_ip_now_gets_the_strongest_verdict(self):
         """The point of the bead: the verdict was weak exactly where the
@@ -245,3 +277,50 @@ class TestSourcedPerIpLimits:
         out = preflight.assess(catalog.get_service("honeygain"), already_deployed_slugs={"honeygain"})
         assert out["verdict"] == preflight.EARNS_NOTHING
         assert "one device per IP" in " ".join(f["message"] for f in out["findings"])
+
+
+class TestReadmeMatchesTheCatalog:
+    """The README table is hand-maintained, so it drifts silently.
+
+    It kept publishing Repocket's unsourced "2 devices per IP" after the catalog
+    dropped it, which is the same wrong number in a more visible place. Only
+    services that DECLARE a limit are checked — the rows showing an unsourced 1
+    are a known, documented gap, not something to assert as correct.
+    """
+
+    def _row_for(self, readme: str, slug: str) -> str | None:
+        for line in readme.splitlines():
+            if f"docs/guides/{slug}.md" in line and line.startswith("|"):
+                return line
+        return None
+
+    def test_every_declared_limit_matches_its_readme_cell(self):
+        from pathlib import Path
+
+        from app import catalog
+
+        readme = Path("README.md").read_text(encoding="utf-8")
+        checked = 0
+        for svc in catalog.get_services():
+            limit = (svc.get("requirements") or {}).get("devices_per_ip")
+            if limit is None:
+                continue
+            row = self._row_for(readme, svc["slug"])
+            if row is None:
+                continue
+            cells = [c.strip() for c in row.split("|")]
+            expected = "Unlimited" if limit == 0 else str(limit)
+            assert expected in cells, (
+                f"{svc['slug']}: catalog says devices_per_ip={limit} but the README row has "
+                f"no matching cell -> {row.strip()}"
+            )
+            checked += 1
+        assert checked >= 5, "expected the documented services to be covered"
+
+    def test_the_readme_no_longer_publishes_the_unsourced_repocket_figure(self):
+        from pathlib import Path
+
+        row = self._row_for(Path("README.md").read_text(encoding="utf-8"), "repocket")
+        assert row is not None
+        cells = [c.strip() for c in row.split("|")]
+        assert "2" not in cells, "the README still asserts a per-IP limit the catalog dropped"

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -171,3 +171,77 @@ class TestPreflightEndpoint:
     def test_without_a_worker_it_falls_back_to_all_deployments(self):
         result = self._call("honeygain", deployments=[{"slug": "honeygain"}])
         assert result["verdict"] in {preflight.REDUCED, preflight.EARNS_NOTHING}
+
+
+class TestProviderForbidsWhatCashPilotDoes:
+    """The strongest verdict: the tool causes the breach on the user's behalf.
+
+    EarnApp's own help centre forbids "Virtual Machines (VMs), Docker
+    containers, ... personal or home servers" and states the penalty as
+    termination without notice plus cancellation of pending payments. CashPilot
+    deploys every service as a Docker container, so shipping EarnApp silently
+    would make the tool the cause of the ban.
+    """
+
+    def test_it_is_reported_and_says_what_actually_happens(self):
+        svc = {"slug": "x", "name": "X", "requirements": {"container_prohibited": True}}
+        out = preflight.assess(svc)
+        assert out["verdict"] == preflight.EARNS_NOTHING
+        message = " ".join(f["message"] for f in out["findings"])
+        assert "Docker containers" in message
+        assert "termination without notice" in message.lower() or "without notice" in message
+
+    def test_it_still_does_not_block_the_deploy(self):
+        """Informed consent: the user may accept the risk knowingly."""
+        svc = {"slug": "x", "requirements": {"container_prohibited": True}}
+        assert preflight.assess(svc)["blocking"] is False
+
+    def test_a_service_without_the_flag_is_unaffected(self):
+        out = preflight.assess({"slug": "x", "requirements": {}})
+        assert not any("Docker containers" in f["message"] for f in out["findings"])
+
+    def test_the_real_catalog_flags_earnapp(self):
+        from app import catalog
+
+        assert preflight.assess(catalog.get_service("earnapp"))["verdict"] == preflight.EARNS_NOTHING
+
+    def test_the_flag_is_not_set_on_services_merely_wanting_a_residential_ip(self):
+        """It requires a first-party source, never an inference from residential_ip."""
+        from app import catalog
+
+        allowed = {"earnapp"}
+        for svc in catalog.get_services():
+            if (svc.get("requirements") or {}).get("container_prohibited"):
+                assert svc["slug"] in allowed, (
+                    f"{svc['slug']} declares container_prohibited — confirm a first-party source "
+                    "and add it to docs/research/per-ip-device-limits.md before allowing it here"
+                )
+
+
+class TestSourcedPerIpLimits:
+    """Values must trace to a provider statement; see docs/research/per-ip-device-limits.md."""
+
+    @pytest.mark.parametrize("slug", ["honeygain", "iproyal", "earnfm", "ebesucher"])
+    def test_the_four_documented_services_declare_one_per_ip(self, slug):
+        from app import catalog
+
+        assert (catalog.get_service(slug)["requirements"] or {}).get("devices_per_ip") == 1
+
+    @pytest.mark.parametrize("slug", ["repocket", "proxyrack", "packetstream", "bitping", "urnetwork"])
+    def test_services_with_no_provider_source_stay_absent(self, slug):
+        """A widely-repeated review-site number is not a source.
+
+        repocket previously declared devices_per_ip: 2 on exactly that basis.
+        """
+        from app import catalog
+
+        assert "devices_per_ip" not in (catalog.get_service(slug)["requirements"] or {})
+
+    def test_a_second_device_behind_one_ip_now_gets_the_strongest_verdict(self):
+        """The point of the bead: the verdict was weak exactly where the
+        mistake is most likely, because the limit was never recorded."""
+        from app import catalog
+
+        out = preflight.assess(catalog.get_service("honeygain"), already_deployed_slugs={"honeygain"})
+        assert out["verdict"] == preflight.EARNS_NOTHING
+        assert "one device per IP" in " ".join(f["message"] for f in out["findings"])


### PR DESCRIPTION
The deploy preflight could not give its strongest verdict **exactly where the mistake is most likely**, because the limit it needs was recorded for 4 of 50 services. Two things were wrong: values were missing, and one that was present had no source.

## Added — each traced to a first-party statement

Quoted in full in `docs/research/per-ip-device-limits.md`.

| Service | `devices_per_ip` | Source |
|---|---|---|
| honeygain | **1** | Help centre: *"Users may connect 1 device per one IP/Network."* |
| iproyal (Pawns) | **1** | ToS: *"limits the number of devices per single IP address to one (1)."* |
| earnfm | **1** | Help centre: *"One Device Per Network."* |
| ebesucher | **1** | Blog: each device needs *"a unique IP address."* |

## Removed — `repocket: devices_per_ip: 2`

**It has no provider source.** Repocket documents a five-device limit per *account*, which is a different thing; the "2 per IP" figure traces only to review sites repeating each other. This is the exact failure the bead exists to prevent, and it was already shipping — a wrong number tells the user something false with full confidence, while an absent one only degrades the verdict to "check the provider's terms".

Same reasoning leaves `proxyrack`, `packetstream`, `bitping` and `urnetwork` absent, each with a note recording what *is* documented. **A test asserts these stay absent**, so the next person to find the number on a blog has to find a source first.

Where a provider documents *sharing* without a number (`earnapp`, `spide`), the key stays absent and the effect goes in the note — "your second device earns nothing extra" is not a device count.

## Separately, and more seriously: EarnApp forbids what this project does

Verified first-party against EarnApp's own help centre:

> **No. Installing EarnApp on Virtual Machines (VMs), Docker containers, or hosting services is strictly prohibited.**
>
> Prohibited: VMs · **Docker containers** · Cloud hosting · **Personal or home servers** · Any device used for **business or monetization** purposes.
>
> Penalty: account **terminated without prior notice**, pending payments **canceled**.

CashPilot deploys every service as a Docker container on a home server. Shipping EarnApp silently would make this tool the cause of the ban.

It is recorded as `requirements.container_prohibited` and reported as the strongest verdict the preflight has. **It still does not block** — this is a risk a user is entitled to accept knowingly, but not one they should discover afterwards.

The flag requires a first-party source and must never be inferred from a residential-IP rule, so a test fails if any service picks it up without one.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1626 passed**, coverage 94.45%