### PR TITLE
feat: is anything actually crossing the wire? (CashPilot-t6y)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import secrets
+import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from time import monotonic
@@ -38,6 +39,7 @@ from app import (
     exchange_rates,
     fleet_key,
     metrics,
+    net_activity,
     notify,
     power,
     preflight,
@@ -129,6 +131,48 @@ def _decoded_worker(worker: dict[str, Any]) -> dict[str, Any]:
     return decoded
 
 
+# Previous network counter reading per (worker, slug), for turning Docker's
+# CUMULATIVE totals into a rate. In memory on purpose: losing it on restart
+# costs one unknown reading, whereas persisting a stale baseline across a
+# restart risks pairing it with counters that reset in the meantime.
+_net_baselines: dict[tuple[Any, str], tuple[int, float]] = {}
+
+
+def _traffic_state(slug: str, containers: list[dict[str, Any]]) -> str | None:
+    """MOVING/SILENT/UNKNOWN for a service, from two counter readings.
+
+    Returns None when there is nothing to say at all, so the caller can leave
+    the signal out entirely rather than assert "unknown" about a service whose
+    containers were never seen.
+    """
+    now = time.monotonic()
+    rates: list[float] = []
+    measured = False
+
+    for container in containers:
+        total = net_activity.totals(container)
+        if total is None:
+            continue
+        measured = True
+        key = (container.get("_worker_id"), slug)
+        previous = _net_baselines.get(key)
+        _net_baselines[key] = (total, now)
+        if previous is None:
+            continue
+        value = net_activity.rate(previous[0], total, now - previous[1])
+        if value is not None:
+            rates.append(value)
+
+    if not measured:
+        return None
+    if not rates:
+        # Counters exist but no usable interval yet — first sight of this
+        # container, or its counters reset. Saying "unknown" is the point.
+        return net_activity.UNKNOWN
+    # Any instance moving data means the service is not silent.
+    return net_activity.classify(max(rates))
+
+
 async def _get_all_worker_containers() -> list[dict[str, Any]]:
     """Collect container/app data from all online workers' heartbeat data in DB."""
     workers = await database.list_workers()
@@ -155,6 +199,8 @@ async def _get_all_worker_containers() -> list[dict[str, Any]]:
                             "image": c.get("image", ""),
                             "cpu_percent": c.get("cpu_percent", 0),
                             "memory_mb": c.get("memory_mb", 0),
+                            "net_rx_bytes": c.get("net_rx_bytes"),
+                            "net_tx_bytes": c.get("net_tx_bytes"),
                             "category": "",
                             "deployed_by": worker_name,
                             "_node": worker_name,
@@ -1965,6 +2011,7 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
 
     running = True
     log_hits: list[dict[str, str]] = []
+    traffic: str | None = None
     signals = producer_state.signals_for(service)
     try:
         containers = await _get_all_worker_containers()
@@ -1973,6 +2020,7 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         # the wrong shape, passed.
         matches = [c for c in containers if egress.container_slug(c) == slug]
         running = any(str(c.get("status", "")).lower() == "running" for c in matches)
+        traffic = _traffic_state(slug, matches)
         if signals and running:
             wid = worker_id if worker_id is not None else (matches[0].get("_worker_id") if matches else None)
             if wid is not None:
@@ -1988,6 +2036,7 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         has_collector=has_collector,
         earned_recently=earned_recently,
         log_hits=log_hits,
+        traffic=traffic,
         container_running=running,
     )
 

--- a/app/net_activity.py
+++ b/app/net_activity.py
@@ -1,0 +1,125 @@
+"""Is anything actually crossing the wire? (CashPilot-t6y)
+
+The third producer-state signal. Earnings movement needs a collector, which 30+
+catalogued services do not have, and log signals need a pattern somebody wrote
+down. Network counters need neither: every Docker container has them.
+
+What makes this hard is that Docker's counters are CUMULATIVE totals since the
+container started, so a single reading says nothing. Two readings give a rate —
+and only if nothing reset in between.
+
+Three rules, each from a way this signal lies if taken at face value:
+
+* **A counter that went BACKWARDS is a restart, not negative traffic.** The
+  totals reset to zero when the container is recreated, so subtracting the old
+  reading yields a large negative number; treating that as a rate would report
+  a wild figure or, worse, silently clamp to zero and call a busy service idle.
+  A backwards step means "we lost the baseline", which is UNKNOWN.
+
+* **Missing counters are not zero counters.** A container on the host network
+  has NO `networks` key in Docker's stats at all — verified on a real fleet,
+  where the single busiest service (a dVPN exit moving ~15 MB/s) reported
+  nothing. Reading that absence as no-traffic would mark the best earner dead.
+  Decided at runtime from what Docker reports, not from the catalog: an override
+  can host-network a container the catalog says nothing about.
+
+* **The idle threshold is measured, not assumed.** Idle-but-connected containers
+  are not silent: on a real fleet they sit anywhere from ~5 B/s to ~600 B/s of
+  keepalive chatter, so a threshold of "zero" would be wrong for almost all of
+  them. See docs/research/idle-network-traffic.md for the measurements.
+
+And one rule about what the signal can CONCLUDE. Bandwidth resale is
+buyer-driven and bursty: a perfectly healthy node earns nothing while nobody is
+buying. Silence therefore supports IDLE at most, and never FAILING — no amount
+of quiet proves a service is broken.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MOVING = "moving"
+SILENT = "silent"
+UNKNOWN = "unknown"
+
+# Below this, a container is transferring essentially nothing. Derived from
+# measuring every managed container on a live fleet over two minutes: the
+# quietest still-connected service sat at ~5.5 B/s, while two genuinely inactive
+# ones sat at exactly 0.0 B/s. So the only distinction this data supports is
+# "no measurable traffic at all" versus "some". Deliberately conservative: the
+# cost of calling a working service silent is far higher than missing an idle
+# one, because the first is a false alarm the user has to chase.
+SILENT_BYTES_PER_SEC = 2.0
+
+# A sample older than this is not a useful baseline: the longer the gap, the more
+# likely a restart happened inside it and reset the counters without us seeing
+# the step backwards.
+MAX_BASELINE_AGE_SECONDS = 900.0
+
+# Two samples closer together than this produce a rate dominated by timing jitter.
+MIN_INTERVAL_SECONDS = 5.0
+
+
+def totals(container: dict[str, Any] | None) -> int | None:
+    """Combined rx+tx byte counter for one container, or None if unavailable.
+
+    None is returned whenever the worker could not read the counters — most
+    often a host-network container, where Docker reports no interfaces at all.
+    """
+    if not isinstance(container, dict):
+        return None
+    rx = container.get("net_rx_bytes")
+    tx = container.get("net_tx_bytes")
+    if rx is None and tx is None:
+        return None
+    try:
+        total = int(rx or 0) + int(tx or 0)
+    except (TypeError, ValueError):
+        return None
+    return total if total >= 0 else None
+
+
+def rate(previous: int | None, current: int | None, seconds: float) -> float | None:
+    """Bytes per second between two cumulative readings, or None.
+
+    None means "we cannot tell", and every branch that returns it is a case
+    where a number would be a fabrication:
+    a missing reading, an interval too short or too long to trust, or a counter
+    that went backwards because the container restarted.
+    """
+    if previous is None or current is None:
+        return None
+    if seconds < MIN_INTERVAL_SECONDS or seconds > MAX_BASELINE_AGE_SECONDS:
+        return None
+    if current < previous:
+        # Counters reset on restart. The old baseline is meaningless now.
+        return None
+    return (current - previous) / seconds
+
+
+def classify(bytes_per_second: float | None) -> str:
+    """MOVING / SILENT / UNKNOWN for a rate."""
+    if bytes_per_second is None:
+        return UNKNOWN
+    return SILENT if bytes_per_second < SILENT_BYTES_PER_SEC else MOVING
+
+
+def describe(state: str, bytes_per_second: float | None) -> str:
+    """One plain sentence a user can act on."""
+    if state == MOVING:
+        return f"The container is moving data ({_human(bytes_per_second)})."
+    if state == SILENT:
+        return (
+            "The container has moved essentially no data since the last check. "
+            "For a bandwidth service that can simply mean nobody is buying right now."
+        )
+    return "CashPilot could not measure this container's network traffic."
+
+
+def _human(bytes_per_second: float | None) -> str:
+    value = float(bytes_per_second or 0.0)
+    for unit in ("B/s", "KB/s", "MB/s"):
+        if value < 1024 or unit == "MB/s":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} MB/s"

--- a/app/net_activity.py
+++ b/app/net_activity.py
@@ -117,9 +117,15 @@ def describe(state: str, bytes_per_second: float | None) -> str:
 
 
 def _human(bytes_per_second: float | None) -> str:
+    """A rate in the largest unit that keeps it readable.
+
+    MB/s is the last unit, so the loop always returns from inside it — there is
+    no trailing fallback, because a line that cannot execute is not a safety
+    net, it is just a line nobody can ever check.
+    """
     value = float(bytes_per_second or 0.0)
-    for unit in ("B/s", "KB/s", "MB/s"):
-        if value < 1024 or unit == "MB/s":
+    for unit in ("B/s", "KB/s"):
+        if value < 1024:
             return f"{value:.1f} {unit}"
         value /= 1024
     return f"{value:.1f} MB/s"

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -406,8 +406,15 @@ def start_service(slug: str) -> None:
     logger.info("Started container %s", container.name)
 
 
-def _collect_stats(c) -> tuple[float, float]:
-    """Collect CPU% and memory for a single container. Returns (cpu_pct, mem_mb)."""
+def _collect_stats(c) -> tuple[float, float, int | None, int | None]:
+    """Collect CPU%, memory and cumulative network counters for one container.
+
+    Returns ``(cpu_pct, mem_mb, rx_bytes, tx_bytes)``. The counters are None
+    when Docker reports no interfaces — which is what happens for a container on
+    the HOST network, where the ``networks`` key is absent entirely. That is not
+    zero traffic and must never be reported as such: on a real fleet the single
+    busiest service is host-networked.
+    """
     try:
         stats = c.stats(stream=False)
         cpu_delta = stats["cpu_stats"]["cpu_usage"]["total_usage"] - stats["precpu_stats"]["cpu_usage"]["total_usage"]
@@ -418,9 +425,24 @@ def _collect_stats(c) -> tuple[float, float]:
         )
         cpu_pct = round((cpu_delta / system_delta) * num_cpus * 100, 2) if system_delta > 0 else 0.0
         mem_mb = round(stats["memory_stats"].get("usage", 0) / (1024 * 1024), 1)
-        return cpu_pct, mem_mb
+        rx, tx = _network_totals(stats)
+        return cpu_pct, mem_mb, rx, tx
     except (KeyError, ZeroDivisionError, APIError):
-        return 0.0, 0.0
+        return 0.0, 0.0, None, None
+
+
+def _network_totals(stats: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Cumulative rx/tx across every interface, or (None, None) if unreported."""
+    networks = stats.get("networks")
+    if not isinstance(networks, dict) or not networks:
+        return None, None
+    rx = tx = 0
+    for iface in networks.values():
+        if not isinstance(iface, dict):
+            continue
+        rx += int(iface.get("rx_bytes") or 0)
+        tx += int(iface.get("tx_bytes") or 0)
+    return rx, tx
 
 
 def get_status() -> list[dict[str, Any]]:
@@ -448,7 +470,7 @@ def get_status() -> list[dict[str, Any]]:
         try:
             seen_ids.add(c.id)
             slug = c.labels.get(LABEL_SERVICE, "unknown")
-            cpu_pct, mem_mb = _collect_stats(c)
+            cpu_pct, mem_mb, net_rx, net_tx = _collect_stats(c)
             results.append(
                 {
                     "slug": slug,
@@ -457,6 +479,9 @@ def get_status() -> list[dict[str, Any]]:
                     "image": c.image.tags[0] if c.image.tags else str(c.image.short_id),
                     "cpu_percent": cpu_pct,
                     "memory_mb": mem_mb,
+                    # Cumulative since container start; None when unavailable.
+                    "net_rx_bytes": net_rx,
+                    "net_tx_bytes": net_tx,
                     "created": c.attrs.get("Created", ""),
                     "container_id": c.short_id,
                     "deployed_by": c.labels.get(LABEL_DEPLOYED_BY, "unknown"),
@@ -484,7 +509,7 @@ def get_status() -> list[dict[str, Any]]:
                     slug = image_map.get(image_name.split(":")[0], "")
                 if slug:
                     seen_ids.add(c.id)
-                    cpu_pct, mem_mb = _collect_stats(c)
+                    cpu_pct, mem_mb, net_rx, net_tx = _collect_stats(c)
                     results.append(
                         {
                             "slug": slug,
@@ -493,6 +518,8 @@ def get_status() -> list[dict[str, Any]]:
                             "image": image_name or str(c.image.short_id),
                             "cpu_percent": cpu_pct,
                             "memory_mb": mem_mb,
+                            "net_rx_bytes": net_rx,
+                            "net_tx_bytes": net_tx,
                             "created": c.attrs.get("Created", ""),
                             "container_id": c.short_id,
                             "deployed_by": "external",

--- a/app/producer_state.py
+++ b/app/producer_state.py
@@ -18,14 +18,19 @@ Three signals feed it. Two are implemented here:
   and keeping the patterns in YAML follows the rule that service-specific
   knowledge never lives in ``app/``.
 
-The third, container network counters, needs the rx/tx figures wired through the
-Docker worker heartbeat and is tracked separately.
+* **Network counters** (CashPilot-t6y) — every container has them, so this is
+  the only signal that needs neither a collector nor a hand-written pattern.
+  It can only ever WEAKEN confidence, never condemn: bandwidth resale is
+  buyer-driven, so a healthy node moves nothing while nobody is buying. See
+  ``app/net_activity.py``.
 """
 
 from __future__ import annotations
 
 import re
 from typing import Any
+
+from app import net_activity
 
 # States, best to worst. FAILING beats IDLE: a log line saying "login failed" is
 # a concrete, actionable diagnosis, whereas idleness is only an observation.
@@ -82,6 +87,7 @@ def assess(
     earned_recently: bool | None,
     log_hits: list[dict[str, str]] | None = None,
     container_running: bool = True,
+    traffic: str | None = None,
 ) -> dict[str, Any]:
     """Combine the available signals into one producer state.
 
@@ -123,8 +129,29 @@ def assess(
             "Only declared log signals can say anything about it."
         )
 
+    # Network traffic. Deliberately the weakest of the three: it can support an
+    # idle reading and it can rescue a collector-less service from UNKNOWN, but
+    # it never condemns. Silence is not proof of breakage when demand is what
+    # drives the traffic, and it never outranks a real earnings observation.
+    if traffic == net_activity.SILENT and earned_recently is not True:
+        candidates.append(IDLE)
+        reasons.append(net_activity.describe(net_activity.SILENT, None))
+    elif traffic == net_activity.MOVING:
+        reasons.append("The container is moving data over the network.")
+        if earned_recently is None and not has_collector:
+            # Not PRODUCING: bytes on the wire are not money. But a service we
+            # otherwise know nothing about is at least demonstrably alive, which
+            # is worth saying rather than leaving a bare "unknown".
+            reasons.append("That does not prove it is earning, only that it is not inert.")
+
     state = max(candidates, key=lambda s: _RANK[s]) if candidates else UNKNOWN
-    return {"slug": slug, "state": state, "reasons": reasons, "log_hits": log_hits}
+    return {
+        "slug": slug,
+        "state": state,
+        "reasons": reasons,
+        "log_hits": log_hits,
+        "traffic": traffic or net_activity.UNKNOWN,
+    }
 
 
 def signals_for(service: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/docs/research/idle-network-traffic.md
+++ b/docs/research/idle-network-traffic.md
@@ -1,0 +1,63 @@
+# What "idle" actually looks like on the wire
+
+Measurements behind `SILENT_BYTES_PER_SEC` in `app/net_activity.py`
+(CashPilot-t6y). The bead was explicit that the threshold must come from real
+idle traffic rather than from assuming zero, so it does.
+
+**Method.** Every `cashpilot.managed` container on a live host, two readings of
+`/proc/net/dev` inside the container 120 seconds apart, rate = delta / 120.
+Single host, single 2-minute window — enough to disprove "idle means zero", not
+enough to calibrate anything finer. Treat the number as a floor, not a tuned
+constant.
+
+Date: 2026-08-02.
+
+| Container | rx B/s | tx B/s |
+|---|---:|---:|
+| mysterium | 815,589 | 15,275,715 |
+| honeygain | 6,709 | 6,773 |
+| proxylite | 5,971 | 1,394 |
+| anyone-protocol | 2,490 | 2,591 |
+| storj | 1,018 | 5,878 |
+| earnfm | 546 | 661 |
+| repocket | 525 | 571 |
+| bitping | 117 | 118 |
+| proxyrack | 36 | 22 |
+| packetstream | 35 | 12 |
+| earnapp | 19 | 12 |
+| proxybase | 5.5 | 7.3 |
+| **traffmonetizer** | **0.0** | **0.0** |
+| **iproyal** | **0.0** | **0.0** |
+
+## What this shows
+
+**Idle is not zero.** Eleven of fourteen containers moved measurable traffic
+while earning little or nothing — keepalives, heartbeats, control-plane chatter.
+A threshold of zero would have called all of them active.
+
+**Zero does happen, and it means something.** Two containers moved *literally
+nothing* in two minutes. That is the only distinction this data supports, so
+the threshold sits just above it (2 B/s) and the signal answers one question:
+did anything at all cross the wire?
+
+**Traffic volume is not earnings.** Mysterium moved 15 MB/s because it is a
+dVPN exit carrying other people's traffic; Storj's 5.9 MB/s tx is customer data
+being served. Neither number tells you what was paid. This is why the signal can
+only ever weaken confidence in `app/producer_state.py`, never assert PRODUCING.
+
+**Silence is not breakage.** Bandwidth resale is buyer-driven: a healthy node
+moves nothing while nobody is buying. Hence SILENT supports IDLE and never
+FAILING.
+
+## The trap that shaped the code
+
+Docker's `stats` API omits the `networks` key **entirely** for containers on the
+host network — no interfaces, no counters. On this fleet the single busiest
+service (mysterium, above) is host-networked, so a naive reading would score the
+best earner as zero traffic and call it dead.
+
+The catalog does declare this one — `services/bandwidth/mysterium.yml` sets
+`network_mode: "host"` — but the code still decides at RUNTIME from what Docker
+actually reports. A container can be started host-networked by an override the
+catalog knows nothing about, and the counters are either present or they are
+not, whatever any YAML claims.

--- a/tests/test_net_activity.py
+++ b/tests/test_net_activity.py
@@ -253,3 +253,26 @@ class TestProducerStateEndpointCarriesTraffic:
         out = self._call([{"slug": "demo", "status": "running", "_worker_id": 1}])
         assert out["traffic"] == na.UNKNOWN
         assert not any("no data" in r for r in out["reasons"])
+
+
+class TestRateFormatting:
+    @pytest.mark.parametrize(
+        ("rate_bps", "expected"),
+        [
+            (0.0, "0.0 B/s"),
+            (5.5, "5.5 B/s"),
+            (1023.0, "1023.0 B/s"),
+            (1024.0, "1.0 KB/s"),
+            (6708.6, "6.6 KB/s"),
+            (1024.0 * 1024, "1.0 MB/s"),
+            (15_275_715.3, "14.6 MB/s"),
+        ],
+    )
+    def test_it_picks_the_unit_that_keeps_the_number_readable(self, rate_bps, expected):
+        assert na._human(rate_bps) == expected
+
+    def test_a_missing_rate_formats_as_zero_rather_than_raising(self):
+        assert na._human(None) == "0.0 B/s"
+
+    def test_the_moving_description_includes_the_rate(self):
+        assert "14.6 MB/s" in na.describe(na.MOVING, 15_275_715.3)

--- a/tests/test_net_activity.py
+++ b/tests/test_net_activity.py
@@ -1,0 +1,255 @@
+"""Network counters as a producer-state signal (CashPilot-t6y).
+
+Docker's counters are CUMULATIVE, so every test here is really about the ways a
+raw total lies: a counter that reset, a counter that was never reported, and an
+idle threshold that "obviously" ought to be zero and is not.
+
+The measurements behind the threshold are in docs/research/idle-network-traffic.md
+— taken from a live fleet, because the bead was explicit that assuming zero is
+how this signal goes wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import net_activity as na
+from app import producer_state as ps
+
+
+class TestACounterThatWentBackwardsIsARestart:
+    def test_a_reset_yields_unknown_not_a_negative_rate(self):
+        """The container restarted; the old baseline means nothing now."""
+        assert na.rate(1_000_000, 500, 60) is None
+
+    def test_a_reset_is_not_silently_clamped_to_zero(self):
+        """Clamping would report a busy service as silent — the worst outcome."""
+        assert na.classify(na.rate(1_000_000, 500, 60)) == na.UNKNOWN
+
+    def test_an_unchanged_counter_is_a_real_zero_rate(self):
+        assert na.rate(1000, 1000, 60) == 0.0
+        assert na.classify(na.rate(1000, 1000, 60)) == na.SILENT
+
+
+class TestMissingCountersAreNotZero:
+    def test_a_container_reporting_no_interfaces_is_unknown(self):
+        """Host-network containers have NO networks key at all in Docker stats.
+
+        Verified on a live fleet, where the busiest service by far — a dVPN exit
+        moving ~15 MB/s — is host-networked and reports nothing.
+        """
+        assert na.totals({"slug": "mysterium"}) is None
+        assert na.totals({"net_rx_bytes": None, "net_tx_bytes": None}) is None
+
+    def test_a_partially_reported_container_still_counts(self):
+        assert na.totals({"net_rx_bytes": 10, "net_tx_bytes": None}) == 10
+
+    def test_malformed_counters_are_unknown_rather_than_guessed(self):
+        assert na.totals({"net_rx_bytes": "lots", "net_tx_bytes": 1}) is None
+        assert na.totals({"net_rx_bytes": -5, "net_tx_bytes": -5}) is None
+        assert na.totals(None) is None
+        assert na.totals("not-a-container") is None
+
+    def test_both_counters_are_summed(self):
+        assert na.totals({"net_rx_bytes": 100, "net_tx_bytes": 23}) == 123
+
+
+class TestIntervalsWeCannotTrust:
+    def test_no_baseline_means_no_rate(self):
+        assert na.rate(None, 500, 60) is None
+        assert na.rate(500, None, 60) is None
+
+    def test_too_short_an_interval_is_dominated_by_jitter(self):
+        assert na.rate(0, 1000, 0.5) is None
+
+    def test_too_old_a_baseline_may_hide_a_restart_inside_it(self):
+        assert na.rate(0, 1000, na.MAX_BASELINE_AGE_SECONDS + 1) is None
+
+    def test_a_sane_interval_produces_a_rate(self):
+        assert na.rate(0, 6000, 60) == 100.0
+
+
+class TestTheThresholdIsMeasuredNotAssumed:
+    def test_it_is_not_zero(self):
+        """Idle-but-connected containers are not silent.
+
+        On the measured fleet the quietest still-connected service sat at
+        ~5.5 B/s of keepalive chatter, so a zero threshold would call almost
+        every healthy idle container "moving".
+        """
+        assert na.SILENT_BYTES_PER_SEC > 0
+
+    def test_the_quietest_measured_live_container_reads_as_moving(self):
+        """5.5 B/s was a real reading from a connected, working service."""
+        assert na.classify(5.5) == na.MOVING
+
+    def test_a_genuinely_dead_container_reads_as_silent(self):
+        """Two services measured at exactly 0.0 B/s over two minutes."""
+        assert na.classify(0.0) == na.SILENT
+
+    @pytest.mark.parametrize("rate_bps", [545.5, 6708.6, 815589.1, 15275715.3])
+    def test_every_busy_measured_container_reads_as_moving(self, rate_bps):
+        assert na.classify(rate_bps) == na.MOVING
+
+    def test_a_human_description_is_always_available(self):
+        for state in (na.MOVING, na.SILENT, na.UNKNOWN):
+            assert na.describe(state, 1234.0)
+
+
+class TestItNeverCondemns:
+    """Silence is not proof of breakage when demand drives the traffic."""
+
+    def test_silence_supports_idle_but_never_failing(self):
+        out = ps.assess(slug="x", has_collector=False, earned_recently=None, traffic=na.SILENT)
+        assert out["state"] == ps.IDLE
+
+    def test_silence_does_not_override_observed_earnings(self):
+        """Money moved. A quiet minute does not undo that."""
+        out = ps.assess(slug="x", has_collector=True, earned_recently=True, traffic=na.SILENT)
+        assert out["state"] == ps.PRODUCING
+
+    def test_traffic_never_outranks_a_failure_log(self):
+        out = ps.assess(
+            slug="x",
+            has_collector=True,
+            earned_recently=None,
+            traffic=na.MOVING,
+            log_hits=[{"pattern": "banned", "means": "The provider has banned this node.", "state": "failing"}],
+        )
+        assert out["state"] == ps.FAILING
+
+    def test_moving_data_is_not_reported_as_earning(self):
+        """Bytes on the wire are not money."""
+        out = ps.assess(slug="x", has_collector=False, earned_recently=None, traffic=na.MOVING)
+        assert out["state"] == ps.UNKNOWN
+        assert any("does not prove it is earning" in r for r in out["reasons"])
+
+    def test_unknown_traffic_changes_nothing(self):
+        with_unknown = ps.assess(slug="x", has_collector=True, earned_recently=False, traffic=na.UNKNOWN)
+        without = ps.assess(slug="x", has_collector=True, earned_recently=False)
+        assert with_unknown["state"] == without["state"]
+
+    def test_the_traffic_state_is_reported_back(self):
+        assert ps.assess(slug="x", has_collector=True, earned_recently=True, traffic=na.MOVING)["traffic"] == na.MOVING
+        assert ps.assess(slug="x", has_collector=True, earned_recently=True)["traffic"] == na.UNKNOWN
+
+
+class TestTheBaselineCache:
+    def _state(self, slug, containers):
+        from app import main
+
+        return main._traffic_state(slug, containers)
+
+    def setup_method(self):
+        from app import main
+
+        main._net_baselines.clear()
+
+    def test_the_first_sighting_cannot_produce_a_rate(self):
+        assert self._state("x", [{"_worker_id": 1, "net_rx_bytes": 100, "net_tx_bytes": 100}]) == na.UNKNOWN
+
+    def test_a_service_with_no_containers_says_nothing_at_all(self):
+        assert self._state("x", []) is None
+
+    def test_containers_without_counters_say_nothing_at_all(self):
+        assert self._state("x", [{"_worker_id": 1, "slug": "x"}]) is None
+
+    def test_a_second_reading_produces_a_verdict(self, monkeypatch):
+        import time
+
+        from app import main
+
+        clock = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+        assert self._state("x", [{"_worker_id": 1, "net_rx_bytes": 0, "net_tx_bytes": 0}]) == na.UNKNOWN
+        clock[0] += 60
+        out = main._traffic_state("x", [{"_worker_id": 1, "net_rx_bytes": 60_000, "net_tx_bytes": 0}])
+        assert out == na.MOVING
+
+    def test_a_restart_between_readings_reports_unknown(self, monkeypatch):
+        import time
+
+        from app import main
+
+        clock = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+        self._state("x", [{"_worker_id": 1, "net_rx_bytes": 10_000_000, "net_tx_bytes": 0}])
+        clock[0] += 60
+        assert main._traffic_state("x", [{"_worker_id": 1, "net_rx_bytes": 42, "net_tx_bytes": 0}]) == na.UNKNOWN
+
+    def test_instances_are_tracked_per_worker(self, monkeypatch):
+        import time
+
+        from app import main
+
+        clock = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+        both = [
+            {"_worker_id": 1, "net_rx_bytes": 0, "net_tx_bytes": 0},
+            {"_worker_id": 2, "net_rx_bytes": 0, "net_tx_bytes": 0},
+        ]
+        self._state("x", both)
+        clock[0] += 60
+        # Worker 1 idle, worker 2 busy: the service is not silent.
+        out = main._traffic_state(
+            "x",
+            [
+                {"_worker_id": 1, "net_rx_bytes": 0, "net_tx_bytes": 0},
+                {"_worker_id": 2, "net_rx_bytes": 600_000, "net_tx_bytes": 0},
+            ],
+        )
+        assert out == na.MOVING
+
+
+class TestTheWorkerReportsTheCounters:
+    def test_host_networked_containers_report_none(self):
+        from app import orchestrator
+
+        assert orchestrator._network_totals({"memory_stats": {}}) == (None, None)
+        assert orchestrator._network_totals({"networks": {}}) == (None, None)
+        assert orchestrator._network_totals({"networks": "eth0"}) == (None, None)
+
+    def test_every_interface_is_summed(self):
+        from app import orchestrator
+
+        stats = {"networks": {"eth0": {"rx_bytes": 10, "tx_bytes": 20}, "eth1": {"rx_bytes": 1, "tx_bytes": 2}}}
+        assert orchestrator._network_totals(stats) == (11, 22)
+
+    def test_a_malformed_interface_entry_is_skipped(self):
+        from app import orchestrator
+
+        stats = {"networks": {"eth0": "bad", "eth1": {"rx_bytes": 5, "tx_bytes": 5}}}
+        assert orchestrator._network_totals(stats) == (5, 5)
+
+
+class TestProducerStateEndpointCarriesTraffic:
+    def _call(self, containers, earned=None):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        main._net_baselines.clear()
+        svc = {"slug": "demo", "docker": {}}
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.catalog, "get_service", return_value=svc),
+                patch.dict("app.collectors.COLLECTOR_MAP", {}, clear=True),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value=earned or {})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
+            ):
+                return await main.api_producer_state(MagicMock(), "demo")
+
+        return asyncio.run(run())
+
+    RUNNING = [{"slug": "demo", "status": "running", "_worker_id": 1, "net_rx_bytes": 5, "net_tx_bytes": 5}]
+
+    def test_the_first_call_reports_unknown_traffic(self):
+        assert self._call(self.RUNNING)["traffic"] == na.UNKNOWN
+
+    def test_a_host_networked_container_does_not_claim_silence(self):
+        out = self._call([{"slug": "demo", "status": "running", "_worker_id": 1}])
+        assert out["traffic"] == na.UNKNOWN
+        assert not any("no data" in r for r in out["reasons"])

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -75,7 +75,7 @@ class TestCollectStats:
             },
             "memory_stats": {"usage": 209_715_200},  # 200 MB
         }
-        cpu_pct, mem_mb = orchestrator._collect_stats(c)
+        cpu_pct, mem_mb, _, _ = orchestrator._collect_stats(c)
         assert cpu_pct == 20.0
         assert mem_mb == 200.0
 
@@ -86,7 +86,7 @@ class TestCollectStats:
             "precpu_stats": {"cpu_usage": {"total_usage": 500}, "system_cpu_usage": 500},
             "memory_stats": {"usage": 0},
         }
-        cpu_pct, mem_mb = orchestrator._collect_stats(c)
+        cpu_pct, mem_mb, _, _ = orchestrator._collect_stats(c)
         assert cpu_pct == 0.0
         assert mem_mb == 0.0
 
@@ -97,18 +97,18 @@ class TestCollectStats:
             "precpu_stats": {"cpu_usage": {"total_usage": 50}, "system_cpu_usage": 400},
             "memory_stats": {},  # no "usage" key
         }
-        _, mem_mb = orchestrator._collect_stats(c)
+        _, mem_mb, _, _ = orchestrator._collect_stats(c)
         assert mem_mb == 0.0
 
     def test_missing_key_returns_zero_tuple(self):
         c = MagicMock()
         c.stats.return_value = {"cpu_stats": {}}  # precpu_stats missing -> KeyError
-        assert orchestrator._collect_stats(c) == (0.0, 0.0)
+        assert orchestrator._collect_stats(c) == (0.0, 0.0, None, None)
 
     def test_stats_api_error_returns_zero_tuple(self):
         c = MagicMock()
         c.stats.side_effect = APIError("stats unavailable")
-        assert orchestrator._collect_stats(c) == (0.0, 0.0)
+        assert orchestrator._collect_stats(c) == (0.0, 0.0, None, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The third producer-state signal, and the only one needing **neither a collector nor a hand-written log pattern** — every Docker container has network counters. That matters because 30+ catalogued services have no collector at all, so for them this is the only evidence available.

Docker's counters are **cumulative** totals since container start, so one reading says nothing and two say something only if nothing reset in between.

## Three rules, each from a way this signal lies

**A counter that went backwards is a restart, not negative traffic.** Subtracting the old baseline gives a large negative number; silently clamping it to zero would call a busy service idle. Backwards means the baseline is gone → `UNKNOWN`.

**Missing counters are not zero counters.** Docker omits the `networks` key *entirely* for host-network containers. On the reference fleet the single busiest service — a dVPN exit moving **~15 MB/s** — is host-networked and reports nothing. Reading absence as no-traffic would mark the best earner dead.

**The idle threshold is measured, not assumed.** The bead asked for this explicitly, so I sampled every managed container on a live host over two minutes:

| Container | rx B/s | tx B/s |
|---|---:|---:|
| mysterium | 815,589 | 15,275,715 |
| honeygain | 6,709 | 6,773 |
| earnfm | 546 | 661 |
| earnapp | 19 | 12 |
| proxybase | 5.5 | 7.3 |
| **traffmonetizer** | **0.0** | **0.0** |
| **iproyal** | **0.0** | **0.0** |

**Eleven of fourteen moved measurable traffic while earning little or nothing** — keepalives and control chatter. A threshold of zero would have called all of them active. Two moved *literally nothing*. That's the only distinction the data supports, so the threshold sits just above it and the signal answers exactly one question: did anything at all cross the wire?

Full table and method in `docs/research/idle-network-traffic.md`.

## What it is allowed to conclude

Deliberately narrow. Bandwidth resale is buyer-driven, so a healthy node moves nothing while nobody is buying:

- `SILENT` supports **IDLE** and never FAILING, and never overrides observed earnings or a failure log.
- `MOVING` never asserts PRODUCING — **bytes on the wire are not money**. For a collector-less service it says only that the container is demonstrably not inert, which beats a bare "unknown".

The baseline cache is in memory on purpose: losing it on restart costs one unknown reading, whereas persisting it risks pairing a stale baseline with counters that reset while we were down.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1771 passed**, coverage 94.72%
- 36 new tests, endpoints covered up front — including a host-networked container proving it does not claim silence, and a restart-mid-interval proving it does not clamp to zero.