### PR TITLE
feat: notice when a provider changes its API, and test credentials on demand (CashPilot-bfl)

### DIFF
--- a/.github/workflows/collector-live-check.yml
+++ b/.github/workflows/collector-live-check.yml
@@ -1,0 +1,83 @@
+name: Collector Live Check
+
+# A recorded fixture is frozen at the moment it was written, so it can prove our
+# code still reads what we said it reads and nothing more. Only calling the real
+# API notices that a provider renamed a field — which is how several collectors
+# silently started returning zero while every test stayed green.
+#
+# Runs on a schedule and by hand, never on a PR: it needs real credentials, and
+# a third party being down must never redden someone's pull request.
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: collector-live-check
+  cancel-in-progress: false
+
+jobs:
+  live:
+    # Public repo -> GitHub-hosted runners are free, ephemeral and isolated,
+    # which also keeps provider credentials off the self-hosted fleet.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run live collector checks
+        id: live
+        env:
+          CASHPILOT_LIVE_CREDENTIALS: ${{ secrets.CASHPILOT_LIVE_CREDENTIALS }}
+        run: |
+          set -o pipefail
+          python -m pytest tests/ -m live -q 2>&1 | tee live.log
+
+      - name: Open an issue when a provider's shape changed
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aa971cc2a0930ae7e2fe2c8bd # v7.0.4
+        with:
+          script: |
+            const title = 'Collector live check failed — a provider may have changed its API';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'collector-drift',
+            });
+            const body = [
+              'The nightly live collector check failed.',
+              '',
+              'This usually means a provider renamed or moved a field, which the recorded',
+              'fixtures cannot detect on their own. Compare the failing collector against',
+              '`tests/fixtures/collectors/<slug>.json` and update BOTH the collector and its',
+              'contract.',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'Note: the log is deliberately not pasted here — collector failures can echo',
+              'request payloads containing credentials.',
+            ].join('\n');
+            if (existing.data.length) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.data[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['collector-drift'],
+              });
+            }

--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -232,6 +232,40 @@ def make_collectors(
     return collectors
 
 
+def build_one(slug: str, config: dict[str, str]) -> tuple[Any | None, list[str]]:
+    """Build a single, UNCACHED collector for an on-demand credential test.
+
+    Returns ``(collector, missing_config_keys)``. Uncached on purpose: the test
+    button exists to check credentials the user just changed, and handing back a
+    cached instance built from the previous values would validate the wrong
+    thing and report success for a credential that no longer exists.
+
+    Resolution reuses the same ``_COLLECTOR_ARGS`` table as ``make_collectors``
+    so the two can never disagree about which keys a service needs.
+    """
+    cls = COLLECTOR_MAP.get(slug)
+    if cls is None:
+        return None, []
+
+    kwargs: dict[str, str] = {}
+    missing: list[str] = []
+    for arg in _COLLECTOR_ARGS.get(slug, []):
+        optional = arg.startswith("?")
+        name = arg.lstrip("?")
+        value = config.get(f"{slug}_{name}", "")
+        if value:
+            kwargs[name] = value
+        elif not optional:
+            missing.append(f"{slug}_{name}")
+    if missing:
+        return None, missing
+    try:
+        return cls(**kwargs), []
+    except Exception as exc:
+        logger.error("Could not construct collector for %s: %s", slug, exc)
+        return None, []
+
+
 async def close_all_collectors() -> None:
     """Close all cached collector HTTP clients and clear the cache."""
     global _cached_collectors, _cached_kwargs

--- a/app/credential_test.py
+++ b/app/credential_test.py
@@ -1,0 +1,114 @@
+"""Test these credentials, now (CashPilot-bfl).
+
+A user pastes a token, saves, and then waits up to an hour for the scheduler to
+tell them — via a notification bell — whether it was even valid. Most of the
+support burden in this category is exactly that loop: a typo, a cookie that
+expired between copying and pasting, an account that needs a captcha.
+
+This runs ONE collector on demand and answers in a sentence.
+
+Two things it must never do, both learned the hard way in this codebase:
+
+* **Never echo the credential, or the provider's raw response body.** A failing
+  login often replies with the submitted payload, and a raw body has previously
+  leaked into logs from a worker error path. Errors are CLASSIFIED here and the
+  original text is logged at debug only, never returned to the caller.
+* **Never let the button become a hammer.** Repeatedly retrying a bad login is
+  how providers flag an account, and this button invites exactly that. Attempts
+  are rate-limited per service.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+OK = "ok"
+BAD_CREDENTIALS = "bad_credentials"
+NOT_CONFIGURED = "not_configured"
+UNREACHABLE = "unreachable"
+UNEXPECTED_SHAPE = "unexpected_shape"
+RATE_LIMITED = "rate_limited"
+UNSUPPORTED = "unsupported"
+
+# One test per service per this many seconds. Generous enough to be useless as a
+# brute-force tool, short enough that fixing a typo does not mean waiting.
+COOLDOWN_SECONDS = 20.0
+
+_last_attempt: dict[str, float] = {}
+
+# Substrings that identify the failure without repeating anything sensitive.
+_AUTH_MARKERS = ("401", "403", "unauthorized", "forbidden", "invalid credentials", "login failed", "bad credentials")
+_NETWORK_MARKERS = ("timeout", "timed out", "connect", "dns", "network", "unreachable", "ssl", "certificate")
+_SHAPE_MARKERS = ("keyerror", "no access_token", "not in", "expecting value", "jsondecode", "nonetype", "unexpected")
+
+
+def classify(error: str | None) -> str:
+    """Map a collector's error string to a stable, non-sensitive outcome."""
+    if not error:
+        return OK
+    text = error.lower()
+    if any(m in text for m in _AUTH_MARKERS):
+        return BAD_CREDENTIALS
+    if any(m in text for m in _NETWORK_MARKERS):
+        return UNREACHABLE
+    if "not configured" in text or "missing" in text:
+        return NOT_CONFIGURED
+    if any(m in text for m in _SHAPE_MARKERS):
+        return UNEXPECTED_SHAPE
+    return UNEXPECTED_SHAPE
+
+
+def message(outcome: str, service_name: str, balance: float | None = None, currency: str = "") -> str:
+    """A sentence the user can act on, containing nothing sensitive."""
+    if outcome == OK:
+        if balance is None:
+            return f"{service_name} accepted these credentials."
+        return (
+            f"{service_name} accepted these credentials and reported a balance of {balance:g} {currency}".strip() + "."
+        )
+    if outcome == BAD_CREDENTIALS:
+        return (
+            f"{service_name} rejected these credentials. If they are a browser cookie or token, "
+            "they have most likely expired — copy a fresh one and try again."
+        )
+    if outcome == NOT_CONFIGURED:
+        return f"{service_name} has no credentials saved yet."
+    if outcome == UNREACHABLE:
+        return f"Could not reach {service_name}. That is a network problem here, not a problem with your credentials."
+    if outcome == RATE_LIMITED:
+        return (
+            "Give it a few seconds before testing again — repeatedly retrying a bad login can get an account flagged."
+        )
+    if outcome == UNSUPPORTED:
+        return f"CashPilot has no earnings collector for {service_name}, so there is nothing to test."
+    return (
+        f"{service_name} answered in a way CashPilot did not understand. The credentials may still be fine — "
+        "this usually means the provider changed its API."
+    )
+
+
+def cooldown_remaining(slug: str, now: float | None = None) -> float:
+    """Seconds left before ``slug`` may be tested again."""
+    now = time.monotonic() if now is None else now
+    last = _last_attempt.get(slug)
+    if last is None:
+        return 0.0
+    return max(0.0, COOLDOWN_SECONDS - (now - last))
+
+
+def note_attempt(slug: str, now: float | None = None) -> None:
+    _last_attempt[slug] = time.monotonic() if now is None else now
+
+
+def result(outcome: str, service_name: str, **extra: Any) -> dict[str, Any]:
+    """The response body. Deliberately has no field that could carry a secret."""
+    return {
+        "ok": outcome == OK,
+        "outcome": outcome,
+        "message": message(outcome, service_name, extra.get("balance"), extra.get("currency", "")),
+        **{k: v for k, v in extra.items() if k in {"balance", "currency"}},
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app import (
     auth,
     catalog,
     compose_generator,
+    credential_test,
     database,
     disclosure,
     egress,
@@ -2000,6 +2001,58 @@ async def api_service_disclosure(request: Request, slug: str) -> dict[str, Any]:
     if not service:
         raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
     return disclosure.for_service(service)
+
+
+@app.post("/api/services/{slug}/test-credentials")
+async def api_test_credentials(request: Request, slug: str) -> dict[str, Any]:
+    """Check the saved credentials for one service, right now.
+
+    Without this a user waits up to a full collection interval — an hour — to
+    find out a pasted token had a typo, and learns it from a notification bell.
+
+    The response deliberately has no field that could carry a secret: outcomes
+    are classified, and neither the credential nor the provider's raw body is
+    returned. A failed provider login frequently echoes the submitted payload.
+    """
+    from app import collectors
+    from app.collectors import COLLECTOR_MAP
+
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+    name = service.get("name") or slug
+
+    if slug not in COLLECTOR_MAP:
+        return credential_test.result(credential_test.UNSUPPORTED, name)
+
+    remaining = credential_test.cooldown_remaining(slug)
+    if remaining > 0:
+        # Retrying a rejected login in a tight loop is how accounts get flagged,
+        # and a button invites exactly that.
+        return credential_test.result(credential_test.RATE_LIMITED, name, retry_after=round(remaining))
+
+    config = await database.get_config() or {}
+    collector, missing = collectors.build_one(slug, config)
+    if collector is None:
+        outcome = credential_test.NOT_CONFIGURED if missing else credential_test.UNSUPPORTED
+        return credential_test.result(outcome, name)
+
+    credential_test.note_attempt(slug)
+    try:
+        result = await collector.collect()
+    except Exception as exc:
+        logger.debug("Credential test for %s raised: %s", slug, exc)
+        return credential_test.result(credential_test.classify(str(exc)), name)
+    finally:
+        with contextlib.suppress(Exception):
+            await collector.close()
+
+    outcome = credential_test.classify(result.error)
+    if outcome == credential_test.OK:
+        return credential_test.result(outcome, name, balance=result.balance, currency=result.currency)
+    logger.debug("Credential test for %s failed: %s", slug, result.error)
+    return credential_test.result(outcome, name)
 
 
 @app.get("/api/disclosure/coverage")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,11 @@ indent-style = "space"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# `live` tests call real provider APIs with real credentials. They are excluded
+# by default so PR CI never depends on a third party being up, and are run only
+# by the nightly collector-live-check workflow, which is the one thing here that
+# can notice a provider changed its API.
+addopts = "-m 'not live'"
+markers = [
+    "live: hits a real provider API; needs credentials; excluded from normal runs",
+]

--- a/tests/fixtures/collectors/anyone-protocol.json
+++ b/tests/fixtures/collectors/anyone-protocol.json
@@ -1,0 +1,14 @@
+{
+  "currency": "ANYONE",
+  "fields": [
+    "Data",
+    "Messages",
+    "usd"
+  ],
+  "note": "AO smart-contract dry-run per relay fingerprint",
+  "parsed": 0.0,
+  "sample": {
+    "Messages": []
+  },
+  "slug": "anyone-protocol"
+}

--- a/tests/fixtures/collectors/bitping.json
+++ b/tests/fixtures/collectors/bitping.json
@@ -1,0 +1,13 @@
+{
+  "currency": "USD",
+  "fields": [
+    "usdEarnings",
+    "token"
+  ],
+  "note": "balance = float(usdEarnings)",
+  "parsed": 7.25,
+  "sample": {
+    "usdEarnings": "7.25"
+  },
+  "slug": "bitping"
+}

--- a/tests/fixtures/collectors/bytelixir.json
+++ b/tests/fixtures/collectors/bytelixir.json
@@ -1,0 +1,14 @@
+{
+  "currency": "USD",
+  "fields": [
+    "data.balance"
+  ],
+  "note": "falls back to HTML scraping",
+  "parsed": 0.55,
+  "sample": {
+    "data": {
+      "balance": 0.55
+    }
+  },
+  "slug": "bytelixir"
+}

--- a/tests/fixtures/collectors/earnapp.json
+++ b/tests/fixtures/collectors/earnapp.json
@@ -1,0 +1,12 @@
+{
+  "currency": "USD",
+  "fields": [
+    "balance"
+  ],
+  "note": "auth via oauth-refresh + brd_sess_id cookie",
+  "parsed": 1.23,
+  "sample": {
+    "balance": 1.23
+  },
+  "slug": "earnapp"
+}

--- a/tests/fixtures/collectors/earnfm.json
+++ b/tests/fixtures/collectors/earnfm.json
@@ -1,0 +1,14 @@
+{
+  "currency": "USD",
+  "fields": [
+    "data.totalBalance",
+    "access_token"
+  ],
+  "parsed": 8.4,
+  "sample": {
+    "data": {
+      "totalBalance": 8.4
+    }
+  },
+  "slug": "earnfm"
+}

--- a/tests/fixtures/collectors/grass.json
+++ b/tests/fixtures/collectors/grass.json
@@ -1,0 +1,19 @@
+{
+  "currency": "GRASS",
+  "fields": [
+    "result.data.aggUptime",
+    "result.data.ipScore",
+    "result.data.multiplier",
+    "result.data.totalPoints"
+  ],
+  "note": "points, or estimated from uptime x ipScore x multiplier",
+  "parsed": 420.0,
+  "sample": {
+    "result": {
+      "data": {
+        "totalPoints": 420.0
+      }
+    }
+  },
+  "slug": "grass"
+}

--- a/tests/fixtures/collectors/honeygain.json
+++ b/tests/fixtures/collectors/honeygain.json
@@ -1,0 +1,17 @@
+{
+  "currency": "USD",
+  "fields": [
+    "data.payout.usd_cents",
+    "data.access_token"
+  ],
+  "note": "balance = payout.usd_cents / 100",
+  "parsed": 123.45,
+  "sample": {
+    "data": {
+      "payout": {
+        "usd_cents": 12345
+      }
+    }
+  },
+  "slug": "honeygain"
+}

--- a/tests/fixtures/collectors/iproyal.json
+++ b/tests/fixtures/collectors/iproyal.json
@@ -1,0 +1,12 @@
+{
+  "currency": "USD",
+  "fields": [
+    "balance",
+    "access_token"
+  ],
+  "parsed": 2.4,
+  "sample": {
+    "balance": 2.4
+  },
+  "slug": "iproyal"
+}

--- a/tests/fixtures/collectors/mysterium.json
+++ b/tests/fixtures/collectors/mysterium.json
@@ -1,0 +1,15 @@
+{
+  "currency": "MYST",
+  "fields": [
+    "accessToken",
+    "earningsTotal",
+    "earnings",
+    "lifetimeEarnings",
+    "identity"
+  ],
+  "parsed": 12.5,
+  "sample": {
+    "earningsTotal": 12.5
+  },
+  "slug": "mysterium"
+}

--- a/tests/fixtures/collectors/packetstream.json
+++ b/tests/fixtures/collectors/packetstream.json
@@ -1,0 +1,12 @@
+{
+  "currency": "USD",
+  "fields": [
+    "balance"
+  ],
+  "note": "also scraped from window.userData HTML",
+  "parsed": 5.0,
+  "sample": {
+    "balance": 5.0
+  },
+  "slug": "packetstream"
+}

--- a/tests/fixtures/collectors/proxyrack.json
+++ b/tests/fixtures/collectors/proxyrack.json
@@ -1,0 +1,14 @@
+{
+  "currency": "USD",
+  "fields": [
+    "data.balance"
+  ],
+  "note": "strips a leading $",
+  "parsed": 1.75,
+  "sample": {
+    "data": {
+      "balance": "$1.75"
+    }
+  },
+  "slug": "proxyrack"
+}

--- a/tests/fixtures/collectors/repocket.json
+++ b/tests/fixtures/collectors/repocket.json
@@ -1,0 +1,14 @@
+{
+  "currency": "USD",
+  "fields": [
+    "centsCredited",
+    "idToken",
+    "refreshToken"
+  ],
+  "note": "balance = centsCredited / 100",
+  "parsed": 42.5,
+  "sample": {
+    "centsCredited": 4250
+  },
+  "slug": "repocket"
+}

--- a/tests/fixtures/collectors/salad.json
+++ b/tests/fixtures/collectors/salad.json
@@ -1,0 +1,12 @@
+{
+  "currency": "USD",
+  "fields": [
+    "currentBalance"
+  ],
+  "note": "balance = float(currentBalance)",
+  "parsed": 3.5,
+  "sample": {
+    "currentBalance": 3.5
+  },
+  "slug": "salad"
+}

--- a/tests/fixtures/collectors/storj.json
+++ b/tests/fixtures/collectors/storj.json
@@ -1,0 +1,20 @@
+{
+  "currency": "USD",
+  "fields": [
+    "currentMonth.diskSpacePayout",
+    "currentMonth.egressBandwidthPayout",
+    "currentMonth.egressRepairAuditPayout",
+    "estimatedPayout",
+    "currentMonthExpectations"
+  ],
+  "note": "cents summed then / 100",
+  "parsed": 2.5,
+  "sample": {
+    "currentMonth": {
+      "diskSpacePayout": 150,
+      "egressBandwidthPayout": 75,
+      "egressRepairAuditPayout": 25
+    }
+  },
+  "slug": "storj"
+}

--- a/tests/fixtures/collectors/traffmonetizer.json
+++ b/tests/fixtures/collectors/traffmonetizer.json
@@ -1,0 +1,13 @@
+{
+  "currency": "USD",
+  "fields": [
+    "data.balance"
+  ],
+  "parsed": 9.99,
+  "sample": {
+    "data": {
+      "balance": 9.99
+    }
+  },
+  "slug": "traffmonetizer"
+}

--- a/tests/test_collector_contracts.py
+++ b/tests/test_collector_contracts.py
@@ -1,0 +1,346 @@
+"""Collector contracts (CashPilot-bfl).
+
+The existing collector tests assert subclassing, async-ness and attribute
+presence. None of that notices when a provider renames a field, which is how
+the ProxyBase/Repocket/EarnFM breakages shipped: the collector stopped finding
+the balance and every test stayed green.
+
+Two honest limits on what this file can do, stated because the alternative is
+pretending otherwise:
+
+* A recorded fixture is frozen at the moment it was written. It cannot detect
+  that a provider changed its API *today* — only that OUR code no longer reads
+  what we said it reads. The nightly ``-m live`` job
+  (.github/workflows/collector-live-check.yml) is the only thing here that
+  checks reality, which is why it exists.
+* The fixtures pin FIELD NAMES the collector depends on. That is the thing that
+  actually breaks, and it is checkable without credentials or a network.
+
+What this file therefore guarantees: every collector has a declared contract, a
+new collector cannot be added without one, and a refactor that stops reading a
+declared field fails CI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.collectors import COLLECTOR_MAP
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "collectors"
+
+
+def _fixture(slug: str) -> dict:
+    return json.loads((FIXTURE_DIR / f"{slug}.json").read_text(encoding="utf-8"))
+
+
+def _source(slug: str) -> str:
+    """The collector's own source, resolved via the CLASS not the slug.
+
+    COLLECTOR_MAP is keyed by catalog slug ("mysterium", "anyone-protocol")
+    while the modules are named after the provider's API ("mystnodes.py",
+    "anyone.py"). Deriving the path from the slug silently looks at the wrong
+    file — or no file at all.
+    """
+    module = COLLECTOR_MAP[slug].__module__.rsplit(".", 1)[-1]
+    return (Path(__file__).parents[1] / "app" / "collectors" / f"{module}.py").read_text(encoding="utf-8")
+
+
+ALL_SLUGS = sorted(COLLECTOR_MAP)
+
+
+class TestEveryCollectorHasAContract:
+    def test_no_collector_ships_without_a_fixture(self):
+        """A new collector with no contract is exactly the untested case."""
+        missing = [s for s in ALL_SLUGS if not (FIXTURE_DIR / f"{s}.json").exists()]
+        assert not missing, (
+            f"collectors without a contract fixture: {missing}. Add "
+            f"tests/fixtures/collectors/<slug>.json declaring the fields it parses."
+        )
+
+    def test_no_fixture_describes_a_collector_that_no_longer_exists(self):
+        orphans = [p.stem for p in FIXTURE_DIR.glob("*.json") if p.stem not in COLLECTOR_MAP]
+        assert not orphans, f"fixtures for removed collectors: {orphans}"
+
+    @pytest.mark.parametrize("slug", ALL_SLUGS)
+    def test_the_contract_is_well_formed(self, slug):
+        fx = _fixture(slug)
+        assert fx["slug"] == slug
+        assert fx["fields"], f"{slug}: a contract with no fields checks nothing"
+        assert isinstance(fx["currency"], str) and fx["currency"]
+        assert "sample" in fx
+
+
+class TestTheCodeStillReadsWhatWeSayItReads:
+    """A refactor that drops a declared field must fail here, not in production."""
+
+    @pytest.mark.parametrize("slug", ALL_SLUGS)
+    def test_every_declared_field_appears_in_the_collector(self, slug):
+        source = _source(slug)
+        fx = _fixture(slug)
+        for dotted in fx["fields"]:
+            leaf = dotted.split(".")[-1]
+            assert leaf in source, (
+                f"{slug}: the contract declares it parses {dotted!r}, but {leaf!r} does not appear in "
+                f"app/collectors/{slug}.py. Either the code changed and the fixture is stale, "
+                "or the fixture was wrong to begin with."
+            )
+
+    @pytest.mark.parametrize("slug", ALL_SLUGS)
+    def test_the_declared_currency_matches_the_collector(self, slug):
+        fx = _fixture(slug)
+        currency = fx["currency"]
+        if currency == "USD":
+            # USD is the EarningsResult default, so its absence proves nothing.
+            return
+        assert currency in _source(slug), (
+            f"{slug}: contract says it reports {currency}, which does not appear in the collector"
+        )
+
+
+class TestSampleShapesMatchTheDeclaredFields:
+    """The sample must actually contain the fields the contract claims.
+
+    Otherwise the fixture documents a shape nobody could parse, which is worse
+    than no fixture — it looks like evidence.
+    """
+
+    @pytest.mark.parametrize("slug", ALL_SLUGS)
+    def test_a_declared_path_resolves_in_the_sample_when_present(self, slug):
+        fx = _fixture(slug)
+        sample = fx["sample"]
+        resolved = 0
+        for dotted in fx["fields"]:
+            node = sample
+            for part in dotted.split("."):
+                if not isinstance(node, dict) or part not in node:
+                    node = None
+                    break
+                node = node[part]
+            if node is not None:
+                resolved += 1
+        assert resolved >= 1, (
+            f"{slug}: not one declared field resolves in the recorded sample, so the sample "
+            "does not demonstrate the shape it claims to"
+        )
+
+
+class TestParsingRealShapes:
+    """End-to-end parse for the collectors whose balance maths is deterministic.
+
+    Deliberately not all fifteen: several authenticate across several hops or
+    fall back to HTML scraping, and a mock elaborate enough to drive those would
+    be asserting against my own invention rather than against a provider.
+    """
+
+    def _run(self, collector, payloads):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        def response(body):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json = MagicMock(return_value=body)
+            resp.text = json.dumps(body)
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=[response(p) for p in payloads])
+        client.post = AsyncMock(side_effect=[response(p) for p in payloads])
+        client.is_closed = False
+        client.aclose = AsyncMock()
+
+        with patch.object(collector, "_get_client", return_value=client):
+            return asyncio.run(collector.collect())
+
+    def test_honeygain_reads_cents(self):
+        from app.collectors.honeygain import HoneygainCollector
+
+        fx = _fixture("honeygain")
+        c = HoneygainCollector(email="a@b.c", password="x")
+        c._token = "already-authenticated"
+        out = self._run(c, [fx["sample"]])
+        assert out.error is None
+        assert out.balance == fx["parsed"]
+        assert out.currency == fx["currency"]
+
+    def test_salad_reads_the_balance_directly(self):
+        from app.collectors.salad import SaladCollector
+
+        fx = _fixture("salad")
+        out = self._run(SaladCollector(auth_cookie="c"), [fx["sample"]])
+        assert out.error is None
+        assert out.balance == fx["parsed"]
+
+    def test_a_renamed_field_is_caught_rather_than_read_as_zero(self):
+        """The failure this bead exists for: the provider renames the key."""
+        from app.collectors.salad import SaladCollector
+
+        out = self._run(SaladCollector(auth_cookie="c"), [{"balanceCurrent": 3.5}])
+        assert out.balance == 0.0 or out.error is not None, (
+            "a renamed field must surface as an error or a zero, never as a plausible number"
+        )
+
+
+class TestCredentialSelfTest:
+    """The button that answers "are these credentials valid?" in a second.
+
+    The security requirement outranks the feature: a failing provider login
+    frequently echoes the submitted payload, and a raw body has leaked into
+    logs from a worker path in this codebase before. Nothing sensitive may
+    appear in the response.
+    """
+
+    def _call(self, slug, config=None, collect=None, raises=None):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import credential_test, main
+
+        credential_test._last_attempt.clear()
+        collector = MagicMock()
+        collector.close = AsyncMock()
+        if raises is not None:
+            collector.collect = AsyncMock(side_effect=raises)
+        else:
+            collector.collect = AsyncMock(return_value=collect)
+
+        build = (collector, []) if (collect is not None or raises is not None) else (None, ["k"])
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value=config or {})),
+                patch("app.collectors.build_one", return_value=build),
+            ):
+                return await main.api_test_credentials(MagicMock(), slug)
+
+        return asyncio.run(run())
+
+    def _result(self, balance=0.0, currency="USD", error=None):
+        from app.collectors.base import EarningsResult
+
+        return EarningsResult(platform="honeygain", balance=balance, currency=currency, error=error)
+
+    def test_valid_credentials_report_the_balance(self):
+        out = self._call("honeygain", collect=self._result(balance=12.5))
+        assert out["ok"] is True
+        assert "12.5" in out["message"]
+
+    def test_a_rejected_login_says_so_without_echoing_anything(self):
+        out = self._call("honeygain", collect=self._result(error="401 Unauthorized for token abc123secret"))
+        assert out["ok"] is False
+        assert out["outcome"] == "bad_credentials"
+        assert "abc123secret" not in json.dumps(out), "the response leaked the provider's raw error"
+
+    def test_a_raised_exception_never_leaks_its_text(self):
+        out = self._call("honeygain", raises=RuntimeError("connect failed to https://user:hunter2@api"))
+        assert "hunter2" not in json.dumps(out)
+        assert out["outcome"] == "unreachable"
+
+    def test_no_response_field_can_carry_a_secret(self):
+        out = self._call("honeygain", collect=self._result(balance=1.0))
+        assert set(out) <= {"ok", "outcome", "message", "balance", "currency"}
+
+    def test_an_unknown_service_is_a_404(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._call("no-such-service")
+        assert exc.value.status_code == 404
+
+    def test_a_service_with_no_collector_says_there_is_nothing_to_test(self):
+        out = self._call("grass" if "grass" not in COLLECTOR_MAP else "teneo")
+        assert out["outcome"] in {"unsupported", "not_configured"}
+
+    def test_unconfigured_credentials_are_reported_as_such(self):
+        out = self._call("honeygain")
+        assert out["outcome"] == "not_configured"
+
+    def test_a_second_attempt_is_rate_limited(self):
+        """Retrying a rejected login in a loop is how an account gets flagged."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import credential_test, main
+
+        credential_test._last_attempt.clear()
+        collector = MagicMock()
+        collector.close = AsyncMock()
+        collector.collect = AsyncMock(return_value=self._result(balance=1.0))
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value={})),
+                patch("app.collectors.build_one", return_value=(collector, [])),
+            ):
+                first = await main.api_test_credentials(MagicMock(), "honeygain")
+                second = await main.api_test_credentials(MagicMock(), "honeygain")
+                return first, second
+
+        first, second = asyncio.run(run())
+        assert first["ok"] is True
+        assert second["outcome"] == "rate_limited"
+        assert collector.collect.await_count == 1, "the provider was hit twice despite the cooldown"
+
+    def test_the_collector_is_closed_even_when_it_raises(self):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import credential_test, main
+
+        credential_test._last_attempt.clear()
+        collector = MagicMock()
+        collector.close = AsyncMock()
+        collector.collect = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value={})),
+                patch("app.collectors.build_one", return_value=(collector, [])),
+            ):
+                return await main.api_test_credentials(MagicMock(), "honeygain")
+
+        asyncio.run(run())
+        collector.close.assert_awaited()
+
+
+class TestOutcomeClassification:
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            (None, "ok"),
+            ("401 Unauthorized", "bad_credentials"),
+            ("HTTP 403 Forbidden", "bad_credentials"),
+            ("Read timed out", "unreachable"),
+            ("Connection refused", "unreachable"),
+            ("Honeygain not configured", "not_configured"),
+            ("KeyError: 'usd_cents'", "unexpected_shape"),
+            ("something nobody anticipated", "unexpected_shape"),
+        ],
+    )
+    def test_errors_map_to_stable_outcomes(self, error, expected):
+        from app import credential_test
+
+        assert credential_test.classify(error) == expected
+
+    def test_every_outcome_has_a_message_a_user_can_act_on(self):
+        from app import credential_test
+
+        for outcome in (
+            "ok",
+            "bad_credentials",
+            "not_configured",
+            "unreachable",
+            "unexpected_shape",
+            "rate_limited",
+            "unsupported",
+        ):
+            msg = credential_test.message(outcome, "Honeygain")
+            assert len(msg) > 20 and msg.endswith((".", "!"))

--- a/tests/test_collector_contracts.py
+++ b/tests/test_collector_contracts.py
@@ -344,3 +344,96 @@ class TestOutcomeClassification:
         ):
             msg = credential_test.message(outcome, "Honeygain")
             assert len(msg) > 20 and msg.endswith((".", "!"))
+
+
+class TestBuildingASingleCollector:
+    """`build_one` is what the credential self-test runs.
+
+    Deliberately UNCACHED: the button exists to check credentials the user just
+    changed, and handing back a cached instance built from the previous values
+    would validate the wrong thing and report success for a credential that no
+    longer exists.
+    """
+
+    def test_it_builds_a_collector_when_every_required_key_is_present(self):
+        from app import collectors
+
+        collector, missing = collectors.build_one("honeygain", {"honeygain_email": "a@b.c", "honeygain_password": "pw"})
+        assert collector is not None
+        assert missing == []
+        assert collector.platform == "honeygain"
+
+    def test_it_names_the_missing_keys_rather_than_failing_vaguely(self):
+        from app import collectors
+
+        collector, missing = collectors.build_one("honeygain", {})
+        assert collector is None
+        assert missing == ["honeygain_email", "honeygain_password"]
+
+    def test_a_partially_configured_service_names_only_what_is_absent(self):
+        from app import collectors
+
+        _, missing = collectors.build_one("honeygain", {"honeygain_email": "a@b.c"})
+        assert missing == ["honeygain_password"]
+
+    def test_an_unknown_slug_yields_nothing_and_no_missing_keys(self):
+        """Nothing is missing because nothing was ever required."""
+        from app import collectors
+
+        assert collectors.build_one("no-such-service", {}) == (None, [])
+
+    def test_each_call_returns_a_fresh_instance(self):
+        """A cached one would validate the credentials the user just replaced."""
+        from app import collectors
+
+        config = {"honeygain_email": "a@b.c", "honeygain_password": "pw"}
+        first, _ = collectors.build_one("honeygain", config)
+        second, _ = collectors.build_one("honeygain", config)
+        assert first is not second
+
+    def test_it_never_populates_the_shared_collector_cache(self):
+        from app import collectors
+
+        collectors._cached_collectors.pop("honeygain", None)
+        collectors.build_one("honeygain", {"honeygain_email": "a@b.c", "honeygain_password": "pw"})
+        assert "honeygain" not in collectors._cached_collectors
+
+    def test_optional_arguments_are_not_required(self):
+        """A '?'-prefixed argument must not block construction when absent."""
+        from app import collectors
+
+        optional_slugs = [
+            slug for slug, args in collectors._COLLECTOR_ARGS.items() if any(a.startswith("?") for a in args)
+        ]
+        if not optional_slugs:
+            pytest.skip("no collector declares an optional argument")
+        slug = optional_slugs[0]
+        required = {f"{slug}_{a}": "x" for a in collectors._COLLECTOR_ARGS[slug] if not a.startswith("?")}
+        collector, missing = collectors.build_one(slug, required)
+        assert missing == []
+        assert collector is not None
+
+    def test_a_constructor_that_raises_is_reported_as_no_collector(self):
+        from unittest.mock import patch
+
+        from app import collectors
+
+        with patch.dict(
+            collectors.COLLECTOR_MAP, {"honeygain": lambda **kw: (_ for _ in ()).throw(ValueError("nope"))}
+        ):
+            collector, missing = collectors.build_one(
+                "honeygain", {"honeygain_email": "a@b.c", "honeygain_password": "pw"}
+            )
+        assert collector is None
+        assert missing == []
+
+    def test_it_resolves_the_same_keys_as_the_scheduled_factory(self):
+        """Two resolvers that disagree would validate different credentials."""
+        from app import collectors
+
+        for slug, args in collectors._COLLECTOR_ARGS.items():
+            if slug not in collectors.COLLECTOR_MAP:
+                continue
+            _, missing = collectors.build_one(slug, {})
+            expected = sorted(f"{slug}_{a}" for a in args if not a.startswith("?"))
+            assert sorted(missing) == expected, f"{slug}: build_one disagrees with _COLLECTOR_ARGS"


### PR DESCRIPTION
The collector tests assert subclassing, async-ness and attribute presence. **None of that notices a provider renaming a field** — which is exactly how the ProxyBase/Repocket/EarnFM breakages shipped: the collector stopped finding the balance and every test stayed green.

Three parts, and it's worth being blunt about what each can actually prove.

## 1. Contract fixtures — what they can prove

`tests/fixtures/collectors/*.json` pin the **field names** each collector depends on, plus its currency and a representative shape. Tests assert:

- every collector has one (a new collector can't ship without a contract);
- no fixture describes a collector that no longer exists;
- every declared field still appears in the collector's own source, so a refactor that stops reading one fails CI;
- the recorded sample actually contains the fields it claims — a fixture documenting an unparseable shape is *worse* than none, because it looks like evidence.

**What they cannot do is notice a provider changed its API today.** They're frozen at the moment they were written. That's said plainly in the module docstring rather than left implied.

## 2. The nightly live check — the part that touches reality

Runs the real collectors behind a `live` pytest marker, **excluded by default** so a PR never depends on a third party being up, and opens (or comments on) a `collector-drift` issue when a shape changes.

On `ubuntu-latest` deliberately: free on a public repo, ephemeral, and it keeps provider credentials off the self-hosted fleet. **The issue body does not paste the log** — a failing collector can echo a request payload.

## 3. Credential self-test

`POST /api/services/{slug}/test-credentials` answers *"are these valid?"* in a second, instead of waiting up to an hour for the scheduler to say so via a notification bell.

Two constraints shaped it more than the feature did:

- **It cannot echo the credential or the provider's raw body.** A failed login frequently replies with the submitted payload, and a raw body has leaked into logs from a worker path in this repo before. Outcomes are *classified*; the original text is logged at debug only; the response has no field able to carry a secret. A test asserts a token embedded in an error never reaches the caller.
- **A test button invites a retry loop**, and retrying a rejected login repeatedly is how providers flag an account. Rate-limited per service, with a test asserting the provider is hit **once**, not twice.

The collector is built *uncached* via a new `collectors.build_one`, reusing the same argument table as `make_collectors` so the two can't disagree about which keys a service needs. Cached would have validated the credentials the user just replaced.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1818 passed**, coverage 94.37%
- Endpoint tests up front, including the leak and rate-limit cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated option to test service credentials on demand.
  - Results now show clear statuses for valid, invalid, missing, unsupported, or unreachable services.
  - Successful checks can display the current balance and currency.
  - Credential test attempts are rate-limited to prevent repeated requests.

- **Bug Fixes**
  - Sensitive credentials and raw provider errors are excluded from responses.

- **Chores**
  - Added scheduled live checks to detect collector issues automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->