### PR TITLE
feat: encrypted export of irreplaceable service state (CashPilot-qqo)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -43,6 +43,9 @@ COPY --chown=cashpilot:root app/fleet_key.py ./app/
 # Egress identity: pure helpers, deliberately free of app-level imports so
 # the worker image stays minimal.
 COPY --chown=cashpilot:root app/egress.py ./app/
+# Encrypted state export: encryption happens on the WORKER so the UI only
+# ever handles ciphertext.
+COPY --chown=cashpilot:root app/state_backup.py ./app/
 COPY --chown=cashpilot:root app/worker_api.py ./app/
 COPY --chown=cashpilot:root app/orchestrator.py ./app/
 COPY --chown=cashpilot:root app/catalog.py ./app/

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -7,6 +7,7 @@ inspection for cashpilot-managed containers via the Docker SDK.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import time
@@ -316,6 +317,49 @@ def _critical_volume_targets(slug: str) -> dict[str, str] | None:
     except Exception:  # pragma: no cover - defensive
         logger.exception("Could not resolve critical volumes for %s", slug)
         return None
+
+
+def read_critical_state(slug: str) -> tuple[bytes, list[str]]:
+    """Read a service's irreplaceable state as a deterministic tar archive.
+
+    Returns ``(tar_bytes, targets)``. Only the mounts the catalog marks
+    ``critical_volumes`` are read — never the whole container. That list is the
+    same inventory the delete guard refuses on, so "what is irreplaceable" has
+    one definition rather than two that can drift apart.
+
+    The container is PAUSED for the duration when it is running. A keystore or
+    sqlite file copied while it is being written produces a backup that opens
+    perfectly and restores a corrupt node — the worst possible outcome, because
+    it fails only when it is finally needed. Pause is used rather than stop so a
+    node does not lose its uptime score for a backup.
+    """
+    targets = _critical_volume_targets(slug)
+    if not targets:
+        raise ValueError(
+            f"{slug} declares no critical_volumes, so there is no irreplaceable state to export. "
+            "Adding a backup for a service whose state is re-downloadable would teach a false habit."
+        )
+
+    container = _find_container(slug)
+    was_running = container.status == "running"
+    chunks: list[bytes] = []
+    read: list[str] = []
+
+    if was_running:
+        container.pause()
+    try:
+        for target in sorted(targets):
+            stream, _stat = container.get_archive(target)
+            chunks.append(b"".join(stream))
+            read.append(target)
+    finally:
+        if was_running:
+            # Unpause even if the read failed: leaving a paused earner behind
+            # would silently stop the income this feature exists to protect.
+            with contextlib.suppress(Exception):
+                container.unpause()
+
+    return b"".join(chunks), read
 
 
 def remove_service(slug: str, delete_volumes: bool = False, allow_delete_critical: bool = False) -> dict[str, Any]:

--- a/app/state_backup.py
+++ b/app/state_backup.py
@@ -1,0 +1,272 @@
+"""Encrypted export of irreplaceable service state (CashPilot-qqo).
+
+Users overwhelmingly do not back up node identities and wallets, because nothing
+tells them those files exist. When a disk dies the held payout balance, the relay
+stake, or the wallet is simply gone — and no other feature in this project
+survives that.
+
+It is also the most dangerous thing here, because it hands the worker a new
+capability: reading key material out of a container volume. The worker already
+holds the Docker socket, so the question is not whether it *could* but whether
+the design ever gives anyone a reason to.
+
+The constraints below are not tunable knobs. Each one closes a specific way this
+feature turns into an exfiltration channel.
+
+**The installation must not be able to decrypt its own exports.** No server-held
+wrapping key, no fallback to the Fernet key that protects credentials. If
+CashPilot could open the bundle, then anyone who compromises CashPilot inherits
+every node identity it ever exported — turning a backup feature into the single
+highest-value target in the system. So the user supplies the target: either an
+X25519 recipient public key, where no secret ever enters CashPilot at all, or a
+passphrase which is used and discarded.
+
+**No destination but the response to the authenticated caller.** No upload, no
+sync, no webhook. The moment such a path exists in the code, a compromised UI
+can switch it on; the absence of the code is the control.
+
+**No scheduled export.** A timer needs a stored secret, which is precisely the
+server-held key the first rule forbids. Alert on "no verified backup" instead.
+
+**AEAD, not encryption alone.** ChaCha20-Poly1305 so tampering is detected
+rather than decrypted into garbage, with the header authenticated as associated
+data so nobody can swap the metadata that says which service a bundle belongs to.
+
+And the part users get wrong: **losing the passphrase means the backup is gone.**
+There is no recovery, by construction. Anything that could recover it would
+violate the first rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from typing import Any
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey, X25519PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+MAGIC = b"CASHPILOT-BACKUP"
+VERSION = 1
+
+MODE_PASSPHRASE = "passphrase"
+MODE_RECIPIENT = "recipient"
+
+# scrypt parameters. Deliberately expensive: the threat is an offline attack on a
+# stolen bundle, where the only defence is the cost of each guess.
+_SCRYPT_N = 2**15
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SALT_BYTES = 16
+_NONCE_BYTES = 12
+_KEY_BYTES = 32
+
+_HKDF_INFO = b"cashpilot-backup-v1"
+
+# A passphrase short enough to brute-force offline is not protection, and this
+# is the one secret with no server-side rate limit in front of it.
+MIN_PASSPHRASE_LENGTH = 12
+
+
+class BackupError(Exception):
+    """Raised when a bundle cannot be produced or opened."""
+
+
+def generate_recipient_keypair() -> tuple[str, str]:
+    """A fresh X25519 keypair as (private_key_hex, public_key_hex).
+
+    Offered so a user without an age setup can still use recipient mode. The
+    PRIVATE half is returned once, to the caller, and never stored — a copy kept
+    anywhere in this installation would recreate exactly the "CashPilot can
+    decrypt its own backups" property this design exists to prevent.
+    """
+    private = X25519PrivateKey.generate()
+    return (
+        private.private_bytes_raw().hex(),
+        private.public_key().public_bytes_raw().hex(),
+    )
+
+
+def _derive_from_passphrase(passphrase: str, salt: bytes) -> bytes:
+    kdf = Scrypt(salt=salt, length=_KEY_BYTES, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P)
+    return kdf.derive(passphrase.encode("utf-8"))
+
+
+def _derive_shared(shared: bytes, salt: bytes) -> bytes:
+    return HKDF(algorithm=hashes.SHA256(), length=_KEY_BYTES, salt=salt, info=_HKDF_INFO).derive(shared)
+
+
+def seal(
+    payload: bytes,
+    *,
+    passphrase: str | None = None,
+    recipient_public_key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> bytes:
+    """Encrypt ``payload`` into a self-describing bundle.
+
+    Exactly one of ``passphrase`` or ``recipient_public_key`` must be given.
+    Recipient mode is preferred: no secret enters CashPilot at all, so a
+    compromised installation cannot open bundles it produced earlier even with
+    full memory access at the time.
+    """
+    if bool(passphrase) == bool(recipient_public_key):
+        raise BackupError("Provide exactly one of a passphrase or a recipient public key.")
+
+    salt = secrets.token_bytes(_SALT_BYTES)
+    nonce = secrets.token_bytes(_NONCE_BYTES)
+    header: dict[str, Any] = {
+        "magic": MAGIC.decode(),
+        "version": VERSION,
+        "salt": salt.hex(),
+        "nonce": nonce.hex(),
+        "metadata": metadata or {},
+        # Lets a restore prove it got the same bytes back without the plaintext
+        # ever being written anywhere.
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+    if passphrase:
+        if len(passphrase) < MIN_PASSPHRASE_LENGTH:
+            raise BackupError(
+                f"Passphrase must be at least {MIN_PASSPHRASE_LENGTH} characters. "
+                "This is the only thing standing between a stolen bundle and a node identity."
+            )
+        header["mode"] = MODE_PASSPHRASE
+        key = _derive_from_passphrase(passphrase, salt)
+    else:
+        header["mode"] = MODE_RECIPIENT
+        try:
+            recipient = X25519PublicKey.from_public_bytes(bytes.fromhex(str(recipient_public_key)))
+        except (ValueError, TypeError) as exc:
+            raise BackupError("Recipient public key must be 32 bytes of hex (an X25519 public key).") from exc
+        ephemeral = X25519PrivateKey.generate()
+        header["ephemeral_public_key"] = ephemeral.public_key().public_bytes_raw().hex()
+        key = _derive_shared(ephemeral.exchange(recipient), salt)
+
+    header_bytes = json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    # The header is authenticated, not encrypted: swapping the metadata that
+    # says which service a bundle belongs to must invalidate it.
+    ciphertext = ChaCha20Poly1305(key).encrypt(nonce, payload, header_bytes)
+    return len(header_bytes).to_bytes(4, "big") + header_bytes + ciphertext
+
+
+def read_header(bundle: bytes) -> dict[str, Any]:
+    """The unencrypted, authenticated header. Never contains key material."""
+    if len(bundle) < 4:
+        raise BackupError("Not a CashPilot backup bundle.")
+    length = int.from_bytes(bundle[:4], "big")
+    if length <= 0 or len(bundle) < 4 + length:
+        raise BackupError("Not a CashPilot backup bundle.")
+    try:
+        header = json.loads(bundle[4 : 4 + length].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackupError("Not a CashPilot backup bundle.") from exc
+    if header.get("magic") != MAGIC.decode():
+        raise BackupError("Not a CashPilot backup bundle.")
+    if header.get("version") != VERSION:
+        raise BackupError(f"Unsupported bundle version {header.get('version')!r}.")
+    return header
+
+
+def open_bundle(
+    bundle: bytes,
+    *,
+    passphrase: str | None = None,
+    recipient_private_key: str | None = None,
+) -> bytes:
+    """Decrypt a bundle, or raise BackupError.
+
+    The failure message never distinguishes a wrong passphrase from a corrupted
+    bundle in a way that would help an attacker, and never echoes any input.
+    """
+    header = read_header(bundle)
+    length = int.from_bytes(bundle[:4], "big")
+    header_bytes = bundle[4 : 4 + length]
+    ciphertext = bundle[4 + length :]
+
+    try:
+        salt = bytes.fromhex(header["salt"])
+        nonce = bytes.fromhex(header["nonce"])
+    except (KeyError, ValueError) as exc:
+        raise BackupError("Bundle header is malformed.") from exc
+
+    mode = header.get("mode")
+    if mode == MODE_PASSPHRASE:
+        if not passphrase:
+            raise BackupError("This bundle needs the passphrase it was created with.")
+        key = _derive_from_passphrase(passphrase, salt)
+    elif mode == MODE_RECIPIENT:
+        if not recipient_private_key:
+            raise BackupError("This bundle needs the private key matching the recipient it was created for.")
+        try:
+            private = X25519PrivateKey.from_private_bytes(bytes.fromhex(recipient_private_key))
+            ephemeral = X25519PublicKey.from_public_bytes(bytes.fromhex(header["ephemeral_public_key"]))
+        except (KeyError, ValueError, TypeError) as exc:
+            raise BackupError("Bundle header is malformed, or the private key is not valid X25519.") from exc
+        key = _derive_shared(private.exchange(ephemeral), salt)
+    else:
+        raise BackupError(f"Unknown bundle mode {mode!r}.")
+
+    try:
+        payload = ChaCha20Poly1305(key).decrypt(nonce, ciphertext, header_bytes)
+    except InvalidTag as exc:
+        raise BackupError(
+            "Could not decrypt this bundle. Either the passphrase or key is wrong, or the file has "
+            "been altered. There is no recovery path — that is the point of the design."
+        ) from exc
+
+    expected = header.get("sha256")
+    if expected and hashlib.sha256(payload).hexdigest() != expected:
+        raise BackupError("Bundle decrypted but its contents do not match the recorded checksum.")
+    return payload
+
+
+def verify(
+    bundle: bytes,
+    live_payload: bytes,
+    *,
+    passphrase: str | None = None,
+    recipient_private_key: str | None = None,
+) -> dict[str, Any]:
+    """Does this bundle still match what is on disk right now?
+
+    "I have a backup file" and "I have a backup that works" are different
+    claims, and believing the first when only the second matters is how people
+    discover a dead node and an unusable file on the same afternoon.
+
+    Compares digests, never plaintext, and writes nothing.
+    """
+    try:
+        restored = open_bundle(bundle, passphrase=passphrase, recipient_private_key=recipient_private_key)
+    except BackupError as exc:
+        return {"ok": False, "matches": False, "reason": str(exc)}
+
+    live_digest = hashlib.sha256(live_payload).hexdigest()
+    backup_digest = hashlib.sha256(restored).hexdigest()
+    matches = secrets.compare_digest(live_digest, backup_digest)
+    return {
+        "ok": True,
+        "matches": matches,
+        "backup_sha256": backup_digest,
+        "live_sha256": live_digest,
+        "reason": (
+            "This backup matches the state currently on disk."
+            if matches
+            else "This backup opens correctly but no longer matches the live volume — it is out of date."
+        ),
+    }
+
+
+def looks_like_bundle(data: bytes) -> bool:
+    """Cheap check used before spending scrypt work on obvious junk."""
+    try:
+        read_header(data)
+    except BackupError:
+        return False
+    return True

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -13,6 +13,7 @@ Configure via environment variables:
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import hmac
 import logging
@@ -33,7 +34,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from app import egress, fleet_key, orchestrator
+from app import egress, fleet_key, orchestrator, state_backup
 
 try:
     from app.catalog import get_services as _catalog_get_services
@@ -1008,6 +1009,103 @@ async def api_container_logs(request: Request, slug: str, lines: int = 50) -> di
         raise HTTPException(status_code=404, detail=str(exc))
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc))
+
+
+class BackupRequest(BaseModel):
+    """Target for an export. Exactly one of the two must be supplied.
+
+    A passphrase arrives, is used to derive a key, and is discarded with the
+    request. It is never written to disk, never logged, and never returned.
+    """
+
+    passphrase: str | None = None
+    recipient_public_key: str | None = None
+
+
+class VerifyRequest(BackupRequest):
+    """A bundle to check against the state currently on disk."""
+
+    bundle_b64: str = ""
+
+
+@app.post("/api/containers/{slug}/backup")
+async def api_backup(slug: str, body: BackupRequest, request: Request) -> dict[str, Any]:
+    """Export this service's irreplaceable state, encrypted HERE.
+
+    Encryption happens on the worker so the UI only ever handles ciphertext:
+    plaintext key material must not cross the wire even inside the fleet, and it
+    must not sit in the UI's memory where a different compromise would reach it.
+
+    The bundle is returned in THIS response and nowhere else. There is
+    deliberately no upload, sync or webhook path in the code — the absence is
+    what makes the guarantee checkable, rather than a policy nobody audits.
+    """
+    _verify_api_key(request)
+    try:
+        payload, targets = await asyncio.to_thread(orchestrator.read_critical_state, slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Backup read failed for %s: %s", slug, exc)
+        raise HTTPException(status_code=500, detail="Could not read this service's state") from exc
+
+    try:
+        bundle = await asyncio.to_thread(
+            lambda: state_backup.seal(
+                payload,
+                passphrase=body.passphrase,
+                recipient_public_key=body.recipient_public_key,
+                metadata={"slug": slug, "worker": WORKER_NAME, "targets": targets},
+            )
+        )
+    except state_backup.BackupError as exc:
+        # Safe to surface: these messages are about the CALLER's inputs and
+        # deliberately contain neither the passphrase nor any state.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "slug": slug,
+        "targets": targets,
+        "bytes": len(bundle),
+        "bundle_b64": base64.b64encode(bundle).decode("ascii"),
+    }
+
+
+@app.post("/api/containers/{slug}/backup/verify")
+async def api_backup_verify(slug: str, body: VerifyRequest, request: Request) -> dict[str, Any]:
+    """Does this bundle still match what is on disk?
+
+    "I have a backup file" and "I have a backup that works" are different
+    claims. Believing the first is how people find a dead node and an unusable
+    file on the same afternoon.
+
+    Decryption happens in memory on the worker and nothing is written anywhere;
+    only digests are compared, so no plaintext is produced for the caller.
+    """
+    _verify_api_key(request)
+    try:
+        bundle = base64.b64decode(body.bundle_b64 or "", validate=True)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=400, detail="Bundle is not valid base64") from exc
+    if not state_backup.looks_like_bundle(bundle):
+        raise HTTPException(status_code=400, detail="That file is not a CashPilot backup bundle")
+
+    try:
+        payload, _targets = await asyncio.to_thread(orchestrator.read_critical_state, slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Backup verify read failed for %s: %s", slug, exc)
+        raise HTTPException(status_code=500, detail="Could not read this service's state") from exc
+
+    return await asyncio.to_thread(
+        lambda: state_backup.verify(
+            bundle,
+            payload,
+            passphrase=body.passphrase,
+            recipient_private_key=body.recipient_public_key,
+        )
+    )
 
 
 @app.get("/api/health")

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,76 @@
+# Backing up what cannot be replaced
+
+Some services keep state on your machine that **exists nowhere else**: a node
+identity, a relay key, a wallet generated inside the container on first run.
+Lose the disk and you lose the held payout balance and the node's accumulated
+reputation with it. Redeploying gives you a *new* node, starting from zero.
+
+Most people never back these up, because nothing tells them the files exist.
+
+CashPilot knows which mounts matter — the catalog marks them `critical_volumes`,
+the same list the delete guard refuses on — so it can export exactly those.
+
+## The one thing to understand first
+
+!!! danger "Lose the passphrase and the backup is gone"
+
+    There is **no recovery**. Not by CashPilot, not by resetting anything, not
+    by asking anyone. This is deliberate: a backup CashPilot could recover is a
+    backup that anyone who compromises CashPilot can also recover.
+
+    Write the passphrase down somewhere that is not the machine being backed up.
+
+## How it works
+
+**Encryption happens on the worker**, on the machine that holds the data. The UI
+only ever handles ciphertext, so plaintext key material never crosses the fleet
+network and never sits in the dashboard's memory.
+
+**You choose the target**, and CashPilot cannot decrypt either kind:
+
+- **A recipient public key** (preferred). An X25519 public key — CashPilot never
+  sees the private half, so it *cannot* open the bundle even in principle. Use
+  your own, or have CashPilot generate a pair and keep the private key yourself.
+- **A passphrase**, which is used to derive a key and then discarded with the
+  request. Minimum 12 characters, because the realistic attack on a stolen
+  bundle is offline guessing, and length is the only defence.
+
+**The container is paused while its state is read.** A keystore or SQLite file
+copied mid-write produces a backup that opens perfectly and restores a broken
+node — a failure that only shows up when you finally need it. Pause rather than
+stop, so a node does not lose uptime score for a backup.
+
+**The bundle is returned in the response and nowhere else.** There is no upload,
+no cloud sync, no webhook — not disabled, *absent*. Once such a path exists in
+the code, anyone who compromises the UI can switch it on.
+
+**There is no scheduled backup**, for the same reason: a timer needs a stored
+secret, which is exactly the server-held key that would break the first rule.
+
+## Is my backup actually any good?
+
+"I have a backup file" and "I have a backup that works" are different claims,
+and people discover the difference on the worst possible day.
+
+The verify endpoint decrypts the bundle **in memory on the worker** and compares
+its digest against the state currently on disk. Nothing is written, and no
+plaintext is produced. It answers three ways:
+
+| Answer | Meaning |
+|---|---|
+| matches | This bundle restores exactly what is running now. |
+| does not match | It opens fine but is **out of date** — the node has moved on. |
+| cannot open | Wrong passphrase or key, or the file has been altered. |
+
+Verify after taking a backup, and again after you move it anywhere.
+
+## What is not covered
+
+- **Restore is not yet implemented.** Writing into a volume is the destructive
+  half of this feature and is deliberately a separate change.
+- Services with no `critical_volumes` entry are refused rather than backed up.
+  If a service's state is re-downloadable, a backup teaches a false habit; if it
+  is genuinely irreplaceable and missing from the catalog, that is a catalog bug
+  worth reporting.
+- Credentials in CashPilot's own database are a different thing, protected by a
+  different key. This feature is only about state inside service containers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - Direction and Roadmap: roadmap.md
   - Security Defaults: security-defaults.md
   - Fleet Management: fleet.md
+  - Backing Up Node Identities: backup.md
   - Prometheus Metrics: guides/prometheus-metrics.md
   - Upgrade to v1.0.0: upgrade-v1.md
   - Service Guides:

--- a/tests/test_state_backup.py
+++ b/tests/test_state_backup.py
@@ -1,0 +1,482 @@
+"""Encrypted state export (CashPilot-qqo).
+
+The tests that matter here are not "does it round-trip" — that is the easy half.
+They are the ones asserting the properties that make this feature safe to have
+at all, because a backup feature that CashPilot can decrypt is a worse thing to
+own than no backup feature.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app import state_backup as sb
+
+
+def _module_ast():
+    import ast
+    import pathlib
+
+    return ast.parse(pathlib.Path(sb.__file__).read_text(encoding="utf-8"))
+
+
+def _modules_imported() -> set[str]:
+    import ast
+
+    found: set[str] = set()
+    for node in ast.walk(_module_ast()):
+        if isinstance(node, ast.Import):
+            found.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            found.add(node.module)
+    return found
+
+
+def _names_used() -> set[str]:
+    import ast
+
+    found: set[str] = set()
+    for node in ast.walk(_module_ast()):
+        if isinstance(node, ast.Name):
+            found.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            found.add(node.attr)
+    return found
+
+
+def _strings_used() -> set[str]:
+    import ast
+
+    tree = _module_ast()
+    docstrings = {
+        ast.get_docstring(n) for n in ast.walk(tree) if isinstance(n, ast.Module | ast.FunctionDef | ast.ClassDef)
+    }
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value not in docstrings
+    }
+
+
+PASSPHRASE = "a-long-enough-passphrase"
+PAYLOAD = b"node-identity-keystore-bytes"
+
+
+class TestTheInstallationCannotDecryptItsOwnExports:
+    """The single property the whole design exists to provide."""
+
+    def test_a_recipient_bundle_needs_the_private_key_nobody_here_holds(self):
+        _, public = sb.generate_recipient_keypair()
+        bundle = sb.seal(PAYLOAD, recipient_public_key=public)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bundle, passphrase=PASSPHRASE)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bundle)
+
+    def test_the_public_key_alone_cannot_open_it(self):
+        _, public = sb.generate_recipient_keypair()
+        bundle = sb.seal(PAYLOAD, recipient_public_key=public)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bundle, recipient_private_key=public)
+
+    def test_a_different_private_key_cannot_open_it(self):
+        _, public = sb.generate_recipient_keypair()
+        other_private, _ = sb.generate_recipient_keypair()
+        bundle = sb.seal(PAYLOAD, recipient_public_key=public)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bundle, recipient_private_key=other_private)
+
+    def test_the_generated_private_key_is_returned_and_not_retained(self):
+        """It is handed to the caller once; nothing here may keep a copy."""
+        private, public = sb.generate_recipient_keypair()
+        assert private != public
+        assert len(bytes.fromhex(private)) == 32
+        assert not (_names_used() & {"write_text", "write_bytes", "sqlite3", "connect"}), (
+            "the backup module must not persist anything"
+        )
+
+    def test_no_fernet_or_server_key_is_referenced_in_code(self):
+        """Checked against the AST, not the text.
+
+        A substring search over the source also matches the docstring that
+        EXPLAINS why there is no server-held key, so it fails on the very
+        comment documenting the property. Only real references count.
+        """
+        forbidden = {"Fernet", "fernet_key", "CASHPILOT_ENCRYPTION_KEY", "CASHPILOT_SECRET_KEY"}
+        used = _names_used() | _strings_used()
+        assert not (used & forbidden), (
+            f"{used & forbidden} referenced in the backup module — a server-held key would let a "
+            "compromised installation open every bundle it ever produced"
+        )
+
+
+class TestThereIsNoWayToSendABundleAnywhere:
+    """The absence of transport code is the control, not a policy."""
+
+    def test_the_module_imports_no_network_client(self):
+        """Checked against the import graph, not the text.
+
+        The docstring mentions "the Docker socket" while explaining the threat
+        model, so a substring search reports a socket import that does not
+        exist.
+        """
+        forbidden = {"httpx", "requests", "urllib", "urllib.request", "smtplib", "boto3", "socket", "ftplib"}
+        imported = _modules_imported()
+        assert not (imported & forbidden), f"{imported & forbidden} would make an upload path possible"
+
+    def test_it_imports_only_stdlib_and_the_existing_crypto_dependency(self):
+        allowed_prefixes = ("hashlib", "json", "secrets", "typing", "cryptography", "__future__", "os", "pathlib")
+        stray = {m for m in _modules_imported() if not m.startswith(allowed_prefixes)}
+        assert not stray, f"unexpected dependency in the backup module: {stray}"
+
+
+class TestTamperingIsDetected:
+    def test_a_modified_ciphertext_is_rejected(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        flipped = bytearray(bundle)
+        flipped[-1] ^= 0x01
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bytes(flipped), passphrase=PASSPHRASE)
+
+    def test_swapping_the_metadata_invalidates_the_bundle(self):
+        """The header is authenticated, so a bundle cannot be relabelled.
+
+        The replacement keeps the header LENGTH identical, so this really does
+        exercise the AEAD rather than tripping the length prefix.
+        """
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE, metadata={"slug": "mysterium"})
+        relabelled = bundle.replace(b'"slug":"mysterium"', b'"slug":"MYSTERIUM"')
+        assert relabelled != bundle
+        assert len(relabelled) == len(bundle)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(relabelled, passphrase=PASSPHRASE)
+
+    def test_a_truncated_bundle_is_rejected(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        with pytest.raises(sb.BackupError):
+            sb.open_bundle(bundle[:-4], passphrase=PASSPHRASE)
+
+    @pytest.mark.parametrize("junk", [b"", b"abc", b"\x00\x00\x00\x05hello", b"x" * 200])
+    def test_junk_is_not_mistaken_for_a_bundle(self, junk):
+        assert sb.looks_like_bundle(junk) is False
+        with pytest.raises(sb.BackupError):
+            sb.read_header(junk)
+
+
+class TestPassphraseMode:
+    def test_it_round_trips(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        assert sb.open_bundle(bundle, passphrase=PASSPHRASE) == PAYLOAD
+
+    def test_a_wrong_passphrase_fails_without_saying_which_part_was_wrong(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        with pytest.raises(sb.BackupError) as exc:
+            sb.open_bundle(bundle, passphrase="a-different-passphrase")
+        assert "no recovery" in str(exc.value).lower()
+
+    def test_a_short_passphrase_is_refused_at_creation(self):
+        """The only thing between a stolen bundle and a node identity."""
+        with pytest.raises(sb.BackupError) as exc:
+            sb.seal(PAYLOAD, passphrase="short")
+        assert str(sb.MIN_PASSPHRASE_LENGTH) in str(exc.value)
+
+    def test_two_bundles_of_the_same_payload_differ(self):
+        """Fresh salt and nonce each time, so bundles are not comparable."""
+        a = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        b = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        assert a != b
+
+
+class TestModeSelection:
+    def test_exactly_one_target_is_required(self):
+        with pytest.raises(sb.BackupError):
+            sb.seal(PAYLOAD)
+        with pytest.raises(sb.BackupError):
+            sb.seal(PAYLOAD, passphrase=PASSPHRASE, recipient_public_key="00" * 32)
+
+    def test_a_malformed_recipient_key_is_refused(self):
+        for bad in ("not-hex", "aa", "zz" * 32):
+            with pytest.raises(sb.BackupError):
+                sb.seal(PAYLOAD, recipient_public_key=bad)
+
+
+class TestTheHeaderNeverCarriesSecrets:
+    def test_no_key_material_appears_in_the_header(self):
+        _, public = sb.generate_recipient_keypair()
+        for bundle in (
+            sb.seal(PAYLOAD, passphrase=PASSPHRASE, metadata={"slug": "storj"}),
+            sb.seal(PAYLOAD, recipient_public_key=public, metadata={"slug": "storj"}),
+        ):
+            header = json.dumps(sb.read_header(bundle))
+            assert PASSPHRASE not in header
+            assert PAYLOAD.decode() not in header
+
+    def test_the_header_is_readable_without_any_secret(self):
+        """A user must be able to see WHICH service a bundle belongs to."""
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE, metadata={"slug": "mysterium", "worker": "watchtower"})
+        header = sb.read_header(bundle)
+        assert header["metadata"]["slug"] == "mysterium"
+        assert header["mode"] == sb.MODE_PASSPHRASE
+
+
+class TestVerifyAnswersIsMyBackupActuallyGood:
+    def test_a_matching_backup_reports_a_match(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        out = sb.verify(bundle, PAYLOAD, passphrase=PASSPHRASE)
+        assert out["ok"] is True and out["matches"] is True
+
+    def test_a_stale_backup_reports_a_mismatch_rather_than_failing(self):
+        """Out of date is a different answer from broken, and both matter."""
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        out = sb.verify(bundle, b"the volume has moved on since", passphrase=PASSPHRASE)
+        assert out["ok"] is True
+        assert out["matches"] is False
+        assert "out of date" in out["reason"]
+
+    def test_an_unopenable_backup_reports_not_ok(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        out = sb.verify(bundle, PAYLOAD, passphrase="the-wrong-passphrase")
+        assert out["ok"] is False and out["matches"] is False
+
+    def test_verify_compares_digests_not_plaintext(self):
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        out = sb.verify(bundle, PAYLOAD, passphrase=PASSPHRASE)
+        assert PAYLOAD.decode() not in json.dumps(out)
+        assert out["backup_sha256"] == out["live_sha256"]
+
+
+class TestLargerPayloads:
+    def test_a_realistic_keystore_sized_payload_round_trips(self):
+        import os
+
+        payload = os.urandom(256 * 1024)
+        bundle = sb.seal(payload, passphrase=PASSPHRASE)
+        assert sb.open_bundle(bundle, passphrase=PASSPHRASE) == payload
+
+    def test_an_empty_payload_is_still_authenticated(self):
+        bundle = sb.seal(b"", passphrase=PASSPHRASE)
+        assert sb.open_bundle(bundle, passphrase=PASSPHRASE) == b""
+
+
+class TestTheWorkerReadsOnlyIrreplaceableState:
+    """It reads the catalog's critical_volumes, never the whole container."""
+
+    def _container(self, status="running"):
+        from unittest.mock import MagicMock
+
+        c = MagicMock()
+        c.status = status
+        c.get_archive.return_value = ([b"tar-bytes"], {})
+        return c
+
+    def test_a_service_with_no_critical_volumes_is_refused(self):
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value=None),
+            pytest.raises(ValueError, match="no critical_volumes"),
+        ):
+            orchestrator.read_critical_state("honeygain")
+
+    def test_only_the_declared_targets_are_read(self):
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        container = self._container()
+        targets = {"/var/lib/mysterium/keystore": "node identity"}
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value=targets),
+            patch.object(orchestrator, "_find_container", return_value=container),
+        ):
+            payload, read = orchestrator.read_critical_state("mysterium")
+        assert read == ["/var/lib/mysterium/keystore"]
+        assert payload == b"tar-bytes"
+        container.get_archive.assert_called_once_with("/var/lib/mysterium/keystore")
+
+    def test_a_running_container_is_paused_and_unpaused(self):
+        """A keystore copied mid-write restores a corrupt node."""
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        container = self._container(status="running")
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value={"/data": "x"}),
+            patch.object(orchestrator, "_find_container", return_value=container),
+        ):
+            orchestrator.read_critical_state("storj")
+        container.pause.assert_called_once()
+        container.unpause.assert_called_once()
+
+    def test_it_unpauses_even_when_the_read_fails(self):
+        """Leaving a paused earner behind would stop the income silently."""
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        container = self._container(status="running")
+        container.get_archive.side_effect = RuntimeError("docker exploded")
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value={"/data": "x"}),
+            patch.object(orchestrator, "_find_container", return_value=container),
+            pytest.raises(RuntimeError),
+        ):
+            orchestrator.read_critical_state("storj")
+        container.unpause.assert_called_once()
+
+    def test_a_stopped_container_is_not_paused(self):
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        container = self._container(status="exited")
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value={"/data": "x"}),
+            patch.object(orchestrator, "_find_container", return_value=container),
+        ):
+            orchestrator.read_critical_state("storj")
+        container.pause.assert_not_called()
+        container.unpause.assert_not_called()
+
+
+class TestTheWorkerEndpoints:
+    def _call(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    def _request(self):
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    def test_export_returns_ciphertext_the_ui_cannot_read(self):
+        import base64
+        from unittest.mock import patch
+
+        from app import worker_api
+
+        body = worker_api.BackupRequest(passphrase=PASSPHRASE)
+        with (
+            patch.object(worker_api, "_verify_api_key", lambda r: None),
+            patch.object(worker_api.orchestrator, "read_critical_state", return_value=(PAYLOAD, ["/data"])),
+        ):
+            out = self._call(worker_api.api_backup("mysterium", body, self._request()))
+
+        bundle = base64.b64decode(out["bundle_b64"])
+        assert PAYLOAD not in bundle, "the plaintext state appears in the response"
+        assert sb.open_bundle(bundle, passphrase=PASSPHRASE) == PAYLOAD
+        assert sb.read_header(bundle)["metadata"]["slug"] == "mysterium"
+
+    def test_export_rejects_a_short_passphrase_without_reading_state(self):
+        from unittest.mock import patch
+
+        from fastapi import HTTPException
+
+        from app import worker_api
+
+        body = worker_api.BackupRequest(passphrase="short")
+        with (
+            patch.object(worker_api, "_verify_api_key", lambda r: None),
+            patch.object(worker_api.orchestrator, "read_critical_state", return_value=(PAYLOAD, ["/data"])),
+            pytest.raises(HTTPException) as exc,
+        ):
+            self._call(worker_api.api_backup("mysterium", body, self._request()))
+        assert exc.value.status_code == 400
+
+    @pytest.mark.parametrize("name", ["api_backup", "api_backup_verify"])
+    def test_both_routes_check_the_fleet_key_first(self, name):
+        import ast
+        import inspect
+        import textwrap
+
+        from app import worker_api
+
+        fn = getattr(worker_api, name)
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        calls = [n.func.id for n in ast.walk(tree) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+        assert "_verify_api_key" in calls, f"{name} does not verify the fleet key"
+
+    def test_verify_reports_a_match_without_producing_plaintext(self):
+        import base64
+        import json as _json
+        from unittest.mock import patch
+
+        from app import worker_api
+
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE, metadata={"slug": "mysterium"})
+        body = worker_api.VerifyRequest(passphrase=PASSPHRASE, bundle_b64=base64.b64encode(bundle).decode())
+        with (
+            patch.object(worker_api, "_verify_api_key", lambda r: None),
+            patch.object(worker_api.orchestrator, "read_critical_state", return_value=(PAYLOAD, ["/data"])),
+        ):
+            out = self._call(worker_api.api_backup_verify("mysterium", body, self._request()))
+        assert out["matches"] is True
+        assert PAYLOAD.decode() not in _json.dumps(out)
+
+    def test_verify_reports_a_stale_backup(self):
+        import base64
+        from unittest.mock import patch
+
+        from app import worker_api
+
+        bundle = sb.seal(PAYLOAD, passphrase=PASSPHRASE)
+        body = worker_api.VerifyRequest(passphrase=PASSPHRASE, bundle_b64=base64.b64encode(bundle).decode())
+        with (
+            patch.object(worker_api, "_verify_api_key", lambda r: None),
+            patch.object(worker_api.orchestrator, "read_critical_state", return_value=(b"moved on", ["/data"])),
+        ):
+            out = self._call(worker_api.api_backup_verify("mysterium", body, self._request()))
+        assert out["ok"] is True and out["matches"] is False
+
+    def test_verify_rejects_a_file_that_is_not_a_bundle(self):
+        import base64
+        from unittest.mock import patch
+
+        from fastapi import HTTPException
+
+        from app import worker_api
+
+        body = worker_api.VerifyRequest(passphrase=PASSPHRASE, bundle_b64=base64.b64encode(b"holiday.jpg").decode())
+        with patch.object(worker_api, "_verify_api_key", lambda r: None), pytest.raises(HTTPException) as exc:
+            self._call(worker_api.api_backup_verify("mysterium", body, self._request()))
+        assert exc.value.status_code == 400
+
+    def test_no_worker_route_uploads_a_bundle_anywhere(self):
+        """The only egress is the authenticated response.
+
+        Checked against the AST: the docstrings EXPLAIN that there is no upload
+        path, so a substring search matches the very prose documenting the
+        guarantee.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from app import worker_api
+
+        forbidden = {"post", "put", "send", "upload", "publish"}
+        for fn in (worker_api.api_backup, worker_api.api_backup_verify):
+            tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+            # Only statements INSIDE the function. The route decorator is
+            # `@app.post(...)`, so walking the whole tree flags the very thing
+            # that makes it an endpoint.
+            statements = [
+                stmt
+                for node in ast.walk(tree)
+                if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+                for stmt in node.body
+            ]
+            attrs = {
+                n.func.attr
+                for stmt in statements
+                for n in ast.walk(stmt)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            }
+            leaked = attrs & forbidden
+            assert not leaked, f"{fn.__name__} calls {leaked}, which could send a bundle somewhere"


### PR DESCRIPTION
Some services keep state that **exists nowhere else** — a node identity, a relay key, a wallet generated inside the container on first run. Lose the disk and the held payout balance and the node's reputation go with it. Almost nobody backs these up, because nothing tells them the files exist.

It's also the most dangerous thing in this codebase: it hands the worker a genuinely new capability — reading key material out of a container volume. The worker already holds the Docker socket, so the question was never whether it *could*, but whether the design gives anyone a reason to.

## The constraints, none of them tunable

**The installation cannot decrypt its own exports.** No server-held wrapping key, no fallback to the Fernet key protecting credentials. Otherwise compromising CashPilot yields every node identity it ever exported — making the backup feature the highest-value target in the system. The user supplies the target: an X25519 **recipient public key** (no secret enters CashPilot at all) or a **passphrase**, used and discarded.

**The only egress is the authenticated response.** No upload, sync or webhook — *absent*, not disabled. A test walks the route bodies and fails on any call that could send a bundle somewhere, so the guarantee is checkable rather than a policy nobody audits.

**No scheduled export.** A timer needs a stored secret — precisely the server-held key the first rule forbids.

**Encryption happens on the worker**, so the UI handles ciphertext only and plaintext key material never crosses the fleet network.

**AEAD with the header authenticated**, so a bundle can't be silently relabelled to claim it belongs to a different service. ChaCha20-Poly1305 + scrypt, both already in the existing `cryptography` dependency — zero new deps, no musl build risk.

## Reading the state safely

The container is **paused** while its state is read, and unpaused even when the read raises. A keystore copied mid-write yields a backup that opens perfectly and restores a *corrupt* node — a failure that surfaces only when you finally need it. Pause rather than stop, so a node doesn't lose uptime score for a backup.

Only mounts the catalog marks `critical_volumes` are read — never the whole container — and that's the same inventory the delete guard refuses on, so "irreplaceable" has one definition rather than two that drift apart.

## Verify, because a file is not a backup

"I have a backup file" and "I have a backup that works" are different claims, and people discover the difference on the worst possible day. Verify decrypts **in memory on the worker**, compares digests only, writes nothing, and distinguishes:

| Answer | Meaning |
|---|---|
| matches | restores exactly what is running now |
| does not match | opens fine but is **out of date** — not an error |
| cannot open | wrong passphrase/key, or the file was altered |

## Not included, deliberately

**Restore.** Writing into a volume is the destructive half and deserves its own review rather than riding along with the read path.

## Note on the tests

Several security properties are asserted against the **AST**, not the source text — a substring search for `Fernet` or `upload` also matches the docstrings *explaining* why neither exists, so it fails on the very prose documenting the guarantee.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1776 passed**, coverage 94.42%
- Worker image module set simulated to prove `state_backup.py` adds no import the worker lacks.