### PR TITLE
feat: payouts, lifetime-vs-balance, and how far off the cashout is (CashPilot-1og)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -355,6 +355,26 @@ CREATE TABLE IF NOT EXISTS user_preferences (
 -- earnings flatlines later). Persisted rather than kept in memory so they survive a
 -- restart: passive income is unattended, and an alert that only exists in a running
 -- process is an alert nobody ever sees.
+CREATE TABLE IF NOT EXISTS payouts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform     TEXT    NOT NULL,
+    amount       REAL    NOT NULL,
+    currency     TEXT    NOT NULL DEFAULT 'USD',
+    -- USD per 1 unit of `currency` WHEN THE PAYOUT LANDED, mirroring the
+    -- earnings table. A MYST payout valued at today's rate would silently
+    -- restate history every time the token moves.
+    fx_rate_usd  REAL,
+    -- 0 until a human says this really was a payout. A balance also falls for
+    -- provider corrections and reset sessions, and recording a guess as income
+    -- corrupts lifetime-earned in a way the user cannot see.
+    confirmed    INTEGER NOT NULL DEFAULT 0,
+    method       TEXT    NOT NULL DEFAULT '',
+    detected_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    confirmed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_payouts_platform ON payouts(platform, confirmed);
+
 CREATE TABLE IF NOT EXISTS alerts (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     kind       TEXT    NOT NULL,
@@ -1844,5 +1864,145 @@ async def vacuum_database() -> None:
         await db.commit()
         await db.execute("VACUUM")
         await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Payouts (CashPilot-1og)
+# ---------------------------------------------------------------------------
+
+
+async def record_probable_payout(
+    platform: str,
+    amount: float,
+    currency: str = "USD",
+    fx_rate_usd: float | None = None,
+) -> int | None:
+    """Record a balance drop that LOOKS like a payout, unconfirmed.
+
+    Returns the row id, or None when an unconfirmed one is already pending for
+    this platform. Without that guard every collection cycle would file another
+    copy of the same drop, and the user would face a growing pile of duplicate
+    prompts for one event.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT id FROM payouts WHERE platform = ? AND confirmed = 0 LIMIT 1",
+            (platform,),
+        )
+        if await cursor.fetchone():
+            return None
+        cursor = await db.execute(
+            "INSERT INTO payouts (platform, amount, currency, fx_rate_usd) VALUES (?, ?, ?, ?)",
+            (platform, float(amount), currency, fx_rate_usd),
+        )
+        await db.commit()
+        return cursor.lastrowid
+    finally:
+        await db.close()
+
+
+async def confirm_payout(payout_id: int, method: str = "") -> bool:
+    """Mark a probable payout as real. Only a human should reach this."""
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "UPDATE payouts SET confirmed = 1, method = ?, confirmed_at = datetime('now') "
+            "WHERE id = ? AND confirmed = 0",
+            (method, payout_id),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+    finally:
+        await db.close()
+
+
+async def reject_payout(payout_id: int) -> bool:
+    """Delete a probable payout the user says was not one.
+
+    Deleted rather than flagged: a rejected guess is not data about earnings,
+    and keeping it invites some later query from counting it.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute("DELETE FROM payouts WHERE id = ? AND confirmed = 0", (payout_id,))
+        await db.commit()
+        return cursor.rowcount > 0
+    finally:
+        await db.close()
+
+
+async def get_payouts(platform: str | None = None, confirmed_only: bool = False) -> list[dict[str, Any]]:
+    """Payout rows, newest first."""
+    query = "SELECT * FROM payouts"
+    clauses: list[str] = []
+    params: list[Any] = []
+    if platform:
+        clauses.append("platform = ?")
+        params.append(platform)
+    if confirmed_only:
+        clauses.append("confirmed = 1")
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " ORDER BY detected_at DESC"
+
+    db = await _get_db()
+    try:
+        cursor = await db.execute(query, params)
+        rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def get_confirmed_payout_totals() -> dict[str, float]:
+    """Confirmed payout total per platform, in USD.
+
+    Uses the fx rate recorded when the payout landed, so a token payout keeps
+    the value it actually had rather than being restated by today's price.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT platform, SUM(amount * COALESCE(fx_rate_usd, 1.0)) AS total "
+            "FROM payouts WHERE confirmed = 1 GROUP BY platform"
+        )
+        return {row["platform"]: float(row["total"] or 0.0) for row in await cursor.fetchall()}
+    finally:
+        await db.close()
+
+
+async def get_latest_balance(platform: str) -> float | None:
+    """The most recent recorded balance for a platform, or None if never seen.
+
+    None matters: a first-ever reading has nothing to compare against, and
+    treating an absent history as zero would make every initial collection look
+    like a huge gain — or, for payout detection, make the first reading after a
+    fresh install look like a drop.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT balance FROM earnings WHERE platform = ? ORDER BY date DESC, id DESC LIMIT 1",
+            (platform,),
+        )
+        row = await cursor.fetchone()
+        return float(row["balance"]) if row else None
+    finally:
+        await db.close()
+
+
+async def get_balance_history(platform: str, days: int = 30) -> list[dict[str, Any]]:
+    """Oldest-first balance readings for a platform, for rate projection."""
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT date, balance, currency, fx_rate_usd FROM earnings "
+            "WHERE platform = ? AND date >= date('now', ?) ORDER BY date ASC",
+            (platform, f"-{int(days)} days"),
+        )
+        return [dict(r) for r in await cursor.fetchall()]
     finally:
         await db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,7 @@ from app import (
     metrics,
     net_activity,
     notify,
+    payouts,
     power,
     preflight,
     producer_state,
@@ -299,6 +300,36 @@ async def _run_health_check() -> None:
         logger.warning("Health check skipped: %s", exc)
 
 
+async def _detect_payout(result: Any) -> None:
+    """Notice a balance drop that looks like a cashout, and ask.
+
+    Never records income on its own. A balance also falls for a provider
+    correction or a reset session, and an unconfirmed guess written as earnings
+    corrupts lifetime-earned permanently and invisibly.
+    """
+    try:
+        previous = await database.get_latest_balance(result.platform)
+        if previous is None:
+            return
+        probable = payouts.detect(previous, result.balance, catalog.get_service(result.platform))
+        if not probable:
+            return
+        payout_id = await database.record_probable_payout(
+            platform=result.platform,
+            amount=probable["amount"],
+            currency=result.currency,
+            fx_rate_usd=exchange_rates.to_usd(1.0, result.currency),
+        )
+        if payout_id is None:
+            # One already pending for this platform; a second prompt for the
+            # same event teaches the user to dismiss them.
+            return
+        await database.record_alert("payout", result.platform, probable["reason"])
+    except Exception as exc:
+        # Earnings collection must not fail because payout detection did.
+        logger.warning("Payout detection failed for %s: %s", getattr(result, "platform", "?"), exc)
+
+
 async def _collect_bounded(collector) -> Any:
     """Run a single collector's `collect()` under the shared concurrency limit."""
     async with _collection_semaphore:
@@ -425,6 +456,9 @@ async def _run_collection() -> None:
                             )
                         )
                 else:
+                    # Compare against the last reading BEFORE writing the new one:
+                    # a payout is only visible as the step between two snapshots.
+                    await _detect_payout(result)
                     await database.upsert_earnings(
                         platform=result.platform,
                         balance=result.balance,
@@ -2109,6 +2143,66 @@ async def api_test_credentials(request: Request, slug: str) -> dict[str, Any]:
         return credential_test.result(outcome, name, balance=result.balance, currency=result.currency)
     logger.debug("Credential test for %s failed: %s", slug, result.error)
     return credential_test.result(outcome, name)
+
+
+@app.get("/api/earnings/payouts")
+async def api_payouts(request: Request, platform: str | None = None) -> dict[str, Any]:
+    """Payouts, split into confirmed income and drops still awaiting a human."""
+    _require_auth_api(request)
+    rows = await database.get_payouts(platform=platform)
+    return {
+        "confirmed": [r for r in rows if r.get("confirmed")],
+        "probable": [r for r in rows if not r.get("confirmed")],
+    }
+
+
+@app.post("/api/earnings/payouts/{payout_id}/confirm")
+async def api_confirm_payout(request: Request, payout_id: int, method: str = "") -> dict[str, Any]:
+    """Confirm a drop really was a payout. Only a human reaches this."""
+    _require_auth_api(request)
+    if not await database.confirm_payout(payout_id):
+        raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
+    return {"ok": True, "id": payout_id, "confirmed": True}
+
+
+@app.post("/api/earnings/payouts/{payout_id}/reject")
+async def api_reject_payout(request: Request, payout_id: int) -> dict[str, Any]:
+    """This drop was not a payout — forget it entirely."""
+    _require_auth_api(request)
+    if not await database.reject_payout(payout_id):
+        raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
+    return {"ok": True, "id": payout_id, "removed": True}
+
+
+@app.get("/api/services/{slug}/payout-progress")
+async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
+    """Current balance, lifetime earned, and how far off the payout is.
+
+    These are three different questions and were previously one number that went
+    DOWN when the user got paid. The projection is the answer to the most
+    demotivating unknown in this category — a 20 USD minimum can be months on
+    one device, and not knowing that is what makes people give up.
+    """
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+
+    balance = await database.get_latest_balance(slug)
+    history = await database.get_balance_history(slug, days=30)
+    confirmed = await database.get_payouts(platform=slug, confirmed_only=True)
+
+    current = float(balance or 0.0)
+    return {
+        "slug": slug,
+        "current_balance": round(current, 6),
+        # Lifetime counts CONFIRMED payouts only. A probable one folded in here
+        # would let a single misread drop inflate earnings forever, invisibly.
+        "lifetime_earned": payouts.lifetime_earned(current, confirmed),
+        "confirmed_payout_count": len(confirmed),
+        "balance_known": balance is not None,
+        "projection": payouts.project(current, service, history),
+    }
 
 
 @app.get("/api/disclosure/coverage")

--- a/app/payouts.py
+++ b/app/payouts.py
@@ -1,0 +1,225 @@
+"""Payouts, and the two numbers people actually want (CashPilot-1og).
+
+The earnings table stores balance SNAPSHOTS, so a payout is invisible: the
+balance simply drops. Two consequences, and both of them mislead.
+
+First, one number is doing two jobs. "Earned" goes DOWN when you get paid, which
+is the opposite of what the word means. Lifetime earned and current balance are
+different questions — *how much has this ever made me* and *how much is sitting
+there waiting* — and neither is answerable while they are conflated.
+
+Second, and more demotivating: nobody can see how far away the payout is. A USD
+20 minimum can be two or three months on a single device, and not knowing that
+is what makes people quit before they ever cash out. Telling them "43 days at
+your current rate" is a small feature that answers the biggest open question in
+this category.
+
+Two rules run through everything below:
+
+* **Never auto-confirm a payout.** A balance falls for reasons that are not a
+  payout: a provider correction, a reversed fraud check, a lost session that
+  resets a counter. Recording an unconfirmed guess as income permanently
+  corrupts lifetime-earned, and the user cannot tell it happened. So a drop is
+  reported as PROBABLE and waits for a human.
+* **Refuse to project rather than project badly.** A confident wrong date is
+  worse than "not enough data yet", because the user plans around it. Zero rate,
+  falling rate, and too little history are three different honest answers, not
+  three ways of saying zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Minimum history before a trailing rate means anything. Below this a single
+# good day sets the projection, and the number swings wildly day to day.
+MIN_DAYS_FOR_PROJECTION = 3
+
+# Beyond this a projection stops being information. "Four years" is not a plan,
+# and rendering a precise date that far out invites belief it does not deserve.
+MAX_PROJECTION_DAYS = 365
+
+# Verdicts for a projection.
+REACHED = "reached"
+PROJECTED = "projected"
+NOT_ENOUGH_DATA = "not_enough_data"
+NOT_EARNING = "not_earning"
+TOO_FAR = "too_far"
+NO_THRESHOLD = "no_threshold"
+NO_MINIMUM_REQUIRED = "no_minimum_required"
+
+
+def min_payout(service: dict[str, Any] | None) -> float | None:
+    """The provider's minimum cashout.
+
+    Three-valued, for the same reason as every other threshold in this project:
+
+    * a positive number is a real minimum;
+    * ``0.0`` is a documented "no minimum, cash out any amount" — a real answer,
+      which at least one catalogued service actually declares;
+    * ``None`` means undocumented, or a value that does not parse.
+
+    Collapsing 0 into None would tell a user with no minimum that there is
+    nothing to count down to, when the truth is the opposite: they can cash out
+    right now.
+    """
+    if not service:
+        return None
+    raw = (service.get("cashout") or {}).get("min_amount")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def looks_like_payout(previous: float, current: float, threshold: float | None) -> bool:
+    """Did this balance fall far enough to look like a cashout?
+
+    Requires a documented threshold. Guessing one — say, "any drop over 20%" —
+    would fire on every provider correction and train the user to dismiss the
+    prompt, which is worse than never asking.
+    """
+    # A zero minimum cannot drive detection: every drop of any size would
+    # qualify, so the prompt would fire on ordinary provider noise and train the
+    # user to dismiss it.
+    if not threshold:
+        return False
+    return (previous - current) >= threshold
+
+
+def detect(previous: float, current: float, service: dict[str, Any] | None) -> dict[str, Any] | None:
+    """A PROBABLE payout, or None. Never a confirmed one.
+
+    The amount recorded is the size of the drop, which is what a payout of this
+    balance would have been. If the user rejects it, nothing is recorded at all.
+    """
+    threshold = min_payout(service)
+    if not looks_like_payout(previous, current, threshold):
+        return None
+    return {
+        "platform": service.get("slug") if service else None,
+        "amount": round(previous - current, 6),
+        "confirmed": False,
+        "reason": (
+            f"The balance fell by {previous - current:.2f}, which is at least this service's "
+            f"{threshold:.2f} minimum cashout. That usually means you were paid — but a provider "
+            "correction can look identical, so CashPilot will not record it as income until you say so."
+        ),
+    }
+
+
+def lifetime_earned(current_balance: float, confirmed_payouts: list[dict[str, Any]] | None) -> float:
+    """Everything this platform has ever produced.
+
+    Only CONFIRMED payouts count. Including probable ones would let a single
+    misread drop inflate lifetime earnings forever, silently.
+    """
+    total = float(current_balance or 0.0)
+    for payout in confirmed_payouts or []:
+        if payout.get("confirmed"):
+            total += float(payout.get("amount") or 0.0)
+    return round(total, 6)
+
+
+def daily_rate(history: list[dict[str, Any]] | None) -> float | None:
+    """Average gain per day from a balance series, or None if unknowable.
+
+    Each entry needs ``balance``. Negative steps are treated as payouts and
+    skipped rather than subtracted — otherwise a cashout would read as a month
+    of negative earnings and drag the projection into nonsense.
+    """
+    points = [p for p in (history or []) if p.get("balance") is not None]
+    if len(points) < MIN_DAYS_FOR_PROJECTION:
+        return None
+
+    gained = 0.0
+    for older, newer in zip(points, points[1:], strict=False):
+        step = float(newer["balance"]) - float(older["balance"])
+        if step > 0:
+            gained += step
+    days = len(points) - 1
+    return gained / days if days > 0 else None
+
+
+def project(
+    current_balance: float,
+    service: dict[str, Any] | None,
+    history: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """How long until this can be cashed out?
+
+    Every branch that cannot answer says so specifically. "Not enough data yet"
+    and "this is not earning" are different problems with different fixes, and
+    collapsing them into one shrug helps nobody.
+    """
+    threshold = min_payout(service)
+    balance = float(current_balance or 0.0)
+
+    if threshold is None:
+        return {
+            "state": NO_THRESHOLD,
+            "days": None,
+            "summary": "This service does not publish a minimum cashout, so there is nothing to count down to.",
+        }
+    if threshold == 0:
+        return {
+            "state": NO_MINIMUM_REQUIRED,
+            "days": 0,
+            "remaining": 0.0,
+            "summary": "This service has no minimum — whatever has accrued can be cashed out at any time.",
+        }
+    if balance >= threshold:
+        return {
+            "state": REACHED,
+            "days": 0,
+            "remaining": 0.0,
+            "summary": f"You have reached the {threshold:g} minimum — this can be cashed out now.",
+        }
+
+    remaining = threshold - balance
+    rate = daily_rate(history)
+    if rate is None:
+        return {
+            "state": NOT_ENOUGH_DATA,
+            "days": None,
+            "remaining": round(remaining, 4),
+            "summary": (
+                f"{remaining:.2f} to go. There is not enough history yet to say how long that will take — "
+                f"come back after a few more days of collection."
+            ),
+        }
+    if rate <= 0:
+        return {
+            "state": NOT_EARNING,
+            "days": None,
+            "remaining": round(remaining, 4),
+            "summary": (
+                f"{remaining:.2f} to go, but this has earned nothing recently, so at the current rate it "
+                "will not get there at all."
+            ),
+        }
+
+    days = remaining / rate
+    if days > MAX_PROJECTION_DAYS:
+        return {
+            "state": TOO_FAR,
+            "days": None,
+            "remaining": round(remaining, 4),
+            "rate_per_day": round(rate, 6),
+            "summary": (
+                f"At {rate:.4f} a day it would take over a year to reach the {threshold:g} minimum. "
+                "That is worth knowing before you leave it running."
+            ),
+        }
+    return {
+        "state": PROJECTED,
+        "days": round(days, 1),
+        "remaining": round(remaining, 4),
+        "rate_per_day": round(rate, 6),
+        "summary": f"About {days:.0f} day(s) to the {threshold:g} minimum, at {rate:.4f} a day.",
+    }

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -1,0 +1,324 @@
+"""Payouts and payout projection (CashPilot-1og).
+
+Two failures this exists to prevent, and both of them mislead quietly:
+
+* One number doing two jobs. "Earned" went DOWN when the user got paid, because
+  the earnings table stores balance snapshots and a payout is invisible in them.
+* Nobody could see how far away the payout was. A 20 USD minimum can be months
+  on one device, and not knowing that is what makes people quit.
+
+The tests that matter most are the ones about NOT recording and NOT projecting:
+an unconfirmed guess written as income corrupts lifetime-earned invisibly, and a
+confident wrong date is worse than saying there is not enough data.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import payouts
+
+HONEYGAIN = {"slug": "honeygain", "name": "Honeygain", "cashout": {"min_amount": 20.0}}
+NO_MINIMUM = {"slug": "x", "name": "X", "cashout": {}}
+
+
+def series(*balances: float) -> list[dict[str, float]]:
+    return [{"balance": b} for b in balances]
+
+
+class TestNothingIsEverAutoConfirmed:
+    """A balance falls for reasons that are not a payout."""
+
+    def test_a_detected_drop_is_never_confirmed(self):
+        out = payouts.detect(25.0, 1.0, HONEYGAIN)
+        assert out is not None
+        assert out["confirmed"] is False
+
+    def test_the_reason_tells_the_user_why_it_is_asking(self):
+        out = payouts.detect(25.0, 1.0, HONEYGAIN)
+        assert "correction" in out["reason"]
+        assert "until you say so" in out["reason"]
+
+    def test_a_drop_smaller_than_the_minimum_is_not_a_payout(self):
+        assert payouts.detect(25.0, 24.0, HONEYGAIN) is None
+
+    def test_a_drop_exactly_at_the_minimum_counts(self):
+        assert payouts.detect(25.0, 5.0, HONEYGAIN) is not None
+
+    def test_a_rise_is_never_a_payout(self):
+        assert payouts.detect(1.0, 25.0, HONEYGAIN) is None
+
+    def test_a_service_with_no_documented_minimum_never_fires(self):
+        """Inventing a threshold would fire on every provider correction."""
+        assert payouts.detect(1000.0, 0.0, NO_MINIMUM) is None
+        assert payouts.detect(1000.0, 0.0, None) is None
+
+    def test_a_malformed_minimum_is_treated_as_undocumented(self):
+        for bad in ({"min_amount": "twenty"}, {"min_amount": -5}, {}):
+            assert payouts.min_payout({"slug": "x", "cashout": bad}) is None
+
+    def test_a_documented_zero_minimum_is_a_real_answer(self):
+        """At least one catalogued service declares min_amount: 0.
+
+        Reading that as "undocumented" would tell a user with no minimum that
+        there is nothing to count down to, when in fact they can cash out now.
+        """
+        zero = {"slug": "x", "cashout": {"min_amount": 0}}
+        assert payouts.min_payout(zero) == 0.0
+        out = payouts.project(1.23, zero, series(1.0, 1.1, 1.2, 1.23))
+        assert out["state"] == payouts.NO_MINIMUM_REQUIRED
+        assert "at any time" in out["summary"]
+
+    def test_a_zero_minimum_never_drives_payout_detection(self):
+        """Every drop of any size would qualify, so the prompt becomes noise."""
+        zero = {"slug": "x", "cashout": {"min_amount": 0}}
+        assert payouts.detect(10.0, 0.0, zero) is None
+
+
+class TestLifetimeCountsConfirmedPayoutsOnly:
+    def test_lifetime_is_balance_plus_confirmed(self):
+        confirmed = [{"amount": 20.0, "confirmed": 1}, {"amount": 30.0, "confirmed": 1}]
+        assert payouts.lifetime_earned(5.0, confirmed) == 55.0
+
+    def test_a_probable_payout_does_not_inflate_lifetime(self):
+        """A single misread drop would otherwise inflate earnings forever."""
+        assert payouts.lifetime_earned(5.0, [{"amount": 999.0, "confirmed": 0}]) == 5.0
+
+    def test_no_payouts_means_lifetime_equals_balance(self):
+        assert payouts.lifetime_earned(7.5, None) == 7.5
+        assert payouts.lifetime_earned(7.5, []) == 7.5
+
+    def test_lifetime_never_goes_down_when_you_get_paid(self):
+        """The whole point: the number that means "earned" must not fall."""
+        before = payouts.lifetime_earned(25.0, [])
+        after = payouts.lifetime_earned(0.0, [{"amount": 25.0, "confirmed": 1}])
+        assert after >= before
+
+
+class TestTheRateIgnoresPayouts:
+    def test_a_payout_does_not_read_as_negative_earnings(self):
+        """Otherwise a cashout drags the projection into nonsense."""
+        with_payout = series(1.0, 2.0, 3.0, 0.0, 1.0, 2.0)
+        assert payouts.daily_rate(with_payout) > 0
+
+    def test_a_flat_series_earns_nothing(self):
+        assert payouts.daily_rate(series(1.0, 1.0, 1.0, 1.0)) == 0.0
+
+    def test_too_little_history_is_unknown_not_zero(self):
+        assert payouts.daily_rate(series(1.0)) is None
+        assert payouts.daily_rate([]) is None
+        assert payouts.daily_rate(None) is None
+
+    def test_the_rate_is_per_day_not_per_reading(self):
+        assert payouts.daily_rate(series(0.0, 1.0, 2.0, 3.0)) == 1.0
+
+
+class TestItRefusesToProjectRatherThanProjectBadly:
+    def test_not_enough_history_says_exactly_that(self):
+        out = payouts.project(1.0, HONEYGAIN, series(1.0))
+        assert out["state"] == payouts.NOT_ENOUGH_DATA
+        assert out["days"] is None
+        assert "not enough history" in out["summary"]
+
+    def test_a_service_earning_nothing_says_it_will_not_get_there(self):
+        """Different problem from "not enough data", and a different fix."""
+        out = payouts.project(1.0, HONEYGAIN, series(1.0, 1.0, 1.0, 1.0))
+        assert out["state"] == payouts.NOT_EARNING
+        assert out["days"] is None
+        assert "will not get there" in out["summary"]
+
+    def test_an_absurdly_distant_date_is_not_rendered_as_a_date(self):
+        """ "Four years" is not a plan, and a precise date invites belief."""
+        out = payouts.project(0.0, HONEYGAIN, series(0.0, 0.001, 0.002, 0.003))
+        assert out["state"] == payouts.TOO_FAR
+        assert out["days"] is None
+        assert "over a year" in out["summary"]
+
+    def test_a_reachable_balance_says_cash_out_now(self):
+        out = payouts.project(25.0, HONEYGAIN, series(1.0, 2.0, 3.0))
+        assert out["state"] == payouts.REACHED
+        assert out["days"] == 0
+
+    def test_a_service_with_no_minimum_has_nothing_to_count_down_to(self):
+        out = payouts.project(5.0, NO_MINIMUM, series(1.0, 2.0, 3.0, 4.0))
+        assert out["state"] == payouts.NO_THRESHOLD
+
+    def test_a_real_projection_reports_days_and_the_rate(self):
+        out = payouts.project(10.0, HONEYGAIN, series(1.0, 2.0, 3.0, 4.0, 5.0))
+        assert out["state"] == payouts.PROJECTED
+        assert out["days"] == pytest.approx(10.0, abs=0.5)
+        assert out["rate_per_day"] == 1.0
+        assert out["remaining"] == 10.0
+
+    def test_every_state_carries_a_sentence_a_user_can_act_on(self):
+        cases = [
+            (1.0, HONEYGAIN, series(1.0)),
+            (1.0, HONEYGAIN, series(1.0, 1.0, 1.0)),
+            (25.0, HONEYGAIN, series(1.0, 2.0, 3.0)),
+            (5.0, NO_MINIMUM, series(1.0, 2.0, 3.0, 4.0)),
+            (10.0, HONEYGAIN, series(1.0, 2.0, 3.0, 4.0, 5.0)),
+        ]
+        for balance, service, history in cases:
+            out = payouts.project(balance, service, history)
+            assert out["summary"] and out["summary"].endswith(".")
+
+
+class TestAgainstTheRealCatalog:
+    def test_documented_minimums_are_read_from_the_catalog(self):
+        from app import catalog
+
+        assert payouts.min_payout(catalog.get_service("honeygain")) == 20.0
+        assert payouts.min_payout(catalog.get_service("storj")) == 4.0
+
+    def test_every_catalogued_minimum_is_a_usable_number(self):
+        """A malformed min_amount silently disables payout detection."""
+        from app import catalog
+
+        for svc in catalog.get_services():
+            raw = (svc.get("cashout") or {}).get("min_amount")
+            if raw is None:
+                continue
+            assert payouts.min_payout(svc) is not None, (
+                f"{svc['slug']}: cashout.min_amount {raw!r} does not parse, so payout detection "
+                "and the projection are both silently off for this service"
+            )
+
+
+class TestEndpoints:
+    def _call(self, fn, *args, **patches):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=patches.get("balance"))),
+            patch.object(main.database, "get_balance_history", AsyncMock(return_value=patches.get("history", []))),
+            patch.object(main.database, "get_payouts", AsyncMock(return_value=patches.get("payouts", []))),
+            patch.object(main.database, "confirm_payout", AsyncMock(return_value=patches.get("ok", True))),
+            patch.object(main.database, "reject_payout", AsyncMock(return_value=patches.get("ok", True))),
+        ):
+            return asyncio.run(fn(MagicMock(), *args))
+
+    def test_progress_splits_balance_from_lifetime(self):
+        from app import main
+
+        out = self._call(
+            main.api_payout_progress,
+            "honeygain",
+            balance=5.0,
+            history=series(1.0, 2.0, 3.0, 4.0, 5.0),
+            payouts=[{"amount": 20.0, "confirmed": 1}],
+        )
+        assert out["current_balance"] == 5.0
+        assert out["lifetime_earned"] == 25.0, "lifetime must include the confirmed payout"
+        assert out["projection"]["state"] == payouts.PROJECTED
+
+    def test_progress_for_a_never_collected_service_says_the_balance_is_unknown(self):
+        from app import main
+
+        out = self._call(main.api_payout_progress, "honeygain", balance=None)
+        assert out["balance_known"] is False
+        assert out["projection"]["state"] == payouts.NOT_ENOUGH_DATA
+
+    def test_an_unknown_service_is_a_404(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main.api_payout_progress, "no-such-service")
+        assert exc.value.status_code == 404
+
+    def test_listing_separates_probable_from_confirmed(self):
+        from app import main
+
+        rows = [{"id": 1, "confirmed": 1, "amount": 20.0}, {"id": 2, "confirmed": 0, "amount": 5.0}]
+        out = self._call(main.api_payouts, payouts=rows)
+        assert [r["id"] for r in out["confirmed"]] == [1]
+        assert [r["id"] for r in out["probable"]] == [2]
+
+    def test_confirming_a_missing_payout_is_a_404(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main.api_confirm_payout, 99, ok=False)
+        assert exc.value.status_code == 404
+
+    def test_rejecting_a_missing_payout_is_a_404(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main.api_reject_payout, 99, ok=False)
+        assert exc.value.status_code == 404
+
+    def test_confirm_and_reject_report_what_they_did(self):
+        from app import main
+
+        assert self._call(main.api_confirm_payout, 1)["confirmed"] is True
+        assert self._call(main.api_reject_payout, 1)["removed"] is True
+
+
+class TestDetectionIsHookedIntoCollectionSafely:
+    def _result(self, platform="honeygain", balance=1.0, currency="USD"):
+        from app.collectors.base import EarningsResult
+
+        return EarningsResult(platform=platform, balance=balance, currency=currency)
+
+    def test_a_first_ever_reading_is_not_a_payout(self):
+        """Nothing to compare against; an absent history is not a balance of zero."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=None)),
+            patch.object(main.database, "record_probable_payout", AsyncMock()) as record,
+        ):
+            asyncio.run(main._detect_payout(self._result()))
+        record.assert_not_awaited()
+
+    def test_a_real_drop_is_recorded_and_alerted(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=25.0)),
+            patch.object(main.database, "record_probable_payout", AsyncMock(return_value=7)) as record,
+            patch.object(main.database, "record_alert", AsyncMock(return_value=True)) as alert,
+        ):
+            asyncio.run(main._detect_payout(self._result(balance=1.0)))
+        record.assert_awaited_once()
+        alert.assert_awaited_once()
+
+    def test_a_pending_duplicate_does_not_alert_again(self):
+        """One event must not produce a growing pile of identical prompts."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=25.0)),
+            patch.object(main.database, "record_probable_payout", AsyncMock(return_value=None)),
+            patch.object(main.database, "record_alert", AsyncMock()) as alert,
+        ):
+            asyncio.run(main._detect_payout(self._result(balance=1.0)))
+        alert.assert_not_awaited()
+
+    def test_a_failure_here_never_breaks_earnings_collection(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_latest_balance", AsyncMock(side_effect=RuntimeError("db down"))):
+            asyncio.run(main._detect_payout(self._result()))

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -322,3 +322,150 @@ class TestDetectionIsHookedIntoCollectionSafely:
 
         with patch.object(main.database, "get_latest_balance", AsyncMock(side_effect=RuntimeError("db down"))):
             asyncio.run(main._detect_payout(self._result()))
+
+
+class TestThePayoutTableAgainstRealSqlite:
+    """The SQL, executed rather than mocked.
+
+    Everything above mocks the database, which proves the logic and nothing
+    about whether the statements are valid. These are new tables, new indexes
+    and new queries; a typo in one would pass every test above and fail the
+    first time a real payout was recorded.
+    """
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        import asyncio
+        from unittest.mock import patch
+
+        from app import database
+
+        with (
+            patch.object(database, "DB_DIR", tmp_path),
+            patch.object(database, "DB_PATH", tmp_path / "cashpilot.db"),
+        ):
+            asyncio.run(database.init_db())
+            yield database
+
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    def test_the_table_and_index_are_created(self, db):
+        async def check():
+            conn = await db._get_db()
+            try:
+                cur = await conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table','index')")
+                return {r["name"] for r in await cur.fetchall()}
+            finally:
+                await conn.close()
+
+        names = self._run(check())
+        assert "payouts" in names
+        assert "idx_payouts_platform" in names
+
+    def test_a_probable_payout_round_trips(self, db):
+        payout_id = self._run(db.record_probable_payout("honeygain", 20.0, "USD", 1.0))
+        assert payout_id
+        rows = self._run(db.get_payouts(platform="honeygain"))
+        assert len(rows) == 1
+        assert rows[0]["amount"] == 20.0
+        assert rows[0]["confirmed"] == 0, "a detected drop must never start confirmed"
+
+    def test_a_second_probable_payout_is_not_filed_while_one_is_pending(self, db):
+        """One event must not become a growing pile of identical prompts."""
+        assert self._run(db.record_probable_payout("honeygain", 20.0))
+        assert self._run(db.record_probable_payout("honeygain", 20.0)) is None
+        assert len(self._run(db.get_payouts(platform="honeygain"))) == 1
+
+    def test_confirming_marks_it_and_stamps_the_time(self, db):
+        payout_id = self._run(db.record_probable_payout("honeygain", 20.0))
+        assert self._run(db.confirm_payout(payout_id, method="paypal")) is True
+        row = self._run(db.get_payouts(platform="honeygain"))[0]
+        assert row["confirmed"] == 1
+        assert row["method"] == "paypal"
+        assert row["confirmed_at"]
+
+    def test_confirming_twice_is_refused(self, db):
+        payout_id = self._run(db.record_probable_payout("honeygain", 20.0))
+        assert self._run(db.confirm_payout(payout_id)) is True
+        assert self._run(db.confirm_payout(payout_id)) is False
+
+    def test_a_confirmed_payout_cannot_be_rejected(self, db):
+        """Rejection deletes; allowing it after confirmation would erase income."""
+        payout_id = self._run(db.record_probable_payout("honeygain", 20.0))
+        self._run(db.confirm_payout(payout_id))
+        assert self._run(db.reject_payout(payout_id)) is False
+        assert len(self._run(db.get_payouts(platform="honeygain"))) == 1
+
+    def test_rejecting_removes_it_entirely(self, db):
+        payout_id = self._run(db.record_probable_payout("honeygain", 20.0))
+        assert self._run(db.reject_payout(payout_id)) is True
+        assert self._run(db.get_payouts(platform="honeygain")) == []
+
+    def test_confirmed_only_filters_out_the_probable(self, db):
+        confirmed = self._run(db.record_probable_payout("honeygain", 20.0))
+        self._run(db.confirm_payout(confirmed))
+        self._run(db.record_probable_payout("iproyal", 5.0))
+        rows = self._run(db.get_payouts(confirmed_only=True))
+        assert [r["platform"] for r in rows] == ["honeygain"]
+
+    def test_totals_use_the_rate_recorded_when_the_payout_landed(self, db):
+        """A token payout must not be restated by today's price."""
+        payout_id = self._run(db.record_probable_payout("mysterium", 10.0, "MYST", 0.25))
+        self._run(db.confirm_payout(payout_id))
+        totals = self._run(db.get_confirmed_payout_totals())
+        assert totals["mysterium"] == pytest.approx(2.5)
+
+    def test_a_missing_rate_is_treated_as_one_to_one(self, db):
+        payout_id = self._run(db.record_probable_payout("honeygain", 7.0, "USD", None))
+        self._run(db.confirm_payout(payout_id))
+        assert self._run(db.get_confirmed_payout_totals())["honeygain"] == pytest.approx(7.0)
+
+    def test_unconfirmed_payouts_are_excluded_from_totals(self, db):
+        self._run(db.record_probable_payout("honeygain", 99.0, "USD", 1.0))
+        assert self._run(db.get_confirmed_payout_totals()) == {}
+
+
+class TestBalanceHistoryAgainstRealSqlite:
+    @pytest.fixture
+    def db(self, tmp_path):
+        import asyncio
+        from unittest.mock import patch
+
+        from app import database
+
+        with (
+            patch.object(database, "DB_DIR", tmp_path),
+            patch.object(database, "DB_PATH", tmp_path / "cashpilot.db"),
+        ):
+            asyncio.run(database.init_db())
+            yield database
+
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    def test_a_platform_never_seen_has_no_balance(self, db):
+        """None, not zero: a first reading has nothing to compare against."""
+        assert self._run(db.get_latest_balance("honeygain")) is None
+
+    def test_the_latest_balance_is_the_most_recent_reading(self, db):
+        self._run(db.upsert_earnings("honeygain", 1.0, "USD", date="2026-01-01"))
+        self._run(db.upsert_earnings("honeygain", 5.0, "USD", date="2026-01-02"))
+        assert self._run(db.get_latest_balance("honeygain")) == 5.0
+
+    def test_history_comes_back_oldest_first(self, db):
+        from datetime import UTC, datetime, timedelta
+
+        today = datetime.now(UTC)
+        for offset, balance in ((2, 1.0), (1, 2.0), (0, 3.0)):
+            day = (today - timedelta(days=offset)).strftime("%Y-%m-%d")
+            self._run(db.upsert_earnings("honeygain", balance, "USD", date=day))
+        history = self._run(db.get_balance_history("honeygain", days=30))
+        assert [row["balance"] for row in history] == [1.0, 2.0, 3.0]
+
+    def test_history_for_an_unknown_platform_is_empty(self, db):
+        assert self._run(db.get_balance_history("nope")) == []


### PR DESCRIPTION
The earnings table stores balance **snapshots**, so a payout is invisible — the balance simply drops. Two things follow, and both mislead quietly.

**One number was doing two jobs.** "Earned" went *down* when the user got paid, which is the opposite of what the word means. Lifetime earned and current balance answer different questions, and neither is answerable while they're conflated.

**Nobody could see how far away the payout was.** A 20 USD minimum can be two or three months on a single device, and not knowing that is what makes people quit before they ever cash out.

## Nothing is ever auto-confirmed

A balance also falls for a provider correction, a reversed fraud check, or a session that resets a counter. An unconfirmed guess written as income **corrupts lifetime-earned permanently and invisibly**.

So a drop is recorded as `probable`, surfaced in the notification bell, and waits for a human. A rejected one is *deleted* rather than flagged, so no later query can count it. Only one unconfirmed payout is kept per platform — otherwise every collection cycle files another copy of the same event and the user learns to dismiss the prompts.

Detection also requires a **documented** threshold (the provider's own `cashout.min_amount`). Guessing one — "any fall over 20%" — would fire on ordinary noise.

## It refuses to project rather than project badly

A confident wrong date is worse than silence, because the user plans around it. These are three different answers with three different fixes, not three ways of writing zero:

| State | Meaning |
|---|---|
| `not_enough_data` | too little history to say anything yet |
| `not_earning` | it will not get there at the current rate |
| `too_far` | over a year away — worth knowing before leaving it running |
| `projected` | "about 34 days, at 0.5 a day" |
| `reached` | cash out now |

The trailing rate **skips negative steps**: a cashout inside the window would otherwise read as weeks of negative earnings.

## What the catalog taught this change

`earncc` declares `min_amount: 0`. That's a documented *"no minimum, cash out anything"*, not a missing value — so `min_payout` is three-valued like every other threshold here. Collapsing zero into `None` would tell a user with no minimum that there's nothing to count down to, when in fact they can cash out right now. A zero still can't drive *detection*, since every drop would qualify.

A test asserts every catalogued `min_amount` parses, because a malformed one silently disables both detection and the projection.

## Details

- Payout values store the **fx rate at the time they landed**, mirroring the earnings table, so a token payout isn't restated every time the token moves.
- Detection failing can never break earnings collection.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1772 passed**, coverage 93.84%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payout detection when earnings balances decrease.
  * Added alerts for probable payouts without automatically counting them as income.
  * Added options to review, confirm, or reject detected payouts.
  * Added payout history, confirmed earnings totals, balance history, and cashout progress projections.
  * Added support for currencies and historical exchange rates.

* **Bug Fixes**
  * Prevented payout-detection issues from interrupting earnings collection.
  * Excluded payouts and balance decreases from daily earning-rate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->