### PR TITLE
feat: is this machine worth keeping powered on? (CashPilot-l01)

### DIFF
--- a/app/machine_economics.py
+++ b/app/machine_economics.py
@@ -1,0 +1,206 @@
+"""Is this MACHINE worth keeping powered on? (CashPilot-l01)
+
+The question people ask is "does this service make money", and for a shared box
+that question has no honest answer. Adding a bandwidth container to a machine
+that is already on costs roughly 1-3 W — about EUR 0.19 a month at EUR
+0.105/kWh — which is **below the measurement error of a consumer smart plug**.
+A per-service "net profit" figure there would be fabricated precision: it would
+look authoritative and be noise.
+
+The question that does have an answer is about the machine. A dedicated ~65 W
+node at EUR 0.20/kWh costs about EUR 9.50 a month against a typical USD 3-6
+gross from a single node. That is net negative, it is knowable, and nobody is
+currently told.
+
+So this module answers per-MACHINE and refuses to answer per-service on a shared
+host. That refusal is the feature, not a limitation of it.
+
+Three rules:
+
+* **Refuse fabricated precision.** Below the resolution of the cheapest thing
+  that could check the number, there is no number — only a shrug with a decimal
+  point on it.
+* **Estimates are labelled estimates.** Everything here rests on a user-entered
+  wattage and tariff. Both are guesses, the output inherits that, and it says so.
+* **Never act on it.** No auto-stop, no throttling, no "helpful" suggestion the
+  code carries out. Show the number and let the operator decide; the electricity
+  is theirs and so is the call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# What a machine draws when it is on but doing nothing much. A small always-on
+# server — NUC, mini PC, Pi 5 — sits around here. A guess, and labelled one.
+DEFAULT_IDLE_WATTS = 65.0
+
+HOURS_PER_MONTH = 730.0
+
+# Below this, the marginal cost of one more container is smaller than a consumer
+# smart plug can measure, so a per-service figure would be invented. Chosen from
+# the bead's own research: a bandwidth container adds roughly 1-3 W.
+SMART_PLUG_RESOLUTION_WATTS = 5.0
+
+# Verdicts, worst first.
+LOSING_MONEY = "losing_money"
+MARGINAL = "marginal"
+PROFITABLE = "profitable"
+UNKNOWN = "unknown"
+NOT_METERED = "not_metered"
+
+
+def monthly_cost(watts: float, price_per_kwh: float) -> float:
+    """Cost of leaving a machine drawing ``watts`` on for a month."""
+    if watts <= 0 or price_per_kwh <= 0:
+        return 0.0
+    return (watts / 1000.0) * HOURS_PER_MONTH * price_per_kwh
+
+
+def break_even_watts(monthly_gross: float, price_per_kwh: float) -> float | None:
+    """The draw at which this machine exactly pays for its own electricity.
+
+    None when there is no tariff — the honest answer, since without a price
+    every wattage breaks even and the question is meaningless.
+    """
+    if price_per_kwh <= 0:
+        return None
+    return (monthly_gross * 1000.0) / (HOURS_PER_MONTH * price_per_kwh)
+
+
+def break_even_price(monthly_gross: float, watts: float) -> float | None:
+    """The electricity price at which this machine stops being worth it."""
+    if watts <= 0:
+        return None
+    return monthly_gross / ((watts / 1000.0) * HOURS_PER_MONTH)
+
+
+def assess_machine(
+    *,
+    name: str,
+    monthly_gross: float,
+    watts: float | None,
+    price_per_kwh: float | None,
+    metered: bool = True,
+    dedicated: bool = False,
+) -> dict[str, Any]:
+    """Should this machine stay powered on for what it earns?
+
+    ``dedicated`` means the machine exists only to run these services, so its
+    WHOLE draw is attributable. On a machine that would be on anyway — a NAS, a
+    home server — only the marginal draw counts, and that is too small to
+    measure, so the honest output is the cost of the box rather than a verdict
+    pretending the services caused it.
+    """
+    gross = float(monthly_gross or 0.0)
+
+    if not metered:
+        # A VPS bill does not move with CPU, so estimated watts would invent a
+        # cost the user is not paying.
+        return {
+            "machine": name,
+            "verdict": NOT_METERED,
+            "monthly_gross": round(gross, 4),
+            "monthly_cost": None,
+            "monthly_net": None,
+            "summary": (
+                f"{name} is not billed by the kilowatt-hour, so electricity is not what decides "
+                "whether it is worth running."
+            ),
+        }
+
+    if price_per_kwh is None or price_per_kwh <= 0 or watts is None or watts <= 0:
+        missing = "your electricity price" if not price_per_kwh else "this machine's power draw"
+        return {
+            "machine": name,
+            "verdict": UNKNOWN,
+            "monthly_gross": round(gross, 4),
+            "monthly_cost": None,
+            "monthly_net": None,
+            "break_even_watts": None,
+            "summary": (
+                f"{name} earned {gross:.2f} last month. Without {missing} CashPilot cannot say "
+                "whether that covers the electricity — and guessing would be worse than not saying."
+            ),
+        }
+
+    cost = monthly_cost(watts, price_per_kwh)
+    net = gross - cost
+    verdict = LOSING_MONEY if net < 0 else (MARGINAL if cost > 0 and net < cost * 0.25 else PROFITABLE)
+
+    return {
+        "machine": name,
+        "verdict": verdict,
+        "monthly_gross": round(gross, 4),
+        "monthly_cost": round(cost, 4),
+        "monthly_net": round(net, 4),
+        "watts": round(float(watts), 1),
+        "price_per_kwh": price_per_kwh,
+        "dedicated": dedicated,
+        # Everything here rests on an entered wattage and tariff.
+        "quality": "estimated",
+        "break_even_watts": round(break_even_watts(gross, price_per_kwh) or 0.0, 1),
+        "break_even_price_per_kwh": round(break_even_price(gross, watts) or 0.0, 4),
+        "summary": _summary(name, gross, cost, net, verdict, dedicated),
+    }
+
+
+def _summary(name: str, gross: float, cost: float, net: float, verdict: str, dedicated: bool) -> str:
+    if verdict == LOSING_MONEY:
+        base = (
+            f"{name} earns about {gross:.2f} a month and costs about {cost:.2f} in electricity — "
+            f"roughly {abs(net):.2f} a month out of pocket."
+        )
+        return base + (
+            " Since this machine runs only these services, turning it off would save that."
+            if dedicated
+            else " This machine would be on anyway, so treat the cost as the price of the box, not of the services."
+        )
+    if verdict == MARGINAL:
+        return (
+            f"{name} earns about {gross:.2f} a month against roughly {cost:.2f} of electricity. "
+            "That is close enough to break-even that the estimate cannot really tell them apart."
+        )
+    return f"{name} earns about {gross:.2f} a month against roughly {cost:.2f} of electricity."
+
+
+def per_service_is_meaningful(marginal_watts: float | None) -> bool:
+    """Whether a per-service cost figure would mean anything at all.
+
+    A container adding 1-3 W to a machine that is already on is below what a
+    consumer smart plug can measure, so a per-service net there is invented
+    precision. GPU compute is the exception — its marginal draw is large enough
+    to matter — but no compute service in this catalog is Docker-deployable
+    today, so that path is currently theoretical.
+    """
+    if marginal_watts is None:
+        return False
+    return marginal_watts >= SMART_PLUG_RESOLUTION_WATTS
+
+
+def fleet_summary(machines: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll the per-machine verdicts into a fleet answer.
+
+    Machines whose cost is unknown are counted separately rather than folded in
+    as zero, so the total never quietly understates what the fleet costs.
+    """
+    known = [m for m in machines if m.get("monthly_cost") is not None]
+    unknown = [m for m in machines if m.get("monthly_cost") is None]
+    gross = sum(float(m.get("monthly_gross") or 0.0) for m in machines)
+    cost = sum(float(m.get("monthly_cost") or 0.0) for m in known)
+
+    return {
+        "machines": machines,
+        "monthly_gross": round(gross, 4),
+        "monthly_cost": round(cost, 4) if known else None,
+        "monthly_net": round(gross - cost, 4) if known else None,
+        "cost_known_for": len(known),
+        "cost_unknown_for": len(unknown),
+        "losing_money": [m["machine"] for m in machines if m.get("verdict") == LOSING_MONEY],
+        "quality": "estimated",
+        "summary": (
+            f"Costs are known for {len(known)} of {len(machines)} machine(s)."
+            if unknown
+            else f"Across {len(machines)} machine(s): about {gross:.2f} earned against {cost:.2f} of electricity."
+        ),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app import (
     exchange_rates,
     fleet_key,
     login_rate_limit,
+    machine_economics,
     metrics,
     net_activity,
     notify,
@@ -2203,6 +2204,66 @@ async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
         "balance_known": balance is not None,
         "projection": payouts.project(current, service, history),
     }
+
+
+@app.get("/api/fleet/economics")
+async def api_fleet_economics(request: Request) -> dict[str, Any]:
+    """Is each machine worth keeping powered on for what it earns?
+
+    Deliberately per-MACHINE. Adding a bandwidth container to a box that is
+    already on costs 1-3 W — below what a consumer smart plug can measure — so a
+    per-service net figure would be fabricated precision. The machine-level
+    question is the one with an answer: a dedicated 65 W node at 0.20/kWh costs
+    about 9.50 a month against a typical 3-6 gross.
+
+    Nothing is ever stopped or throttled on the strength of this. The
+    electricity is the operator's and so is the decision.
+    """
+    _require_auth_api(request)
+    config = await database.get_config() or {}
+    try:
+        price = float(config.get("electricity_price_per_kwh") or 0.0)
+    except (TypeError, ValueError):
+        price = 0.0
+
+    workers = [_decoded_worker(w) for w in await database.list_workers()]
+    earned = await database.get_earned_by_platform(days=30)
+    containers = await _get_all_worker_containers()
+
+    # Attribute each service's gross to the worker running it. A service on two
+    # machines splits evenly: without per-node earnings there is no better
+    # answer, and pretending otherwise would be invented precision again.
+    per_worker_gross: dict[Any, float] = {}
+    hosts: dict[str, list[Any]] = {}
+    for container in containers:
+        slug = egress.container_slug(container)
+        if slug:
+            hosts.setdefault(slug, []).append(container.get("_worker_id"))
+    for slug, worker_ids in hosts.items():
+        share = float(earned.get(slug) or 0.0) / max(1, len(worker_ids))
+        for worker_id in worker_ids:
+            per_worker_gross[worker_id] = per_worker_gross.get(worker_id, 0.0) + share
+
+    assessed = []
+    for worker in workers:
+        info = worker.get("system_info") or {}
+        raw_watts = config.get(f"worker_{worker.get('id')}_watts")
+        try:
+            watts = float(raw_watts) if raw_watts else None
+        except (TypeError, ValueError):
+            watts = None
+        assessed.append(
+            machine_economics.assess_machine(
+                name=worker.get("name") or f"worker {worker.get('id')}",
+                monthly_gross=per_worker_gross.get(worker.get("id"), 0.0),
+                watts=watts,
+                price_per_kwh=price or None,
+                metered=power.is_metered(info),
+                dedicated=bool(config.get(f"worker_{worker.get('id')}_dedicated")),
+            )
+        )
+
+    return machine_economics.fleet_summary(assessed)
 
 
 @app.get("/api/disclosure/coverage")

--- a/tests/test_machine_economics.py
+++ b/tests/test_machine_economics.py
@@ -1,0 +1,223 @@
+"""Machine-level break-even (CashPilot-l01).
+
+The interesting tests here are the REFUSALS.
+
+Adding a bandwidth container to a machine that is already on costs 1-3 W, which
+is below what a consumer smart plug can measure. A per-service "net profit"
+there would look authoritative and be noise, so the module declines to produce
+one. That refusal is the feature.
+
+What it will answer is the machine-level question, because that one has a real
+answer: a dedicated 65 W node at EUR 0.20/kWh costs about EUR 9.50 a month
+against a typical USD 3-6 gross from a single node.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import machine_economics as me
+
+
+class TestItRefusesFabricatedPrecision:
+    @pytest.mark.parametrize("watts", [0.5, 1.0, 2.0, 3.0, 4.9])
+    def test_a_bandwidth_container_is_too_small_to_cost_out(self, watts):
+        """1-3 W is below a consumer smart plug's own measurement error."""
+        assert me.per_service_is_meaningful(watts) is False
+
+    @pytest.mark.parametrize("watts", [5.0, 40.0, 250.0])
+    def test_a_large_marginal_draw_is_worth_costing_out(self, watts):
+        assert me.per_service_is_meaningful(watts) is True
+
+    def test_an_unknown_marginal_draw_is_not_meaningful(self):
+        assert me.per_service_is_meaningful(None) is False
+
+
+class TestTheHonestUnknowns:
+    def test_no_tariff_means_no_verdict(self):
+        out = me.assess_machine(name="box", monthly_gross=4.0, watts=65.0, price_per_kwh=None)
+        assert out["verdict"] == me.UNKNOWN
+        assert out["monthly_net"] is None
+        assert "electricity price" in out["summary"]
+
+    def test_no_wattage_means_no_verdict(self):
+        out = me.assess_machine(name="box", monthly_gross=4.0, watts=None, price_per_kwh=0.20)
+        assert out["verdict"] == me.UNKNOWN
+        assert out["monthly_cost"] is None
+        assert "power draw" in out["summary"]
+
+    def test_it_says_guessing_would_be_worse_than_silence(self):
+        out = me.assess_machine(name="box", monthly_gross=4.0, watts=None, price_per_kwh=None)
+        assert "guessing would be worse" in out["summary"]
+
+    def test_a_vps_is_not_judged_on_electricity(self):
+        """The bill does not move with CPU, so estimated watts invent a cost."""
+        out = me.assess_machine(name="vps", monthly_gross=4.0, watts=65.0, price_per_kwh=0.20, metered=False)
+        assert out["verdict"] == me.NOT_METERED
+        assert out["monthly_cost"] is None
+
+    def test_every_figure_is_labelled_an_estimate(self):
+        out = me.assess_machine(name="box", monthly_gross=4.0, watts=65.0, price_per_kwh=0.20)
+        assert out["quality"] == "estimated"
+
+
+class TestTheAnswerThatMatters:
+    def test_a_dedicated_node_that_loses_money_says_so_plainly(self):
+        """The bead's own worked example: ~65 W at 0.20/kWh is ~9.50 a month."""
+        out = me.assess_machine(name="node", monthly_gross=4.0, watts=65.0, price_per_kwh=0.20, dedicated=True)
+        assert out["verdict"] == me.LOSING_MONEY
+        assert out["monthly_cost"] == pytest.approx(9.49, abs=0.05)
+        assert out["monthly_net"] < 0
+        assert "turning it off would save that" in out["summary"]
+
+    def test_a_shared_machine_is_not_blamed_for_being_on(self):
+        """A NAS would be on anyway; the services did not cause its draw."""
+        out = me.assess_machine(name="nas", monthly_gross=4.0, watts=65.0, price_per_kwh=0.20, dedicated=False)
+        assert out["verdict"] == me.LOSING_MONEY
+        assert "would be on anyway" in out["summary"]
+        assert "turning it off" not in out["summary"]
+
+    def test_a_clearly_profitable_machine_is_reported_as_such(self):
+        out = me.assess_machine(name="box", monthly_gross=50.0, watts=10.0, price_per_kwh=0.10)
+        assert out["verdict"] == me.PROFITABLE
+
+    def test_near_break_even_is_admitted_to_be_indistinguishable(self):
+        out = me.assess_machine(name="box", monthly_gross=9.6, watts=65.0, price_per_kwh=0.20)
+        assert out["verdict"] == me.MARGINAL
+        assert "cannot really tell them apart" in out["summary"]
+
+
+class TestBreakEven:
+    def test_break_even_watts_is_the_draw_that_exactly_pays_for_itself(self):
+        watts = me.break_even_watts(monthly_gross=9.49, price_per_kwh=0.20)
+        assert watts == pytest.approx(65.0, abs=0.5)
+
+    def test_break_even_price_is_the_tariff_where_it_stops_being_worth_it(self):
+        price = me.break_even_price(monthly_gross=9.49, watts=65.0)
+        assert price == pytest.approx(0.20, abs=0.005)
+
+    def test_without_a_tariff_there_is_no_break_even_wattage(self):
+        assert me.break_even_watts(10.0, 0.0) is None
+
+    def test_without_a_draw_there_is_no_break_even_price(self):
+        assert me.break_even_price(10.0, 0.0) is None
+
+    def test_cost_is_zero_for_nonsense_inputs_rather_than_negative(self):
+        assert me.monthly_cost(-5, 0.2) == 0.0
+        assert me.monthly_cost(65, -1) == 0.0
+
+
+class TestFleetRollUp:
+    def _machine(self, name, gross, cost, verdict=me.PROFITABLE):
+        return {"machine": name, "monthly_gross": gross, "monthly_cost": cost, "verdict": verdict}
+
+    def test_machines_with_unknown_cost_are_counted_not_folded_in_as_zero(self):
+        """Otherwise the fleet total quietly understates what it costs."""
+        out = me.fleet_summary([self._machine("a", 10.0, 5.0), self._machine("b", 10.0, None)])
+        assert out["cost_known_for"] == 1
+        assert out["cost_unknown_for"] == 1
+        assert out["monthly_cost"] == 5.0
+        assert "known for 1 of 2" in out["summary"]
+
+    def test_it_names_the_machines_losing_money(self):
+        out = me.fleet_summary([self._machine("good", 20.0, 2.0), self._machine("bad", 1.0, 9.0, me.LOSING_MONEY)])
+        assert out["losing_money"] == ["bad"]
+
+    def test_an_all_known_fleet_reports_a_net(self):
+        out = me.fleet_summary([self._machine("a", 10.0, 4.0), self._machine("b", 5.0, 1.0)])
+        assert out["monthly_gross"] == 15.0
+        assert out["monthly_net"] == 10.0
+
+    def test_a_fleet_with_no_cost_data_reports_no_net(self):
+        out = me.fleet_summary([self._machine("a", 10.0, None)])
+        assert out["monthly_net"] is None
+
+    def test_an_empty_fleet_does_not_explode(self):
+        out = me.fleet_summary([])
+        assert out["monthly_gross"] == 0.0
+
+
+class TestItNeverActsOnTheNumber:
+    def test_the_module_cannot_stop_or_change_anything(self):
+        """No auto-stop, no throttle. The electricity is the operator's."""
+        import ast
+        import pathlib
+
+        tree = ast.parse(pathlib.Path(me.__file__).read_text(encoding="utf-8"))
+        called = {n.func.attr for n in ast.walk(tree) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)}
+        for forbidden in ("stop", "remove", "restart", "kill", "pause", "post", "delete"):
+            assert forbidden not in called, f"machine_economics calls {forbidden!r} — it must only report"
+
+
+class TestEndpoint:
+    def _call(self, config=None, workers=None, earned=None, containers=None):
+        import asyncio
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        rows = [
+            {
+                "id": w["id"],
+                "client_id": f"c{w['id']}",
+                "name": w["name"],
+                "status": "online",
+                "containers": json.dumps([]),
+                "system_info": json.dumps(w.get("system_info", {})),
+                "apps": json.dumps([]),
+            }
+            for w in (workers or [])
+        ]
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value=config or {})),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=rows)),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value=earned or {})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers or [])),
+            ):
+                return await main.api_fleet_economics(MagicMock())
+
+        return asyncio.run(run())
+
+    WORKERS = [{"id": 1, "name": "watchtower"}, {"id": 2, "name": "geiserback"}]
+
+    def test_without_a_tariff_every_machine_reports_unknown(self):
+        out = self._call(workers=self.WORKERS)
+        assert out["monthly_cost"] is None
+        assert all(m["verdict"] == me.UNKNOWN for m in out["machines"])
+
+    def test_earnings_are_attributed_to_the_machine_running_the_service(self):
+        out = self._call(
+            config={"electricity_price_per_kwh": "0.20", "worker_1_watts": "65"},
+            workers=self.WORKERS,
+            earned={"honeygain": 4.0},
+            containers=[{"slug": "honeygain", "status": "running", "_worker_id": 1}],
+        )
+        by_name = {m["machine"]: m for m in out["machines"]}
+        assert by_name["watchtower"]["monthly_gross"] == 4.0
+        assert by_name["geiserback"]["monthly_gross"] == 0.0
+        assert by_name["watchtower"]["verdict"] == me.LOSING_MONEY
+
+    def test_a_service_on_two_machines_splits_its_gross(self):
+        """Without per-node earnings there is no better answer than an even split."""
+        out = self._call(
+            config={"electricity_price_per_kwh": "0.20"},
+            workers=self.WORKERS,
+            earned={"honeygain": 10.0},
+            containers=[
+                {"slug": "honeygain", "status": "running", "_worker_id": 1},
+                {"slug": "honeygain", "status": "running", "_worker_id": 2},
+            ],
+        )
+        assert all(m["monthly_gross"] == 5.0 for m in out["machines"])
+
+    def test_a_malformed_tariff_is_treated_as_absent_not_as_zero_cost(self):
+        out = self._call(config={"electricity_price_per_kwh": "cheap"}, workers=self.WORKERS)
+        assert all(m["verdict"] == me.UNKNOWN for m in out["machines"])
+
+    def test_an_empty_fleet_returns_an_empty_summary(self):
+        out = self._call()
+        assert out["machines"] == []


### PR DESCRIPTION
The question people ask is *"does this service make money"*, and on a shared box **that question has no honest answer**. Adding a bandwidth container to a machine that is already on costs roughly 1-3 W — about €0.19/month at €0.105/kWh — which is **below the measurement error of a consumer smart plug**. A per-service net figure there would look authoritative and be noise.

So this refuses to produce one, and **the refusal is the feature**. `per_service_is_meaningful()` only returns true above the resolution of the cheapest instrument that could verify the number. GPU compute would clear that bar, but no compute service in this catalog is Docker-deployable today — so that half stays theoretical rather than shipping as if it worked.

## The question that does have an answer

A dedicated ~65 W node at €0.20/kWh costs about **€9.50/month** against a typical $3-6 gross from a single node. Net negative, knowable, and nobody is currently told.

## Distinctions it keeps

Collapsing any of these produces a confident wrong number:

- **Dedicated vs shared.** A machine that exists only for these services can be turned off, and the summary says so. A NAS would be on anyway — its draw is the price of the box, not of the services. Blaming the services would push someone into a pointless decision.
- **Unknown vs zero.** No tariff or no wattage yields `unknown`, *names which one is missing*, and says guessing would be worse than silence. In the fleet roll-up, machines with unknown cost are **counted separately rather than folded in as zero**, so the total never quietly understates what the fleet costs.
- **Metered vs not.** A VPS bill doesn't move with CPU, so charging it estimated watts invents a cost the user isn't paying.
- **Confident vs indistinguishable.** Within 25% of break-even the answer is *"the estimate cannot really tell these apart"*, not a decimal pretending otherwise.

## It never acts on the number

No auto-stop, no throttling. A test parses the module and fails if it ever calls `stop`/`remove`/`restart`/`kill`/`pause`. The electricity is the operator's and so is the decision.

## Not included

Reading watts from a **Home Assistant** power sensor. It's the right upgrade path — HA already solves tariffs and PVPC, and reimplementing that would be foolish — but it needs a URL/token config surface that should be designed rather than guessed at here.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1769 passed**, coverage 94.69%