### PR TITLE
feat: own the attribution risk, and contain the lateral one (CashPilot-q0o)

### DIFF
--- a/app/lan_isolation.py
+++ b/app/lan_isolation.py
@@ -1,0 +1,218 @@
+"""Lateral containment, and owning the attribution risk (CashPilot-q0o).
+
+The documented danger of running proxyware is not container escape. It is that
+someone else's traffic exits YOUR address and is attributed to you — the FBI/IC3
+has issued a public notice about residential proxy networks, and researchers
+have shown operators cannot see what traffic leaves their own exit node. The
+second realistic risk is a hostile image scanning the home LAN it was handed:
+Home Assistant, NAS shares, a media server, a password manager.
+
+The first risk cannot be engineered away here. Selling that egress IS the
+product, so any control that blocked it would block the thing the user installed
+CashPilot to do. What can be reduced is LATERAL reach: a bandwidth container has
+no business talking to a NAS.
+
+Two decisions shape this module.
+
+**It states the attribution risk plainly, at deploy time.** Not in an FAQ, not
+in a tooltip. A self-hosting audience is persuaded by a project that owns the
+downside; burying it is what makes people distrust the whole category.
+
+**It does not silently reconfigure the host's network.** Creating bridges and
+firewall rules on someone's machine is a change with real blast radius, and
+several services would break in ways that cost money: Storj needs an inbound
+port and its own dashboard reachable for the collector, and Mysterium runs on
+the host network where no bridge applies at all. So this computes what CAN be
+isolated, names every exception and why, and leaves the act to the operator.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app import disclosure
+
+# Verdicts for whether a service can be confined to an isolated bridge.
+ISOLATABLE = "isolatable"
+NEEDS_EXCEPTIONS = "needs_exceptions"
+NOT_ISOLATABLE = "not_isolatable"
+
+# Private ranges a managed container has no business reaching. Not a firewall
+# implementation — the list a user needs in order to write one.
+RFC1918 = ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+# Link-local carries cloud metadata endpoints; a container reaching those on a
+# VPS can often mint credentials for the whole account.
+LINK_LOCAL = ("169.254.0.0/16",)
+
+DEFAULT_NETWORK_NAME = "cashpilot-isolated"
+
+
+def _docker(service: dict[str, Any] | None) -> dict[str, Any]:
+    return (service or {}).get("docker") or {}
+
+
+def uses_host_network(service: dict[str, Any] | None) -> bool:
+    """Host networking means there is no bridge to isolate it onto."""
+    return str(_docker(service).get("network_mode") or "").strip().lower() == "host"
+
+
+def published_ports(service: dict[str, Any] | None) -> list[str]:
+    """Ports the service must accept connections on."""
+    ports = _docker(service).get("ports") or []
+    return [str(p) for p in ports if str(p).strip()]
+
+
+def exceptions_for(service: dict[str, Any] | None) -> list[dict[str, str]]:
+    """Everything that must stay reachable, and why.
+
+    An isolation rule written without these silently breaks the thing it was
+    meant to protect — and for a storage node, breaking inbound reachability
+    costs held payout balance, not just uptime.
+    """
+    found: list[dict[str, str]] = []
+    if uses_host_network(service):
+        found.append(
+            {
+                "kind": "host_network",
+                "detail": "This service runs on the host network, so a container bridge does not apply to it at all.",
+            }
+        )
+    for port in published_ports(service):
+        found.append(
+            {
+                "kind": "inbound_port",
+                "detail": f"Port {port} must accept inbound connections, or the node cannot do its job.",
+            }
+        )
+    if (service or {}).get("collector") or (service or {}).get("slug") == "storj":
+        api_url_env = [
+            e.get("key")
+            for e in (_docker(service).get("env") or [])
+            if isinstance(e, dict) and "URL" in str(e.get("key", ""))
+        ]
+        if api_url_env:
+            found.append(
+                {
+                    "kind": "collector_reachability",
+                    "detail": (
+                        "CashPilot reads this service's earnings from its own local dashboard, so that "
+                        f"address ({', '.join(str(k) for k in api_url_env)}) must stay reachable from the UI."
+                    ),
+                }
+            )
+    return found
+
+
+def assess(service: dict[str, Any] | None) -> dict[str, Any]:
+    """Can this service be confined to a LAN-isolated bridge?"""
+    if not service:
+        return {"slug": None, "verdict": NOT_ISOLATABLE, "exceptions": [], "summary": "Unknown service."}
+
+    name = service.get("name") or service.get("slug") or "This service"
+    exceptions = exceptions_for(service)
+
+    if uses_host_network(service):
+        verdict = NOT_ISOLATABLE
+        summary = (
+            f"{name} runs on the host network, so it shares the host's interfaces directly and a "
+            "container bridge cannot contain it. Isolating it means a VLAN or a separate machine."
+        )
+    elif exceptions:
+        verdict = NEEDS_EXCEPTIONS
+        summary = (
+            f"{name} can run on an isolated bridge, but {len(exceptions)} exception(s) must be allowed "
+            "through or it will stop working."
+        )
+    else:
+        verdict = ISOLATABLE
+        summary = f"{name} needs no inbound access and can be confined to an isolated bridge as-is."
+
+    return {
+        "slug": service.get("slug"),
+        "verdict": verdict,
+        "exceptions": exceptions,
+        "blocked_destinations": list(RFC1918 + LINK_LOCAL),
+        "network_name": DEFAULT_NETWORK_NAME,
+        "summary": summary,
+    }
+
+
+def attribution_notice(service: dict[str, Any] | None) -> dict[str, Any] | None:
+    """The honest warning shown before deploying, or None when it does not apply.
+
+    Driven by the service's own disclosure block, so it fires exactly where
+    strangers really do route through the user's address — and stays silent for
+    a storage node, where it would be false and would train people to click past
+    it.
+
+    Three outcomes, because "no warning" and "nothing known" are different and
+    a user cannot tell them apart from silence:
+
+    * documented as reselling the IP -> the full notice;
+    * documented as NOT reselling (a storage node) -> None, correctly silent,
+      since a false warning here trains people to click past the real ones;
+    * undocumented -> a notice saying exactly that. Most of the catalog is
+      undocumented, and letting that render as "no risk" would be the worst
+      reading of it.
+    """
+    routes = disclosure.routes_third_party_traffic(service)
+    name = (service or {}).get("name") or (service or {}).get("slug") or "This service"
+
+    if routes is False:
+        return None
+    if routes is None:
+        return {
+            "slug": (service or {}).get("slug"),
+            "documented": False,
+            "headline": f"Nobody has documented what {name} does with your connection.",
+            "body": (
+                "That is not the same as it being safe. Most services in this category resell access "
+                "to your internet connection, which means other people's traffic leaves under your IP "
+                "and is attributed to you. Until somebody writes down what this one does, assume it "
+                "might and check the provider's terms — and your ISP's — yourself."
+            ),
+            "lateral_note": ("Consider putting these containers on a network that cannot reach the rest of your LAN."),
+            "source": "No disclosure entry exists for this service in the catalog.",
+        }
+
+    return {
+        "slug": (service or {}).get("slug"),
+        "documented": True,
+        "headline": f"{name} sells access to your internet connection.",
+        "body": (
+            "Other people's traffic will leave your connection under your IP address, and anything "
+            "they do with it looks like you to the outside world — to your ISP, to sites that block "
+            "the address, and to law enforcement. You cannot see or filter what they send. "
+            "Check your ISP's terms before running this: many consumer contracts prohibit resharing "
+            "the connection, and the account that gets suspended is yours."
+        ),
+        "lateral_note": (
+            "Consider putting these containers on a network that cannot reach the rest of your LAN. "
+            "A hostile image's realistic prize is your NAS, your Home Assistant, or your password "
+            "manager — not the bandwidth."
+        ),
+        "source": "This service's own disclosure entry in the catalog.",
+    }
+
+
+def compose_snippet(network_name: str = DEFAULT_NETWORK_NAME) -> str:
+    """A Docker network definition the operator can actually paste.
+
+    Deliberately returned as text rather than applied. Creating networks and
+    firewall rules on someone's host is their decision, and the rules that
+    matter here are enforced by the host firewall, which Docker cannot express.
+    """
+    blocked = "\n".join(f"#   {cidr}" for cidr in RFC1918 + LINK_LOCAL)
+    return (
+        f"networks:\n"
+        f"  {network_name}:\n"
+        f"    driver: bridge\n"
+        f"    driver_opts:\n"
+        f'      com.docker.network.bridge.name: "{network_name}"\n'
+        f"\n"
+        f"# Docker alone does NOT stop a container reaching your LAN. Add host firewall\n"
+        f"# rules on the {network_name} bridge denying these destinations:\n"
+        f"{blocked}\n"
+        f"# ...while still allowing the exceptions listed for each service, or the\n"
+        f"# services that need inbound ports will silently stop earning.\n"
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app import (
     egress,
     exchange_rates,
     fleet_key,
+    lan_isolation,
     login_rate_limit,
     machine_economics,
     metrics,
@@ -2264,6 +2265,52 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
         )
 
     return machine_economics.fleet_summary(assessed)
+
+
+@app.get("/api/services/{slug}/deploy-risk")
+async def api_deploy_risk(request: Request, slug: str) -> dict[str, Any]:
+    """What the user should know BEFORE deploying this, in plain words.
+
+    The documented risk of proxyware is not container escape — it is that
+    someone else's traffic exits the user's address and is attributed to them.
+    That belongs at the deploy step, not buried in an FAQ: a self-hosting
+    audience is persuaded by a project that owns the downside.
+
+    The notice is driven by the service's own disclosure entry, so it fires
+    where strangers really do route through the user's IP and stays silent for a
+    storage node, where it would be false and would train people to click past
+    warnings that matter.
+    """
+    _require_auth_api(request)
+    service = catalog.get_service(slug)
+    if not service:
+        raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
+
+    return {
+        "slug": slug,
+        "attribution": lan_isolation.attribution_notice(service),
+        "isolation": lan_isolation.assess(service),
+    }
+
+
+@app.get("/api/fleet/isolation-guide")
+async def api_isolation_guide(request: Request) -> dict[str, Any]:
+    """Which services can be LAN-isolated, and what each one needs allowed.
+
+    Returns the recipe rather than applying it. Creating bridges and firewall
+    rules on someone's host is a change with real blast radius, and several
+    services break in ways that cost money when the exceptions are missed.
+    """
+    _require_auth_api(request)
+    assessed = [lan_isolation.assess(s) for s in catalog.get_services()]
+    return {
+        "network_name": lan_isolation.DEFAULT_NETWORK_NAME,
+        "blocked_destinations": list(lan_isolation.RFC1918 + lan_isolation.LINK_LOCAL),
+        "compose_snippet": lan_isolation.compose_snippet(),
+        "isolatable": [a["slug"] for a in assessed if a["verdict"] == lan_isolation.ISOLATABLE],
+        "needs_exceptions": [a for a in assessed if a["verdict"] == lan_isolation.NEEDS_EXCEPTIONS],
+        "not_isolatable": [a for a in assessed if a["verdict"] == lan_isolation.NOT_ISOLATABLE],
+    }
 
 
 @app.get("/api/disclosure/coverage")

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,85 @@
+# Keeping these containers off the rest of your network
+
+The real risk of running proxyware is not a container breaking out. It is two
+much more ordinary things.
+
+**Someone else's traffic leaves under your IP address.** The FBI/IC3 has issued
+a public notice about residential proxy networks, and researchers have shown
+that node operators cannot see what traffic exits through them. Whatever a buyer
+does looks like you — to your ISP, to sites that block the address, and to law
+enforcement. That is not a bug in these services; it is what they sell.
+
+**A hostile image's realistic prize is your LAN.** Not the bandwidth — your Home
+Assistant, your NAS shares, your media server, your password manager. Those sit
+on the same network you just handed a closed-source container.
+
+CashPilot cannot fix the first. Selling that egress is the product, and blocking
+it would break the thing you installed this to do. What it says instead is the
+truth, before you deploy, rather than in an FAQ nobody opens.
+
+The second one you *can* reduce.
+
+## What CashPilot does and does not do
+
+It **tells you** which services can be confined and exactly what each needs
+allowed through: `GET /api/fleet/isolation-guide`.
+
+It **does not** create bridges or firewall rules on your host. That is a change
+with real blast radius, and getting the exceptions wrong costs money rather than
+convenience — a storage node that cannot accept inbound connections stops
+earning and puts its held balance at risk. So the recipe is yours to apply.
+
+## The three answers
+
+| Verdict | Meaning |
+|---|---|
+| **isolatable** | Outbound only. Confine it as-is. |
+| **needs exceptions** | It can be confined, but specific things must stay reachable. |
+| **not isolatable** | It runs on the host network — a container bridge does not apply. Use a VLAN or a separate machine. |
+
+Today `mysterium` is the third case (it declares `network_mode: "host"`), and
+`storj` is the second: it needs its inbound port **and** its local dashboard
+reachable, because that dashboard is where CashPilot reads its earnings.
+
+## Doing it
+
+Put the managed containers on their own bridge:
+
+```yaml
+networks:
+  cashpilot-isolated:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: "cashpilot-isolated"
+```
+
+!!! warning "A Docker bridge alone does not stop LAN access"
+
+    Containers on a user-defined bridge can still reach your other subnets. The
+    rule that matters is on the **host firewall**, applied to that bridge,
+    denying:
+
+    - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — your LAN
+    - `169.254.0.0/16` — cloud metadata. On a VPS, a container that reaches this
+      can often mint credentials for the whole account.
+
+    ...while still allowing every exception the guide lists for the services you
+    run. Miss one and that service silently stops earning.
+
+## A VLAN is stronger
+
+A separate VLAN with its own firewall policy contains host-networked services
+too, and does not depend on getting Docker's bridge rules exactly right. If you
+already run VLANs, that is the better answer.
+
+## Before you deploy
+
+`GET /api/services/{slug}/deploy-risk` returns the attribution notice for a
+service, driven by its own catalog disclosure. Three outcomes, and the third
+matters most:
+
+- documented as reselling your IP — you get the full warning;
+- documented as **not** reselling (a storage node) — no warning, because a false
+  one teaches you to click past the real ones;
+- **not documented at all** — it says exactly that. Most of the catalog is
+  undocumented, and "nobody checked" must never read as "no risk".

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Architecture: architecture.md
   - Direction and Roadmap: roadmap.md
   - Security Defaults: security-defaults.md
+  - Network Isolation: isolation.md
   - Fleet Management: fleet.md
   - Backing Up Node Identities: backup.md
   - Prometheus Metrics: guides/prometheus-metrics.md

--- a/tests/test_lan_isolation.py
+++ b/tests/test_lan_isolation.py
@@ -1,0 +1,185 @@
+"""Lateral containment and the attribution notice (CashPilot-q0o).
+
+The risk this addresses is not container escape. It is that someone else's
+traffic exits the user's address and is attributed to them, plus a hostile
+image's realistic prize: the home LAN it was handed.
+
+The tests that matter are about WHEN the warning fires. A warning on a storage
+node would be false and would train people to click past the ones that are real;
+silence on an undocumented service would let "nobody checked" read as "no risk".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import catalog
+from app import lan_isolation as li
+
+BANDWIDTH = {"slug": "x", "name": "X", "disclosure": {"third_party_traffic": "Yes. Strangers route through you."}}
+STORAGE = {"slug": "y", "name": "Y", "disclosure": {"third_party_traffic": "No. You store fragments."}}
+UNDOCUMENTED = {"slug": "z", "name": "Z"}
+
+
+class TestTheWarningFiresExactlyWhereItIsTrue:
+    def test_a_service_that_resells_the_ip_gets_the_full_notice(self):
+        notice = li.attribution_notice(BANDWIDTH)
+        assert notice["documented"] is True
+        assert "sells access to your internet connection" in notice["headline"]
+        assert "attributed to you" in notice["body"] or "looks like you" in notice["body"]
+
+    def test_a_storage_node_gets_no_warning_at_all(self):
+        """A false warning here trains people to click past the real ones."""
+        assert li.attribution_notice(STORAGE) is None
+
+    def test_an_undocumented_service_says_nobody_checked(self):
+        """Silence would let "not documented" read as "no risk"."""
+        notice = li.attribution_notice(UNDOCUMENTED)
+        assert notice["documented"] is False
+        assert "Nobody has documented" in notice["headline"]
+        assert "not the same as it being safe" in notice["body"]
+
+    def test_the_notice_names_its_own_source(self):
+        assert li.attribution_notice(BANDWIDTH)["source"]
+        assert li.attribution_notice(UNDOCUMENTED)["source"]
+
+    def test_it_tells_the_user_to_check_their_isp_terms(self):
+        """The account that gets suspended is theirs."""
+        assert "ISP" in li.attribution_notice(BANDWIDTH)["body"]
+
+    def test_every_notice_mentions_the_lateral_risk(self):
+        for service in (BANDWIDTH, UNDOCUMENTED):
+            assert "LAN" in li.attribution_notice(service)["lateral_note"]
+
+
+class TestAgainstTheRealCatalog:
+    @pytest.mark.parametrize("slug", ["mysterium", "anyone-protocol", "proxybase-xyz"])
+    def test_the_documented_resellers_all_warn(self, slug):
+        notice = li.attribution_notice(catalog.get_service(slug))
+        assert notice is not None and notice["documented"] is True
+
+    def test_storj_does_not_warn(self):
+        assert li.attribution_notice(catalog.get_service("storj")) is None
+
+    def test_most_of_the_catalog_is_undocumented_and_says_so(self):
+        """46 of 50 today — the notice must not imply they are all safe."""
+        undocumented = [
+            s["slug"] for s in catalog.get_services() if (li.attribution_notice(s) or {}).get("documented") is False
+        ]
+        assert len(undocumented) > 10
+
+
+class TestWhatCanActuallyBeIsolated:
+    def test_a_host_networked_service_cannot_be_confined_by_a_bridge(self):
+        out = li.assess(catalog.get_service("mysterium"))
+        assert out["verdict"] == li.NOT_ISOLATABLE
+        assert "VLAN or a separate machine" in out["summary"]
+
+    def test_a_service_needing_inbound_ports_needs_exceptions(self):
+        """Missing these costs a storage node its held payout balance."""
+        out = li.assess(catalog.get_service("storj"))
+        assert out["verdict"] == li.NEEDS_EXCEPTIONS
+        kinds = {e["kind"] for e in out["exceptions"]}
+        assert "inbound_port" in kinds
+
+    def test_a_plain_outbound_only_service_is_isolatable(self):
+        out = li.assess(catalog.get_service("honeygain"))
+        assert out["verdict"] == li.ISOLATABLE
+        assert out["exceptions"] == []
+
+    def test_every_exception_explains_itself(self):
+        for svc in catalog.get_services():
+            for exception in li.assess(svc)["exceptions"]:
+                assert exception["detail"].endswith("."), f"{svc['slug']}: unexplained exception"
+
+    def test_the_blocked_list_covers_every_private_range_and_metadata(self):
+        blocked = li.assess(catalog.get_service("honeygain"))["blocked_destinations"]
+        assert "10.0.0.0/8" in blocked
+        assert "172.16.0.0/12" in blocked
+        assert "192.168.0.0/16" in blocked
+        # Cloud metadata: a container reaching it on a VPS can mint credentials.
+        assert "169.254.0.0/16" in blocked
+
+    def test_an_unknown_service_is_not_claimed_isolatable(self):
+        assert li.assess(None)["verdict"] == li.NOT_ISOLATABLE
+
+
+class TestItDoesNotTouchTheHostNetwork:
+    def test_the_module_only_produces_text(self):
+        """Creating bridges and firewall rules is the operator's decision."""
+        import ast
+        import pathlib
+
+        tree = ast.parse(pathlib.Path(li.__file__).read_text(encoding="utf-8"))
+        called = {n.func.attr for n in ast.walk(tree) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)}
+        for forbidden in ("run", "check_output", "Popen", "create", "connect", "remove"):
+            assert forbidden not in called, f"lan_isolation calls {forbidden!r} — it must only describe"
+
+    def test_it_imports_no_docker_or_subprocess_client(self):
+        import ast
+        import pathlib
+
+        tree = ast.parse(pathlib.Path(li.__file__).read_text(encoding="utf-8"))
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(a.name for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        assert not (imported & {"docker", "subprocess", "os", "httpx"})
+
+    def test_the_snippet_warns_that_docker_alone_is_not_enough(self):
+        """A bridge without host firewall rules does not stop LAN access."""
+        snippet = li.compose_snippet()
+        assert "does NOT stop" in snippet
+        assert "192.168.0.0/16" in snippet
+
+    def test_the_snippet_warns_about_the_exceptions(self):
+        assert "silently stop earning" in li.compose_snippet()
+
+
+class TestEndpoints:
+    def _call(self, fn, *args):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from app import main
+
+        with patch.object(main, "_require_auth_api", lambda r: None):
+            return asyncio.run(fn(MagicMock(), *args))
+
+    def test_deploy_risk_returns_both_halves(self):
+        from app import main
+
+        out = self._call(main.api_deploy_risk, "mysterium")
+        assert out["attribution"]["documented"] is True
+        assert out["isolation"]["verdict"] == li.NOT_ISOLATABLE
+
+    def test_deploy_risk_for_a_storage_node_has_no_attribution_notice(self):
+        from app import main
+
+        assert self._call(main.api_deploy_risk, "storj")["attribution"] is None
+
+    def test_an_unknown_service_is_a_404(self):
+        from fastapi import HTTPException
+
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            self._call(main.api_deploy_risk, "no-such-service")
+        assert exc.value.status_code == 404
+
+    def test_the_guide_sorts_services_into_the_three_buckets(self):
+        from app import main
+
+        out = self._call(main.api_isolation_guide)
+        assert "honeygain" in out["isolatable"]
+        assert any(s["slug"] == "mysterium" for s in out["not_isolatable"])
+        assert any(s["slug"] == "storj" for s in out["needs_exceptions"])
+
+    def test_the_guide_hands_back_a_pasteable_snippet(self):
+        from app import main
+
+        out = self._call(main.api_isolation_guide)
+        assert "driver: bridge" in out["compose_snippet"]
+        assert out["network_name"] in out["compose_snippet"]


### PR DESCRIPTION
The documented danger of running proxyware **is not container escape**. It's that someone else's traffic exits the user's address and is attributed to them — the FBI/IC3 has a public notice on residential proxy networks, and researchers have shown operators cannot see what leaves their own exit node.

The second real risk is a hostile image scanning the LAN it was handed: Home Assistant, NAS shares, a media server, a password manager.

## The first risk can't be engineered away — so say it

Selling that egress **is the product**. Any control that blocked it would block the reason the user installed this. So CashPilot states it plainly at the deploy step rather than in an FAQ. Owning the downside is what persuades a self-hosting audience.

The notice is driven by the service's **own disclosure entry**, which gives three outcomes rather than two:

| Case | Result |
|---|---|
| documented as reselling your IP | full warning, including that the suspended ISP account is *yours* |
| documented as **not** reselling (storage node) | **silence, deliberately** — a false warning teaches people to click past real ones |
| **undocumented** | a notice saying exactly that |

That third case matters most: most of the catalog is undocumented, and letting *"nobody checked"* render as *"no risk"* would be the worst possible reading.

## The second risk is what can actually be reduced

The module computes what can be confined **without touching anything**. Creating bridges and firewall rules on someone's host has real blast radius, and missing an exception costs money rather than convenience — a storage node that can't accept inbound connections stops earning and puts its held balance at risk.

So it names every exception and why, and leaves the act to the operator. Tests parse the module and fail if it ever calls `run`/`Popen`/`create`/`connect`, or imports `docker` or `subprocess`.

Three verdicts, each true of the real catalog:

- **honeygain** — outbound only, isolatable as-is
- **storj** — needs its inbound port *and* its local dashboard reachable (that's where CashPilot reads earnings)
- **mysterium** — declares `network_mode: "host"`, so no container bridge applies; the honest answer is a VLAN or a separate machine

## The thing that's easy to get wrong

**A Docker bridge alone does NOT stop LAN access.** The rule that matters is on the host firewall. The blocked list includes `169.254.0.0/16` because a container reaching cloud metadata on a VPS can often mint credentials for the whole account.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1761 passed**, coverage 94.71%