### PR TITLE
feat: optional container runtime, explicitly unsupported (CashPilot-54q)

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -155,6 +155,23 @@ def _read_pids_limit() -> int:
 _PIDS_LIMIT = _read_pids_limit()
 
 
+def available_runtimes() -> set[str]:
+    """Runtimes the local Docker daemon actually reports.
+
+    The allowlist is derived from the daemon rather than hardcoded, because a
+    runtime CashPilot has heard of but the host has not installed would fail at
+    container-create time with a Docker error the user cannot act on. Asking the
+    daemon means the only runtimes offered are ones that exist here.
+    """
+    try:
+        info = _get_client().info()
+    except Exception:
+        logger.warning("Could not read Docker runtimes; treating none as available")
+        return set()
+    runtimes = info.get("Runtimes")
+    return set(runtimes) if isinstance(runtimes, dict) else set()
+
+
 def deploy_raw(
     slug: str,
     image: str,
@@ -169,6 +186,7 @@ def deploy_raw(
     labels: dict[str, str] | None = None,
     resources: Any = None,
     category: str = "bandwidth",
+    runtime: str | None = None,
 ) -> str:
     """Deploy a container from a raw spec (no catalog lookup).
 
@@ -239,6 +257,9 @@ def deploy_raw(
         hostname=hostname or f"cashpilot-{slug}",
         detach=True,
         restart_policy={"Name": "unless-stopped"},
+        # None means Docker's default runtime, which is what every service uses
+        # unless an advanced user has deliberately opted one into another.
+        runtime=runtime or None,
         **resource_kwargs,
     )
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -622,6 +622,9 @@ class DeploySpec(BaseModel):
     hostname: str | None = None
     labels: dict[str, str] = {}
     resources: ResourceSpec | None = None
+    # Advanced and unsupported. Absent means Docker's default runtime, which is
+    # what everything uses and what everything is tested against.
+    runtime: str | None = None
 
 
 _BLOCKED_VOLUME_ROOTS = {
@@ -820,7 +823,35 @@ def _catalog_host_network_slugs() -> set[str]:
 _ALLOWED_NETWORK_MODES = {None, "", "bridge", "none", "host"}
 
 
+def _validate_runtime(runtime: str | None) -> None:
+    """Allow only a runtime this daemon actually reports.
+
+    Deliberately NOT a hardcoded list. A runtime CashPilot recognises but the
+    host has not installed would fail at container-create time with a Docker
+    error the user cannot act on; asking the daemon means the only runtimes
+    accepted are ones that exist here.
+
+    Nothing selects a non-default runtime on its own. See docs/isolation.md for
+    why gVisor is not adopted as a default or as a supported profile: it costs
+    roughly 1.7x network throughput on a workload that is pure network I/O, it
+    breaks host-networked services outright, and it does not address the risks
+    that actually occur in this category.
+    """
+    if not runtime:
+        return
+    available = orchestrator.available_runtimes()
+    if runtime not in available:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"This host's Docker daemon does not provide a {runtime!r} runtime. "
+                f"Available: {sorted(available) or 'none reported'}."
+            ),
+        )
+
+
 def _validate_deploy_spec(spec: DeploySpec, slug: str | None = None) -> None:
+    _validate_runtime(spec.runtime)
     if spec.privileged:
         raise HTTPException(status_code=403, detail="Privileged containers are not allowed")
     if spec.cap_add:
@@ -919,6 +950,7 @@ async def api_deploy_container(request: Request, slug: str, spec: DeploySpec) ->
             hostname=spec.hostname,
             labels=spec.labels,
             resources=spec.resources,
+            runtime=spec.runtime,
         )
         return {"status": "deployed", "container_id": container_id}
     except Exception:
@@ -1106,6 +1138,27 @@ async def api_backup_verify(slug: str, body: VerifyRequest, request: Request) ->
             recipient_private_key=body.recipient_public_key,
         )
     )
+
+
+@app.get("/api/runtimes")
+async def api_runtimes(request: Request) -> dict[str, Any]:
+    """Container runtimes this host actually provides.
+
+    Advanced and unsupported. CashPilot never selects one: the default runtime
+    is what every service is tested against, and the alternatives cost real
+    throughput on a workload that is pure network I/O.
+    """
+    _verify_api_key(request)
+    available = sorted(await asyncio.to_thread(orchestrator.available_runtimes))
+    return {
+        "available": available,
+        "default": None,
+        "supported": False,
+        "note": (
+            "Selecting a non-default runtime is an advanced, unsupported choice. It is not a "
+            "hardening recommendation — see the docs for why."
+        ),
+    }
 
 
 @app.get("/api/health")

--- a/docs/security-defaults.md
+++ b/docs/security-defaults.md
@@ -84,3 +84,34 @@ Account emails, API URLs, and public relay fingerprints are stored as-is. Emails
 ## Reporting a problem
 
 See [SECURITY.md](https://github.com/GeiserX/CashPilot/blob/main/SECURITY.md). Please do not open a public issue for a vulnerability.
+
+## Container runtimes: why gVisor is not the answer here
+
+CashPilot supports an optional `runtime` on a deploy spec, allowlisted to
+runtimes your Docker daemon actually reports. **It is advanced, unsupported, and
+nothing selects it for you.** That is a deliberate position, not an oversight.
+
+gVisor (`runsc`) defends against container escape. That is not the risk in this
+category:
+
+- **The escape path is already closed.** Deploys refuse `privileged`, drop every
+  capability and add back only what a service's own catalog entry declares,
+  allowlist `network_mode`, and block host bind mounts including the Docker
+  socket. There is no documented case of a mainstream proxyware image escaping
+  its container.
+- **It does not address what actually happens.** The evidenced risks are IP
+  attribution and lateral movement into your LAN. gVisor addresses neither. See
+  [Network isolation](isolation.md), which does.
+- **It costs about 1.7x network throughput** on a workload that is *pure network
+  I/O* — you would pay for it in the exact dimension you are being paid for.
+- **It breaks things.** `runsc` only simulates `NET_ADMIN`, and host networking
+  negates the isolation anyway, so a host-networked service either fails or
+  gains nothing.
+- **It does not install cleanly** where this runs: Unraid has no package manager
+  and is not systemd, a Raspberry Pi needs a custom 48-bit-VA kernel, and on
+  macOS Docker Desktop already runs everything inside a Linux VM.
+
+If you have already installed a runtime and want a specific service in it, set
+`runtime` on that service and own the outcome. The allowlist is read from your
+daemon, so you cannot select something the host does not have — that would only
+fail later with an error you could not act on.

--- a/tests/test_optional_runtime.py
+++ b/tests/test_optional_runtime.py
@@ -1,0 +1,150 @@
+"""Optional container runtime passthrough (CashPilot-54q).
+
+The research verdict this implements is a REFUSAL: do not adopt gVisor as a
+default or as a supported "hardened profile". The escape path it defends is
+already closed by the deploy-spec validation (privileged refused, capabilities
+and network_mode allowlisted, host bind mounts blocked), and there is no
+documented case of a mainstream proxyware image escaping its container. The
+risks that actually occur here are IP attribution and lateral movement, which
+gVisor does not address — while costing roughly 1.7x network throughput on a
+workload that is pure network I/O.
+
+So what ships is the cheap concession: an advanced user who has already
+installed a runtime can opt one service into it and own the outcome. Nothing
+defaults to it, and nothing recommends it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app import orchestrator, worker_api
+
+
+def spec(**kwargs):
+    return worker_api.DeploySpec(image="example/image:1.0", **kwargs)
+
+
+class TestNothingIsEverDefaulted:
+    def test_the_default_spec_selects_no_runtime(self):
+        assert spec().runtime is None
+
+    def test_a_spec_without_a_runtime_passes_validation_untouched(self):
+        with patch.object(orchestrator, "available_runtimes", return_value=set()) as available:
+            worker_api._validate_runtime(None)
+        available.assert_not_called(), "an absent runtime must not even query the daemon"
+
+    def test_deploy_passes_none_through_so_docker_uses_its_default(self):
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured.update(kwargs)
+            return MagicMock(short_id="abc123")
+
+        client = MagicMock()
+        client.containers.run.side_effect = fake_run
+        client.containers.get.side_effect = orchestrator.NotFound("nope")
+
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.deploy_raw(slug="demo", image="img:1")
+        assert captured["runtime"] is None
+
+
+class TestTheAllowlistComesFromTheDaemon:
+    def test_a_runtime_this_host_provides_is_accepted(self):
+        with patch.object(orchestrator, "available_runtimes", return_value={"runc", "runsc"}):
+            worker_api._validate_runtime("runsc")
+
+    def test_a_runtime_this_host_does_not_provide_is_refused(self):
+        """Otherwise it fails at create time with a Docker error nobody can act on."""
+        with (
+            patch.object(orchestrator, "available_runtimes", return_value={"runc"}),
+            pytest.raises(HTTPException) as exc,
+        ):
+            worker_api._validate_runtime("runsc")
+        assert exc.value.status_code == 400
+        assert "runsc" in exc.value.detail
+        assert "runc" in exc.value.detail, "the error should say what IS available"
+
+    def test_a_host_reporting_no_runtimes_refuses_everything_but_the_default(self):
+        with (
+            patch.object(orchestrator, "available_runtimes", return_value=set()),
+            pytest.raises(HTTPException),
+        ):
+            worker_api._validate_runtime("runsc")
+
+    def test_the_allowlist_is_not_hardcoded(self):
+        """A hardcoded list would offer runtimes the host has never installed."""
+        import ast
+        import pathlib
+
+        source = pathlib.Path(worker_api.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef) and n.name == "_validate_runtime"
+        )
+        literals = {n.value for n in ast.walk(fn) if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+        assert "runsc" not in literals, "the validator must not carry a hardcoded runtime name"
+
+
+class TestReadingTheDaemon:
+    def test_it_returns_what_docker_reports(self):
+        client = MagicMock()
+        client.info.return_value = {"Runtimes": {"runc": {}, "runsc": {}}}
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            assert orchestrator.available_runtimes() == {"runc", "runsc"}
+
+    def test_a_daemon_that_cannot_be_reached_reports_none_rather_than_raising(self):
+        with patch.object(orchestrator, "_get_client", side_effect=RuntimeError("no docker")):
+            assert orchestrator.available_runtimes() == set()
+
+    def test_a_malformed_info_response_reports_none(self):
+        client = MagicMock()
+        client.info.return_value = {"Runtimes": "runc"}
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            assert orchestrator.available_runtimes() == set()
+
+
+class TestTheSpecStillRefusesEverythingElse:
+    """The runtime field must not become a way around the existing guards."""
+
+    def test_privileged_is_still_refused_even_with_a_valid_runtime(self):
+        with (
+            patch.object(orchestrator, "available_runtimes", return_value={"runsc"}),
+            pytest.raises(HTTPException) as exc,
+        ):
+            worker_api._validate_deploy_spec(spec(runtime="runsc", privileged=True))
+        assert exc.value.status_code == 403
+
+    def test_the_runtime_is_validated_before_anything_is_deployed(self):
+        with (
+            patch.object(orchestrator, "available_runtimes", return_value=set()),
+            pytest.raises(HTTPException) as exc,
+        ):
+            worker_api._validate_deploy_spec(spec(runtime="runsc"))
+        assert exc.value.status_code == 400
+
+
+class TestTheEndpointDoesNotRecommendIt:
+    def _call(self):
+        import asyncio
+
+        with patch.object(worker_api, "_verify_api_key", lambda r: None):
+            return asyncio.run(worker_api.api_runtimes(MagicMock()))
+
+    def test_it_lists_what_the_host_provides(self):
+        with patch.object(orchestrator, "available_runtimes", return_value={"runc", "runsc"}):
+            out = self._call()
+        assert out["available"] == ["runc", "runsc"]
+
+    def test_it_selects_nothing_and_says_it_is_unsupported(self):
+        with patch.object(orchestrator, "available_runtimes", return_value={"runc"}):
+            out = self._call()
+        assert out["default"] is None
+        assert out["supported"] is False
+        assert "not a hardening recommendation" in out["note"]


### PR DESCRIPTION
The research verdict this implements is **mostly a refusal**: do not adopt gVisor as a default or as a supported "hardened profile".

## Why not

- **The escape path is already closed.** Deploys refuse `privileged`, drop every capability and add back only what a service's catalog entry declares, allowlist `network_mode`, and block host bind mounts including the Docker socket. There is no documented case of a mainstream proxyware image escaping its container.
- **It doesn't address what actually happens.** The evidenced risks are IP attribution and lateral movement. gVisor addresses neither — `q0o` does.
- **~1.7x network throughput cost** on a workload that is *pure network I/O*: you'd pay for it in the exact dimension you're paid in.
- **It breaks things.** `runsc` only *simulates* `NET_ADMIN`, and host networking negates the isolation anyway — so a host-networked service either fails or gains nothing.
- **It doesn't install cleanly where this runs:** Unraid has no package manager and isn't systemd; a Raspberry Pi needs a custom 48-bit-VA kernel; on macOS Docker Desktop already runs a Linux VM.

## What ships instead

The cheap concession: an optional `runtime` on the deploy spec, so an advanced user who has **already** installed one can opt a single service in and own the outcome.

- **The allowlist is read from the daemon**, not hardcoded — and a test asserts the validator carries no runtime name. A hardcoded list would accept a runtime the host never installed, failing later with a Docker error nobody can act on.
- **Nothing defaults to it.** An absent runtime doesn't even query the daemon; `deploy_raw` passes `None` so Docker uses its own default — what every service is tested against.
- The endpoint listing what a host provides reports `supported: false` and says plainly this is **not a hardening recommendation**.
- The runtime is validated *before* anything else, and a test proves it can't be used to slip past the existing guards.

The docs state the reasoning, not just the switch — the useful thing here is knowing why the obvious hardening step is the wrong one.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1749 passed**, coverage 94.67%