### PR TITLE
feat: drop unsafe-inline from the CSP (CashPilot-guw)

### DIFF
--- a/app/deps.py
+++ b/app/deps.py
@@ -39,6 +39,20 @@ _TRUST_PROXY = os.getenv("CASHPILOT_TRUSTED_PROXY", "").strip().lower() in ("1",
 templates = Jinja2Templates(directory="app/templates")
 
 
+def _csp_nonce(request) -> str:
+    """The per-response CSP nonce, for stamping inline <script> blocks.
+
+    Read from request.state so the value in the markup always matches the one in
+    the header. If they ever diverged every inline script would be blocked and
+    the UI would silently stop working, which is exactly the failure a template
+    author would not think to test for.
+    """
+    return getattr(getattr(request, "state", None), "csp_nonce", "")
+
+
+templates.env.globals["csp_nonce"] = _csp_nonce
+
+
 def _login_redirect() -> RedirectResponse:
     return RedirectResponse("/login", status_code=303)
 

--- a/app/main.py
+++ b/app/main.py
@@ -640,18 +640,34 @@ _HSTS_TRUST_PROXY = os.getenv("CASHPILOT_TRUSTED_PROXY", "").strip().lower() in 
 # Security headers middleware
 class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
+        # A fresh nonce per response. Templates read it via request.state so the
+        # value in the header and the value in the markup can never disagree —
+        # if they did, every inline script would be blocked and the UI would
+        # simply stop working.
+        nonce = secrets.token_urlsafe(16)
+        request.state.csp_nonce = nonce
         response = await call_next(request)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-        # 'unsafe-inline' stays on script-src/style-src until the UI drops inline handlers
-        # (bead guw). base-uri/object-src/form-action are additive hardening that costs
-        # nothing today: block <base> hijack of relative script URLs, disallow plugins,
-        # and stop a form from POSTing credentials off-origin if an XSS is ever found.
+        # script-src no longer allows 'unsafe-inline' (bead guw). Inline event
+        # handlers are gone — every control goes through one delegated listener —
+        # and the few remaining inline <script> blocks carry a per-response
+        # nonce. That matters because this UI renders provider-supplied strings:
+        # with 'unsafe-inline', any markup an attacker gets into one of those
+        # executes.
+        #
+        # style-src keeps 'unsafe-inline' for now: the templates carry inline
+        # style= attributes, which a nonce cannot cover, and a style injection
+        # cannot execute script. Narrower than script, and honest about staying.
+        #
+        # base-uri/object-src/form-action are additive hardening that costs
+        # nothing: block <base> hijack of relative script URLs, disallow plugins,
+        # and stop a form POSTing credentials off-origin if an XSS is ever found.
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "
+            f"script-src 'self' https://cdn.jsdelivr.net 'nonce-{nonce}'; "
             "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; "
             "font-src 'self' https://fonts.gstatic.com; "
             "img-src 'self' data:; "

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -419,7 +419,7 @@ const CP = (() => {
         container.innerHTML = `
           <div style="display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; padding:24px 0; color:var(--text-muted); text-align:center;">
             <span>Couldn't load services${err && err.message ? `: ${escapeHtml(err.message)}` : ''}.</span>
-            <button class="btn btn-ghost btn-sm" onclick="CP.loadServicesTable()">Retry</button>
+            <button class="btn btn-ghost btn-sm" data-action="loadServicesTable">Retry</button>
           </div>`;
       }
     }
@@ -495,9 +495,9 @@ const CP = (() => {
     // earning, but its (separate) earnings-tracking credentials aren't set yet.
     let disconnectedLabel = '';
     if (svc.collector_disconnected) {
-      disconnectedLabel = `<div title="CashPilot couldn't read this balance — check the earnings-tracking credentials" style="font-size:0.6rem; color:var(--error); font-weight:500; display:flex; align-items:center; justify-content:flex-end; gap:4px;">can't read balance${_isOwner ? ` <button class="btn btn-ghost" onclick="event.stopPropagation(); CP.openCredentialModal('${escapeHtml(svc.slug)}')" style="font-size:0.6rem; padding:1px 5px; line-height:1.2; color:var(--error); border:1px solid #ef4444; border-radius:3px; cursor:pointer;">fix</button>` : ''}</div>`;
+      disconnectedLabel = `<div title="CashPilot couldn't read this balance — check the earnings-tracking credentials" style="font-size:0.6rem; color:var(--error); font-weight:500; display:flex; align-items:center; justify-content:flex-end; gap:4px;">can't read balance${_isOwner ? ` <button class="btn btn-ghost" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(svc.slug)}" style="font-size:0.6rem; padding:1px 5px; line-height:1.2; color:var(--error); border:1px solid #ef4444; border-radius:3px; cursor:pointer;">fix</button>` : ''}</div>`;
     } else if (svc.collector_needs_setup) {
-      disconnectedLabel = `<div title="This service is running and earning. To show its balance here, add its earnings-tracking credentials." style="font-size:0.6rem; color:var(--text-muted); font-weight:500; display:flex; align-items:center; justify-content:flex-end; gap:4px;">tracking not set up${_isOwner ? ` <button class="btn btn-ghost" onclick="event.stopPropagation(); CP.openCredentialModal('${escapeHtml(svc.slug)}')" style="font-size:0.6rem; padding:1px 5px; line-height:1.2; color:var(--text-muted); border:1px solid var(--border); border-radius:3px; cursor:pointer;">set up</button>` : ''}</div>`;
+      disconnectedLabel = `<div title="This service is running and earning. To show its balance here, add its earnings-tracking credentials." style="font-size:0.6rem; color:var(--text-muted); font-weight:500; display:flex; align-items:center; justify-content:flex-end; gap:4px;">tracking not set up${_isOwner ? ` <button class="btn btn-ghost" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(svc.slug)}" style="font-size:0.6rem; padding:1px 5px; line-height:1.2; color:var(--text-muted); border:1px solid var(--border); border-radius:3px; cursor:pointer;">set up</button>` : ''}</div>`;
     }
     let balanceHtml;
     if (nativeLabel) {
@@ -539,7 +539,7 @@ const CP = (() => {
       ? (eligible ? 'Cash out earnings' : 'View payout details')
       : 'No payout info available';
     const claimDisabled = !co.dashboard_url;
-    const claimBtn = `<button class="btn btn-icon ${eligible ? 'btn-success' : ''}" onclick="${claimDisabled ? '' : `CP.openClaimModal('${escapeHtml(svc.slug)}')`}" title="${claimTitle}"${claimDisabled ? ' disabled' : ''}>
+    const claimBtn = `<button class="btn btn-icon ${eligible ? 'btn-success' : ''}" data-action="openClaimModal" data-a1="${escapeHtml(svc.slug)}" title="${claimTitle}"${claimDisabled ? ' disabled' : ''}>
            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
          </button>`;
 
@@ -550,7 +550,7 @@ const CP = (() => {
 
     // Settings gear (owner-only) — opens credential + bonus modal
     const settingsBtn = _isOwner
-      ? `<button class="btn btn-icon" onclick="event.stopPropagation(); CP.openCredentialModal('${escapeHtml(svc.slug)}')" title="Credentials &amp; settings">
+      ? `<button class="btn btn-icon" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(svc.slug)}" title="Credentials &amp; settings">
            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
          </button>` : '';
 
@@ -558,7 +558,7 @@ const CP = (() => {
     // For single instance: show action buttons directly
     let actionBtns;
     if (isMulti) {
-      const chevron = `<button class="btn btn-icon expand-toggle" onclick="event.stopPropagation(); CP.toggleInstances('${escapeHtml(svc.slug)}')" title="Expand instances">
+      const chevron = `<button class="btn btn-icon expand-toggle" data-action="toggleInstances" data-stop="1" data-a1="${escapeHtml(svc.slug)}" title="Expand instances">
         <svg class="expand-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
       </button>`;
       actionBtns = `<div class="action-btns">${claimBtn}${settingsBtn}${chevron}</div>`;
@@ -574,13 +574,13 @@ const CP = (() => {
           ${claimBtn}
           ${settingsBtn}
           ${_canWrite ? `
-          <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart"${disabledAttr}>
+          <button class="btn btn-icon" data-action="restartService" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Restart"${disabledAttr}>
             ${ICON_RESTART}
           </button>
-          <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop"${disabledAttr}>
+          <button class="btn btn-icon" data-action="stopService" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Stop"${disabledAttr}>
             ${ICON_STOP}
           </button>
-          <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs"${disabledAttr}>
+          <button class="btn btn-icon" data-action="viewLogs" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Logs"${disabledAttr}>
             ${ICON_LOGS}
           </button>` : ''}
         </div>`;
@@ -588,7 +588,7 @@ const CP = (() => {
 
     // Main row
     let html = `
-    <tr class="breakdown-row${isMulti ? ' expandable' : ''}" data-slug="${escapeHtml(svc.slug)}"${isMulti ? ` onclick="CP.toggleInstances('${escapeHtml(svc.slug)}', event)" style="cursor:pointer;"` : ''}>
+    <tr class="breakdown-row${isMulti ? ' expandable' : ''}" data-slug="${escapeHtml(svc.slug)}"${isMulti ? ` data-action="toggleInstances" data-a1="${escapeHtml(svc.slug)}" data-a2="event" style="cursor:pointer;"` : ''}>
       <td>${nameHtml}<div style="font-size:0.7rem; color:var(--text-muted);">${subtitle}</div></td>
       <td style="text-align:center;"><span class="badge badge-${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span>${instanceLabel}${outdatedBadge}</td>
       <td style="text-align:center;">${healthBadge}</td>
@@ -628,13 +628,13 @@ const CP = (() => {
           <td style="text-align:center; white-space:nowrap;">
             <div class="action-btns">
               ${_canWrite ? `
-              <button class="btn btn-icon" onclick="CP.restartService('${escapeHtml(svc.slug)}${wParam})" title="Restart on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" data-action="restartService" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Restart on ${nodeLabel}"${disabledAttr}>
                 ${ICON_RESTART}
               </button>
-              <button class="btn btn-icon" onclick="CP.stopService('${escapeHtml(svc.slug)}${wParam})" title="Stop on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" data-action="stopService" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Stop on ${nodeLabel}"${disabledAttr}>
                 ${ICON_STOP}
               </button>
-              <button class="btn btn-icon" onclick="CP.viewLogs('${escapeHtml(svc.slug)}${wParam})" title="Logs on ${nodeLabel}"${disabledAttr}>
+              <button class="btn btn-icon" data-action="viewLogs" data-a1="'${escapeHtml(svc.slug)}${wParam}" title="Logs on ${nodeLabel}"${disabledAttr}>
                 ${ICON_LOGS}
               </button>` : ''}
             </div>
@@ -841,9 +841,9 @@ const CP = (() => {
         ${fieldsHtml}
         ${bonusHtml}
         <div style="display:flex; gap:8px; margin-top:14px;">
-          <button class="btn btn-primary btn-sm" onclick="CP.saveCredentialModal()">Save</button>
-          <button class="btn btn-ghost btn-sm" onclick="CP.closeModal('cred-modal')">Cancel</button>
-          <button class="btn btn-ghost btn-sm" style="color:var(--error); margin-left:auto;" onclick="CP.clearServiceCredentials('${escapeHtml(slug)}', '${escapeHtml(col.name)}'); CP.closeModal('cred-modal');">Clear</button>
+          <button class="btn btn-primary btn-sm" data-action="saveCredentialModal">Save</button>
+          <button class="btn btn-ghost btn-sm" data-action="closeModal" data-a1="cred-modal">Cancel</button>
+          <button class="btn btn-ghost btn-sm" style="color:var(--error); margin-left:auto;" data-action="clearServiceCredentials" data-a1="${escapeHtml(slug)}" data-a2="${escapeHtml(col.name)}">Clear</button>
         </div>`;
     } catch (err) {
       if (body) body.innerHTML = `<p style="color:var(--error);">Failed to load: ${escapeHtml(err.message)}</p>`;
@@ -1319,7 +1319,7 @@ const CP = (() => {
     }
 
     return `
-    <div class="${classes.join(' ')}" data-slug="${svc.slug}" onclick="CP.toggleWizardService('${svc.slug}', this)">
+    <div class="${classes.join(' ')}" data-slug="${svc.slug}" data-action="toggleWizardService" data-a1="${svc.slug}" data-a2="this">
       <div class="service-card-header">
         <div class="service-icon">${(svc.name || '?')[0]}</div>
         <div>
@@ -1488,7 +1488,7 @@ const CP = (() => {
           <div id="setup-worker-list-${svc.slug}">${workerRows}</div>
         </div>
         <div style="display:flex; gap:8px; align-items:center;">
-          <button class="btn btn-success" onclick="CP.deployService('${svc.slug}')"${_canWrite ? '' : ' disabled title="Writer access required"'}>
+          <button class="btn btn-success" data-action="deployService" data-a1="${svc.slug}"${_canWrite ? '' : ' disabled title="Writer access required"'}>
             Deploy ${escapeHtml(svc.name)}
           </button>
           <span class="deploy-status" id="deploy-status-${svc.slug}" style="margin-left: 4px; font-size: 0.85rem;"></span>
@@ -1624,9 +1624,9 @@ const CP = (() => {
     const hasDocker = svc.docker && svc.docker.image;
     let actionBtn;
     if (isDeployed) {
-      actionBtn = `<button class="btn btn-secondary btn-sm" onclick="CP.openServiceDetail('${svc.slug}')">Manage</button>`;
+      actionBtn = `<button class="btn btn-secondary btn-sm" data-action="openServiceDetail" data-a1="${svc.slug}">Manage</button>`;
     } else if (hasDocker) {
-      actionBtn = `<button class="btn btn-primary btn-sm" onclick="CP.openServiceDetail('${svc.slug}')">Deploy</button>`;
+      actionBtn = `<button class="btn btn-primary btn-sm" data-action="openServiceDetail" data-a1="${svc.slug}">Deploy</button>`;
     } else {
       const url = (svc.referral && svc.referral.signup_url) || svc.website || '#';
       actionBtn = `<a href="${escapeHtml(url)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">Visit</a>`;
@@ -1807,7 +1807,7 @@ const CP = (() => {
         <div style="font-size:0.8rem; color:var(--text-muted); background:var(--bg-subtle, rgba(255,255,255,0.03)); border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin:10px 0;">
           The credentials above run the service. To also see its <strong>balance</strong> on the dashboard,
           add earnings-tracking credentials under
-          <a href="#" onclick="event.preventDefault(); CP.openCredentialModal('${escapeHtml(svc.slug)}')" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
+          <a href="#" data-action="openCredentialModal" data-prevent="1" data-a1="${escapeHtml(svc.slug)}" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
           after deploying. This is optional — the service earns either way.
         </div>`;
       }
@@ -1821,7 +1821,7 @@ const CP = (() => {
           <div id="deploy-worker-list">${workerRows}</div>
         </div>
         <div style="display:flex; gap:8px; align-items:center;">
-          <button class="btn btn-success" onclick="CP.deployServiceToWorkers('${svc.slug}')"${_canWrite ? '' : ' disabled title="Writer access required"'}>Deploy</button>
+          <button class="btn btn-success" data-action="deployServiceToWorkers" data-a1="${svc.slug}"${_canWrite ? '' : ' disabled title="Writer access required"'}>Deploy</button>
           <span id="deploy-status-${svc.slug}" style="font-size:0.85rem;"></span>
         </div>`;
       }
@@ -1847,9 +1847,9 @@ const CP = (() => {
           <strong style="min-width:100px;">${escapeHtml(inst.worker.name)}</strong>
           <span class="badge ${badgeClass}" style="font-size:0.75rem;">${escapeHtml(s)}</span>
           ${_canWrite ? `<div style="margin-left:auto; display:flex; gap:4px;">
-            <button class="btn btn-secondary btn-sm" onclick="CP.workerAction('${svc.slug}','restart',${inst.worker.id})">Restart</button>
-            <button class="btn btn-secondary btn-sm" onclick="CP.workerAction('${svc.slug}','stop',${inst.worker.id})">Stop</button>
-            <button class="btn btn-ghost btn-sm" onclick="CP.loadWorkerLogs('${svc.slug}',${inst.worker.id},'logs-${svc.slug}-${inst.worker.id}')">Logs</button>
+            <button class="btn btn-secondary btn-sm" data-action="workerAction" data-a1="${svc.slug}" data-a2="restart" data-a3="${inst.worker.id}">Restart</button>
+            <button class="btn btn-secondary btn-sm" data-action="workerAction" data-a1="${svc.slug}" data-a2="stop" data-a3="${inst.worker.id}">Stop</button>
+            <button class="btn btn-ghost btn-sm" data-action="loadWorkerLogs" data-a1="${svc.slug}" data-a2="${inst.worker.id}" data-a3="logs-${svc.slug}-${inst.worker.id}">Logs</button>
           </div>` : ''}
         </div>
         <div class="log-viewer" id="logs-${svc.slug}-${inst.worker.id}" style="display:none; max-height:200px;"></div>`;
@@ -1975,7 +1975,7 @@ const CP = (() => {
     }).join('');
     container.innerHTML = rows + `
     <div style="display:flex;justify-content:flex-end;margin-top:12px;">
-      <button class="btn btn-primary" onclick="CP.saveEnvSettings()">Save Variables</button>
+      <button class="btn btn-primary" data-action="saveEnvSettings">Save Variables</button>
     </div>`;
   }
 
@@ -2054,7 +2054,7 @@ const CP = (() => {
         </div>`;
       }).join('');
       const clearBtn = configured && _isOwner
-        ? `<div style="margin-top:8px; text-align:right;"><button class="btn btn-ghost btn-sm" style="color:var(--error); font-size:0.75rem;" onclick="CP.clearServiceCredentials('${escapeHtml(col.slug)}', '${escapeHtml(col.name)}')">Clear Credentials</button></div>`
+        ? `<div style="margin-top:8px; text-align:right;"><button class="btn btn-ghost btn-sm" style="color:var(--error); font-size:0.75rem;" data-action="clearServiceCredentials" data-a1="${escapeHtml(col.slug)}" data-a2="${escapeHtml(col.name)}">Clear Credentials</button></div>`
         : '';
       return `
       <details class="collector-section" id="collector-${col.slug}">
@@ -2101,6 +2101,9 @@ const CP = (() => {
     try {
       await api(`/api/config/${encodeURIComponent(slug)}`, { method: 'DELETE' });
       toast(`${name} credentials cleared`, 'success');
+      // The caller used to close the modal in a second inline call; folded in
+      // here so the button declares one action rather than two.
+      closeModal('cred-modal');
       loadSettings();
     } catch (err) {
       toast(`Clear failed: ${err.message}`, 'error');
@@ -2236,7 +2239,7 @@ const CP = (() => {
             <div class="notify-item-platform">${escapeHtml(a.platform)}</div>
             <div class="notify-item-msg" title="${escapeHtml(a.error)}">${escapeHtml(a.error)}</div>
           </div>
-          ${_isOwner ? `<button class="btn btn-ghost btn-sm" onclick="event.stopPropagation(); CP.openCredentialModal('${escapeHtml(a.platform)}')" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
+          ${_isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
         </div>
       `).join('');
     } catch {

--- a/app/static/js/delegate.js
+++ b/app/static/js/delegate.js
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// Event delegation (CashPilot-guw)
+//
+// Its own file, loaded by EVERY page including the standalone templates
+// that never load app.js. Living inside app.js meant the onboarding and
+// login pages had buttons whose handlers were never registered — they
+// rendered perfectly and did nothing. Only a browser could see that.
+//
+// Every button used to carry an inline onclick=. That forced
+// script-src 'unsafe-inline' in the CSP, which means ANY markup an attacker can
+// inject executes — and this UI renders provider-supplied strings.
+//
+// One delegated listener replaces all of them. Handlers are named in
+// data-action and resolved against the CP namespace, so a typo fails loudly at
+// click time in one place rather than silently doing nothing in fifty.
+// ---------------------------------------------------------------------------
+document.addEventListener('click', (event) => {
+  const el = event.target.closest('[data-action]');
+  if (!el) return;
+
+  // Rows are themselves clickable, so a button inside one has to stop the row
+  // from also firing. This replaces the inline event.stopPropagation() calls.
+  if (el.dataset.stop === '1') event.stopPropagation();
+  if (el.dataset.prevent === '1') event.preventDefault();
+  if (el.hasAttribute('disabled')) return;
+
+  const run = (name, args) => {
+    if (!name) return;
+    // CP first, then a page-local global: a few controls belong to one template
+    // (the onboarding wizard, the fleet page) and have no business on the shared
+    // namespace. Anything else is a typo, and it says so rather than doing
+    // nothing — a silently dead button is the failure mode this refactor could
+    // most easily introduce fifty times over.
+    const ns = typeof CP !== 'undefined' ? CP : {};
+    const fn = typeof ns[name] === 'function' ? ns[name] : window[name];
+    if (typeof fn !== 'function') {
+      console.error(`No handler named ${name} (checked CP and window)`);
+      return;
+    }
+    fn(...args);
+  };
+
+  const args = [];
+  for (let i = 1; i <= 3; i += 1) {
+    const value = el.dataset[`a${i}`];
+    if (value === undefined) break;
+    args.push(value);
+  }
+  run(el.dataset.action, args);
+  // A few controls did two things in one inline handler.
+  run(el.dataset.then, []);
+});
+

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/style.css">
-  <script>
+  <script nonce="{{ csp_nonce(request) }}">
     (function(){var t=localStorage.getItem('cp-theme')||'dark';document.documentElement.setAttribute('data-theme',t)})();
   </script>
   <style>
@@ -184,5 +184,6 @@
     </div>
     {% endif %}
   </div>
+  <script src="/static/js/delegate.js"></script>
 </body>
 </html>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,12 +9,25 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" data-async-style>
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"></noscript>
-  <script>
+  <script nonce="{{ csp_nonce(request) }}">
     (function(){var t=localStorage.getItem('cp-theme')||'dark';document.documentElement.setAttribute('data-theme',t)})();
   </script>
   {% block head %}{% endblock %}
+  <script nonce="{{ csp_nonce(request) }}">
+    // Async font loading used an inline onload= handler, which a nonce cannot
+    // cover — a nonce applies to a script element, never to an inline event
+    // attribute. Same effect, one listener, no 'unsafe-inline'.
+    function asyncStyleSwap() {
+      document.querySelectorAll('link[data-async-style]').forEach((link) => {
+        if (link.rel === 'stylesheet') return;
+        link.addEventListener('load', () => { link.rel = 'stylesheet'; }, { once: true });
+        if (link.sheet) link.rel = 'stylesheet';
+      });
+    }
+    asyncStyleSwap();
+  </script>
 </head>
 <body data-page="{% block page %}{% endblock %}">
 
@@ -134,7 +147,7 @@
               <span class="theme-label">Light mode</span>
             </button>
             <div class="avatar-dropdown-divider"></div>
-            <button class="avatar-dropdown-item" id="change-password-btn" onclick="CP.openChangePasswordModal()">
+            <button class="avatar-dropdown-item" id="change-password-btn" data-action="openChangePasswordModal">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
               Change password
             </button>
@@ -160,7 +173,7 @@
     <div class="modal" style="max-width: 800px;">
       <div class="modal-header">
         <h3 class="modal-title" id="logs-modal-title">Logs</h3>
-        <button class="modal-close" onclick="CP.closeModal('logs-modal'); CP.stopLogPolling();" aria-label="Close">
+        <button class="modal-close" data-action="closeModal" data-a1="logs-modal" data-then="stopLogPolling" aria-label="Close">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
@@ -175,7 +188,7 @@
     <div class="modal" style="max-width: 700px;">
       <div class="modal-header">
         <h3 class="modal-title" id="service-detail-title">Service</h3>
-        <button class="modal-close" onclick="CP.closeModal('service-detail-modal')" aria-label="Close">
+        <button class="modal-close" data-action="closeModal" data-a1="service-detail-modal" aria-label="Close">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
@@ -190,7 +203,7 @@
     <div class="modal" style="max-width: 420px;">
       <div class="modal-header">
         <h3 class="modal-title">Change Password</h3>
-        <button class="modal-close" onclick="CP.closeModal('password-modal')" aria-label="Close">
+        <button class="modal-close" data-action="closeModal" data-a1="password-modal" aria-label="Close">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
@@ -210,8 +223,8 @@
         </div>
         <div id="chpw-error" style="display:none; color:var(--error); font-size:0.82rem; margin-bottom:12px;"></div>
         <div style="display:flex; gap:8px; justify-content:flex-end;">
-          <button class="btn btn-ghost btn-sm" onclick="CP.closeModal('password-modal')">Cancel</button>
-          <button class="btn btn-primary btn-sm" id="pwd-submit" onclick="CP.submitPasswordChange()">Change Password</button>
+          <button class="btn btn-ghost btn-sm" data-action="closeModal" data-a1="password-modal">Cancel</button>
+          <button class="btn btn-primary btn-sm" id="pwd-submit" data-action="submitPasswordChange">Change Password</button>
         </div>
       </div>
     </div>
@@ -219,10 +232,11 @@
   {% endif %}
 
   {% if user %}
-  <script>window._userRole = '{{ user.r }}';</script>
+  <script nonce="{{ csp_nonce(request) }}">window._userRole = '{{ user.r }}';</script>
   {% endif %}
   <script async src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js" integrity="sha384-T/4KgSWuZEPozpPz7rnnp/5lDSnpY1VPJCojf1S81uTHS1E38qgLfMgVsAeRCWc4" crossorigin="anonymous"></script>
   <script src="/static/js/app.js"></script>
   {% block scripts %}{% endblock %}
+  <script src="/static/js/delegate.js"></script>
 </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -33,8 +33,8 @@
   <div class="card-header">
     <span class="card-title">Earnings</span>
     <div class="tab-strip">
-      <button class="tab-btn chart-period-btn active" data-days="7" onclick="CP.loadEarningsChart('7')">7 days</button>
-      <button class="tab-btn chart-period-btn" data-days="30" onclick="CP.loadEarningsChart('30')">30 days</button>
+      <button class="tab-btn chart-period-btn active" data-days="7" data-action="loadEarningsChart" data-a1="7">7 days</button>
+      <button class="tab-btn chart-period-btn" data-days="30" data-action="loadEarningsChart" data-a1="30">30 days</button>
     </div>
   </div>
   <div class="chart-container">
@@ -47,7 +47,7 @@
   <div class="card-header">
     <span class="card-title">Deployed Services</span>
     <div style="display:flex; gap:8px; align-items:center;">
-      <button class="btn btn-ghost btn-sm" onclick="CP.refreshServices()" title="Refresh">
+      <button class="btn btn-ghost btn-sm" data-action="refreshServices" title="Refresh">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
       </button>
       <a href="/setup" class="btn btn-primary btn-sm">+ Add Service</a>
@@ -63,7 +63,7 @@
   <div class="modal" style="max-width: 420px;">
     <div class="modal-header">
       <h3 class="modal-title" id="cred-modal-title">Update Credentials</h3>
-      <button class="modal-close" onclick="CP.closeModal('cred-modal')">
+      <button class="modal-close" data-action="closeModal" data-a1="cred-modal">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
     </div>
@@ -78,7 +78,7 @@
   <div class="modal" style="max-width: 480px;">
     <div class="modal-header">
       <h3 class="modal-title" id="claim-modal-title">Claim Earnings</h3>
-      <button class="modal-close" onclick="CP.closeModal('claim-modal')">
+      <button class="modal-close" data-action="closeModal" data-a1="claim-modal">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
     </div>

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -43,8 +43,8 @@ CASHPILOT_WORKER_NAME=server-name</code>
       <div style="display: flex; gap: 8px; align-items: center; margin-top: 8px;">
         <span id="api-key-status" class="badge badge-category" style="font-size:0.72rem;">Checking…</span>
         {% if user.r == 'owner' %}
-        <button class="btn btn-ghost btn-sm" onclick="toggleApiKey()" id="reveal-btn">Reveal API Key</button>
-        <button class="btn btn-ghost btn-sm" onclick="copyWorkerEnv()">Copy</button>
+        <button class="btn btn-ghost btn-sm" data-action="toggleApiKey" id="reveal-btn">Reveal API Key</button>
+        <button class="btn btn-ghost btn-sm" data-action="copyWorkerEnv">Copy</button>
         {% endif %}
       </div>
     </div>
@@ -67,7 +67,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce(request) }}">
 (function() {
   let fleetTimer = null;
   let _apiKeyRevealed = false;

--- a/app/templates/onboarding.html
+++ b/app/templates/onboarding.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" data-async-style>
   <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -236,6 +236,12 @@
     }
     @keyframes spin { to { transform: rotate(360deg); } }
   </style>
+  <script nonce="{{ csp_nonce(request) }}">
+    document.querySelectorAll('link[data-async-style]').forEach((link) => {
+      link.addEventListener('load', () => { link.rel = 'stylesheet'; }, { once: true });
+      if (link.sheet) link.rel = 'stylesheet';
+    });
+  </script>
 </head>
 <body>
   <!-- Synthwave background -->
@@ -349,7 +355,7 @@
           </div>
           <h1>Welcome</h1>
           <p class="subtitle">Your self-hosted passive income platform. Deploy and monitor bandwidth, storage, and compute services via Docker.</p>
-          <button class="btn" onclick="goToStep(2)">Get Started</button>
+          <button class="btn" data-action="goToStep" data-a1="2">Get Started</button>
         </div>
       </div>
 
@@ -371,7 +377,7 @@
           <p class="subtitle">Set up your admin account to get started.</p>
           <div class="info-badge">This will be the owner account with full access.</div>
           <div class="error-msg" id="reg-error"></div>
-          <form id="register-form" onsubmit="return handleRegister(event)">
+          <form id="register-form">
             <div class="field">
               <label for="username">Username</label>
               <input type="text" id="username" name="username" required autocomplete="username" autofocus>
@@ -385,7 +391,7 @@
               <input type="password" id="password_confirm" name="password_confirm" required autocomplete="new-password">
             </div>
             <div class="actions">
-              <button type="button" class="btn btn-ghost" onclick="goToStep(1)">Back</button>
+              <button type="button" class="btn btn-ghost" data-action="goToStep" data-a1="1">Back</button>
               <button type="submit" class="btn" id="submit-btn">Create Account</button>
             </div>
           </form>
@@ -419,7 +425,9 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce(request) }}">
+    document.getElementById('register-form')?.addEventListener('submit', handleRegister);
+
     function goToStep(n) {
       document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
       document.getElementById('step-' + n).classList.add('active');
@@ -488,5 +496,6 @@
       return false;
     }
   </script>
+  <script src="/static/js/delegate.js"></script>
 </body>
 </html>

--- a/app/templates/service_detail.html
+++ b/app/templates/service_detail.html
@@ -152,7 +152,7 @@
       {% endif %}
 
       <div style="display: flex; gap: 8px; align-items: center;">
-        <button class="btn btn-success" onclick="CP.deployService('{{ service.slug }}')">Deploy</button>
+        <button class="btn btn-success" data-action="deployService" data-a1="{{ service.slug }}">Deploy</button>
         <span id="deploy-status-{{ service.slug }}" style="font-size: 0.85rem;"></span>
       </div>
     </div>
@@ -161,15 +161,15 @@
     <div class="card" style="margin-bottom: 16px;">
       <h3 class="card-title" style="margin-bottom: 12px;">Container</h3>
       <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px;">
-        <button class="btn btn-secondary btn-sm" onclick="CP.startService('{{ service.slug }}')">Start</button>
-        <button class="btn btn-secondary btn-sm" onclick="CP.restartService('{{ service.slug }}')">Restart</button>
-        <button class="btn btn-secondary btn-sm" onclick="CP.stopService('{{ service.slug }}')">Stop</button>
-        <button class="btn btn-danger btn-sm" onclick="CP.removeService('{{ service.slug }}')">Remove</button>
+        <button class="btn btn-secondary btn-sm" data-action="startService" data-a1="{{ service.slug }}">Start</button>
+        <button class="btn btn-secondary btn-sm" data-action="restartService" data-a1="{{ service.slug }}">Restart</button>
+        <button class="btn btn-secondary btn-sm" data-action="stopService" data-a1="{{ service.slug }}">Stop</button>
+        <button class="btn btn-danger btn-sm" data-action="removeService" data-a1="{{ service.slug }}">Remove</button>
       </div>
 
       <h4 style="font-size: 0.9rem; margin-bottom: 8px; color: var(--text-secondary);">Logs</h4>
       <div class="log-viewer" id="detail-logs-{{ service.slug }}">(Click Load Logs to view)</div>
-      <button class="btn btn-ghost btn-sm" style="margin-top: 8px;" onclick="CP.loadDetailLogs('{{ service.slug }}')">Load Logs</button>
+      <button class="btn btn-ghost btn-sm" style="margin-top: 8px;" data-action="loadDetailLogs" data-a1="{{ service.slug }}">Load Logs</button>
     </div>
   </div>
 </div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -31,8 +31,8 @@
   </div>
 
   <div style="margin-top: 16px; display: flex; gap: 8px; align-items: center;">
-    <button class="btn btn-primary" onclick="CP.saveCollectorCredentials()">Save Credentials</button>
-    <button class="btn btn-secondary" onclick="CP.testCollectors()">Test Collection Now</button>
+    <button class="btn btn-primary" data-action="saveCollectorCredentials">Save Credentials</button>
+    <button class="btn btn-secondary" data-action="testCollectors">Test Collection Now</button>
     <span id="collector-save-status" style="font-size: 0.85rem; color: var(--text-muted);"></span>
   </div>
 </div>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -116,7 +116,7 @@
 
 <!-- Wizard Footer -->
 <div class="wizard-footer">
-  <button class="btn btn-secondary" id="wizard-prev" onclick="CP.wizardPrev()" style="display: none;">Back</button>
-  <button class="btn btn-primary" id="wizard-next" onclick="CP.wizardNext()">Next</button>
+  <button class="btn btn-secondary" id="wizard-prev" data-action="wizardPrev" style="display: none;">Back</button>
+  <button class="btn btn-primary" id="wizard-next" data-action="wizardNext">Next</button>
 </div>
 {% endblock %}

--- a/scripts/ui_check.mjs
+++ b/scripts/ui_check.mjs
@@ -1,0 +1,59 @@
+// Drive the CashPilot UI in headless Chrome and report what a browser actually
+// sees: inline handlers still present, Content-Security-Policy violations, and
+// uncaught JS errors (CashPilot-guw).
+//
+// The CSP and app.js beads sat blocked for several sessions on "cannot verify
+// without a browser". Static checks cannot see a CSP violation or a handler
+// that silently stopped firing, and this is a live revenue UI, so shipping the
+// change on a read-through was not acceptable. Chrome is already installed on
+// any machine a developer uses; Node has a global WebSocket, so this needs no
+// dependencies at all.
+//
+//   ./scripts/ui_check.sh http://127.0.0.1:8099/onboarding
+//
+// Exits non-zero on any CSP violation or uncaught error, so it can gate a
+// change rather than merely describe one.
+const [,, url] = process.argv;
+const port = 9222;
+const res = await fetch(`http://127.0.0.1:${port}/json/new?${encodeURIComponent(url)}`, {method: 'PUT'});
+const target = await res.json();
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+let id = 0;
+const pending = new Map();
+const violations = [];
+const errors = [];
+const send = (method, params = {}) => new Promise(r => { pending.set(++id, r); ws.send(JSON.stringify({id, method, params})); });
+
+await new Promise(r => ws.addEventListener('open', r));
+ws.addEventListener('message', ev => {
+  const m = JSON.parse(ev.data);
+  if (m.id && pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); }
+  if (m.method === 'Log.entryAdded') {
+    const e = m.params.entry;
+    if (/Content Security Policy/i.test(e.text)) violations.push(e.text.slice(0, 160));
+    else if (e.level === 'error') errors.push(e.text.slice(0, 160));
+  }
+  if (m.method === 'Runtime.exceptionThrown') {
+    errors.push((m.params.exceptionDetails.exception?.description || 'exception').slice(0, 160));
+  }
+});
+await send('Log.enable'); await send('Runtime.enable'); await send('Page.enable');
+await send('Page.navigate', {url});
+await new Promise(r => setTimeout(r, 2500));
+const inline = await send('Runtime.evaluate', {
+  expression: `JSON.stringify({
+    onclick: document.querySelectorAll('[onclick]').length,
+    dataAction: document.querySelectorAll('[data-action]').length,
+    title: document.title
+  })`, returnByValue: true});
+const seen = JSON.parse(inline.result.value);
+console.log(`page          : ${seen.title}`);
+console.log(`inline onclick: ${seen.onclick}`);
+console.log(`data-action   : ${seen.dataAction}`);
+console.log(`csp_violations: ${violations.length}`, violations.slice(0, 5));
+console.log(`js_errors     : ${errors.length}`, errors.slice(0, 5));
+ws.close();
+
+// A CSP violation or an uncaught error means the page is broken in a way no
+// static check would have caught, which is the entire reason this exists.
+if (violations.length || errors.length) process.exit(1);

--- a/scripts/ui_check.sh
+++ b/scripts/ui_check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Boot headless Chrome, point ui_check.mjs at a running CashPilot UI, tear down.
+#
+# Verifies in a real browser what static analysis cannot see: that no CSP
+# violation fires and no handler silently stopped working.
+set -euo pipefail
+
+URL="${1:-http://127.0.0.1:8099/onboarding}"
+PORT="${CHROME_DEBUG_PORT:-9222}"
+PROFILE="$(mktemp -d)"
+
+CHROME=""
+for candidate in \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" \
+  "$(command -v google-chrome || true)" \
+  "$(command -v chromium || true)"; do
+  if [ -x "$candidate" ]; then CHROME="$candidate"; break; fi
+done
+if [ -z "$CHROME" ]; then
+  echo "No Chrome/Chromium found. This check needs a real browser engine; a" >&2
+  echo "static parse cannot see a CSP violation." >&2
+  exit 2
+fi
+
+"$CHROME" --headless=new --disable-gpu --no-first-run \
+  --remote-debugging-port="$PORT" --user-data-dir="$PROFILE" about:blank \
+  >"$PROFILE/chrome.log" 2>&1 &
+CHROME_PID=$!
+trap 'kill "$CHROME_PID" 2>/dev/null || true; rm -rf "$PROFILE"' EXIT
+
+for _ in $(seq 1 30); do
+  if curl -sf -m 2 "http://127.0.0.1:$PORT/json/version" >/dev/null; then break; fi
+  sleep 1
+done
+
+node "$(dirname "$0")/ui_check.mjs" "$URL"

--- a/tests/test_csp_no_inline.py
+++ b/tests/test_csp_no_inline.py
@@ -1,0 +1,129 @@
+"""No inline handlers, so the CSP can drop unsafe-inline (CashPilot-guw).
+
+`script-src 'unsafe-inline'` means any markup an attacker gets injected
+executes, and this UI renders provider-supplied strings. Removing it needs two
+things at once: every inline event attribute gone (a nonce cannot cover those —
+nonces apply to `<script>`, never to `onclick=`), and the remaining inline
+`<script>` blocks carrying a per-response nonce.
+
+These are the static guards. The behavioural half — that the buttons still fire
+and no violation is raised — needs a real browser and lives in
+`scripts/ui_check.sh`, because a parse can see neither.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = sorted((ROOT / "app" / "templates").glob("*.html"))
+JS = sorted((ROOT / "app" / "static" / "js").glob("*.js"))
+
+# Any of these as an ATTRIBUTE is an inline handler, which a nonce cannot cover.
+INLINE_EVENT = re.compile(
+    r"""<[^>]*\son(?:click|change|input|submit|keyup|keydown|keypress|focus|blur|load|error|"""
+    r"""mouseover|mouseout|toggle)\s*=""",
+    re.I,
+)
+
+
+class TestNoInlineEventHandlersRemain:
+    @pytest.mark.parametrize("path", TEMPLATES, ids=lambda p: p.name)
+    def test_no_template_carries_an_inline_handler(self, path):
+        found = INLINE_EVENT.findall(path.read_text(encoding="utf-8"))
+        assert not found, f"{path.name} still has inline event handlers: {found[:3]}"
+
+    @pytest.mark.parametrize("path", JS, ids=lambda p: p.name)
+    def test_no_rendered_markup_carries_an_inline_handler(self, path):
+        """app.js builds HTML strings; an onclick= inside one is still inline."""
+        source = path.read_text(encoding="utf-8")
+        code = "\n".join(line for line in source.splitlines() if not line.strip().startswith("//"))
+        found = INLINE_EVENT.findall(code)
+        assert not found, f"{path.name} renders inline handlers: {found[:3]}"
+
+
+class TestTheCspActuallyDroppedIt:
+    def _source(self) -> str:
+        return (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+
+    def test_script_src_no_longer_allows_unsafe_inline(self):
+        script_src = re.search(r'"script-src[^"]*"', self._source())
+        assert script_src, "script-src directive not found"
+        assert "unsafe-inline" not in script_src.group(0)
+
+    def test_script_src_carries_a_nonce(self):
+        assert "nonce-{nonce}" in self._source()
+
+    def test_a_fresh_nonce_is_generated_per_response(self):
+        source = self._source()
+        assert "secrets.token_urlsafe" in source
+        assert "request.state.csp_nonce" in source
+
+    def test_style_src_still_allows_inline_and_the_exception_is_explained(self):
+        """Inline style= attributes remain; a style injection cannot execute."""
+        source = self._source()
+        style_src = re.search(r'"style-src[^"]*"', source)
+        assert style_src and "unsafe-inline" in style_src.group(0)
+        assert "style-src keeps 'unsafe-inline'" in source, "an exception left unexplained becomes permanent"
+
+
+class TestEveryInlineScriptIsNonced:
+    @pytest.mark.parametrize("path", TEMPLATES, ids=lambda p: p.name)
+    def test_no_unnonced_inline_script_block(self, path):
+        """An unnonced block is silently blocked and the page half-works."""
+        text = path.read_text(encoding="utf-8")
+        bare = re.findall(r"<script(?![^>]*(?:src=|nonce=))[^>]*>", text)
+        assert not bare, f"{path.name} has an inline <script> with no nonce: {bare[:2]}"
+
+
+class TestDelegationIsAvailableEverywhere:
+    def test_the_delegated_listener_lives_in_its_own_file(self):
+        """Inside app.js it never loaded on the standalone templates.
+
+        The onboarding and login pages do not load app.js, so their buttons
+        rendered perfectly and did nothing at all. Only a browser caught it.
+        """
+        assert (ROOT / "app" / "static" / "js" / "delegate.js").exists()
+
+    @pytest.mark.parametrize("name", ["base.html", "onboarding.html", "auth.html"], ids=lambda n: n)
+    def test_every_entry_template_loads_it(self, name):
+        text = (ROOT / "app" / "templates" / name).read_text(encoding="utf-8")
+        assert "delegate.js" in text, f"{name} renders data-action buttons but never loads the listener"
+
+    def test_it_resolves_page_local_handlers_too(self):
+        """A few controls belong to one template and are not on CP."""
+        text = (ROOT / "app" / "static" / "js" / "delegate.js").read_text(encoding="utf-8")
+        assert "window[name]" in text
+
+    def test_it_reports_an_unknown_handler_instead_of_doing_nothing(self):
+        """A silently dead button is the failure this refactor could introduce."""
+        text = (ROOT / "app" / "static" / "js" / "delegate.js").read_text(encoding="utf-8")
+        assert "console.error" in text
+
+    def test_it_tolerates_app_js_being_absent(self):
+        text = (ROOT / "app" / "static" / "js" / "delegate.js").read_text(encoding="utf-8")
+        assert "typeof CP !== 'undefined'" in text
+
+
+class TestEveryDeclaredActionExists:
+    def test_no_data_action_names_a_handler_nobody_defined(self):
+        actions: set[str] = set()
+        for path in TEMPLATES + JS:
+            actions |= set(
+                re.findall(r'data-(?:action|then)="([A-Za-z_][A-Za-z0-9_]*)"', path.read_text(encoding="utf-8"))
+            )
+        assert actions, "no data-action attributes found at all — the migration did not happen"
+
+        app_js = (ROOT / "app" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+        exported = set(re.findall(r"^\s{4}([A-Za-z_][A-Za-z0-9_]*),\s*$", app_js, re.M))
+        page_local: set[str] = set()
+        for path in TEMPLATES:
+            text = path.read_text(encoding="utf-8")
+            page_local |= set(re.findall(r"function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", text))
+            page_local |= set(re.findall(r"window\.([A-Za-z_][A-Za-z0-9_]*)\s*=", text))
+
+        missing = sorted(actions - exported - page_local)
+        assert not missing, f"data-action names with no handler anywhere: {missing}"

--- a/tests/test_csp_no_inline.py
+++ b/tests/test_csp_no_inline.py
@@ -75,7 +75,11 @@ class TestEveryInlineScriptIsNonced:
     def test_no_unnonced_inline_script_block(self, path):
         """An unnonced block is silently blocked and the page half-works."""
         text = path.read_text(encoding="utf-8")
-        bare = re.findall(r"<script(?![^>]*(?:src=|nonce=))[^>]*>", text)
+        # Case-insensitive: HTML tag and attribute names are, so a <SCRIPT>
+        # or NONCE= would otherwise walk straight past a guard whose whole job
+        # is to catch exactly that. CodeQL flagged this as a bad HTML filter,
+        # and it was right — a case-sensitive check here is security theatre.
+        bare = re.findall(r"<script(?![^>]*(?:src=|nonce=))[^>]*>", text, re.I)
         assert not bare, f"{path.name} has an inline <script> with no nonce: {bare[:2]}"
 
 
@@ -113,7 +117,11 @@ class TestEveryDeclaredActionExists:
         actions: set[str] = set()
         for path in TEMPLATES + JS:
             actions |= set(
-                re.findall(r'data-(?:action|then)="([A-Za-z_][A-Za-z0-9_]*)"', path.read_text(encoding="utf-8"))
+                re.findall(
+                    r'data-(?:action|then)="([A-Za-z_][A-Za-z0-9_]*)"',
+                    path.read_text(encoding="utf-8"),
+                    re.I,
+                )
             )
         assert actions, "no data-action attributes found at all — the migration did not happen"
 


### PR DESCRIPTION
`script-src 'unsafe-inline'` means **any markup an attacker gets injected executes** — and this UI renders provider-supplied strings.

Removing it needed two things at once, because a nonce covers script *elements* and never inline event *attributes*:

- **53 inline handlers gone**, migrated to one delegated listener keyed on `data-action` — plus four async-font `onload=` attributes and a form `onsubmit=` that the first pass missed entirely.
- **The five remaining inline `<script>` blocks carry a per-response nonce**, read from `request.state` so the header value and the markup value can never disagree. If they did, every inline script would be blocked and the UI would silently stop working.

`style-src` keeps `'unsafe-inline'` **and says why**: the templates carry inline `style=` attributes, which a nonce cannot cover, and a style injection cannot execute. An exception left unexplained becomes permanent.

## The verification came first

This bead sat blocked for several sessions on *"cannot verify without a browser"* — which was true and mattered. So `scripts/ui_check.sh` drives **headless Chrome over CDP** and reports what a browser actually sees: inline handlers present, CSP violations, uncaught errors. No dependencies (Chrome is already installed; Node has a global `WebSocket`). It exits non-zero on a violation, so it **gates** a change rather than describing one.

It earned itself twice:

1. It caught an inline handler still firing after the `onclick` migration looked complete — the font-preload `onload=` and the form `onsubmit=`. Neither would ever be found by searching for "onclick".
2. **It caught the real bug.** Putting the delegated listener in `app.js` left the onboarding and login pages without it — those templates are standalone and never load `app.js`, so their buttons rendered perfectly and **did nothing at all**. No error, no visual difference, nothing a static check or a code review would see. The listener now lives in `delegate.js`, loaded by every entry template, and tolerates `CP` being undefined.

## Handler resolution

CP first, then a page-local global — a few controls belong to one template and have no business on the shared namespace. Anything else **logs an error rather than doing nothing**: a silently dead button is the failure this refactor could most easily have introduced fifty times over.

## Verified, not inferred

- Zero inline handlers, zero CSP violations, zero JS errors on every reachable page.
- A delegated button proven to still work end to end: the wizard advances **step-1 → step-2**.

Static guards keep it that way: no template or rendered string may carry an inline event attribute, no inline script may lack a nonce, every entry template must load the listener, and every `data-action` must name a handler that exists.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1767 passed**, coverage 94.65%