### PR TITLE
refactor: break the main -> routers -> main import cycle (CashPilot-sux)

### DIFF
--- a/app/login_rate_limit.py
+++ b/app/login_rate_limit.py
@@ -1,0 +1,58 @@
+"""Login rate limiting (CashPilot-sux).
+
+Lifted out of ``app.main`` because it was the last thing the routers genuinely
+needed from it. Everything else they imported through ``app.main`` —
+``templates``, ``client_ip``, the auth guards — already lives in ``app.deps``
+and was only being re-exported, so moving this one module-level dict is what
+actually breaks the ``main -> routers -> main`` import cycle rather than merely
+moving it around.
+
+The state stays a module-level dict on purpose, and ``app.main`` re-exports the
+SAME object. Tests reach for ``app.main._login_attempts`` and a conftest fixture
+clears it between tests; rebinding it here — or handing out a copy — would leave
+those pointing at a dict nothing reads, and the fixture would silently stop
+isolating tests from each other.
+"""
+
+from __future__ import annotations
+
+from time import monotonic
+
+from fastapi import HTTPException
+
+# A plain dict, NOT a defaultdict, so a stale empty bucket never lingers. Every
+# distinct client IP that ever hits /login would otherwise leave a permanent key
+# behind once its attempts aged out, growing without bound for the life of the
+# process — a slow leak that only shows up on a host exposed long enough to see
+# a lot of addresses.
+_login_attempts: dict[str, list[float]] = {}
+
+MAX_ATTEMPTS = 5
+WINDOW_SECONDS = 300
+
+
+def check_login_rate(ip: str) -> None:
+    """Raise 429 when this address has failed too often, recently.
+
+    Also prunes the bucket as a side effect, which is what keeps the dict from
+    growing: entries are dropped the next time their address is seen, and an
+    address that never returns leaves nothing that a later lookup would revive.
+    """
+    now = monotonic()
+    attempts = [t for t in _login_attempts.get(ip, []) if now - t < WINDOW_SECONDS]
+    if attempts:
+        _login_attempts[ip] = attempts
+    else:
+        _login_attempts.pop(ip, None)
+    if len(attempts) >= MAX_ATTEMPTS:
+        raise HTTPException(status_code=429, detail="Too many login attempts. Try again in a few minutes.")
+
+
+def record_failed_login(ip: str) -> None:
+    """Count one failed attempt against this address."""
+    _login_attempts.setdefault(ip, []).append(monotonic())
+
+
+def clear(ip: str) -> None:
+    """Forget an address's failures, after it successfully logs in."""
+    _login_attempts.pop(ip, None)

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,6 @@ import re
 import secrets
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from time import monotonic
 from typing import Any
 
 import httpx
@@ -37,6 +36,7 @@ from app import (
     egress,
     exchange_rates,
     fleet_key,
+    login_rate_limit,
     metrics,
     notify,
     power,
@@ -82,28 +82,19 @@ def _spawn(coro) -> asyncio.Task:
     return task
 
 
-# Login rate limiting. Plain dict (not defaultdict) so a stale/empty bucket
-# never lingers forever — every distinct client IP that ever hits /login
-# would otherwise leave a permanent key behind, even after its attempts have
-# all aged out, growing unbounded over the process lifetime.
-_login_attempts: dict[str, list[float]] = {}
-_LOGIN_MAX_ATTEMPTS = 5
-_LOGIN_WINDOW_SECONDS = 300
-
-
-def _check_login_rate(ip: str) -> None:
-    now = monotonic()
-    attempts = [t for t in _login_attempts.get(ip, []) if now - t < _LOGIN_WINDOW_SECONDS]
-    if attempts:
-        _login_attempts[ip] = attempts
-    else:
-        _login_attempts.pop(ip, None)
-    if len(attempts) >= _LOGIN_MAX_ATTEMPTS:
-        raise HTTPException(status_code=429, detail="Too many login attempts. Try again in a few minutes.")
-
-
-def _record_failed_login(ip: str) -> None:
-    _login_attempts.setdefault(ip, []).append(monotonic())
+# Login rate limiting moved to app.login_rate_limit (bead sux) — it was the last
+# thing the routers genuinely needed from this module, and extracting it is what
+# breaks the main -> routers -> main import cycle.
+#
+# Re-exported by REFERENCE, not copied: tests patch app.main._check_login_rate
+# and a conftest fixture clears app.main._login_attempts between tests. Binding a
+# copy here would leave both pointing at an object nothing reads, and the fixture
+# would silently stop isolating tests.
+_login_attempts = login_rate_limit._login_attempts
+_LOGIN_MAX_ATTEMPTS = login_rate_limit.MAX_ATTEMPTS
+_LOGIN_WINDOW_SECONDS = login_rate_limit.WINDOW_SECONDS
+_check_login_rate = login_rate_limit.check_login_rate
+_record_failed_login = login_rate_limit.record_failed_login
 
 
 def _safe_json(raw: str, fallback: Any = None) -> Any:

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,7 +1,13 @@
 """Authentication + onboarding routes (login, register, logout, onboarding).
 
-Handlers reference shared state through ``app.main`` so test patches on
-``app.main.database.*`` / ``app.main.auth.*`` continue to land.
+Imports its dependencies directly from ``app.deps`` and friends rather than
+reaching through ``app.main``. That is what removes the main -> routers -> main
+import cycle (bead sux): everything these handlers used from ``app.main`` was
+already a re-export of something in ``app.deps``, except the login rate limiter,
+which now lives in ``app.login_rate_limit``.
+
+Test patches on ``app.database.*`` and ``app.auth.*`` still land, because those
+name the same module objects this module holds references to.
 """
 
 from __future__ import annotations
@@ -11,7 +17,11 @@ import re
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-import app.main as main
+# setup_token is aliased because it is ALSO a Form parameter name inside
+# do_register, so importing it bare would be shadowed exactly where it is used.
+from app import auth as auth_module
+from app import database, deps, login_rate_limit, metrics
+from app import setup_token as setup_token_module
 
 router = APIRouter()
 
@@ -19,12 +29,12 @@ router = APIRouter()
 @router.get("/login", response_class=HTMLResponse)
 async def page_login(request: Request, error: str = ""):
     # If no users exist, redirect to onboarding
-    if not await main.database.has_any_users():
+    if not await database.has_any_users():
         return RedirectResponse("/onboarding", status_code=303)
     # If already logged in, go to dashboard
-    if main.auth.get_current_user(request):
+    if auth_module.get_current_user(request):
         return RedirectResponse("/", status_code=303)
-    return main.templates.TemplateResponse(
+    return deps.templates.TemplateResponse(
         request,
         "auth.html",
         {
@@ -45,17 +55,17 @@ async def do_login(
     username: str = Form(...),
     password: str = Form(...),
 ):
-    client_ip = main.client_ip(request) or "unknown"
+    client_ip = deps.client_ip(request) or "unknown"
     try:
-        main._check_login_rate(client_ip)
+        login_rate_limit.check_login_rate(client_ip)
     except HTTPException:
-        main.metrics.record_rate_limit()
+        metrics.record_rate_limit()
         raise
-    user = await main.database.get_user_by_username(username)
-    if not user or not await main.auth.verify_password_async(password, user["password"]):
-        main._record_failed_login(client_ip)
-        main.metrics.record_login(success=False)
-        return main.templates.TemplateResponse(
+    user = await database.get_user_by_username(username)
+    if not user or not await auth_module.verify_password_async(password, user["password"]):
+        login_rate_limit.record_failed_login(client_ip)
+        metrics.record_login(success=False)
+        return deps.templates.TemplateResponse(
             request,
             "auth.html",
             {
@@ -70,28 +80,28 @@ async def do_login(
             status_code=401,
         )
 
-    main._login_attempts.pop(client_ip, None)
-    main.metrics.record_login(success=True)
-    token = main.auth.create_session_token(user["id"], user["username"], user["role"])
+    login_rate_limit.clear(client_ip)
+    metrics.record_login(success=True)
+    token = auth_module.create_session_token(user["id"], user["username"], user["role"])
     response = RedirectResponse("/", status_code=303)
-    return main.auth.set_session_cookie(response, token, request)
+    return auth_module.set_session_cookie(response, token, request)
 
 
 @router.get("/register", response_class=HTMLResponse)
 async def page_register(request: Request, error: str = ""):
-    is_first = not await main.database.has_any_users()
+    is_first = not await database.has_any_users()
     # Only allow registration if first user OR if requester is owner
     if not is_first:
-        user = main.auth.get_current_user(request)
+        user = auth_module.get_current_user(request)
         if not user or user.get("r") != "owner":
             return RedirectResponse("/login", status_code=303)
     # The GET page is gated only by the network check so the operator can reach the
     # form; the setup token is entered into a form field and verified on POST (never
     # via URL, which would leak it into access logs / browser history).
     if is_first:
-        main._require_private_network(request)
+        deps._require_private_network(request)
 
-    return main.templates.TemplateResponse(
+    return deps.templates.TemplateResponse(
         request,
         "auth.html",
         {
@@ -114,19 +124,19 @@ async def do_register(
     password_confirm: str = Form(...),
     setup_token: str = Form(""),
 ):
-    is_first = not await main.database.has_any_users()
+    is_first = not await database.has_any_users()
 
     # Only allow registration if first user or owner
     if not is_first:
-        user = main.auth.get_current_user(request)
+        user = auth_module.get_current_user(request)
         if not user or user.get("r") != "owner":
             raise HTTPException(status_code=403, detail="Only owners can add users")
 
     if is_first:
-        main._require_first_run_access(request, setup_token)
+        deps._require_first_run_access(request, setup_token)
 
     if not re.match(r"^[a-zA-Z0-9_-]{3,32}$", username):
-        return main.templates.TemplateResponse(
+        return deps.templates.TemplateResponse(
             request,
             "auth.html",
             {
@@ -143,7 +153,7 @@ async def do_register(
         )
 
     if password != password_confirm:
-        return main.templates.TemplateResponse(
+        return deps.templates.TemplateResponse(
             request,
             "auth.html",
             {
@@ -160,7 +170,7 @@ async def do_register(
         )
 
     if len(password) < 10:
-        return main.templates.TemplateResponse(
+        return deps.templates.TemplateResponse(
             request,
             "auth.html",
             {
@@ -176,9 +186,9 @@ async def do_register(
             status_code=400,
         )
 
-    existing = await main.database.get_user_by_username(username)
+    existing = await database.get_user_by_username(username)
     if existing:
-        return main.templates.TemplateResponse(
+        return deps.templates.TemplateResponse(
             request,
             "auth.html",
             {
@@ -196,13 +206,13 @@ async def do_register(
 
     # First user is always owner
     role = "owner" if is_first else "viewer"
-    hashed = await main.auth.hash_password_async(password)
+    hashed = await auth_module.hash_password_async(password)
     if is_first:
         # Atomic: only one concurrent first-run registration can win, so a single
         # setup token can't be raced into minting two owners.
-        user_id = await main.database.create_first_owner(username, hashed)
+        user_id = await database.create_first_owner(username, hashed)
         if user_id is None:
-            return main.templates.TemplateResponse(
+            return deps.templates.TemplateResponse(
                 request,
                 "auth.html",
                 {
@@ -218,27 +228,27 @@ async def do_register(
                 status_code=409,
             )
     else:
-        user_id = await main.database.create_user(username, hashed, role)
+        user_id = await database.create_user(username, hashed, role)
 
     if is_first:
         # Owner now exists — retire the one-time setup token permanently.
-        await main.database.delete_config_keys(["_setup_token"])
-        main.setup_token.clear()
+        await database.delete_config_keys(["_setup_token"])
+        setup_token_module.clear()
 
-    token = main.auth.create_session_token(user_id, username, role)
+    token = auth_module.create_session_token(user_id, username, role)
     dest = "/setup" if is_first else "/"
     response = RedirectResponse(dest, status_code=303)
-    return main.auth.set_session_cookie(response, token, request)
+    return auth_module.set_session_cookie(response, token, request)
 
 
 @router.get("/logout")
 async def do_logout():
     response = RedirectResponse("/login", status_code=303)
-    return main.auth.clear_session_cookie(response)
+    return auth_module.clear_session_cookie(response)
 
 
 @router.get("/onboarding", response_class=HTMLResponse)
 async def page_onboarding(request: Request):
-    if await main.database.has_any_users():
+    if await database.has_any_users():
         return RedirectResponse("/login", status_code=303)
-    return main.templates.TemplateResponse(request, "onboarding.html")
+    return deps.templates.TemplateResponse(request, "onboarding.html")

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -1,7 +1,7 @@
 """Protected HTML page routes (dashboard, setup, catalog, settings, fleet).
 
 Handlers reference shared state through ``app.main`` so test patches on
-``app.main.auth.*`` / ``app.main.database.*`` continue to land.
+``app.auth_module.*`` / ``app.database.*`` continue to land.
 """
 
 from __future__ import annotations
@@ -9,50 +9,51 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-import app.main as main
+from app import auth as auth_module
+from app import database, deps
 
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse)
 async def page_dashboard(request: Request):
-    user = main.auth.get_current_user(request)
+    user = auth_module.get_current_user(request)
     if not user:
-        if not await main.database.has_any_users():
+        if not await database.has_any_users():
             return RedirectResponse("/onboarding", status_code=303)
         return RedirectResponse("/login", status_code=303)
-    return main.templates.TemplateResponse(request, "dashboard.html", {"user": user})
+    return deps.templates.TemplateResponse(request, "dashboard.html", {"user": user})
 
 
 @router.get("/setup", response_class=HTMLResponse)
 async def page_setup(request: Request):
-    user = main.auth.get_current_user(request)
+    user = auth_module.get_current_user(request)
     if not user:
-        return main._login_redirect()
-    return main.templates.TemplateResponse(request, "setup.html", {"user": user})
+        return deps._login_redirect()
+    return deps.templates.TemplateResponse(request, "setup.html", {"user": user})
 
 
 @router.get("/catalog", response_class=HTMLResponse)
 async def page_catalog(request: Request):
-    user = main.auth.get_current_user(request)
+    user = auth_module.get_current_user(request)
     if not user:
-        return main._login_redirect()
-    return main.templates.TemplateResponse(request, "catalog.html", {"user": user})
+        return deps._login_redirect()
+    return deps.templates.TemplateResponse(request, "catalog.html", {"user": user})
 
 
 @router.get("/settings", response_class=HTMLResponse)
 async def page_settings(request: Request):
-    user = main.auth.get_current_user(request)
+    user = auth_module.get_current_user(request)
     if not user:
-        return main._login_redirect()
-    if not main.auth.require_role(user, "owner"):
+        return deps._login_redirect()
+    if not auth_module.require_role(user, "owner"):
         raise HTTPException(status_code=403, detail="Owner access required")
-    return main.templates.TemplateResponse(request, "settings.html", {"user": user})
+    return deps.templates.TemplateResponse(request, "settings.html", {"user": user})
 
 
 @router.get("/fleet", response_class=HTMLResponse)
 async def page_fleet(request: Request):
-    user = main.auth.get_current_user(request)
+    user = auth_module.get_current_user(request)
     if not user:
-        return main._login_redirect()
-    return main.templates.TemplateResponse(request, "fleet.html", {"user": user})
+        return deps._login_redirect()
+    return deps.templates.TemplateResponse(request, "fleet.html", {"user": user})

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -2,7 +2,7 @@
 
 The change-password routes (Task 4 / H4) deliberately stay in ``app.main`` to
 avoid the direct-import problem. Handlers reference shared state through
-``app.main`` so test patches on ``app.main.database.*`` continue to land.
+``app.main`` so test patches on ``app.database.*`` continue to land.
 """
 
 from __future__ import annotations
@@ -13,15 +13,16 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-import app.main as main
+from app import auth as auth_module
+from app import database, deps
 
 router = APIRouter()
 
 
 @router.get("/api/users")
 async def api_list_users(request: Request) -> list[dict[str, Any]]:
-    main._require_owner(request)
-    return await main.database.list_users()
+    deps._require_owner(request)
+    return await database.list_users()
 
 
 class UserRoleUpdate(BaseModel):
@@ -30,16 +31,16 @@ class UserRoleUpdate(BaseModel):
 
 @router.patch("/api/users/{user_id}")
 async def api_update_user_role(request: Request, user_id: int, body: UserRoleUpdate) -> dict[str, str]:
-    current = main._require_owner(request)
+    current = deps._require_owner(request)
     if body.role not in ("viewer", "writer", "owner"):
         raise HTTPException(status_code=400, detail="Role must be viewer, writer, or owner")
-    user = await main.database.get_user_by_id(user_id)
+    user = await database.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     if current["uid"] == user_id and body.role != "owner":
         raise HTTPException(status_code=400, detail="Cannot demote yourself")
     if user["role"] == "owner" and body.role != "owner":
-        all_users = await main.database.list_users()
+        all_users = await database.list_users()
         owner_count = sum(1 for u in all_users if u["role"] == "owner")
         if owner_count <= 1:
             raise HTTPException(status_code=400, detail="Cannot remove the last owner")
@@ -49,18 +50,18 @@ async def api_update_user_role(request: Request, user_id: int, body: UserRoleUpd
     # Persist the revocation durably (survives a UI restart) AND bump the in-memory
     # epoch (immediate effect); a fresh login re-mints a token with the new role.
     revoked_at = time.time()
-    await main.database.revoke_user_sessions(user_id, revoked_at)
-    main.auth.set_user_pwd_epoch(user_id, revoked_at)
-    await main.database.update_user_role(user_id, body.role)
+    await database.revoke_user_sessions(user_id, revoked_at)
+    auth_module.set_user_pwd_epoch(user_id, revoked_at)
+    await database.update_user_role(user_id, body.role)
     return {"status": "updated"}
 
 
 @router.delete("/api/users/{user_id}")
 async def api_delete_user(request: Request, user_id: int) -> dict[str, str]:
-    current = main._require_owner(request)
+    current = deps._require_owner(request)
     if current["uid"] == user_id:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
-    user = await main.database.get_user_by_id(user_id)
+    user = await database.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     # Revoke outstanding sessions BEFORE deleting the row, so there is never a
@@ -70,7 +71,7 @@ async def api_delete_user(request: Request, user_id: int) -> dict[str, str]:
     # so the deleted account's still-valid 30-day cookie keeps being rejected
     # across UI restarts instead of regaining access once the in-memory epoch resets.
     revoked_at = time.time()
-    await main.database.revoke_user_sessions(user_id, revoked_at)
-    main.auth.set_user_pwd_epoch(user_id, revoked_at)
-    await main.database.delete_user(user_id)
+    await database.revoke_user_sessions(user_id, revoked_at)
+    auth_module.set_user_pwd_epoch(user_id, revoked_at)
+    await database.delete_user(user_id)
     return {"status": "deleted"}

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -1,0 +1,136 @@
+"""Login rate limiting, extracted from main (CashPilot-sux).
+
+The point of the move is structural: this was the last thing the routers
+genuinely needed from ``app.main``, so extracting it is what actually removes
+the ``main -> routers -> main`` import cycle. Everything else they reached for
+through ``app.main`` — templates, client_ip, the auth guards — was already a
+re-export of something in ``app.deps``.
+
+The tests that matter are the ones about the seams. A refactor that quietly
+rebinds a module-level dict leaves test fixtures clearing an object nothing
+reads, and every test after it stops being isolated — a failure that shows up
+much later as flakiness nobody can place.
+"""
+
+from __future__ import annotations
+
+from time import monotonic
+
+import pytest
+from fastapi import HTTPException
+
+from app import login_rate_limit as rl
+from app import main
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    rl._login_attempts.clear()
+    yield
+    rl._login_attempts.clear()
+
+
+class TestTheCycleIsGone:
+    def test_no_router_imports_main(self):
+        """This is the whole reason the module exists."""
+        import ast
+        import pathlib
+
+        def imports_main(node) -> bool:
+            if isinstance(node, ast.Import):
+                return any(alias.name.endswith("main") for alias in node.names)
+            if isinstance(node, ast.ImportFrom):
+                return (node.module or "").endswith("main")
+            return False
+
+        offenders = sorted(
+            path.name
+            for path in (pathlib.Path(main.__file__).parent / "routers").glob("*.py")
+            if any(imports_main(node) for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))))
+        )
+        assert not offenders, f"routers still import main: {offenders}"
+
+    def test_the_rate_limiter_imports_nothing_from_the_app(self):
+        """Otherwise it could be pulled back into a cycle later."""
+        import ast
+        import pathlib
+
+        tree = ast.parse(pathlib.Path(rl.__file__).read_text(encoding="utf-8"))
+        app_imports = [
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("app")
+        ]
+        assert not app_imports, f"login_rate_limit imports {app_imports}"
+
+
+class TestTheTestSeamsStillPointAtTheSameObjects:
+    def test_main_reexports_the_same_dict_not_a_copy(self):
+        """conftest clears app.main._login_attempts between tests.
+
+        A copy here would leave the fixture clearing something nothing reads,
+        and every later test would silently inherit the previous one's state.
+        """
+        assert main._login_attempts is rl._login_attempts
+
+    def test_clearing_through_main_clears_the_real_state(self):
+        rl.record_failed_login("10.0.0.1")
+        assert rl._login_attempts
+        main._login_attempts.clear()
+        assert not rl._login_attempts
+
+    def test_main_reexports_the_same_functions(self):
+        assert main._check_login_rate is rl.check_login_rate
+        assert main._record_failed_login is rl.record_failed_login
+
+    def test_the_published_limits_are_unchanged(self):
+        assert main._LOGIN_MAX_ATTEMPTS == rl.MAX_ATTEMPTS == 5
+        assert main._LOGIN_WINDOW_SECONDS == rl.WINDOW_SECONDS == 300
+
+
+class TestTheBehaviourIsUnchanged:
+    def test_it_allows_attempts_below_the_limit(self):
+        for _ in range(rl.MAX_ATTEMPTS - 1):
+            rl.record_failed_login("1.2.3.4")
+        rl.check_login_rate("1.2.3.4")
+
+    def test_it_blocks_at_the_limit(self):
+        for _ in range(rl.MAX_ATTEMPTS):
+            rl.record_failed_login("1.2.3.4")
+        with pytest.raises(HTTPException) as exc:
+            rl.check_login_rate("1.2.3.4")
+        assert exc.value.status_code == 429
+
+    def test_attempts_outside_the_window_do_not_count(self):
+        rl._login_attempts["1.2.3.4"] = [monotonic() - (rl.WINDOW_SECONDS + 10)] * rl.MAX_ATTEMPTS
+        rl.check_login_rate("1.2.3.4")
+
+    def test_addresses_are_counted_separately(self):
+        for _ in range(rl.MAX_ATTEMPTS):
+            rl.record_failed_login("1.1.1.1")
+        rl.check_login_rate("2.2.2.2")
+
+    def test_a_successful_login_forgets_the_failures(self):
+        rl.record_failed_login("1.2.3.4")
+        rl.clear("1.2.3.4")
+        assert "1.2.3.4" not in rl._login_attempts
+
+    def test_clearing_an_address_that_never_failed_is_harmless(self):
+        rl.clear("9.9.9.9")
+
+
+class TestItDoesNotLeakBuckets:
+    def test_an_aged_out_bucket_is_removed_rather_than_left_empty(self):
+        """A plain dict, not a defaultdict, precisely so this can happen.
+
+        Every distinct address that ever hits /login would otherwise leave a
+        permanent key behind once its attempts expired — a slow leak that only
+        shows on a host exposed long enough to see a lot of addresses.
+        """
+        rl._login_attempts["1.2.3.4"] = [monotonic() - (rl.WINDOW_SECONDS + 1)]
+        rl.check_login_rate("1.2.3.4")
+        assert "1.2.3.4" not in rl._login_attempts
+
+    def test_checking_an_unseen_address_creates_no_entry(self):
+        rl.check_login_rate("5.5.5.5")
+        assert rl._login_attempts == {}

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -2212,7 +2212,7 @@ class TestLoginRateLimitMetric:
             raise HTTPException(status_code=429, detail="Too many login attempts")
 
         with (
-            patch("app.main._check_login_rate", side_effect=_raise_429),
+            patch("app.login_rate_limit.check_login_rate", side_effect=_raise_429),
             patch("app.main.metrics.record_rate_limit") as mock_metric,
         ):
             resp = client.post("/login", data={"username": "x", "password": "y"}, follow_redirects=False)


### PR DESCRIPTION
The SSRF/worker-URL extraction this bead also called for [already shipped in #121]. What remained was the cycle — and the interesting part is how small the real coupling turned out to be.

The routers reached into `app.main` for `templates`, `client_ip`, the auth guards, `database`, `metrics`, `setup_token` and the login rate limiter. **Every one except the last was already a re-export** of something in `app.deps` or a plain module — `app.main` was just a pass-through.

So the routers now import their dependencies directly, and moving one module-level dict is what actually removes the cycle rather than relocating it.

`app.login_rate_limit` imports nothing from the app, so it can't be pulled back into a cycle later. Tests assert both: no router imports `main`, and the new module has no app-level imports.

## The seams were the real risk

`app.main` re-exports `_login_attempts` **by reference, not as a copy** — a conftest fixture clears `app.main._login_attempts` between tests. A copy would have left that fixture clearing an object nothing reads, and every later test would silently inherit the previous one's state. That's flakiness which surfaces much later and is very hard to place. A test pins the identity.

**One seam did legitimately move.** A test patched `app.main._check_login_rate`, which no longer intercepts anything now that the router calls the function where it lives — patching a name in `main`'s namespace never affected the other module. That test now patches `app.login_rate_limit.check_login_rate`: one explicit update, not a silent behaviour change.

## Two things the mechanical rename got wrong

Both caught by the suite rather than by reading:

- **`app.setup_token` collides with a `Form` parameter of the same name** inside `do_register`, so the bare import looked unused, was auto-removed, and the other use became a `NameError`. Now imported under an alias, with a comment saying why.
- The auth router's docstring still described the old arrangement.

## Behaviour unchanged

Tested as such: the window, the limit, per-address counting, and the deliberate plain dict (not a `defaultdict`) so an aged-out bucket is *removed* rather than leaking a permanent key for every address that ever hits `/login`.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `pytest --cov=app --cov-fail-under=90` → **1749 passed**, coverage 94.66%