### PR TITLE
fix: correct nine defects found auditing v1.10.0

### DIFF
--- a/.github/workflows/collector-live-check.yml
+++ b/.github/workflows/collector-live-check.yml
@@ -45,7 +45,11 @@ jobs:
           CASHPILOT_LIVE_CREDENTIALS: ${{ secrets.CASHPILOT_LIVE_CREDENTIALS }}
         run: |
           set -o pipefail
-          python -m pytest tests/ -m live -q 2>&1 | tee live.log
+          # Exit 5 is pytest's "no tests collected". No test carries the `live`
+          # marker yet, so without this the job fails EVERY night and files a
+          # false drift alert — which trains the maintainer to ignore the one
+          # alert designed to catch a real provider change.
+          python -m pytest tests/ -m live -q 2>&1 | tee live.log || [ "${PIPESTATUS[0]}" = "5" ]
 
       - name: Open an issue when a provider's shape changed
         if: failure()

--- a/app/database.py
+++ b/app/database.py
@@ -718,6 +718,80 @@ async def get_earnings_history(
         await db.close()
 
 
+def _usd_rate(currency: str, raw: Any) -> float | None:
+    """The USD price of one unit, or None when the reading cannot be priced.
+
+    USD is parity BY DEFINITION — trusting a stored rate on a USD row would let
+    a bad rate rewrite money the collector reported exactly. For anything else
+    only a finite positive number is a price:
+
+    * ``0`` reports the platform as having earned nothing, which is
+      indistinguishable from a genuinely flat balance;
+    * a negative defeats the payout clamp, which applies to the delta while the
+      sign is applied after it, so the total comes out NEGATIVE;
+    * ``inf``/``nan`` poison the total outright.
+
+    Anything rejected here is treated as unpriced — excluded and reported —
+    rather than believed.
+    """
+    if currency == "USD":
+        return 1.0
+    if raw is None:
+        return None
+    value = float(raw)
+    return value if math.isfinite(value) and value > 0 else None
+
+
+async def _usd_earned_per_date(db: Any) -> tuple[dict[str, float], int]:
+    """USD earned per calendar date, summed across platforms.
+
+    ONE implementation behind both the dashboard cards and the trend chart.
+    They previously carried separate copies of the arithmetic and both filtered
+    ``currency = 'USD'``, so an installation earning MYST, GRASS or ANYONE saw
+    "$0.00 today", "$0.00 this month" and a flat-zero chart while its balances
+    climbed — verified against a MystNodes-only fixture, which reported 0.00
+    where the correct figure was 0.20.
+
+    Same rules as :func:`get_earned_by_platform`, and deliberately so:
+
+    * the delta is taken in the NATIVE currency and only then priced, because a
+      balance is a running total and converting before subtracting puts the
+      movement of the exchange rate inside the earnings figure;
+    * a platform with no predecessor reading contributes nothing, rather than
+      counting its whole opening balance as one day's earnings;
+    * a reading that cannot be priced drops the baseline instead of anchoring
+      the next delta, so an unpriced stretch is not silently counted whole.
+    """
+    cursor = await db.execute(
+        """
+        SELECT platform, date, balance, currency, fx_rate_usd
+        FROM earnings
+        ORDER BY platform, date
+        """
+    )
+    per_date: dict[str, float] = {}
+    previous: dict[str, tuple[str, float]] = {}
+    unpriced = 0
+    for row in await cursor.fetchall():
+        platform = row["platform"]
+        currency = (row["currency"] or "USD").upper()
+        rate = _usd_rate(currency, row["fx_rate_usd"])
+        if rate is None:
+            previous.pop(platform, None)
+            unpriced += 1
+            continue
+        balance = float(row["balance"] or 0.0)
+        before = previous.get(platform)
+        if before is not None and before[0] == currency:
+            # Clamped per platform BEFORE summing: a payout drops one
+            # platform's balance, and an unclamped drop would cancel real
+            # earnings on another platform in the same day's total.
+            gained = max(0.0, balance - before[1]) * rate
+            per_date[row["date"]] = per_date.get(row["date"], 0.0) + gained
+        previous[platform] = (currency, balance)
+    return per_date, unpriced
+
+
 async def get_earnings_dashboard_summary() -> dict[str, Any]:
     """Return aggregated earnings stats for the dashboard."""
     db = await _get_db()
@@ -742,78 +816,25 @@ async def get_earnings_dashboard_summary() -> dict[str, Any]:
         row = await cursor.fetchone()
         total = row["total"]
 
-        # Today's earnings: delta from yesterday per platform
-        cursor = await db.execute(
-            """
-            -- MAX(delta, 0) per platform BEFORE summing: a payout on one
-            -- platform drops its balance, and without the per-platform clamp
-            -- that drop cancels real earnings on another platform in the sum.
-            SELECT COALESCE(SUM(MAX(t.balance - COALESCE(y.balance, 0), 0)), 0) as earned
-            FROM (
-                SELECT platform, balance FROM earnings
-                WHERE date = ? AND currency = 'USD'
-            ) t
-            LEFT JOIN (
-                SELECT platform, balance FROM earnings
-                WHERE date = ? AND currency = 'USD'
-            ) y ON t.platform = y.platform
-            """,
-            (today, yesterday),
-        )
-        row = await cursor.fetchone()
-        today_earned = max(0.0, row["earned"])
+        # Today, this month and yesterday all come from one priced series.
+        # They used to be three separate SQL aggregates that each filtered
+        # currency = 'USD', so every non-USD platform was missing from all
+        # three at once and the cards read $0.00 while balances climbed.
+        per_date, unpriced = await _usd_earned_per_date(db)
+        if unpriced:
+            _logger.warning(
+                "%d earnings reading(s) have no usable USD rate and are left out of the "
+                "dashboard totals, which are therefore understated.",
+                unpriced,
+            )
 
-        # This month's earnings: latest balance minus first-of-month balance
-        cursor = await db.execute(
-            """
-            SELECT COALESCE(SUM(
-                MAX(latest.balance - COALESCE(month_start.balance, 0), 0)
-            ), 0) as earned
-            FROM (
-                SELECT e.platform, e.balance
-                FROM earnings e
-                INNER JOIN (
-                    SELECT platform, MAX(date) as max_date
-                    FROM earnings WHERE currency = 'USD'
-                    GROUP BY platform
-                ) m ON e.platform = m.platform AND e.date = m.max_date
-                WHERE e.currency = 'USD'
-            ) latest
-            LEFT JOIN (
-                SELECT e.platform, e.balance
-                FROM earnings e
-                INNER JOIN (
-                    SELECT platform, MIN(date) as min_date
-                    FROM earnings
-                    WHERE date >= ? AND currency = 'USD'
-                    GROUP BY platform
-                ) m ON e.platform = m.platform AND e.date = m.min_date
-                WHERE e.currency = 'USD'
-            ) month_start ON latest.platform = month_start.platform
-            """,
-            (first_of_month,),
-        )
-        row = await cursor.fetchone()
-        month_earned = max(0.0, row["earned"])
+        today_earned = per_date.get(today, 0.0)
+        # The month is the sum of clamped daily deltas rather than one delta
+        # from the first of the month, so a mid-month payout counts as zero on
+        # its own day instead of erasing the whole month's earnings.
+        month_earned = sum(earned for day, earned in per_date.items() if day >= first_of_month)
 
-        # Yesterday's delta for percentage change
-        day_before = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
-        cursor = await db.execute(
-            """
-            SELECT COALESCE(SUM(MAX(y.balance - COALESCE(dy.balance, 0), 0)), 0) as earned
-            FROM (
-                SELECT platform, balance FROM earnings
-                WHERE date = ? AND currency = 'USD'
-            ) y
-            LEFT JOIN (
-                SELECT platform, balance FROM earnings
-                WHERE date = ? AND currency = 'USD'
-            ) dy ON y.platform = dy.platform
-            """,
-            (yesterday, day_before),
-        )
-        row = await cursor.fetchone()
-        yesterday_earned = max(0.0, row["earned"])
+        yesterday_earned = per_date.get(yesterday, 0.0)
 
         today_change = 0.0
         if yesterday_earned > 0:
@@ -871,43 +892,30 @@ async def get_daily_earnings(days: int = 7) -> list[dict[str, Any]]:
     """Return daily aggregated earnings for charting (delta per day)."""
     db = await _get_db()
     try:
-        # Per-platform balances, not a cross-platform sum. Summing first and
-        # diffing the total lets a payout drop on one platform cancel real
-        # earnings on another (see get_earnings_dashboard_summary). We clamp each
-        # platform's daily delta at zero, then sum - so a payout counts as zero
-        # earned on that platform, never as a negative eating the rest.
-        # One extra day before the range so the first delta has a predecessor.
-        cursor = await db.execute(
-            """
-            SELECT date, platform, balance
-            FROM earnings
-            WHERE date >= date('now', ?) AND currency = 'USD'
-            ORDER BY date
-            """,
-            (f"-{days + 1} days",),
-        )
-        rows = await cursor.fetchall()
-
-        # date -> {platform -> balance}
-        by_date: dict[str, dict[str, float]] = {}
-        for row in rows:
-            by_date.setdefault(row["date"], {})[row["platform"]] = row["balance"]
+        # Shares the priced series with the dashboard cards, so the chart and
+        # the "Today" card can no longer disagree. The previous version built
+        # its own per-date balance map filtered to currency = 'USD', which drew
+        # a flat-zero line for a fleet earning MYST, GRASS or ANYONE.
+        #
+        # It also treated a platform's FIRST-EVER reading as a delta against
+        # zero, so a newly added service drew a spike the size of its whole
+        # opening balance. The shared helper requires a predecessor.
+        per_date, unpriced = await _usd_earned_per_date(db)
+        if unpriced:
+            _logger.warning(
+                "%d earnings reading(s) have no usable USD rate and are left out of the "
+                "daily chart, which is therefore understated.",
+                unpriced,
+            )
 
         now = datetime.now(UTC)
         result = []
         for i in range(days - 1, -1, -1):
             d = now - timedelta(days=i)
-            date_str = d.strftime("%Y-%m-%d")
-            prev_str = (d - timedelta(days=1)).strftime("%Y-%m-%d")
-
-            current = by_date.get(date_str, {})
-            previous = by_date.get(prev_str, {})
-            earned = sum(max(0.0, bal - previous.get(platform, 0.0)) for platform, bal in current.items())
-
             result.append(
                 {
                     "date": d.strftime("%b %d"),
-                    "amount": round(earned, 2),
+                    "amount": round(per_date.get(d.strftime("%Y-%m-%d"), 0.0), 2),
                 }
             )
 
@@ -1599,24 +1607,8 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
             balance = float(row["balance"] or 0.0)
             # USD is parity by definition. Trusting a stored rate on a USD row
             # would let a bad rate rewrite money the collector reported exactly.
-            rate = 1.0 if currency == "USD" else row["fx_rate_usd"]
+            rate = _usd_rate(currency, row["fx_rate_usd"])
             earned.setdefault(platform, 0.0)
-
-            # Only a finite positive number is a price. Everything else is bad
-            # data and must be treated as unpriced rather than believed:
-            #   0        reports the platform as having earned nothing, which
-            #            is indistinguishable from a genuinely flat balance;
-            #   negative defeats the payout clamp, which applies to the delta
-            #            while the sign is applied after it, so the platform
-            #            total comes out NEGATIVE and drags down every figure
-            #            derived from it;
-            #   inf/nan  poison the total outright — inf earnings, or a NaN
-            #            that compares false against every threshold it later
-            #            meets. (SQLite happens to store NaN as NULL today, so
-            #            only inf is reachable through the database; the check
-            #            does not depend on that continuing to be true.)
-            if rate is not None and not (math.isfinite(float(rate)) and float(rate) > 0):
-                rate = None
 
             if rate is None:
                 # No rate means this reading cannot be priced, so it can neither

--- a/app/database.py
+++ b/app/database.py
@@ -536,10 +536,58 @@ async def close_shared() -> None:
         await conn.close()
 
 
+async def _dedupe_earnings_before_indexing(db: Any) -> None:
+    """Clear the way for the unique earnings index on an old volume.
+
+    ``_SCHEMA`` is replayed on EVERY startup, and it contains
+    ``CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_date``. On an
+    installation whose ``/data`` predates that index and that accumulated two
+    rows for the same platform and date, creating it raises IntegrityError —
+    inside ``executescript``, which nothing catches, during ``lifespan`` — and
+    the application does not start AT ALL. Verified: a two-duplicate-row
+    database fails ``init_db`` with "UNIQUE constraint failed".
+
+    That is the one piece of schema evolution here without a defensive
+    migration; every other column change is guarded by a ``PRAGMA table_info``
+    check. Recovering by hand means opening SQLite on a container that will not
+    boot, which is a bad thing to ask of someone whose dashboard just died.
+
+    Deliberately conservative: this touches nothing unless the index is genuinely
+    absent AND duplicates genuinely exist, and it keeps the HIGHEST id per
+    (platform, date) — the most recently written row, which is what an upsert
+    would have left behind had the index been there all along.
+    """
+    cursor = await db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_earnings_platform_date'"
+    )
+    if await cursor.fetchone():
+        return  # Index already present, so duplicates cannot exist.
+
+    cursor = await db.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'earnings'")
+    if not await cursor.fetchone():
+        return  # Fresh install; the table is about to be created cleanly.
+
+    cursor = await db.execute("SELECT COUNT(*) - COUNT(DISTINCT platform || '|' || date) AS extra FROM earnings")
+    row = await cursor.fetchone()
+    extra = int(row["extra"] or 0)
+    if extra <= 0:
+        return
+
+    _logger.warning(
+        "Found %d duplicate earnings row(s) predating the unique index. Keeping the most recent "
+        "reading for each platform and date and removing the rest, so the index can be created "
+        "and the application can start.",
+        extra,
+    )
+    await db.execute("DELETE FROM earnings WHERE id NOT IN (SELECT MAX(id) FROM earnings GROUP BY platform, date)")
+    await db.commit()
+
+
 async def init_db() -> None:
     """Create tables if they don't exist."""
     db = await _get_db()
     try:
+        await _dedupe_earnings_before_indexing(db)
         await db.executescript(_SCHEMA)
         # Migrate workers table: add client_id (UNIQUE) and apps columns
         cursor = await db.execute("PRAGMA table_info(workers)")

--- a/app/database.py
+++ b/app/database.py
@@ -1568,16 +1568,21 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
     Deltas are clamped per platform before summing, the same rule the dashboard
     uses (CashPilot-glc): a payout drops a balance, and an unclamped drop would
     read as negative earnings and understate what the service actually paid.
+
+    The delta is taken in the NATIVE currency and only then priced. Converting
+    each cumulative balance to USD first and subtracting afterwards would let a
+    rate move alone move the earnings figure: 100 MYST at $0.50 followed by 110
+    MYST at $0.40 subtracts to a loss and clamps to zero, hiding 10 MYST that
+    really was earned, while an unchanged balance at a risen rate invents
+    earnings out of nothing.
     """
     db = await _get_db()
     try:
         cursor = await db.execute(
             """
-            SELECT platform, date,
-                   balance * COALESCE(fx_rate_usd, 1.0) AS balance
+            SELECT platform, date, balance, currency, fx_rate_usd
             FROM earnings
             WHERE date >= date('now', ?)
-              AND (currency = 'USD' OR fx_rate_usd IS NOT NULL)
             ORDER BY platform, date
             """,
             (f"-{max(1, int(days))} days",),
@@ -1585,14 +1590,38 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
         rows = await cursor.fetchall()
 
         earned: dict[str, float] = {}
-        previous: dict[str, float] = {}
+        previous: dict[str, tuple[str, float]] = {}
+        unpriced = 0
         for row in rows:
-            platform, balance = row["platform"], float(row["balance"])
-            if platform in previous:
-                earned[platform] = earned.get(platform, 0.0) + max(0.0, balance - previous[platform])
-            else:
-                earned.setdefault(platform, 0.0)
-            previous[platform] = balance
+            platform = row["platform"]
+            currency = (row["currency"] or "USD").upper()
+            balance = float(row["balance"] or 0.0)
+            # USD is parity by definition. Trusting a stored rate on a USD row
+            # would let a bad rate rewrite money the collector reported exactly.
+            rate = 1.0 if currency == "USD" else row["fx_rate_usd"]
+            earned.setdefault(platform, 0.0)
+
+            if rate is None:
+                # No rate means this reading cannot be priced, so it can neither
+                # contribute earnings nor anchor the next delta. Dropping the
+                # baseline is what stops a later reading from being differenced
+                # across the gap and counting the unpriced period twice.
+                previous.pop(platform, None)
+                unpriced += 1
+                continue
+
+            before = previous.get(platform)
+            if before is not None and before[0] == currency:
+                earned[platform] += max(0.0, balance - before[1]) * float(rate)
+            previous[platform] = (currency, balance)
+
+        if unpriced:
+            _logger.warning(
+                "%d earnings reading(s) in the last %d days have no USD rate and were left out "
+                "of the per-platform totals, which are therefore understated.",
+                unpriced,
+                days,
+            )
         return earned
     finally:
         await db.close()

--- a/app/database.py
+++ b/app/database.py
@@ -1573,9 +1573,11 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
     try:
         cursor = await db.execute(
             """
-            SELECT platform, date, balance
+            SELECT platform, date,
+                   balance * COALESCE(fx_rate_usd, 1.0) AS balance
             FROM earnings
-            WHERE date >= date('now', ?) AND currency = 'USD'
+            WHERE date >= date('now', ?)
+              AND (currency = 'USD' OR fx_rate_usd IS NOT NULL)
             ORDER BY platform, date
             """,
             (f"-{max(1, int(days))} days",),
@@ -1966,10 +1968,32 @@ async def get_confirmed_payout_totals() -> dict[str, float]:
     db = await _get_db()
     try:
         cursor = await db.execute(
-            "SELECT platform, SUM(amount * COALESCE(fx_rate_usd, 1.0)) AS total "
+            # COALESCE(fx_rate_usd, 1.0) would price an unrated token payout at
+            # PARITY WITH USD — a 500 MYST payout becomes $500 instead of ~$15.
+            # A payout whose rate was never captured is not worth "the same
+            # number of dollars"; it is worth an unknown amount, so it is
+            # excluded and counted separately rather than silently invented.
+            "SELECT platform, "
+            "  SUM(CASE WHEN currency = 'USD' THEN amount "
+            "           WHEN fx_rate_usd IS NOT NULL THEN amount * fx_rate_usd "
+            "           ELSE 0 END) AS total, "
+            "  SUM(CASE WHEN currency != 'USD' AND fx_rate_usd IS NULL THEN 1 ELSE 0 END) AS unpriced "
             "FROM payouts WHERE confirmed = 1 GROUP BY platform"
         )
-        return {row["platform"]: float(row["total"] or 0.0) for row in await cursor.fetchall()}
+        totals: dict[str, float] = {}
+        for row in await cursor.fetchall():
+            totals[row["platform"]] = float(row["total"] or 0.0)
+            if row["unpriced"]:
+                # Say it rather than let the total quietly read low. The
+                # alternative — pricing them at parity — reads high by roughly
+                # the token's price, which is far worse.
+                _logger.warning(
+                    "%s: %d confirmed payout(s) have no recorded exchange rate and are "
+                    "excluded from the total, which is therefore an UNDERSTATEMENT.",
+                    row["platform"],
+                    row["unpriced"],
+                )
+        return totals
     finally:
         await db.close()
 

--- a/app/database.py
+++ b/app/database.py
@@ -1601,6 +1601,16 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
             rate = 1.0 if currency == "USD" else row["fx_rate_usd"]
             earned.setdefault(platform, 0.0)
 
+            # A rate of zero or less is not a price, it is bad data, and it must
+            # be treated as unpriced rather than believed. Zero would silently
+            # report the platform as having earned nothing, which is
+            # indistinguishable from a real flat balance; a negative rate is
+            # worse, because the clamp above applies to the delta and the sign
+            # is applied after it, so the total would come out NEGATIVE and
+            # drag down every figure computed from it.
+            if rate is not None and float(rate) <= 0:
+                rate = None
+
             if rate is None:
                 # No rate means this reading cannot be priced, so it can neither
                 # contribute earnings nor anchor the next delta. Dropping the

--- a/app/database.py
+++ b/app/database.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -1601,14 +1602,20 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
             rate = 1.0 if currency == "USD" else row["fx_rate_usd"]
             earned.setdefault(platform, 0.0)
 
-            # A rate of zero or less is not a price, it is bad data, and it must
-            # be treated as unpriced rather than believed. Zero would silently
-            # report the platform as having earned nothing, which is
-            # indistinguishable from a real flat balance; a negative rate is
-            # worse, because the clamp above applies to the delta and the sign
-            # is applied after it, so the total would come out NEGATIVE and
-            # drag down every figure computed from it.
-            if rate is not None and float(rate) <= 0:
+            # Only a finite positive number is a price. Everything else is bad
+            # data and must be treated as unpriced rather than believed:
+            #   0        reports the platform as having earned nothing, which
+            #            is indistinguishable from a genuinely flat balance;
+            #   negative defeats the payout clamp, which applies to the delta
+            #            while the sign is applied after it, so the platform
+            #            total comes out NEGATIVE and drags down every figure
+            #            derived from it;
+            #   inf/nan  poison the total outright — inf earnings, or a NaN
+            #            that compares false against every threshold it later
+            #            meets. (SQLite happens to store NaN as NULL today, so
+            #            only inf is reachable through the database; the check
+            #            does not depend on that continuing to be true.)
+            if rate is not None and not (math.isfinite(float(rate)) and float(rate) > 0):
                 rate = None
 
             if rate is None:

--- a/app/lan_isolation.py
+++ b/app/lan_isolation.py
@@ -84,7 +84,11 @@ def exceptions_for(service: dict[str, Any] | None) -> list[dict[str, str]]:
                 "detail": f"Port {port} must accept inbound connections, or the node cannot do its job.",
             }
         )
-    if (service or {}).get("collector") or (service or {}).get("slug") == "storj":
+    # Keyed on HAVING a collector, not on being one particular service. The
+    # `or slug == "storj"` this replaces never changed an outcome — storj
+    # declares a collector, so the first clause already matched — while
+    # hardcoding a slug in app/ is exactly what the catalog exists to avoid.
+    if (service or {}).get("collector"):
         api_url_env = [
             e.get("key")
             for e in (_docker(service).get("env") or [])

--- a/app/main.py
+++ b/app/main.py
@@ -168,9 +168,16 @@ def _traffic_state(slug: str, containers: list[dict[str, Any]]) -> str | None:
     return net_activity.classify(max(rates))
 
 
-async def _get_all_worker_containers() -> list[dict[str, Any]]:
-    """Collect container/app data from all online workers' heartbeat data in DB."""
-    workers = await database.list_workers()
+async def _get_all_worker_containers(workers: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    """Collect container/app data from all online workers' heartbeat data in DB.
+
+    ``workers`` lets a caller that has ALREADY fetched the worker list hand it
+    in rather than causing a second `SELECT *` and a second full JSON decode of
+    every row in the same request. Everyone else keeps calling this with no
+    arguments and gets the fetch for free.
+    """
+    if workers is None:
+        workers = await database.list_workers()
     result: list[dict[str, Any]] = []
     for w in workers:
         if w.get("status") != "online":
@@ -2278,9 +2285,13 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
     except (TypeError, ValueError):
         price = 0.0
 
-    workers = [_decoded_worker(w) for w in await database.list_workers()]
+    # Fetched once and reused: this used to query the worker table here and
+    # then again inside _get_all_worker_containers, decoding every row twice
+    # to build the same list in a single request.
+    raw_workers = await database.list_workers()
+    workers = [_decoded_worker(w) for w in raw_workers]
     earned = await database.get_earned_by_platform(days=30)
-    containers = await _get_all_worker_containers()
+    containers = await _get_all_worker_containers(raw_workers)
 
     # Attribute each service's gross to the worker running it. A service on two
     # machines splits evenly: without per-node earnings there is no better

--- a/app/main.py
+++ b/app/main.py
@@ -2109,7 +2109,12 @@ async def api_test_credentials(request: Request, slug: str) -> dict[str, Any]:
     from app import collectors
     from app.collectors import COLLECTOR_MAP
 
-    _require_auth_api(request)
+    # Owner, not merely authenticated: this fires an authenticated login to a
+    # third party using the OWNER's stored credentials and reads the balance
+    # back. /api/collectors/meta already requires owner for the same material,
+    # and POST /api/collect — which is strictly less privileged — requires
+    # writer. A viewer must not be able to reach any of it.
+    _require_owner(request)
     service = catalog.get_service(slug)
     if not service:
         raise HTTPException(status_code=404, detail=f"Unknown service '{slug}'")
@@ -2161,7 +2166,9 @@ async def api_payouts(request: Request, platform: str | None = None) -> dict[str
 @app.post("/api/earnings/payouts/{payout_id}/confirm")
 async def api_confirm_payout(request: Request, payout_id: int, method: str = "") -> dict[str, Any]:
     """Confirm a drop really was a payout. Only a human reaches this."""
-    _require_auth_api(request)
+    # Writer, not viewer: this mutates financial records, and rejection is a
+    # hard DELETE. A read-only account must not be able to destroy them.
+    _require_writer(request)
     if not await database.confirm_payout(payout_id):
         raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
     return {"ok": True, "id": payout_id, "confirmed": True}
@@ -2170,7 +2177,9 @@ async def api_confirm_payout(request: Request, payout_id: int, method: str = "")
 @app.post("/api/earnings/payouts/{payout_id}/reject")
 async def api_reject_payout(request: Request, payout_id: int) -> dict[str, Any]:
     """This drop was not a payout — forget it entirely."""
-    _require_auth_api(request)
+    # Writer, not viewer: this mutates financial records, and rejection is a
+    # hard DELETE. A read-only account must not be able to destroy them.
+    _require_writer(request)
     if not await database.reject_payout(payout_id):
         raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
     return {"ok": True, "id": payout_id, "removed": True}
@@ -2223,7 +2232,12 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
     _require_auth_api(request)
     config = await database.get_config() or {}
     try:
-        price = float(config.get("electricity_price_per_kwh") or 0.0)
+        # Two features shipped in one release reading DIFFERENT keys for the
+        # same tariff, so setting one left the other reporting "cost unknown"
+        # forever — and both unknown-paths are deliberately quiet, which is
+        # exactly what hid it. power_price_per_kwh is canonical (it shipped
+        # first); the newer name is honoured so nobody's existing config breaks.
+        price = float(config.get("power_price_per_kwh") or config.get("electricity_price_per_kwh") or 0.0)
     except (TypeError, ValueError):
         price = 0.0
 

--- a/app/main.py
+++ b/app/main.py
@@ -347,6 +347,41 @@ async def _detect_payout(result: Any) -> dict[str, str] | None:
     return None
 
 
+async def _pending_payout_alerts(seen: set[str] | None = None) -> list[dict[str, str]]:
+    """One alert per payout still waiting for a yes or no.
+
+    The question outlives the collection run that noticed it. Rebuilding the
+    bell only from what was just detected made the prompt disappear on the next
+    run, which is the one thing a prompt must not do — an unanswered payout is
+    unanswered until the user answers it.
+    """
+    seen = seen or set()
+    try:
+        rows = await database.get_payouts()
+    except Exception as exc:
+        logger.warning("Could not load pending payouts for the alert bell: %s", exc)
+        return []
+    pending: list[dict[str, str]] = []
+    for row in rows:
+        platform = row.get("platform", "")
+        if row.get("confirmed") or platform in seen:
+            continue
+        seen.add(platform)
+        amount = row.get("amount")
+        currency = row.get("currency") or ""
+        pending.append(
+            {
+                "kind": "payout",
+                "platform": platform,
+                "error": f"Balance dropped by {amount:.2f} {currency}".rstrip()
+                + " — was this a payout? Confirm or reject it."
+                if isinstance(amount, int | float)
+                else "A balance drop looks like a payout — confirm or reject it.",
+            }
+        )
+    return pending
+
+
 async def _collect_bounded(collector) -> Any:
     """Run a single collector's `collect()` under the shared concurrency limit."""
     async with _collection_semaphore:
@@ -502,6 +537,18 @@ async def _run_collection() -> None:
                         # Recovered — drop the stored alert so a future failure counts
                         # as new and notifies again.
                         await database.clear_alerts("collector", result.platform)
+            # Re-add every payout still awaiting an answer, not just ones
+            # detected on THIS run. `record_probable_payout` returns None while
+            # one is already pending, so a freshly detected payout produced an
+            # alert once and then vanished from the bell on the very next
+            # collection — before the user had a chance to confirm or reject
+            # it. The pending rows in the database are the real source of
+            # truth for "there is still a question outstanding", so the bell is
+            # rebuilt from them rather than from what happened to be noticed in
+            # the last few seconds.
+            alerts.extend(
+                await _pending_payout_alerts(seen={a["platform"] for a in alerts if a.get("kind") == "payout"})
+            )
             _collector_alerts = alerts
 
             await _flatline_check()
@@ -2204,6 +2251,29 @@ async def api_payouts(request: Request, platform: str | None = None) -> dict[str
     }
 
 
+async def _payout_platform(payout_id: int) -> str | None:
+    """Which platform a payout row belongs to, before it is deleted."""
+    with contextlib.suppress(Exception):
+        for row in await database.get_payouts():
+            if row.get("id") == payout_id:
+                return row.get("platform")
+    return None
+
+
+async def _retire_payout_alert(payout_id: int, platform: str | None = None) -> None:
+    """Drop the bell entry for a payout that has now been answered."""
+    global _collector_alerts
+    if platform is None:
+        platform = await _payout_platform(payout_id)
+    if not platform:
+        return
+    with contextlib.suppress(Exception):
+        await database.clear_alerts("payout", platform)
+    _collector_alerts = [
+        a for a in _collector_alerts if not (a.get("kind") == "payout" and a.get("platform") == platform)
+    ]
+
+
 @app.post("/api/earnings/payouts/{payout_id}/confirm")
 async def api_confirm_payout(request: Request, payout_id: int, method: str = "") -> dict[str, Any]:
     """Confirm a drop really was a payout. Only a human reaches this."""
@@ -2215,6 +2285,10 @@ async def api_confirm_payout(request: Request, payout_id: int, method: str = "")
     # confirmation recorded an empty method however the caller was paid.
     if not await database.confirm_payout(payout_id, method=method):
         raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
+    # The question has been answered, so retire the prompt. Left behind, the
+    # stored alert would be restored on the next restart and ask again about a
+    # payout the user already confirmed.
+    await _retire_payout_alert(payout_id)
     return {"ok": True, "id": payout_id, "confirmed": True}
 
 
@@ -2224,8 +2298,10 @@ async def api_reject_payout(request: Request, payout_id: int) -> dict[str, Any]:
     # Writer, not viewer: this mutates financial records, and rejection is a
     # hard DELETE. A read-only account must not be able to destroy them.
     _require_writer(request)
+    platform = await _payout_platform(payout_id)
     if not await database.reject_payout(payout_id):
         raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
+    await _retire_payout_alert(payout_id, platform=platform)
     return {"ok": True, "id": payout_id, "removed": True}
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -302,20 +302,26 @@ async def _run_health_check() -> None:
         logger.warning("Health check skipped: %s", exc)
 
 
-async def _detect_payout(result: Any) -> None:
+async def _detect_payout(result: Any) -> dict[str, str] | None:
     """Notice a balance drop that looks like a cashout, and ask.
 
     Never records income on its own. A balance also falls for a provider
     correction or a reset session, and an unconfirmed guess written as earnings
     corrupts lifetime-earned permanently and invisibly.
+
+    Returns the alert to show the user, or None. It has to be RETURNED rather
+    than filed and forgotten: the bell renders one in-memory list built during
+    the collection run, and this function runs in the success branch that never
+    touched that list — so a detected payout was written to the database and
+    then never shown to anybody, which defeats the point of asking.
     """
     try:
         previous = await database.get_latest_balance(result.platform)
         if previous is None:
-            return
+            return None
         probable = payouts.detect(previous, result.balance, catalog.get_service(result.platform))
         if not probable:
-            return
+            return None
         payout_id = await database.record_probable_payout(
             platform=result.platform,
             amount=probable["amount"],
@@ -325,11 +331,13 @@ async def _detect_payout(result: Any) -> None:
         if payout_id is None:
             # One already pending for this platform; a second prompt for the
             # same event teaches the user to dismiss them.
-            return
+            return None
         await database.record_alert("payout", result.platform, probable["reason"])
+        return {"kind": "payout", "platform": result.platform, "error": probable["reason"]}
     except Exception as exc:
         # Earnings collection must not fail because payout detection did.
         logger.warning("Payout detection failed for %s: %s", getattr(result, "platform", "?"), exc)
+    return None
 
 
 async def _collect_bounded(collector) -> Any:
@@ -398,10 +406,18 @@ async def _warm_collector_alerts() -> None:
     seen: set[str] = set()
     restored: list[dict[str, str]] = []
     for alert in stored:
-        if alert["kind"] != "collector" or alert["subject"] in seen:
+        # Payouts belong here too. Dropping every non-collector kind meant a
+        # detected payout was recorded and then never shown, so the prompt the
+        # user is supposed to answer never appeared. Dedup by kind AND subject:
+        # a platform can legitimately have both a failing collector and a
+        # pending payout, and they are different things to tell someone.
+        if alert["kind"] not in ("collector", "payout"):
             continue
-        seen.add(alert["subject"])
-        restored.append({"platform": alert["subject"], "error": alert["message"]})
+        key = f"{alert['kind']}:{alert['subject']}"
+        if key in seen:
+            continue
+        seen.add(key)
+        restored.append({"kind": alert["kind"], "platform": alert["subject"], "error": alert["message"]})
     _collector_alerts = restored
 
 
@@ -444,7 +460,7 @@ async def _run_collection() -> None:
                     # providers is a live credential. The alert is now durable and readable
                     # by any authenticated role, so it must never hold a secret.
                     safe_error = notify.redact(result.error)
-                    alerts.append({"platform": result.platform, "error": safe_error})
+                    alerts.append({"kind": "collector", "platform": result.platform, "error": safe_error})
                     metrics.record_collection_error(result.platform)
                     # Push out-of-band only the FIRST time this failure appears — a
                     # collector broken for a week must not notify every single hour.
@@ -460,7 +476,9 @@ async def _run_collection() -> None:
                 else:
                     # Compare against the last reading BEFORE writing the new one:
                     # a payout is only visible as the step between two snapshots.
-                    await _detect_payout(result)
+                    payout_alert = await _detect_payout(result)
+                    if payout_alert:
+                        alerts.append(payout_alert)
                     await database.upsert_earnings(
                         platform=result.platform,
                         balance=result.balance,
@@ -2053,7 +2071,12 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         if slug in earned:
             earned_recently = earned[slug] > 0
 
-    running = True
+    # None, not True. If the container lookup below throws, this value is what
+    # survives, and claiming "running" on no evidence is exactly the assumption
+    # this whole module exists to refuse: assess() would skip its unknown path
+    # and, on a still-cached earnings figure, report the service as PRODUCING
+    # at a moment when we cannot tell whether the container is even up.
+    running: bool | None = None
     log_hits: list[dict[str, str]] = []
     traffic: str | None = None
     signals = producer_state.signals_for(service)
@@ -2135,6 +2158,17 @@ async def api_test_credentials(request: Request, slug: str) -> dict[str, Any]:
         outcome = credential_test.NOT_CONFIGURED if missing else credential_test.UNSUPPORTED
         return credential_test.result(outcome, name)
 
+    # Re-check immediately before claiming the slot. The first check above is
+    # separated from this point by `await database.get_config()`, and an await
+    # is where the event loop can run the other request: two clicks could both
+    # pass the cooldown, both build a collector, and both reach the provider.
+    # Hammering a provider with repeated logins is what gets accounts flagged,
+    # which is the entire reason the cooldown exists. `build_one` is
+    # synchronous, so re-check and claim are adjacent with no await between
+    # them and the window is closed without needing a lock.
+    remaining = credential_test.cooldown_remaining(slug)
+    if remaining > 0:
+        return credential_test.result(credential_test.RATE_LIMITED, name, retry_after=round(remaining))
     credential_test.note_attempt(slug)
     try:
         result = await collector.collect()
@@ -2169,7 +2203,10 @@ async def api_confirm_payout(request: Request, payout_id: int, method: str = "")
     # Writer, not viewer: this mutates financial records, and rejection is a
     # hard DELETE. A read-only account must not be able to destroy them.
     _require_writer(request)
-    if not await database.confirm_payout(payout_id):
+    # Forward `method`. The endpoint has always accepted it and the database
+    # has always had a column for it, but it was never passed along, so every
+    # confirmation recorded an empty method however the caller was paid.
+    if not await database.confirm_payout(payout_id, method=method):
         raise HTTPException(status_code=404, detail="No unconfirmed payout with that id")
     return {"ok": True, "id": payout_id, "confirmed": True}
 
@@ -2348,7 +2385,9 @@ async def api_collector_alerts(request: Request) -> list[dict[str, str]]:
         clean = error_msg[:_MAX_ALERT_ERROR_LEN]
         if len(error_msg) > _MAX_ALERT_ERROR_LEN:
             clean += "..."
-        sanitized.append({"platform": alert["platform"], "error": clean})
+        # `kind` is additive and defaults to "collector", so a frontend that
+        # does not read it behaves exactly as before.
+        sanitized.append({"kind": alert.get("kind", "collector"), "platform": alert["platform"], "error": clean})
     return sanitized
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2808,7 +2808,21 @@ async def api_list_workers(request: Request) -> list[dict[str, Any]]:
 
 
 def _parse_worker_json(w: dict[str, Any]) -> None:
-    """Parse stored JSON columns and compute counts for a worker dict."""
+    """Parse stored JSON columns and compute counts for a worker dict.
+
+    Also drops the worker's encrypted fleet key, because ``list_workers`` is a
+    ``SELECT *`` and every path that renders a worker to a client goes through
+    here. The key is a credential: it is what a worker authenticates with, and
+    it has no use in a dashboard. Encrypted at rest is not a reason to hand the
+    ciphertext to every logged-in viewer — it makes the Fernet key the only
+    thing standing between a read-only account and the whole fleet's
+    credentials, when nothing needed to publish it at all.
+
+    Stripped here rather than in ``list_workers`` on purpose: the stale-worker
+    purge legitimately reads ``api_key_enc`` to tell an enrolled worker from one
+    that never enrolled, and it does not go through this function.
+    """
+    w.pop("api_key_enc", None)
     w["containers"] = _safe_json(w.get("containers", "[]"))
     w["apps"] = _safe_json(w.get("apps", "[]"))
     w["system_info"] = _safe_json(w.get("system_info", "{}"), {})

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import docker
@@ -534,11 +535,53 @@ def _network_totals(stats: dict[str, Any]) -> tuple[int | None, int | None]:
     return rx, tx
 
 
+#: Concurrent `stats` calls. Bounded because the aim is to stop the heartbeat
+#: growing with the container count, not to flood the Docker daemon — an
+#: unbounded fan-out on a busy host trades one problem for another.
+_STATS_CONCURRENCY = 8
+
+
+def _collect_stats_bulk(containers: list[Any]) -> dict[str, tuple[float, float, int | None, int | None]]:
+    """Stats for many containers at once, keyed by container id.
+
+    `stats(stream=False)` costs ~1-2s per container and was called in a serial
+    loop, so a heartbeat took time proportional to the number of containers on
+    the host. The loop sleeps AFTER sending, so this stretches the real
+    heartbeat interval rather than skipping cycles: at 60s nominal and 180s
+    before the UI marks a worker offline, a host would start flapping somewhere
+    past 60-80 containers. Today's reference fleet runs ~14 on its busiest
+    host, so this is a margin that shrinks as people add services, not a fire.
+
+    The calls are read-only GETs issued through the shared client, which is a
+    `requests.Session` subclass backed by urllib3's lock-protected connection
+    pool. docker-py has never published a thread-safety guarantee — the
+    question is open in their tracker — so this is a deliberate, bounded bet on
+    widely-relied-upon behaviour rather than a documented contract.
+    """
+    if not containers:
+        return {}
+    results: dict[str, tuple[float, float, int | None, int | None]] = {}
+    with ThreadPoolExecutor(max_workers=min(_STATS_CONCURRENCY, len(containers))) as pool:
+        futures = {pool.submit(_collect_stats, c): c for c in containers}
+        for future in as_completed(futures):
+            container = futures[future]
+            try:
+                results[container.id] = future.result()
+            except Exception as exc:
+                # One unreadable container must not cost us the whole fleet's
+                # stats; _collect_stats already degrades to zeros itself.
+                logger.warning("Stats unavailable for %s: %s", getattr(container, "short_id", "?"), exc)
+                results[container.id] = (0.0, 0.0, None, None)
+    return results
+
+
 def get_status() -> list[dict[str, Any]]:
     """Return live status of all known containers (labeled + image-matched).
 
-    This is SLOW (~1-2s per container) because it calls Docker stats API.
-    Use get_status_cached() for page loads; this is for background refresh.
+    Calls the Docker stats API for every container, which is slow per container
+    (~1-2s); the calls are issued concurrently, but this is still far heavier
+    than a plain list. Use get_status_cached() for page loads; this is for
+    background refresh.
     """
     global _status_cache, _status_cache_time
 
@@ -555,11 +598,12 @@ def get_status() -> list[dict[str, Any]]:
     seen_ids: set[str] = set()
 
     results: list[dict[str, Any]] = []
+    labeled_stats = _collect_stats_bulk(list(labeled))
     for c in labeled:
         try:
             seen_ids.add(c.id)
             slug = c.labels.get(LABEL_SERVICE, "unknown")
-            cpu_pct, mem_mb, net_rx, net_tx = _collect_stats(c)
+            cpu_pct, mem_mb, net_rx, net_tx = labeled_stats.get(c.id, (0.0, 0.0, None, None))
             results.append(
                 {
                     "slug": slug,
@@ -588,6 +632,9 @@ def get_status() -> list[dict[str, Any]]:
         except Exception as exc:
             logger.warning("Failed to list all containers: %s", exc)
             all_containers = []
+        # Resolve which externally-deployed containers we actually care about
+        # BEFORE fetching stats, so nothing is paid for a container we skip.
+        matched: list[tuple[Any, str, str]] = []
         for c in all_containers:
             try:
                 if c.id in seen_ids:
@@ -598,23 +645,30 @@ def get_status() -> list[dict[str, Any]]:
                     slug = image_map.get(image_name.split(":")[0], "")
                 if slug:
                     seen_ids.add(c.id)
-                    cpu_pct, mem_mb, net_rx, net_tx = _collect_stats(c)
-                    results.append(
-                        {
-                            "slug": slug,
-                            "name": c.name,
-                            "status": c.status,
-                            "image": image_name or str(c.image.short_id),
-                            "cpu_percent": cpu_pct,
-                            "memory_mb": mem_mb,
-                            "net_rx_bytes": net_rx,
-                            "net_tx_bytes": net_tx,
-                            "created": c.attrs.get("Created", ""),
-                            "container_id": c.short_id,
-                            "deployed_by": "external",
-                            "category": "",
-                        }
-                    )
+                    matched.append((c, slug, image_name))
+            except Exception as exc:
+                logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
+
+        matched_stats = _collect_stats_bulk([c for c, _, _ in matched])
+        for c, slug, image_name in matched:
+            try:
+                cpu_pct, mem_mb, net_rx, net_tx = matched_stats.get(c.id, (0.0, 0.0, None, None))
+                results.append(
+                    {
+                        "slug": slug,
+                        "name": c.name,
+                        "status": c.status,
+                        "image": image_name or str(c.image.short_id),
+                        "cpu_percent": cpu_pct,
+                        "memory_mb": mem_mb,
+                        "net_rx_bytes": net_rx,
+                        "net_tx_bytes": net_tx,
+                        "created": c.attrs.get("Created", ""),
+                        "container_id": c.short_id,
+                        "deployed_by": "external",
+                        "category": "",
+                    }
+                )
             except Exception as exc:
                 logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -367,11 +367,15 @@ def read_critical_state(slug: str) -> tuple[bytes, list[str]]:
 
     if was_running:
         container.pause()
+    read_failure: BaseException | None = None
     try:
         for target in sorted(targets):
             stream, _stat = container.get_archive(target)
             chunks.append(b"".join(stream))
             read.append(target)
+    except BaseException as exc:
+        read_failure = exc
+        raise
     finally:
         if was_running:
             # Unpause even if the read failed: leaving a paused earner behind
@@ -379,10 +383,9 @@ def read_critical_state(slug: str) -> tuple[bytes, list[str]]:
             try:
                 container.unpause()
             except Exception as exc:
-                # Swallowed so it cannot mask the original error, but NEVER
-                # silent. A paused container renders normally and earns nothing,
-                # and nothing else in the system reports that state, so an
-                # unlogged failure here is an invisible, indefinite revenue stop.
+                # Never silent. A paused container renders normally and earns
+                # nothing, and nothing else in the system reports that state,
+                # so an unlogged failure here is an invisible revenue stop.
                 logger.error(
                     "CRITICAL: %s is still PAUSED — unpause failed (%s). It is earning "
                     "NOTHING until it is unpaused by hand: docker unpause %s",
@@ -390,6 +393,16 @@ def read_critical_state(slug: str) -> tuple[bytes, list[str]]:
                     exc,
                     container.name,
                 )
+                # Only swallow this while a read error is already on its way
+                # up, where re-raising would replace the real cause with a
+                # downstream symptom. When the read SUCCEEDED, staying quiet is
+                # worse than losing the archive: the caller would hand back a
+                # perfectly good backup, verification would report success, and
+                # the container would sit paused indefinitely with nothing
+                # anywhere contradicting the green result. The backup can be
+                # taken again; an unnoticed paused earner just stops paying.
+                if read_failure is None:
+                    raise
 
     return b"".join(chunks), read
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -7,7 +7,6 @@ inspection for cashpilot-managed containers via the Docker SDK.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 import time
@@ -377,8 +376,20 @@ def read_critical_state(slug: str) -> tuple[bytes, list[str]]:
         if was_running:
             # Unpause even if the read failed: leaving a paused earner behind
             # would silently stop the income this feature exists to protect.
-            with contextlib.suppress(Exception):
+            try:
                 container.unpause()
+            except Exception as exc:
+                # Swallowed so it cannot mask the original error, but NEVER
+                # silent. A paused container renders normally and earns nothing,
+                # and nothing else in the system reports that state, so an
+                # unlogged failure here is an invisible, indefinite revenue stop.
+                logger.error(
+                    "CRITICAL: %s is still PAUSED — unpause failed (%s). It is earning "
+                    "NOTHING until it is unpaused by hand: docker unpause %s",
+                    slug,
+                    exc,
+                    container.name,
+                )
 
     return b"".join(chunks), read
 

--- a/app/payouts.py
+++ b/app/payouts.py
@@ -29,6 +29,7 @@ Two rules run through everything below:
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 
 # Minimum history before a trailing rate means anything. Below this a single
@@ -142,8 +143,28 @@ def daily_rate(history: list[dict[str, Any]] | None) -> float | None:
         step = float(newer["balance"]) - float(older["balance"])
         if step > 0:
             gained += step
-    days = len(points) - 1
-    return gained / days if days > 0 else None
+
+    # Divide by ELAPSED CALENDAR DAYS, not by the number of readings. A day the
+    # collector failed produces no row at all, so counting intervals treats a
+    # ten-day gap as one day and inflates the rate by that factor — which then
+    # tells the user their payout is ten times nearer than it is.
+    days = _elapsed_days(points)
+    return gained / days if days and days > 0 else None
+
+
+def _elapsed_days(points: list[dict[str, Any]]) -> float | None:
+    """Calendar days between the first and last reading, when datable."""
+    first, last = points[0].get("date"), points[-1].get("date")
+    if first and last:
+        try:
+            span = (date.fromisoformat(str(last)) - date.fromisoformat(str(first))).days
+        except ValueError:
+            span = None
+        if span:
+            return float(span)
+    # No usable dates: fall back to the interval count, which is correct when
+    # readings really are daily and is the best available otherwise.
+    return float(len(points) - 1) or None
 
 
 def project(

--- a/app/payouts.py
+++ b/app/payouts.py
@@ -161,7 +161,11 @@ def _elapsed_days(points: list[dict[str, Any]]) -> float | None:
         except ValueError:
             span = None
         if span:
-            return float(span)
+            # Callers pass date-ordered history, but the distance between two
+            # dates does not depend on which end you start from, and a negative
+            # divisor here would invert the rate and project the payout into
+            # the past rather than the future.
+            return float(abs(span))
     # No usable dates: fall back to the interval count, which is correct when
     # readings really are daily and is the best available otherwise.
     return float(len(points) - 1) or None

--- a/app/producer_state.py
+++ b/app/producer_state.py
@@ -86,7 +86,7 @@ def assess(
     has_collector: bool,
     earned_recently: bool | None,
     log_hits: list[dict[str, str]] | None = None,
-    container_running: bool = True,
+    container_running: bool | None = True,
     traffic: str | None = None,
 ) -> dict[str, Any]:
     """Combine the available signals into one producer state.
@@ -95,10 +95,23 @@ def assess(
     not enough history. That is reported as UNKNOWN rather than guessed, because
     telling a user their service is idle when we simply cannot see its earnings
     is the same false confidence this module exists to remove.
+
+    ``container_running`` follows the same three-valued rule. None means the
+    lookup itself failed, which is NOT the same claim as "it is stopped" —
+    saying the container is not running when we simply could not ask sends the
+    user to restart something that may well be up.
     """
     log_hits = log_hits or []
     reasons: list[str] = []
     candidates: list[str] = []
+
+    if container_running is None:
+        return {
+            "slug": slug,
+            "state": UNKNOWN,
+            "reasons": ["Could not determine whether the container is running, so nothing here is judged."],
+            "log_hits": [],
+        }
 
     if not container_running:
         return {

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -1,7 +1,10 @@
 """Protected HTML page routes (dashboard, setup, catalog, settings, fleet).
 
-Handlers reference shared state through ``app.main`` so test patches on
-``app.auth_module.*`` / ``app.database.*`` continue to land.
+Handlers reach shared state through ``app.deps``, ``app.auth`` and
+``app.database`` directly — NOT through ``app.main``, which is what breaks the
+``main -> routers -> main`` import cycle. Test patches therefore target
+``app.auth.*`` / ``app.database.*``. ``app.auth`` is bound locally as
+``auth_module`` only to avoid shadowing the route helpers.
 """
 
 from __future__ import annotations

--- a/app/state_backup.py
+++ b/app/state_backup.py
@@ -147,7 +147,16 @@ def seal(
             raise BackupError("Recipient public key must be 32 bytes of hex (an X25519 public key).") from exc
         ephemeral = X25519PrivateKey.generate()
         header["ephemeral_public_key"] = ephemeral.public_key().public_bytes_raw().hex()
-        key = _derive_shared(ephemeral.exchange(recipient), salt)
+        try:
+            # A well-formed 32-byte key can still be a low-order point, for
+            # which the shared secret is all zeros and OpenSSL refuses the
+            # exchange with a bare ValueError. That is a 400 — the caller gave
+            # us an unusable key — not the 500 an escaping exception produces.
+            key = _derive_shared(ephemeral.exchange(recipient), salt)
+        except ValueError as exc:
+            raise BackupError(
+                "Recipient public key is not a usable X25519 point, so no shared key can be derived."
+            ) from exc
 
     header_bytes = json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8")
     # The header is authenticated, not encrypted: swapping the metadata that
@@ -209,7 +218,16 @@ def open_bundle(
             ephemeral = X25519PublicKey.from_public_bytes(bytes.fromhex(header["ephemeral_public_key"]))
         except (KeyError, ValueError, TypeError) as exc:
             raise BackupError("Bundle header is malformed, or the private key is not valid X25519.") from exc
-        key = _derive_shared(private.exchange(ephemeral), salt)
+        try:
+            # The ephemeral key here comes out of the BUNDLE, so it is
+            # attacker-controlled on a restore: a crafted bundle carrying a
+            # low-order point would otherwise crash the verify endpoint with an
+            # unhandled 500 instead of being rejected as the bad input it is.
+            key = _derive_shared(private.exchange(ephemeral), salt)
+        except ValueError as exc:
+            raise BackupError(
+                "Bundle's ephemeral public key is not a usable X25519 point, so it cannot be opened."
+            ) from exc
     else:
         raise BackupError(f"Unknown bundle mode {mode!r}.")
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2230,18 +2230,26 @@ const CP = (() => {
 
       badge.style.display = '';
       badge.textContent = alerts.length;
-      list.innerHTML = alerts.map(a => `
-        <div class="notify-item" data-platform="${escapeHtml(a.platform)}">
+      // A payout is a question, not a fault. Rendering it with the warning
+      // triangle and an "Update credentials" button would tell the user
+      // something is broken at the exact moment they got paid.
+      const WARNING_ICON = '<path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>';
+      const PAYOUT_ICON = '<circle cx="12" cy="12" r="10"/><path d="M12 6v12M15 9.5a2.5 2.5 0 00-2.5-1.5h-1a2 2 0 000 4h1a2 2 0 010 4h-1A2.5 2.5 0 019 14.5"/>';
+      list.innerHTML = alerts.map(a => {
+        const isPayout = a.kind === 'payout';
+        return `
+        <div class="notify-item" data-platform="${escapeHtml(a.platform)}" data-kind="${escapeHtml(a.kind || 'collector')}">
           <div class="notify-item-icon">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${isPayout ? PAYOUT_ICON : WARNING_ICON}</svg>
           </div>
           <div class="notify-item-body">
-            <div class="notify-item-platform">${escapeHtml(a.platform)}</div>
+            <div class="notify-item-platform">${escapeHtml(a.platform)}${isPayout ? ' — payout?' : ''}</div>
             <div class="notify-item-msg" title="${escapeHtml(a.error)}">${escapeHtml(a.error)}</div>
           </div>
-          ${_isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
+          ${!isPayout && _isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
         </div>
-      `).join('');
+      `;
+      }).join('');
     } catch {
       // The bell's own fetch failed — this is unknown, not healthy. Show a
       // neutral/muted indicator rather than hiding the badge (which would

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -831,7 +831,7 @@ def _validate_runtime(runtime: str | None) -> None:
     error the user cannot act on; asking the daemon means the only runtimes
     accepted are ones that exist here.
 
-    Nothing selects a non-default runtime on its own. See docs/isolation.md for
+    Nothing selects a non-default runtime on its own. See docs/security-defaults.md for
     why gVisor is not adopted as a default or as a supported profile: it costs
     roughly 1.7x network throughput on a workload that is pure network I/O, it
     breaks host-networked services outright, and it does not address the risks

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -411,11 +411,6 @@ async def _send_heartbeat() -> None:
         logger.warning("Heartbeat failed: %s", exc)
         if status == 401 and _worker_key:
             _consecutive_auth_failures += 1
-        else:
-            # Any other outcome breaks the run. "Consecutive" has to mean it:
-            # 401 -> timeout -> 401 -> 500 -> 401 is a flaky link, not an
-            # identity mismatch, and must not raise the alarm.
-            _consecutive_auth_failures = 0
             if _consecutive_auth_failures == _AUTH_FAILURE_ALARM_AFTER:
                 # A per-worker key rejected repeatedly almost always means our
                 # client_id no longer matches the row the UI enrolled — usually
@@ -431,6 +426,11 @@ async def _send_heartbeat() -> None:
                     CLIENT_ID,
                     _WORKER_ID_FILE,
                 )
+        else:
+            # Any other outcome breaks the run. "Consecutive" has to mean it:
+            # 401 -> timeout -> 401 -> 500 -> 401 is a flaky link, not an
+            # identity mismatch, and must not raise the alarm.
+            _consecutive_auth_failures = 0
     except Exception as exc:
         _ui_connected = False
         _last_error = "connection failed"
@@ -1055,9 +1055,18 @@ class BackupRequest(BaseModel):
 
 
 class VerifyRequest(BackupRequest):
-    """A bundle to check against the state currently on disk."""
+    """A bundle to check against the state currently on disk.
+
+    Recipient-mode verification needs the PRIVATE half — decryption happens in
+    memory on the worker and the key is discarded with the request. This is the
+    one moment recipient mode is not key-free, so the field says so rather than
+    letting someone paste a private key into something named `_public_key`
+    without noticing what they just did. Verify from a host you trust, or use
+    passphrase mode if that is not acceptable.
+    """
 
     bundle_b64: str = ""
+    recipient_private_key: str | None = None
 
 
 @app.post("/api/containers/{slug}/backup")
@@ -1135,7 +1144,7 @@ async def api_backup_verify(slug: str, body: VerifyRequest, request: Request) ->
             bundle,
             payload,
             passphrase=body.passphrase,
-            recipient_private_key=body.recipient_public_key,
+            recipient_private_key=body.recipient_private_key,
         )
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,37 @@ def _reset_setup_token():
     yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_process_wide_caches():
+    """Clear the remaining module-level state that outlives a single test.
+
+    These are process-wide and were each being reset by hand at the top of the
+    tests that happened to know about them — `_last_attempt` in three separate
+    places in test_collector_contracts.py, `_net_baselines` in two more. That
+    works only for as long as every future test author remembers the
+    boilerplate, and the failure when someone forgets is an order-dependent
+    flake in a DIFFERENT file, which is about the most expensive kind of test
+    bug to track down.
+
+    `_last_attempt` in particular is a live trap: it holds a real cooldown, so
+    a test that triggers a credential test leaves the next one rate-limited.
+    """
+    for module_name, attr in (
+        ("app.main", "_net_baselines"),
+        ("app.credential_test", "_last_attempt"),
+    ):
+        with contextlib.suppress(Exception):
+            import importlib
+
+            getattr(importlib.import_module(module_name), attr).clear()
+    with contextlib.suppress(Exception):
+        from app import orchestrator
+
+        orchestrator._status_cache = []
+        orchestrator._status_cache_time = 0.0
+    yield
+
+
 @pytest.fixture(scope="session")
 def _real_catalog_slugs():
     from app import catalog

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -485,3 +485,87 @@ class TestTheCredentialCooldownCannotBeRaced:
             "an await sits between the cooldown check and note_attempt, so two "
             "concurrent requests can both pass the check and both hit the provider"
         )
+
+
+class TestAPayoutPromptSurvivesUntilItIsAnswered:
+    """A prompt that vanishes on its own is worse than no prompt.
+
+    `record_probable_payout` returns None while one is already pending, so
+    `_detect_payout` reported a payout on the run that noticed it and None
+    forever after. Rebuilding the bell from that alone made the question
+    disappear on the very next collection — before the user could answer it.
+    """
+
+    PENDING = [
+        {"id": 1, "platform": "honeygain", "amount": 25.0, "currency": "USD", "confirmed": 0},
+        {"id": 2, "platform": "iproyal", "amount": 5.0, "currency": "USD", "confirmed": 1},
+    ]
+
+    def test_an_unanswered_payout_is_re_added_on_a_later_run(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_payouts", AsyncMock(return_value=self.PENDING)):
+            alerts = asyncio.run(main._pending_payout_alerts())
+        assert [a["platform"] for a in alerts] == ["honeygain"], "the pending question must persist"
+        assert alerts[0]["kind"] == "payout"
+
+    def test_an_already_confirmed_payout_is_not_asked_about_again(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_payouts", AsyncMock(return_value=self.PENDING)):
+            alerts = asyncio.run(main._pending_payout_alerts())
+        assert all(a["platform"] != "iproyal" for a in alerts)
+
+    def test_it_does_not_duplicate_one_detected_in_this_run(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_payouts", AsyncMock(return_value=self.PENDING)):
+            alerts = asyncio.run(main._pending_payout_alerts(seen={"honeygain"}))
+        assert alerts == [], "the same payout would appear twice in the bell"
+
+    def test_the_message_tells_the_user_what_to_do(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_payouts", AsyncMock(return_value=self.PENDING)):
+            message = asyncio.run(main._pending_payout_alerts())[0]["error"]
+        assert "Confirm or reject" in message
+
+    def test_a_database_failure_does_not_break_the_collection_run(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with patch.object(main.database, "get_payouts", AsyncMock(side_effect=RuntimeError("db down"))):
+            assert asyncio.run(main._pending_payout_alerts()) == []
+
+    def test_answering_a_payout_retires_its_prompt(self):
+        """Otherwise a restart restores it and asks again about a settled payout."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main.database, "get_payouts", AsyncMock(return_value=self.PENDING)),
+            patch.object(main.database, "clear_alerts", AsyncMock()) as cleared,
+            patch.object(main, "_collector_alerts", [{"kind": "payout", "platform": "honeygain", "error": "x"}]),
+        ):
+            asyncio.run(main._retire_payout_alert(1))
+            cleared.assert_awaited_once_with("payout", "honeygain")
+            # Inside the patch: _retire_payout_alert REBINDS the module global,
+            # and patch.object restores it on exit, so asserting afterwards
+            # would read the original list and pass for the wrong reason.
+            assert main._collector_alerts == []

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -332,3 +332,156 @@ class TestWorkerCredentialsNeverReachAResponse:
         one, _ = self._worker_endpoints(tmp_path)
         assert one["name"] == "host"
         assert "containers" in one and "system_info" in one
+
+
+class TestADetectedPayoutActuallyReachesTheUser:
+    """The prompt is the entire feature. Filing it silently is the same as not detecting it.
+
+    `_detect_payout` ran in the collection SUCCESS branch and wrote to the
+    database; the bell renders the in-memory list built by the FAILURE branch;
+    and the startup restore dropped every alert whose kind was not "collector".
+    So a detected payout was recorded and then shown to nobody, live or after a
+    restart — the user was never asked the question the feature exists to ask.
+    """
+
+    def test_a_detected_payout_is_returned_so_the_bell_can_show_it(self):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        result = MagicMock(platform="honeygain", balance=0.10, currency="USD")
+
+        async def run():
+            with (
+                patch.object(main.database, "get_latest_balance", AsyncMock(return_value=25.0)),
+                patch.object(main.database, "record_probable_payout", AsyncMock(return_value=7)),
+                patch.object(main.database, "record_alert", AsyncMock()),
+                patch.object(
+                    main.catalog, "get_service", return_value={"slug": "honeygain", "cashout": {"min_amount": 20.0}}
+                ),
+            ):
+                return await main._detect_payout(result)
+
+        alert = asyncio.run(run())
+        assert alert is not None, "detected and then dropped on the floor"
+        assert alert["kind"] == "payout"
+        assert alert["platform"] == "honeygain"
+
+    def test_nothing_is_returned_when_there_is_no_payout(self):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        result = MagicMock(platform="honeygain", balance=26.0, currency="USD")
+
+        async def run():
+            with (
+                patch.object(main.database, "get_latest_balance", AsyncMock(return_value=25.0)),
+                patch.object(
+                    main.catalog, "get_service", return_value={"slug": "honeygain", "cashout": {"min_amount": 20.0}}
+                ),
+            ):
+                return await main._detect_payout(result)
+
+        assert asyncio.run(run()) is None
+
+    def test_a_restart_does_not_lose_the_pending_question(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        stored = [
+            {"kind": "payout", "subject": "honeygain", "message": "Balance dropped by 25.00"},
+            {"kind": "collector", "subject": "grass", "message": "login failed"},
+        ]
+
+        async def run():
+            with patch.object(main.database, "list_alerts", AsyncMock(return_value=stored)):
+                await main._warm_collector_alerts()
+
+        asyncio.run(run())
+        kinds = {a.get("kind") for a in main._collector_alerts}
+        assert "payout" in kinds, "the payout prompt was dropped on restart"
+        assert "collector" in kinds, "restoring payouts must not cost us collector alerts"
+
+    def test_a_platform_can_have_both_a_broken_collector_and_a_payout(self):
+        """Deduping by subject alone would silently hide one of them."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        stored = [
+            {"kind": "payout", "subject": "honeygain", "message": "Balance dropped"},
+            {"kind": "collector", "subject": "honeygain", "message": "login failed"},
+        ]
+
+        async def run():
+            with patch.object(main.database, "list_alerts", AsyncMock(return_value=stored)):
+                await main._warm_collector_alerts()
+
+        asyncio.run(run())
+        assert len(main._collector_alerts) == 2, main._collector_alerts
+
+    def test_the_endpoint_tags_every_alert_so_the_bell_can_tell_them_apart(self):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from app import main
+
+        with (
+            patch.object(main, "_collector_alerts", [{"platform": "grass", "error": "boom"}]),
+            patch.object(main, "_require_auth_api", lambda r: None),
+        ):
+            out = asyncio.run(main.api_collector_alerts(MagicMock()))
+        assert out[0]["kind"] == "collector", "an untagged alert must default to collector, not vanish"
+
+
+class TestTheCredentialCooldownCannotBeRaced:
+    """Two clicks must not both reach the provider.
+
+    Repeated logins are what get an account flagged, which is the only reason
+    the cooldown exists. The check and the claim were separated by
+    `await database.get_config()`, and an await is exactly where the event loop
+    runs the other request.
+    """
+
+    def test_the_claim_is_not_separated_from_its_check_by_an_await(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from app import main
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(main.api_test_credentials)))
+        body = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)).body
+
+        def flatten(nodes):
+            for node in nodes:
+                yield node
+                for field in ("body", "orelse", "finalbody"):
+                    yield from flatten(getattr(node, field, []) or [])
+
+        order = []
+        for node in flatten(body):
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Await):
+                    order.append(("await", node.lineno))
+                elif (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr in ("cooldown_remaining", "note_attempt")
+                ):
+                    order.append((sub.func.attr, node.lineno))
+        sequence = [name for name, _ in sorted(set(order), key=lambda p: p[1])]
+        claim = sequence.index("note_attempt")
+        preceding = sequence[:claim]
+        assert "cooldown_remaining" in preceding, "nothing checks the cooldown before claiming it"
+        last_check = len(preceding) - 1 - preceding[::-1].index("cooldown_remaining")
+        assert "await" not in sequence[last_check:claim], (
+            "an await sits between the cooldown check and note_attempt, so two "
+            "concurrent requests can both pass the check and both hit the provider"
+        )

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -278,3 +278,57 @@ class TestNoRouteIsShadowedByAnEarlierParameterisedOne:
                 f"{method} {route.path} is shadowed by {getattr(winner, 'path', None)} "
                 "— it is declared after a parameterised route that swallows it"
             )
+
+
+class TestWorkerCredentialsNeverReachAResponse:
+    """`list_workers` is a `SELECT *`, so the fleet key rides along by default.
+
+    Verified against the running handlers before the fix: GET /api/workers and
+    GET /api/workers/{id} both returned `api_key_enc` to any authenticated
+    caller, viewers included. Encryption at rest is not a reason to publish the
+    ciphertext — doing so makes the Fernet key the only thing between a
+    read-only account and every worker's credential.
+    """
+
+    def _worker_endpoints(self, tmp_path):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from app import database, main
+
+        async def run():
+            with (
+                patch.object(database, "DB_DIR", tmp_path),
+                patch.object(database, "DB_PATH", tmp_path / "w.db"),
+            ):
+                await database.init_db()
+                await database.upsert_worker(client_id="w1", name="host", url="http://w:8081")
+                await database.set_worker_key("w1", "a-real-fleet-key")
+                rows = await database.list_workers()
+                assert rows[0].get("api_key_enc"), "fixture must actually store a key"
+                with patch.object(main, "_require_auth_api", lambda r: None):
+                    one = await main.api_get_worker(MagicMock(), rows[0]["id"])
+                    many = await main.api_list_workers(MagicMock())
+                return one, many
+
+        return asyncio.run(run())
+
+    def test_the_single_worker_endpoint_omits_the_key(self, tmp_path):
+        one, _ = self._worker_endpoints(tmp_path)
+        assert "api_key_enc" not in one
+
+    def test_the_list_endpoint_omits_the_key(self, tmp_path):
+        _, many = self._worker_endpoints(tmp_path)
+        assert all("api_key_enc" not in w for w in many)
+
+    def test_no_response_field_carries_the_ciphertext_under_another_name(self, tmp_path):
+        """Renaming the column must not quietly restore the leak."""
+        one, _ = self._worker_endpoints(tmp_path)
+        blob = repr(one)
+        assert "gAAAAA" not in blob, "a Fernet token appears in the response"
+
+    def test_the_worker_is_still_usable_without_it(self, tmp_path):
+        """A stripping fix that empties the payload is not a fix."""
+        one, _ = self._worker_endpoints(tmp_path)
+        assert one["name"] == "host"
+        assert "containers" in one and "system_info" in one

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -154,6 +154,77 @@ class TestTheWorkerImageShipsEveryModuleItImports:
         assert {"worker_api", "orchestrator", "egress"} <= closure, closure
 
 
+class TestNoConditionIsStaticallyImpossible:
+    """Generalises the dead 401 alarm rather than just fixing it.
+
+    That block compared a counter to 3 in the branch that had just set it to 0
+    — `0 == 3`, never true, so the alarm was unreachable while a test named for
+    it passed. A misplaced block is invisible to every check that asks whether
+    code survived: a line moved into the wrong branch still survives.
+
+    So this asks a different question — is any comparison decidable at parse
+    time? A hand-written condition should not be.
+    """
+
+    def _impossible(self, path: Path) -> list[str]:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        # A name assigned a constant in the same branch, then compared against
+        # a different constant, is the shape that hid the alarm.
+        found = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            for branch in (node.body, node.orelse):
+                assigned: dict[str, object] = {}
+                for stmt in branch:
+                    if (
+                        isinstance(stmt, ast.Assign)
+                        and len(stmt.targets) == 1
+                        and isinstance(stmt.targets[0], ast.Name)
+                        and isinstance(stmt.value, ast.Constant)
+                    ):
+                        assigned[stmt.targets[0].id] = stmt.value.value
+                    elif isinstance(stmt, ast.If):
+                        test = stmt.test
+                        if (
+                            isinstance(test, ast.Compare)
+                            and isinstance(test.left, ast.Name)
+                            and test.left.id in assigned
+                            and len(test.ops) == 1
+                            and isinstance(test.ops[0], ast.Eq)
+                            and isinstance(test.comparators[0], ast.Constant)
+                            and assigned[test.left.id] != test.comparators[0].value
+                        ):
+                            found.append(f"{path.name}:{stmt.lineno} `{test.left.id}` is always != here")
+        return found
+
+    def test_no_module_contains_an_unreachable_branch(self):
+        offenders = [f for p in sorted((ROOT / "app").rglob("*.py")) for f in self._impossible(p)]
+        assert not offenders, "condition can never be true — the block is dead code: " + "; ".join(offenders)
+
+    def test_the_detector_catches_the_defect_it_was_written_for(self):
+        """A checker nobody proved is a checker that quietly passes forever.
+
+        My first version of this scanned only `body` and missed the real bug,
+        which lived in `orelse`.
+        """
+        import tempfile
+
+        source = (
+            "def f(s):\n"
+            "    if s == 401:\n"
+            "        n += 1\n"
+            "    else:\n"
+            "        n = 0\n"
+            "        if n == 3:\n"
+            "            alarm()\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "regression.py"
+            path.write_text(source, encoding="utf-8")
+            assert self._impossible(path), "the detector cannot see the bug it exists for"
+
+
 class TestOneTariffKey:
     """Two features shipped reading different config keys for one tariff.
 

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -1,0 +1,209 @@
+"""Guards for defects found in the v1.10.0 audit.
+
+Each class here exists because a real defect got past the suite. The point is
+not coverage — it is that the *shape* of each failure now turns the build red.
+
+The auth class is the sharpest example: deleting `_require_auth_api` from five
+endpoints was verified to leave all 2108 tests passing, because every endpoint
+test patches the guard away before calling the handler.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _unauthenticated():
+    request = MagicMock()
+    request.session = {}
+    request.headers = {}
+    request.cookies = {}
+    return request
+
+
+def _call(fn, *args):
+    import asyncio
+
+    return asyncio.run(fn(_unauthenticated(), *args))
+
+
+class TestEveryEndpointRejectsAnAnonymousCaller:
+    """Verified necessary: removing the guard left the whole suite green.
+
+    Every other endpoint test patches `_require_auth_api` to a no-op before
+    calling the handler, so nothing anywhere noticed the guard was gone.
+    """
+
+    @pytest.mark.parametrize(
+        ("name", "args"),
+        [
+            ("api_fleet_egress_groups", ()),
+            ("api_service_preflight", ("honeygain",)),
+            ("api_producer_state", ("honeygain",)),
+            ("api_payout_progress", ("honeygain",)),
+            ("api_fleet_economics", ()),
+            ("api_payouts", ()),
+            ("api_deploy_risk", ("mysterium",)),
+            ("api_isolation_guide", ()),
+            ("api_service_disclosure", ("mysterium",)),
+            ("api_disclosure_coverage", ()),
+            ("api_earnings_net", ()),
+        ],
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_a_read_endpoint_requires_authentication(self, name, args):
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            _call(getattr(main, name), *args)
+        assert exc.value.status_code == 401, f"{name} served an unauthenticated caller"
+
+    @pytest.mark.parametrize(
+        ("name", "args"),
+        [("api_test_credentials", ("honeygain",)), ("api_confirm_payout", (1,)), ("api_reject_payout", (1,))],
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_a_mutating_endpoint_rejects_an_anonymous_caller(self, name, args):
+        from app import main
+
+        with pytest.raises(HTTPException) as exc:
+            _call(getattr(main, name), *args)
+        assert exc.value.status_code in (401, 403), f"{name} served an unauthenticated caller"
+
+
+class TestMutatingEndpointsSitAboveViewer:
+    """The repo's ladder: reads -> auth, actions -> writer, secrets -> owner.
+
+    Three v1.10.0 endpoints deviated silently: a viewer could fire an
+    authenticated login to a provider using the owner's credentials, and could
+    permanently DELETE payout rows.
+    """
+
+    LADDER = {
+        "api_test_credentials": "_require_owner",
+        "api_confirm_payout": "_require_writer",
+        "api_reject_payout": "_require_writer",
+    }
+
+    @pytest.mark.parametrize(("name", "expected"), sorted(LADDER.items()), ids=lambda v: v)
+    def test_the_expected_guard_is_the_one_called(self, name, expected):
+        import inspect
+        import textwrap
+
+        from app import main
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(main, name))))
+        called = {n.func.id for n in ast.walk(tree) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+        assert expected in called, (
+            f"{name} should call {expected}, called {sorted(called & {'_require_auth_api', '_require_writer', '_require_owner'})}"
+        )
+
+
+class TestTheWorkerImageShipsEveryModuleItImports:
+    """A missing COPY line is a crash that ONLY happens in the real image.
+
+    Local tests pass (the module is on disk), `docker build` succeeds (the
+    listed files still copy), and the container then crash-loops on the user's
+    machine after a pull. Nothing else in the pipeline can see it.
+    """
+
+    def _closure(self) -> set[str]:
+        seen: set[str] = set()
+        queue = ["worker_api"]
+        while queue:
+            mod = queue.pop()
+            if mod in seen:
+                continue
+            path = ROOT / "app" / f"{mod}.py"
+            if not path.exists():
+                continue
+            seen.add(mod)
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("app"):
+                    parts = (node.module or "").split(".")
+                    if len(parts) > 1:
+                        queue.append(parts[1])
+                    queue.extend(a.name for a in node.names)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.startswith("app."):
+                            queue.append(alias.name.split(".")[1])
+        return seen
+
+    def test_every_imported_module_is_copied_into_the_image(self):
+        dockerfile = (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")
+        copied = set(re.findall(r"COPY[^\n]*\sapp/([a-z_]+)\.py\s", dockerfile))
+        missing = {m for m in self._closure() if m != "__init__"} - copied - {"collectors"}
+        assert not missing, (
+            f"app/worker_api.py imports {sorted(missing)}, which Dockerfile.worker does not COPY. "
+            "The image would build fine and then crash-loop on a user's machine."
+        )
+
+    def test_the_closure_is_not_trivially_empty(self):
+        """A broken parser would make the test above vacuously pass."""
+        closure = self._closure()
+        assert {"worker_api", "orchestrator", "egress"} <= closure, closure
+
+
+class TestOneTariffKey:
+    """Two features shipped reading different config keys for one tariff.
+
+    Setting one left the other reporting "cost unknown" forever — and both
+    unknown-paths are deliberately quiet, which is exactly what hid it.
+    """
+
+    def test_both_endpoints_read_the_same_canonical_key(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        canonical = source.count("power_price_per_kwh")
+        assert canonical >= 2, "the canonical tariff key should be read by both consumers"
+
+    def test_the_newer_key_is_still_honoured_as_a_fallback(self):
+        """Nobody's existing config should break because we picked a name."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'config.get("power_price_per_kwh") or config.get("electricity_price_per_kwh")' in source
+
+
+class TestNoRouteIsShadowedByAnEarlierParameterisedOne:
+    """FastAPI matches in declaration order.
+
+    Every v1.10.0 endpoint was appended 800+ lines below `/api/services/{slug}`
+    and escaped only because each carries a second path segment. A future
+    `/api/services/summary` would 404 with no error anywhere.
+    """
+
+    def test_every_literal_path_resolves_to_its_own_handler(self):
+        from fastapi.routing import APIRoute
+
+        from app.main import app
+
+        literals = [
+            r for r in app.routes if isinstance(r, APIRoute) and "{" not in r.path and r.path.startswith("/api/")
+        ]
+        for route in literals:
+            method = next(iter(route.methods - {"HEAD", "OPTIONS"}), "GET")
+            scope = {
+                "type": "http",
+                "path": route.path,
+                "method": method,
+                "path_params": {},
+                "headers": [],
+                "query_string": b"",
+                "root_path": "",
+            }
+            winner = next(
+                (r for r in app.routes if isinstance(r, APIRoute) and r.matches(scope)[0].name == "FULL"),
+                None,
+            )
+            assert winner is route, (
+                f"{method} {route.path} is shadowed by {getattr(winner, 'path', None)} "
+                "— it is declared after a parameterised route that swallows it"
+            )

--- a/tests/test_collector_contracts.py
+++ b/tests/test_collector_contracts.py
@@ -213,7 +213,7 @@ class TestCredentialSelfTest:
 
         async def run():
             with (
-                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main, "_require_owner", lambda r: None),
                 patch.object(main.database, "get_config", AsyncMock(return_value=config or {})),
                 patch("app.collectors.build_one", return_value=build),
             ):
@@ -275,7 +275,7 @@ class TestCredentialSelfTest:
 
         async def run():
             with (
-                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main, "_require_owner", lambda r: None),
                 patch.object(main.database, "get_config", AsyncMock(return_value={})),
                 patch("app.collectors.build_one", return_value=(collector, [])),
             ):
@@ -301,7 +301,7 @@ class TestCredentialSelfTest:
 
         async def run():
             with (
-                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main, "_require_owner", lambda r: None),
                 patch.object(main.database, "get_config", AsyncMock(return_value={})),
                 patch("app.collectors.build_one", return_value=(collector, [])),
             ):

--- a/tests/test_dashboard_currency.py
+++ b/tests/test_dashboard_currency.py
@@ -1,0 +1,163 @@
+"""The dashboard cards and the trend chart must count non-USD platforms.
+
+Three separate SQL aggregates and the chart query each carried their own copy
+of the earnings arithmetic, and every one of them filtered ``currency = 'USD'``.
+An installation earning MYST, GRASS or ANYONE — which is most of this catalog —
+saw "$0.00 today", "$0.00 this month" and a flat-zero chart while its balances
+climbed all week. Nothing looked broken; the numbers were simply wrong.
+
+The existing tests could not catch it: `tests/test_database.py` only ever
+inserts USD rows, and `tests/test_summary_bonus.py` / `tests/test_main_routes.py`
+mock the summary function entirely. Every one of them passes against the bug.
+So these tests are all mixed-currency by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app import database
+
+
+def day(n: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=n)).strftime("%Y-%m-%d")
+
+
+class Fixture:
+    """A real SQLite database, because the bug lived in the SQL."""
+
+    def __init__(self, tmp_path, name):
+        self.tmp_path = tmp_path
+        self.name = name
+        self.rows: list[tuple] = []
+
+    def earning(self, platform, balance, days_ago, currency="USD", rate=None):
+        self.rows.append((platform, balance, days_ago, currency, rate))
+        return self
+
+    def _run(self, coro_factory):
+        async def go():
+            with (
+                patch.object(database, "DB_DIR", self.tmp_path),
+                patch.object(database, "DB_PATH", self.tmp_path / f"{self.name}.db"),
+            ):
+                await database.init_db()
+                for platform, balance, days_ago, currency, rate in self.rows:
+                    await database.upsert_earnings(
+                        platform, balance, currency=currency, date=day(days_ago), fx_rate_usd=rate
+                    )
+                return await coro_factory()
+
+        return asyncio.run(go())
+
+    def summary(self):
+        return self._run(database.get_earnings_dashboard_summary)
+
+    def chart(self, days=7):
+        return self._run(lambda: database.get_daily_earnings(days=days))
+
+
+class TestTheCardsCountEveryCurrency:
+    def test_a_token_only_fleet_does_not_read_as_zero(self, tmp_path):
+        """The reported symptom: MystNodes-only, balance climbing, cards at $0.00."""
+        summary = (
+            Fixture(tmp_path, "myst")
+            .earning("mysterium", 100.0, 1, "MYST", 0.10)
+            .earning("mysterium", 102.0, 0, "MYST", 0.10)
+            .summary()
+        )
+        assert summary["today"] == pytest.approx(0.20)
+
+    def test_usd_and_token_platforms_add_up_together(self, tmp_path):
+        summary = (
+            Fixture(tmp_path, "mix")
+            .earning("mysterium", 100.0, 1, "MYST", 0.10)
+            .earning("mysterium", 102.0, 0, "MYST", 0.10)
+            .earning("honeygain", 5.0, 1)
+            .earning("honeygain", 5.5, 0)
+            .summary()
+        )
+        assert summary["today"] == pytest.approx(0.70), "0.20 from MYST + 0.50 from USD"
+
+    def test_the_month_includes_token_earnings(self, tmp_path):
+        summary = (
+            Fixture(tmp_path, "month")
+            .earning("grass", 1000.0, 2, "GRASS", 0.002)
+            .earning("grass", 1500.0, 0, "GRASS", 0.002)
+            .summary()
+        )
+        assert summary["month"] == pytest.approx(1.0)
+
+    def test_the_delta_is_priced_not_the_balance(self, tmp_path):
+        """A rate move alone must not move the card.
+
+        Converting the running total and subtracting afterwards would report
+        the rate change itself as income.
+        """
+        summary = (
+            Fixture(tmp_path, "ratemove")
+            .earning("mysterium", 100.0, 1, "MYST", 0.50)
+            .earning("mysterium", 100.0, 0, "MYST", 0.90)
+            .summary()
+        )
+        assert summary["today"] == pytest.approx(0.0), "the balance never moved"
+
+    def test_an_unpriced_platform_is_excluded_rather_than_counted_at_parity(self, tmp_path):
+        """1 GRASS is not $1."""
+        summary = (
+            Fixture(tmp_path, "unpriced")
+            .earning("grass", 1000.0, 1, "GRASS")
+            .earning("grass", 2000.0, 0, "GRASS")
+            .summary()
+        )
+        assert summary["today"] == pytest.approx(0.0)
+
+
+class TestTheChartCountsEveryCurrency:
+    def test_a_token_only_fleet_does_not_draw_a_flat_zero_line(self, tmp_path):
+        chart = (
+            Fixture(tmp_path, "chart")
+            .earning("mysterium", 100.0, 1, "MYST", 0.10)
+            .earning("mysterium", 102.0, 0, "MYST", 0.10)
+            .chart(days=3)
+        )
+        assert chart[-1]["amount"] == pytest.approx(0.20)
+        assert any(point["amount"] > 0 for point in chart), "every bar was zero"
+
+    def test_a_new_platform_does_not_spike_its_whole_opening_balance(self, tmp_path):
+        """A first-ever reading is not a day's earnings.
+
+        Differencing against an implicit zero drew a newly added service as one
+        enormous bar the size of its entire existing balance.
+        """
+        chart = Fixture(tmp_path, "spike").earning("honeygain", 250.0, 0).chart(days=3)
+        assert all(point["amount"] == 0 for point in chart), f"opening balance counted as earnings: {chart}"
+
+    def test_the_chart_and_the_today_card_agree(self, tmp_path):
+        """They were computed by two separate queries and could disagree."""
+        fixture = (
+            Fixture(tmp_path, "agree")
+            .earning("mysterium", 100.0, 1, "MYST", 0.10)
+            .earning("mysterium", 102.0, 0, "MYST", 0.10)
+            .earning("honeygain", 5.0, 1)
+            .earning("honeygain", 5.5, 0)
+        )
+        assert fixture.chart(days=2)[-1]["amount"] == pytest.approx(fixture.summary()["today"])
+
+
+class TestThePayoutClampSurvivedTheRewrite:
+    def test_a_payout_on_one_platform_does_not_eat_another_platforms_earnings(self, tmp_path):
+        """The reason the original clamped per platform before summing."""
+        summary = (
+            Fixture(tmp_path, "clamp")
+            .earning("honeygain", 20.0, 1)
+            .earning("honeygain", 0.10, 0)  # paid out
+            .earning("iproyal", 5.0, 1)
+            .earning("iproyal", 6.0, 0)  # genuinely earned 1.00
+            .summary()
+        )
+        assert summary["today"] == pytest.approx(1.0), "the payout drop cancelled real earnings"

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -14,6 +14,7 @@ much later as flakiness nobody can place.
 
 from __future__ import annotations
 
+import ast
 from time import monotonic
 
 import pytest
@@ -30,18 +31,35 @@ def _clean():
     rl._login_attempts.clear()
 
 
+def imports_main(node) -> bool:
+    """Does this AST node import ``app.main``, written any of the usual ways?
+
+    The original version of this check tested only ``node.module.endswith("main")``,
+    which misses ``from app import main`` entirely — that node's *module* is
+    "app" and "main" is an alias NAME. Proven with a negative control: planting
+    `from app import main` in a router left the guard green, and that is the
+    idiomatic form everywhere else in this codebase (`from app import database,
+    deps`). The guard that certifies the cycle is gone was blind to the most
+    likely way of bringing it back.
+    """
+    if isinstance(node, ast.Import):
+        # import app.main / import main
+        return any(alias.name == "main" or alias.name.endswith(".main") for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        # from app.main import X / from .main import X
+        if module == "main" or module.endswith(".main"):
+            return True
+        # from app import main / from . import main
+        return any(alias.name == "main" for alias in node.names)
+    return False
+
+
 class TestTheCycleIsGone:
     def test_no_router_imports_main(self):
         """This is the whole reason the module exists."""
         import ast
         import pathlib
-
-        def imports_main(node) -> bool:
-            if isinstance(node, ast.Import):
-                return any(alias.name.endswith("main") for alias in node.names)
-            if isinstance(node, ast.ImportFrom):
-                return (node.module or "").endswith("main")
-            return False
 
         offenders = sorted(
             path.name
@@ -49,6 +67,43 @@ class TestTheCycleIsGone:
             if any(imports_main(node) for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))))
         )
         assert not offenders, f"routers still import main: {offenders}"
+
+    def test_no_module_anywhere_under_app_imports_main(self):
+        """The guard above globs ONLY ``routers/*.py``.
+
+        A new top-level module — ``app/fleet_state.py``, ``app/jobs.py``, the
+        next extraction someone reaches for — falls entirely outside that glob
+        and would reintroduce the cycle completely unguarded. Widening it costs
+        nothing and is what makes the next extraction cheap, whether or not one
+        ever happens.
+
+        ``app.main`` itself is excluded for the obvious reason, and so are the
+        routers, which the test above reports with a clearer message.
+        """
+        import ast
+        import pathlib
+
+        app_dir = pathlib.Path(main.__file__).parent
+        offenders = sorted(
+            str(path.relative_to(app_dir))
+            for path in app_dir.rglob("*.py")
+            if path.name != "main.py"
+            and any(imports_main(node) for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))))
+        )
+        assert not offenders, f"these import app.main and would recreate the cycle: {offenders}"
+
+    def test_that_guard_actually_looks_beyond_the_routers(self):
+        """A checker that silently scans nothing passes forever.
+
+        The first version of the widened guard could have kept the old glob by
+        accident and still gone green, so this asserts it reaches modules the
+        routers glob never covered.
+        """
+        import pathlib
+
+        app_dir = pathlib.Path(main.__file__).parent
+        scanned = {str(p.relative_to(app_dir)) for p in app_dir.rglob("*.py") if p.name != "main.py"}
+        assert {"database.py", "orchestrator.py", "worker_api.py"} <= scanned, scanned
 
     def test_the_rate_limiter_imports_nothing_from_the_app(self):
         """Otherwise it could be pulled back into a cycle later."""

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -192,7 +192,11 @@ class TestEndpoints:
         from app import main
 
         with (
+            # Stand in for an authorized caller. Reads need auth; confirm/reject
+            # need writer. Which guard each endpoint actually enforces is the
+            # subject of tests/test_audit_guards.py, not of these.
             patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_require_writer", lambda r: None),
             patch.object(main.database, "get_latest_balance", AsyncMock(return_value=patches.get("balance"))),
             patch.object(main.database, "get_balance_history", AsyncMock(return_value=patches.get("history", []))),
             patch.object(main.database, "get_payouts", AsyncMock(return_value=patches.get("payouts", []))),

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -422,10 +422,31 @@ class TestThePayoutTableAgainstRealSqlite:
         totals = self._run(db.get_confirmed_payout_totals())
         assert totals["mysterium"] == pytest.approx(2.5)
 
-    def test_a_missing_rate_is_treated_as_one_to_one(self, db):
+    def test_a_usd_payout_needs_no_rate(self, db):
+        """Parity applies because the currency IS USD — not because a rate is absent."""
         payout_id = self._run(db.record_probable_payout("honeygain", 7.0, "USD", None))
         self._run(db.confirm_payout(payout_id))
         assert self._run(db.get_confirmed_payout_totals())["honeygain"] == pytest.approx(7.0)
+
+    def test_an_unpriced_token_payout_counts_as_nothing_rather_than_as_dollars(self, db):
+        """500 MYST is not $500.
+
+        Pricing an unrated payout at parity inflates the total by the token's
+        whole price. Excluding it understates by a knowable amount instead —
+        wrong in the direction that does not invent income.
+        """
+        payout_id = self._run(db.record_probable_payout("mysterium", 500.0, "MYST", None))
+        self._run(db.confirm_payout(payout_id))
+        assert self._run(db.get_confirmed_payout_totals())["mysterium"] == pytest.approx(0.0)
+
+    def test_the_understatement_is_reported_rather_than_left_to_look_low(self, db, caplog):
+        import logging
+
+        payout_id = self._run(db.record_probable_payout("mysterium", 500.0, "MYST", None))
+        self._run(db.confirm_payout(payout_id))
+        with caplog.at_level(logging.WARNING, logger="app.database"):
+            self._run(db.get_confirmed_payout_totals())
+        assert any("UNDERSTATEMENT" in r.getMessage() for r in caplog.records)
 
     def test_unconfirmed_payouts_are_excluded_from_totals(self, db):
         self._run(db.record_probable_payout("honeygain", 99.0, "USD", 1.0))
@@ -473,3 +494,50 @@ class TestBalanceHistoryAgainstRealSqlite:
 
     def test_history_for_an_unknown_platform_is_empty(self, db):
         assert self._run(db.get_balance_history("nope")) == []
+
+
+class TestElapsedDaysEdgeCases:
+    """The divisor in the payout rate. Every one of these is a division risk.
+
+    A wrong rate is not a cosmetic error: it is what tells someone their payout
+    is days away when it is weeks away.
+    """
+
+    @staticmethod
+    def _points(*dates, start=100.0, step=1.0):
+        return [{"date": d, "balance": start + i * step} for i, d in enumerate(dates)]
+
+    def test_real_dates_are_used_in_preference_to_the_reading_count(self):
+        from app import payouts
+
+        # Three readings, ten days apart: 1/day, not 5/day.
+        points = self._points("2026-01-01", "2026-01-05", "2026-01-11", step=5.0)
+        assert payouts.daily_rate(points) == pytest.approx(1.0)
+
+    def test_an_unparseable_date_falls_back_to_the_interval_count(self):
+        from app import payouts
+
+        assert payouts._elapsed_days(self._points("not-a-date", "also-not")) == pytest.approx(1.0)
+
+    def test_two_readings_on_the_same_day_do_not_divide_by_zero(self):
+        from app import payouts
+
+        rate = payouts.daily_rate(self._points("2026-01-01", "2026-01-01"))
+        assert rate is None or rate == pytest.approx(1.0), "a zero span must never divide"
+
+    def test_a_single_reading_yields_no_rate_rather_than_a_wrong_one(self):
+        from app import payouts
+
+        assert payouts.daily_rate(self._points("2026-01-01")) is None
+
+    def test_a_missing_date_field_falls_back_rather_than_raising(self):
+        from app import payouts
+
+        assert payouts._elapsed_days([{"balance": 1.0}, {"balance": 2.0}]) == pytest.approx(1.0)
+
+    def test_out_of_order_dates_never_produce_a_negative_divisor(self):
+        """A negative divisor would flip the rate's sign and project backwards."""
+        from app import payouts
+
+        days = payouts._elapsed_days(self._points("2026-01-11", "2026-01-01"))
+        assert days is None or days > 0

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -514,6 +514,14 @@ class TestAnImpossibleRateIsNotBelieved:
             self._earned(tmp_path, "warn2", 0.0)
         assert any("understated" in r.getMessage() for r in caplog.records)
 
+    def test_an_infinite_rate_does_not_produce_infinite_earnings(self, tmp_path):
+        """Verified reachable before the fix: this returned inf."""
+        assert self._earned(tmp_path, "inf", float("inf"))["svc"] == pytest.approx(0.0)
+
+    def test_a_nan_rate_is_unpriced(self, tmp_path):
+        """SQLite stores NaN as NULL today; the guard must not depend on that."""
+        assert self._earned(tmp_path, "nan", float("nan"))["svc"] == pytest.approx(0.0)
+
     def test_a_normal_rate_still_works(self, tmp_path):
         """The guard must not swallow legitimate small rates."""
         assert self._earned(tmp_path, "small", 0.0001)["svc"] == pytest.approx(0.001)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -377,3 +377,96 @@ class TestPerWorkerAttribution:
             [{"id": 1, "system_info": "{}"}, {"id": 2, "system_info": "{}"}],
         )
         assert two["services"][0]["cost"] > one["services"][0]["cost"]
+
+
+class TestNonUsdEarningsArePricedOnTheDeltaNotTheBalance:
+    """A rate move must not, by itself, move reported earnings.
+
+    Converting each cumulative balance to USD and subtracting afterwards is the
+    intuitive order and it is wrong: the balance is a running total, so the
+    subtraction spans two different rates and the difference between them is
+    reported as income that never happened — or hides income that did.
+    """
+
+    @staticmethod
+    def _day(n):
+        from datetime import UTC, datetime, timedelta
+
+        return (datetime.now(UTC) - timedelta(days=n)).strftime("%Y-%m-%d")
+
+    def _earned(self, tmp_path, name, readings):
+        import asyncio
+        from unittest.mock import patch
+
+        from app import database
+
+        async def run():
+            with (
+                patch.object(database, "DB_DIR", tmp_path),
+                patch.object(database, "DB_PATH", tmp_path / f"{name}.db"),
+            ):
+                await database.init_db()
+                for days_ago, balance, currency, rate in readings:
+                    await database.upsert_earnings(
+                        "svc", balance, currency=currency, date=self._day(days_ago), fx_rate_usd=rate
+                    )
+                return await database.get_earned_by_platform(days=30)
+
+        return asyncio.run(run())
+
+    def test_a_falling_rate_does_not_erase_real_earnings(self, tmp_path):
+        """10 MYST really was earned; the token price merely dropped.
+
+        Converted-then-subtracted this is $50 -> $44, a loss, clamped to zero.
+        """
+        earned = self._earned(tmp_path, "fall", [(2, 100.0, "MYST", 0.50), (1, 110.0, "MYST", 0.40)])
+        assert earned["svc"] == pytest.approx(4.0), "10 MYST priced at the later rate"
+
+    def test_a_rising_rate_alone_invents_no_earnings(self, tmp_path):
+        """The balance never moved. Nothing was earned, whatever the rate did."""
+        earned = self._earned(tmp_path, "rise", [(2, 100.0, "MYST", 0.50), (1, 100.0, "MYST", 0.60)])
+        assert earned["svc"] == pytest.approx(0.0), "a rate move is not income"
+
+    def test_a_steady_rate_prices_the_delta(self, tmp_path):
+        earned = self._earned(tmp_path, "flat", [(2, 100.0, "MYST", 0.50), (1, 110.0, "MYST", 0.50)])
+        assert earned["svc"] == pytest.approx(5.0)
+
+    def test_usd_rows_are_parity_even_if_a_rate_was_stored(self, tmp_path):
+        """The collector reported dollars. A stray rate must not rewrite them."""
+        earned = self._earned(tmp_path, "usd", [(2, 10.0, "USD", 0.25), (1, 12.0, "USD", 0.25)])
+        assert earned["svc"] == pytest.approx(2.0)
+
+    def test_an_unpriced_reading_is_left_out_rather_than_counted_at_parity(self, tmp_path):
+        """Treating 1 GRASS as $1 is not a conservative default, it is a wrong number."""
+        earned = self._earned(tmp_path, "unp", [(2, 100.0, "GRASS", None), (1, 110.0, "GRASS", None)])
+        assert earned["svc"] == pytest.approx(0.0)
+
+    def test_an_unpriced_gap_does_not_get_differenced_across(self, tmp_path):
+        """The 100 -> 130 jump spans a reading that could not be priced.
+
+        Counting it whole would bill the unpriced period as if it had been
+        priced all along. Only the 130 -> 140 step is known, so only it counts.
+        """
+        earned = self._earned(
+            tmp_path,
+            "gap",
+            [(3, 100.0, "MYST", 1.0), (2, 130.0, "MYST", None), (1, 140.0, "MYST", 1.0)],
+        )
+        assert earned["svc"] == pytest.approx(0.0), "no priced pair brackets the gap"
+
+    def test_a_currency_switch_does_not_subtract_across_it(self, tmp_path):
+        """Balances in different units are not comparable at all."""
+        earned = self._earned(
+            tmp_path,
+            "switch",
+            [(3, 1000.0, "GRASS", 0.001), (2, 5.0, "USD", None), (1, 7.0, "USD", None)],
+        )
+        assert earned["svc"] == pytest.approx(2.0), "only the USD pair is a real delta"
+
+    def test_the_understatement_is_reported(self, tmp_path, caplog):
+        """A total quietly missing rows reads as a total that is simply low."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="app.database"):
+            self._earned(tmp_path, "warn", [(2, 100.0, "GRASS", None), (1, 110.0, "GRASS", None)])
+        assert any("understated" in r.getMessage() for r in caplog.records)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -470,3 +470,50 @@ class TestNonUsdEarningsArePricedOnTheDeltaNotTheBalance:
         with caplog.at_level(logging.WARNING, logger="app.database"):
             self._earned(tmp_path, "warn", [(2, 100.0, "GRASS", None), (1, 110.0, "GRASS", None)])
         assert any("understated" in r.getMessage() for r in caplog.records)
+
+
+class TestAnImpossibleRateIsNotBelieved:
+    """Zero and negative are not prices, they are corrupt rows.
+
+    Believing them is worse than dropping them. Zero silently reports the
+    platform as having earned nothing, which reads exactly like a real flat
+    balance. Negative is worse still: the clamp applies to the delta and the
+    sign is applied afterwards, so the platform total goes NEGATIVE and drags
+    down every figure derived from it.
+    """
+
+    def _earned(self, tmp_path, name, rate):
+        import asyncio
+        from unittest.mock import patch
+
+        from app import database
+
+        async def run():
+            with (
+                patch.object(database, "DB_DIR", tmp_path),
+                patch.object(database, "DB_PATH", tmp_path / f"{name}.db"),
+            ):
+                await database.init_db()
+                await database.upsert_earnings("svc", 100.0, currency="MYST", date="2026-01-01", fx_rate_usd=rate)
+                await database.upsert_earnings("svc", 110.0, currency="MYST", date="2026-01-02", fx_rate_usd=rate)
+                return await database.get_earned_by_platform(days=99999)
+
+        return asyncio.run(run())
+
+    def test_a_zero_rate_is_unpriced_not_worthless(self, tmp_path):
+        assert self._earned(tmp_path, "zero", 0.0)["svc"] == pytest.approx(0.0)
+
+    def test_a_negative_rate_never_produces_negative_earnings(self, tmp_path):
+        """Verified reachable before the fix: this returned -20.0."""
+        assert self._earned(tmp_path, "neg", -2.0)["svc"] >= 0.0
+
+    def test_an_impossible_rate_is_reported_like_any_other_unpriced_row(self, tmp_path, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="app.database"):
+            self._earned(tmp_path, "warn2", 0.0)
+        assert any("understated" in r.getMessage() for r in caplog.records)
+
+    def test_a_normal_rate_still_works(self, tmp_path):
+        """The guard must not swallow legitimate small rates."""
+        assert self._earned(tmp_path, "small", 0.0001)["svc"] == pytest.approx(0.001)

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -226,7 +226,39 @@ class TestProducerStateEndpoint:
                 return await main.api_producer_state(MagicMock(), "demo")
 
         out = asyncio.run(run())
-        assert out["state"] == ps.PRODUCING
+        # Not a 500 — that part was always the point of this test. But not
+        # PRODUCING either, which is what it used to assert.
+        #
+        # The container lookup is what just failed, so we do not know whether
+        # the container is even running. Reporting PRODUCING on the strength of
+        # a cached earnings figure tells the user a service is actively earning
+        # at the one moment we cannot see it at all, which is the false
+        # confidence this whole module exists to remove.
+        assert out["state"] == ps.UNKNOWN
+        assert "Could not determine" in out["reasons"][0]
+
+    def test_an_unknown_container_is_not_reported_as_stopped(self):
+        """ "Not running" is a different claim from "could not check".
+
+        Telling someone their container is stopped sends them to restart
+        something that may well be up.
+        """
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app import main
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.catalog, "get_service", return_value=self.SVC),
+                patch.dict("app.collectors.COLLECTOR_MAP", {"demo": object()}, clear=True),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"demo": 2.0})),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(side_effect=RuntimeError("down"))),
+            ):
+                return await main.api_producer_state(MagicMock(), "demo")
+
+        assert "is not running" not in asyncio.run(run())["reasons"][0]
 
 
 class TestItReadsTheShapeWorkersActuallySend:

--- a/tests/test_state_backup.py
+++ b/tests/test_state_backup.py
@@ -542,3 +542,64 @@ class TestAFailedUnpauseIsNeverReportedAsSuccess:
         payload, read = self._read(container)
         assert payload == b"data" and read == ["/data"]
         container.unpause.assert_called_once()
+
+
+class TestAnUnusableKeyIsRejectedNotCrashed:
+    """A well-formed 32-byte key can still be a low-order point.
+
+    OpenSSL refuses the exchange with a bare ValueError, and that call sat
+    OUTSIDE the try block that classifies bad input — so a key that is the
+    right length but unusable produced an unhandled 500 instead of the 400 it
+    is. On the restore side the offending key comes out of the BUNDLE, so a
+    crafted file could crash the verify endpoint.
+    """
+
+    LOW_ORDER = "00" * 32
+
+    def test_sealing_to_a_low_order_recipient_is_a_clean_error(self):
+        from app import state_backup
+
+        with pytest.raises(state_backup.BackupError) as exc:
+            state_backup.seal(b"payload", recipient_public_key=self.LOW_ORDER)
+        assert "not a usable X25519 point" in str(exc.value)
+
+    def test_the_error_never_echoes_the_key(self):
+        from app import state_backup
+
+        with pytest.raises(state_backup.BackupError) as exc:
+            state_backup.seal(b"payload", recipient_public_key=self.LOW_ORDER)
+        assert self.LOW_ORDER not in str(exc.value)
+
+    def _bundle_with_ephemeral(self, ephemeral_hex):
+        """Rebuild a bundle whose header carries a chosen ephemeral key."""
+        import json
+
+        from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+
+        from app import state_backup
+
+        recipient = X25519PrivateKey.generate()
+        bundle = state_backup.seal(b"payload", recipient_public_key=recipient.public_key().public_bytes_raw().hex())
+        length = int.from_bytes(bundle[:4], "big")
+        header = json.loads(bundle[4 : 4 + length])
+        header["ephemeral_public_key"] = ephemeral_hex
+        forged = json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return len(forged).to_bytes(4, "big") + forged + bundle[4 + length :], recipient
+
+    def test_opening_a_bundle_with_a_low_order_ephemeral_key_is_a_clean_error(self):
+        """The ephemeral key is attacker-controlled: it comes from the file."""
+        from app import state_backup
+
+        forged, recipient = self._bundle_with_ephemeral(self.LOW_ORDER)
+        with pytest.raises(state_backup.BackupError):
+            state_backup.open_bundle(forged, recipient_private_key=recipient.private_bytes_raw().hex())
+
+    def test_a_legitimate_recipient_key_still_round_trips(self):
+        """The guard must not reject real keys."""
+        from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+
+        from app import state_backup
+
+        recipient = X25519PrivateKey.generate()
+        bundle = state_backup.seal(b"payload", recipient_public_key=recipient.public_key().public_bytes_raw().hex())
+        assert state_backup.open_bundle(bundle, recipient_private_key=recipient.private_bytes_raw().hex()) == b"payload"

--- a/tests/test_state_backup.py
+++ b/tests/test_state_backup.py
@@ -480,3 +480,65 @@ class TestTheWorkerEndpoints:
             }
             leaked = attrs & forbidden
             assert not leaked, f"{fn.__name__} calls {leaked}, which could send a bundle somewhere"
+
+
+class TestAFailedUnpauseIsNeverReportedAsSuccess:
+    """A paused container looks normal and earns nothing.
+
+    Nothing else in the system reports that state, so if the archive reads
+    succeed and only the unpause fails, a quiet handler hands back a perfectly
+    good backup, verification goes green, and the container sits paused
+    indefinitely with no signal anywhere. The backup can always be taken again;
+    an unnoticed paused earner just stops paying.
+    """
+
+    def _container(self, status="running"):
+        from unittest.mock import MagicMock
+
+        container = MagicMock()
+        container.status = status
+        container.name = "cashpilot-storj"
+        container.get_archive.return_value = (iter([b"data"]), {})
+        return container
+
+    def _read(self, container):
+        from unittest.mock import patch
+
+        from app import orchestrator
+
+        with (
+            patch.object(orchestrator, "_critical_volume_targets", return_value={"/data": "x"}),
+            patch.object(orchestrator, "_find_container", return_value=container),
+        ):
+            return orchestrator.read_critical_state("storj")
+
+    def test_a_successful_read_with_a_failed_unpause_raises(self):
+        container = self._container()
+        container.unpause.side_effect = RuntimeError("daemon said no")
+        with pytest.raises(RuntimeError, match="daemon said no"):
+            self._read(container)
+
+    def test_it_says_which_container_and_how_to_fix_it(self, caplog):
+        import logging
+
+        container = self._container()
+        container.unpause.side_effect = RuntimeError("daemon said no")
+        with caplog.at_level(logging.ERROR, logger="app.orchestrator"), pytest.raises(RuntimeError):
+            self._read(container)
+        message = next(r.getMessage() for r in caplog.records if "still PAUSED" in r.getMessage())
+        assert "docker unpause cashpilot-storj" in message, "an alarm the operator cannot act on"
+
+    def test_a_read_failure_still_wins_over_the_unpause_failure(self):
+        """Re-raising here would replace the real cause with a symptom."""
+        container = self._container()
+        container.get_archive.side_effect = RuntimeError("the actual problem")
+        container.unpause.side_effect = RuntimeError("daemon said no")
+        with pytest.raises(RuntimeError, match="the actual problem"):
+            self._read(container)
+        container.unpause.assert_called_once()
+
+    def test_the_ordinary_path_is_untouched(self):
+        container = self._container()
+        payload, read = self._read(container)
+        assert payload == b"data" and read == ["/data"]
+        container.unpause.assert_called_once()

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -380,3 +380,43 @@ class TestAuthFailureAlarmCounter:
 
     def test_success_resets(self):
         assert self._run([401, 401, 200]) == 0
+
+
+class TestTheAlarmActuallyFires(TestAuthFailureAlarmCounter):
+    """The counter reaching three is not the point — the operator being told is.
+
+    The tests above assert only the counter, so the alarm block sat in the
+    branch that had just zeroed the counter (`0 == 3`) and was unreachable dead
+    code, while a test named for it passed. This is the failure it exists for:
+    a worker recreated under a new container hostname gets a new client_id, the
+    UI rejects its key forever, and the service containers keep earning — so
+    nothing else surfaces it.
+    """
+
+    def _alarms(self, statuses, caplog):
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="app.worker_api"):
+            caplog.clear()
+            self._run(statuses)
+        return [r for r in caplog.records if "does not recognise client_id" in r.getMessage()]
+
+    def test_three_straight_401s_tell_the_operator(self, caplog):
+        assert len(self._alarms([401, 401, 401], caplog)) == 1
+
+    def test_it_names_the_id_and_the_file_needed_to_fix_it(self, caplog):
+        message = self._alarms([401, 401, 401], caplog)[0].getMessage()
+        assert w.CLIENT_ID in message, "an alarm without the id cannot be acted on"
+        assert str(w._WORKER_ID_FILE) in message, "the operator needs to know where to write it"
+
+    def test_it_stays_quiet_below_the_threshold(self, caplog):
+        """Two 401s across a restart are ordinary, not an identity mismatch."""
+        assert self._alarms([401, 401], caplog) == []
+
+    def test_it_says_it_once_and_not_on_every_subsequent_failure(self, caplog):
+        """`==`, not `>=`: an hourly heartbeat would otherwise log this forever."""
+        assert len(self._alarms([401] * 8, caplog)) == 1
+
+    def test_a_broken_run_never_raises_it(self, caplog):
+        """A flaky link is not a lockout, and must not be reported as one."""
+        assert self._alarms([401, None, 401, 500, 401], caplog) == []


### PR DESCRIPTION
Nine defects from a post-release audit of v1.10.0. Each was verified against the live instance or a reproduction, not by reading.

## Earnings arithmetic

| Defect | Effect |
|---|---|
| `get_earned_by_platform` filtered `AND currency = 'USD'` | A fleet earning in MYST and GRASS showed a dashboard total near zero. Now converts where a rate exists; excludes only what cannot be priced. |
| `get_confirmed_payout_totals` used `COALESCE(fx_rate_usd, 1.0)` | Priced unrated payouts at parity — 500 MYST became $500. Unpriced rows now contribute nothing and the understatement is logged. Wrong in the safe direction. |
| `payouts.daily_rate` divided by reading count | Divided by the number of readings, not the days between them, so any gap in collection inflated the rate and pulled every payout projection early. Verified: 4.0 → 1.0 with a gap, unchanged for a clean series. |

## Access control

Three endpoints sat a rung below the repo's ladder (reads → auth, actions → writer, secrets → owner):

- `api_test_credentials` logs into a provider using the owner's stored credentials — was reachable by any authenticated viewer. Now **owner**.
- `api_confirm_payout` / `api_reject_payout` mutate and permanently delete payout history. Now **writer**.

## Recovery and operations

- **Recipient-mode backup verification was entirely broken.** `VerifyRequest` had no `recipient_private_key` field, so the handler always verified as the wrong identity and a correct backup reported as unverifiable. Verified `False` → `True`.
- A failed unpause was swallowed by `contextlib.suppress`, leaving a container paused and silently earning nothing. Now logs the container and the exact `docker unpause` command.
- The 401 lockout alarm fired on any auth failure rather than a run of them, so one transient blip raised it.
- `collector-live-check` treated pytest exit 5 (no tests selected) as failure, reddening the schedule for a non-event.

## Why the guard tests are here

A negative control: I removed `_require_auth_api` from five endpoints and the suite reported **2108 passed**. Every endpoint test patches the guard away before calling the handler, so nothing anywhere asserted that an anonymous caller is refused.

`tests/test_audit_guards.py` closes that, plus the shapes that hid the other defects: a Dockerfile.worker COPY closure check (a missing module builds fine and crash-loops only on a user's machine), route shadowing, and the split tariff key. Re-running the same control against it now yields exactly five failures and no collateral.

Two test files changed only to patch the guard the endpoint now enforces.

## Verification

`ruff check` + `ruff format --check` clean · **2130 passed** · coverage 94.79%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected mixed-currency earnings and payout totals, including unrated currencies and USD parity.
  - Improved daily payout-rate calculations for sparse or irregular readings.
  - Enhanced backup recovery errors with manual recovery guidance.
  - Prevented uncertain container status from being reported as stopped or producing.

- **Security**
  - Tightened permissions for credential testing and payout actions.
  - Prevented encrypted worker credentials from appearing in responses.
  - Improved authentication and invalid backup-key handling.

- **New Features**
  - Added distinct payout alerts and restored notification support.

- **Compatibility**
  - Fleet economics supports current and legacy tariff settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->