### PR TITLE
fix: ten verified audit findings (beads batch 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'Dockerfile'
+      - 'entrypoint.sh'
       - 'Dockerfile.worker'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -72,7 +73,7 @@ jobs:
           BUILD_UI=false
           BUILD_WORKER=false
 
-          if echo "$CHANGED" | grep -qE '^(Dockerfile|pyproject\.toml|uv\.lock|app/(main|database|catalog|auth|compose_generator|exchange_rates|constants|collectors|templates|static|routers|deps|metrics|setup_token))'; then
+          if echo "$CHANGED" | grep -qE '^(Dockerfile|entrypoint\.sh|pyproject\.toml|uv\.lock|app/(main|database|catalog|auth|compose_generator|exchange_rates|constants|collectors|templates|static|routers|deps|metrics|setup_token))'; then
             BUILD_UI=true
           fi
           if echo "$CHANGED" | grep -qE '^services/'; then
@@ -80,7 +81,7 @@ jobs:
             BUILD_WORKER=true
           fi
 
-          if echo "$CHANGED" | grep -qE '^(Dockerfile\.worker|pyproject\.toml|uv\.lock|app/(worker_api|orchestrator|constants|catalog|fleet_key)\.py)'; then
+          if echo "$CHANGED" | grep -qE '^(Dockerfile\.worker|entrypoint\.sh|pyproject\.toml|uv\.lock|app/(worker_api|orchestrator|constants|catalog|fleet_key)\.py)'; then
             BUILD_WORKER=true
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Triggers on version tags (`v*`). Lints with ruff, builds multi-arch (amd64 + arm
 - **Collection interval**: 1 hour. Earnings cached in SQLite, served instantly.
 - **Health check deduplication**: Multi-instance services record only one health event per slug per check cycle (best status wins).
 - **Google Fonts**: Use async preload pattern to avoid blocking page render.
-- **First earnings baseline**: On onboarding, insert synthetic baseline record for prior day so first delta is 0.
+- **First earnings baseline**: a platform's FIRST reading has no predecessor, so it contributes nothing to any earned figure — the delta is only taken when a previous reading exists in the same currency. No synthetic row is written, and none should be: inventing a prior-day balance would make the first real reading look like a gain.
 
 ### Service-Specific: MystNodes / Mysterium
 

--- a/app/database.py
+++ b/app/database.py
@@ -195,7 +195,16 @@ def _load_or_create_fernet() -> Fernet:
         )
     except OSError as exc:
         _fernet_key_persist_error = str(exc)
-        _fernet_key_is_ephemeral = True
+        # Ephemeral only when the key was MINTED here. A key supplied through
+        # CASHPILOT_ENCRYPTION_KEY is identical on every restart, so failing to
+        # cache it to disk loses nothing — the hazard this flag exists for
+        # (a fresh random key on next boot, silently orphaning every stored
+        # credential) cannot happen.
+        #
+        # Treating both cases the same made startup refuse to continue and told
+        # the user to "supply a key via CASHPILOT_ENCRYPTION_KEY" — which is
+        # exactly what they had already done.
+        _fernet_key_is_ephemeral = env_key is None
         _logger.error(
             "Could not persist the credential-encryption key to %s: %s. "
             "Credentials encrypted now will be unreadable after a restart.",
@@ -651,7 +660,17 @@ async def init_db() -> None:
         config_cols = {row["name"] for row in await cursor.fetchall()}
         if "updated_at" not in config_cols:
             await db.execute("ALTER TABLE config ADD COLUMN updated_at TEXT")
-            await db.execute("UPDATE config SET updated_at = datetime('now') WHERE updated_at IS NULL")
+            # Deliberately NOT back-filled with datetime('now').
+            #
+            # Doing so stamped every credential on an upgraded volume with the
+            # moment of the upgrade, so the credential-health page reported all
+            # of them "fresh" — including a Bytelixir session cookie that
+            # expires after two hours and had in fact expired days earlier. An
+            # unknown age was rendered as the most favourable known age.
+            #
+            # NULL is the honest value, and both consumers already handle it:
+            # get_config_updated_at filters WHERE updated_at IS NOT NULL, and
+            # the health endpoint skips unstamped keys.
 
         # Migrate users table: add password_changed_at for session invalidation
         cursor = await db.execute("PRAGMA table_info(users)")

--- a/app/database.py
+++ b/app/database.py
@@ -205,12 +205,27 @@ def _load_or_create_fernet() -> Fernet:
         # the user to "supply a key via CASHPILOT_ENCRYPTION_KEY" — which is
         # exactly what they had already done.
         _fernet_key_is_ephemeral = env_key is None
-        _logger.error(
-            "Could not persist the credential-encryption key to %s: %s. "
-            "Credentials encrypted now will be unreadable after a restart.",
-            _FERNET_KEY_FILE,
-            exc,
-        )
+        if env_key is None:
+            _logger.error(
+                "Could not persist the credential-encryption key to %s: %s. "
+                "Credentials encrypted now will be unreadable after a restart.",
+                _FERNET_KEY_FILE,
+                exc,
+            )
+        else:
+            # Same failure, different consequence. The key came from the
+            # environment, so the next boot gets the identical key and nothing
+            # is lost — as long as the variable stays set. Saying "unreadable
+            # after a restart" here would be simply untrue, and it is the sort
+            # of false alarm that teaches people to ignore the real one.
+            _logger.warning(
+                "Could not cache the credential-encryption key to %s: %s. "
+                "This is not data loss: the key came from CASHPILOT_ENCRYPTION_KEY and will be "
+                "read from there again on the next start. Keep that variable set — without the "
+                "cached file it is now the only copy.",
+                _FERNET_KEY_FILE,
+                exc,
+            )
     return Fernet(key)
 
 
@@ -654,8 +669,10 @@ async def init_db() -> None:
         if "spec_encrypted" not in deployment_cols:
             await db.execute("ALTER TABLE deployments ADD COLUMN spec_encrypted TEXT NOT NULL DEFAULT ''")
         # Migrate config table: add updated_at so credential age is knowable.
-        # Existing rows get the migration time, which is the earliest we can
-        # honestly claim to know about them - never a fabricated older date.
+        # Existing rows are left NULL — see the note on the back-fill below.
+        # (This comment used to say they receive the migration time, which is
+        # exactly the behaviour that was removed; leaving it would have invited
+        # someone to restore the back-fill.)
         cursor = await db.execute("PRAGMA table_info(config)")
         config_cols = {row["name"] for row in await cursor.fetchall()}
         if "updated_at" not in config_cols:

--- a/app/main.py
+++ b/app/main.py
@@ -780,6 +780,13 @@ app = FastAPI(
     title="CashPilot",
     version="0.1.0",
     lifespan=lifespan,
+    # Off by default. FastAPI serves these unauthenticated, and this app's
+    # schema is a map of its own admin surface — every route, parameter and
+    # body shape, including the worker and payout endpoints. Nothing here
+    # needs them in a self-hosted deployment.
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
 )
 metrics.setup(app)
 
@@ -2031,7 +2038,7 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
 
     cfg = await database.get_config()
     try:
-        price = float(cfg.get("power_price_per_kwh") or 0)
+        price = _tariff_price(cfg)
     except (TypeError, ValueError):
         price = 0.0
     currency = str(cfg.get("power_currency") or "EUR")
@@ -2391,7 +2398,7 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
         # forever — and both unknown-paths are deliberately quiet, which is
         # exactly what hid it. power_price_per_kwh is canonical (it shipped
         # first); the newer name is honoured so nobody's existing config breaks.
-        price = float(config.get("power_price_per_kwh") or config.get("electricity_price_per_kwh") or 0.0)
+        price = _tariff_price(config)
     except (TypeError, ValueError):
         price = 0.0
 
@@ -2432,7 +2439,12 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
                 watts=watts,
                 price_per_kwh=price or None,
                 metered=power.is_metered(info),
-                dedicated=bool(config.get(f"worker_{worker.get('id')}_dedicated")),
+                # Config values are TEXT, so bool() made "false", "0" and "no"
+                # all mean dedicated=True — and dedicated flips the advice from
+                # "this machine would be on anyway" to "turning it off would
+                # save that". database._TRUTHY is the parser the rest of the
+                # codebase already uses for exactly this.
+                dedicated=_config_flag(config, f"worker_{worker.get('id')}_dedicated"),
             )
         )
 
@@ -2566,6 +2578,31 @@ async def api_per_node_earnings(request: Request, slug: str) -> list[dict[str, A
     finally:
         with contextlib.suppress(Exception):
             await collector.close()
+
+
+def _config_flag(config: dict[str, Any], key: str) -> bool:
+    """A stored config value read as a boolean.
+
+    Config values are TEXT. `bool("false")` is True, so a user who set a flag
+    to "false", "0" or "no" got the opposite of what they asked for. Uses the
+    same truthy set as database.set_config so a value written by one half of
+    the app means the same thing to the other.
+    """
+    from app.database import _TRUTHY
+
+    return str(config.get(key, "") or "").strip().lower() in _TRUTHY
+
+
+def _tariff_price(config: dict[str, Any]) -> float:
+    """The electricity price per kWh, honouring the legacy key name.
+
+    `electricity_price_per_kwh` was renamed to `power_price_per_kwh`. One
+    endpoint accepted both and the other accepted only the new name, so an
+    upgrading user who had set the old key saw running costs on the fleet page
+    and "cost unknown" on the dashboard, from the same stored value. Both now
+    resolve through here.
+    """
+    return float(config.get("power_price_per_kwh") or config.get("electricity_price_per_kwh") or 0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2427,12 +2427,20 @@ const CP = (() => {
     const items = meta.map(col => {
       // A collector is "configured" if any secret field has a stored value
       // (per _secrets) or any non-secret field carries a real value.
-      const configured = col.fields.some(f => {
-        if (f.secret) return !!secrets[f.key];
-        const val = config[f.key];
-        return val && val.trim() !== '';
-      });
-      const statusBadge = configured
+      // EVERY required field, not any field.
+      //
+      // `.some` meant a service needing an email AND a password showed
+      // "Configured" with only the email set — while the server's own
+      // make_collectors skipped it for the missing one, so it silently never
+      // collected. The badge asserted the opposite of what was happening.
+      const isSet = f => (f.secret ? !!secrets[f.key] : !!(config[f.key] || '').trim());
+      const required = col.fields.filter(f => f.required);
+      const setCount = required.filter(isSet).length;
+      const configured = required.length > 0 && setCount === required.length;
+      const partial = setCount > 0 && setCount < required.length;
+      const statusBadge = partial
+        ? '<span class="badge badge-warning" title="Some required credentials are missing, so this service is not being collected">Incomplete</span>'
+        : configured
         ? '<span class="badge badge-deployed">Configured</span>'
         : '<span class="badge badge-category">Not configured</span>';
       const fields = col.fields.map(f => {
@@ -2468,6 +2476,7 @@ const CP = (() => {
           ${statusBadge}
         </summary>
         <div class="collector-body">
+          ${col.hint ? `<div class="form-hint" style="margin-bottom:12px;">${sanitizeHint(col.hint)}</div>` : ''}
           ${fields}
           ${clearBtn}
         </div>

--- a/services/compute/salad.yml
+++ b/services/compute/salad.yml
@@ -54,4 +54,4 @@ platforms: [windows]
 collector:
   type: api
   notes: "API at app-api.salad.com/api/v1/profile/balance. Auth via 'auth' cookie + X-XSRF-TOKEN header (double-submit). Returns currentBalance (USD) and lifetimeBalance."
-  credential_hint: "Log in at <a href='https://app.salad.com' target='_blank'>app.salad.com</a>, press F12 → Application → Cookies, copy the <b>auth</b> cookie value."
+  credential_hint: "Log in at <a href='https://app.salad.io' target='_blank'>app.salad.io</a>, press F12 → Application → Cookies, copy the <b>auth</b> cookie value."

--- a/tests/test_beads_batch_1.py
+++ b/tests/test_beads_batch_1.py
@@ -273,7 +273,60 @@ class TestTheDocsDescribeTheCodeThatExists:
             assert "synthetic" not in path.read_text(encoding="utf-8").lower(), path.name
 
 
+#: Classes that answer review feedback rather than closing a bead. Kept
+#: separate so the bead count below stays a meaningful check on dropped fixes.
+REVIEW_RESPONSE_CLASSES = {"TestThePersistenceFailureMessageMatchesTheConsequence"}
+
+
 def test_the_batch_touched_ten_beads():
-    """A count, so a silently dropped fix is visible in review."""
-    classes = [name for name, obj in globals().items() if name.startswith("Test") and isinstance(obj, type)]
+    """A count, so a silently dropped fix is visible in review.
+
+    It fired once already, on the class added to answer CodeRabbit — which is
+    the guard doing its job, not a nuisance. Review-response classes are
+    excluded by name rather than by raising the number, so dropping a bead fix
+    still shows up.
+    """
+    classes = [
+        name
+        for name, obj in globals().items()
+        if name.startswith("Test") and isinstance(obj, type) and name not in REVIEW_RESPONSE_CLASSES
+    ]
     assert len(classes) == 10, f"expected 10 bead classes, found {len(classes)}: {sorted(classes)}"
+
+
+class TestThePersistenceFailureMessageMatchesTheConsequence:
+    """From CodeRabbit on this PR, and correct.
+
+    The fix stopped treating a supplied key as ephemeral but left the error
+    text saying "credentials encrypted now will be unreadable after a restart"
+    — untrue while CASHPILOT_ENCRYPTION_KEY is set, and exactly the kind of
+    false alarm that teaches people to ignore the real one.
+    """
+
+    def _source(self) -> str:
+        return (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+
+    def test_a_minted_key_still_gets_the_data_loss_error(self):
+        """The dangerous case must keep its loud message."""
+        source = self._source()
+        assert "Credentials encrypted now will be unreadable after a restart." in source
+        assert "if env_key is None:" in source
+
+    def test_a_supplied_key_gets_a_warning_not_a_data_loss_error(self):
+        source = self._source()
+        assert "This is not data loss" in source
+
+    def test_the_supplied_key_message_says_what_to_do(self):
+        """The user's only real risk is unsetting the variable."""
+        source = self._source()
+        assert "Keep that variable set" in source
+
+    def test_the_migration_comment_matches_the_code_below_it(self):
+        """It said existing rows get the migration time — the removed behaviour.
+
+        Left as it was, it invited someone to restore the back-fill this PR
+        deletes.
+        """
+        source = self._source()
+        assert "Existing rows get the migration time" not in source
+        assert "Existing rows are left NULL" in source

--- a/tests/test_beads_batch_1.py
+++ b/tests/test_beads_batch_1.py
@@ -1,0 +1,279 @@
+"""Regression tests for the first batch of verified audit beads.
+
+Each class names the bead it closes. All ten were independently re-verified
+against this branch before being fixed — the audit's own adversarial pass had
+already refuted 13 of 94 findings, so nothing here was taken on trust.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+class TestUnknownCredentialAgeIsNotFabricatedAsFresh:
+    """CashPilot-c1q / CashPilot-i21 (one defect, filed twice).
+
+    The updated_at migration back-filled every pre-existing row with
+    datetime('now'), so an upgraded volume reported every credential as brand
+    new — including a Bytelixir session cookie that expires after two hours and
+    had in fact expired days earlier. Unknown age rendered as the most
+    favourable known age.
+    """
+
+    def test_the_migration_does_not_stamp_existing_rows(self):
+        source = (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+        assert "UPDATE config SET updated_at = datetime('now')" not in source
+
+    @pytest.mark.asyncio
+    async def test_a_pre_migration_row_reports_unknown_age(self, tmp_path):
+        """End-to-end: an old-schema config table upgraded in place."""
+        import aiosqlite
+
+        from app import database
+
+        db_path = tmp_path / "old.db"
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+            await db.execute("INSERT INTO config (key, value) VALUES ('bytelixir_session_cookie', 'x')")
+            await db.commit()
+
+        with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", db_path):
+            await database.init_db()
+            stamps = await database.get_config_updated_at()
+
+        assert "bytelixir_session_cookie" not in stamps, (
+            "an upgraded row was stamped with the upgrade time and will read as fresh"
+        )
+
+
+class TestAStoredFlagMeansWhatItSays:
+    """CashPilot-153: bool() on a TEXT config value.
+
+    "false", "0" and "no" were all truthy, and the flag decides whether the
+    fleet page says "turning it off would save that" or "this machine would be
+    on anyway" — opposite advice from the same setting.
+    """
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "off", "", "  "])
+    def test_falsey_strings_are_false(self, value):
+        from app.main import _config_flag
+
+        assert _config_flag({"k": value}, "k") is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on"])
+    def test_truthy_strings_are_true(self, value):
+        from app.main import _config_flag
+
+        assert _config_flag({"k": value}, "k") is True
+
+    def test_an_absent_key_is_false(self):
+        from app.main import _config_flag
+
+        assert _config_flag({}, "k") is False
+
+    def test_the_endpoint_uses_it(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "dedicated=bool(config.get(" not in source
+
+
+class TestTheLegacyTariffKeyWorksEverywhere:
+    """CashPilot-a02: one endpoint honoured the old key name, the other did not.
+
+    An upgrading user who had set electricity_price_per_kwh saw running costs
+    on the fleet page and "cost unknown" on the dashboard, from one value.
+    """
+
+    def test_both_key_names_resolve(self):
+        from app.main import _tariff_price
+
+        assert _tariff_price({"power_price_per_kwh": "0.20"}) == 0.20
+        assert _tariff_price({"electricity_price_per_kwh": "0.21"}) == 0.21
+
+    def test_the_current_name_wins_when_both_are_set(self):
+        from app.main import _tariff_price
+
+        assert _tariff_price({"power_price_per_kwh": "0.20", "electricity_price_per_kwh": "0.99"}) == 0.20
+
+    def test_neither_set_is_zero_not_an_error(self):
+        from app.main import _tariff_price
+
+        assert _tariff_price({}) == 0.0
+
+    def test_no_endpoint_reads_the_key_directly_any_more(self):
+        """The asymmetry could only exist because two sites parsed it themselves."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        body = source[source.index("def _tariff_price") + 100 :]
+        assert 'cfg.get("power_price_per_kwh") or 0' not in body
+
+    @pytest.mark.asyncio
+    async def test_the_legacy_key_alone_makes_cost_known(self):
+        """The user-visible symptom, not just the helper."""
+        from app import main
+
+        cfg = {"electricity_price_per_kwh": "0.20", "power_currency": "EUR"}
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main.database, "get_config", AsyncMock(return_value=cfg)),
+            patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=[])),
+            patch.object(main.database, "list_workers", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={})),
+        ):
+            out = await main.api_earnings_net(MagicMock(), days=30)
+        assert out["cost_known"] is True, "the legacy tariff key still reads as no tariff set"
+
+
+class TestTheAdminSchemaIsNotPublished:
+    """CashPilot-4ks: /docs, /redoc and /openapi.json were unauthenticated.
+
+    The schema is a complete map of the admin surface — every route, parameter
+    and body shape, including the worker and payout endpoints.
+    """
+
+    def test_the_interactive_docs_are_disabled(self):
+        from app.main import app
+
+        assert app.docs_url is None
+        assert app.redoc_url is None
+
+    def test_the_schema_endpoint_is_disabled(self):
+        from app.main import app
+
+        assert app.openapi_url is None
+
+    def test_no_route_serves_them(self):
+        from app.main import app
+
+        paths = {getattr(r, "path", "") for r in app.routes}
+        assert not paths & {"/docs", "/redoc", "/openapi.json"}
+
+
+class TestAPartiallyConfiguredCollectorSaysSo:
+    """CashPilot-0id: `.some` meant one of two credentials read as Configured.
+
+    The server skipped that collector for the missing field, so the badge
+    asserted the opposite of what was happening — it silently never collected.
+    """
+
+    def test_the_badge_requires_every_required_field(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "setCount === required.length" in source
+        assert "const configured = col.fields.some(" not in source
+
+    def test_there_is_a_distinct_incomplete_state(self):
+        """Configured and untouched are not the only two possibilities."""
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "Incomplete" in source
+        assert "const partial =" in source
+
+    def test_optional_fields_do_not_block_it(self):
+        """Bytelixir's durable cookies are optional; requiring them would lie the other way."""
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "col.fields.filter(f => f.required)" in source
+
+
+class TestTheCredentialHintReachesSettings:
+    """CashPilot-0rw: the hint was rendered only in the modal.
+
+    services/_schema.yml says it is "shown next to the input in Settings" —
+    the one screen a tracking-only user actually uses.
+    """
+
+    def test_the_collector_body_renders_it(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        body = source[source.index('<div class="collector-body">') :][:400]
+        assert "col.hint" in body
+
+    def test_it_goes_through_the_sanitiser(self):
+        """The hints contain anchors, so raw insertion would be an XSS sink."""
+        source = APP_JS.read_text(encoding="utf-8")
+        body = source[source.index('<div class="collector-body">') :][:400]
+        assert "sanitizeHint(col.hint)" in body
+
+
+class TestChangingTheEntrypointBuildsAnImage:
+    """CashPilot-x2r: entrypoint.sh is the ENTRYPOINT of both images.
+
+    It was in neither the release paths filter nor either detect regex, so a
+    change to the privilege-drop and Docker-socket-group script shipped no
+    image at all.
+    """
+
+    def _release(self) -> str:
+        return (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    def test_it_triggers_the_workflow(self):
+        assert "- 'entrypoint.sh'" in self._release()
+
+    def test_it_builds_both_images(self):
+        """It is COPY'd into both, so one regex is not enough."""
+        source = self._release()
+        assert source.count("entrypoint\\.sh") >= 2
+
+    def test_it_really_is_in_both_dockerfiles(self):
+        """If this stops being true, the two-regex requirement above changes."""
+        for name in ("Dockerfile", "Dockerfile.worker"):
+            assert "entrypoint.sh" in (ROOT / name).read_text(encoding="utf-8")
+
+
+class TestASuppliedEncryptionKeyIsNotTreatedAsEphemeral:
+    """CashPilot-w3g: startup refused when the key file could not be written.
+
+    A key supplied through CASHPILOT_ENCRYPTION_KEY is identical on every
+    restart, so failing to cache it loses nothing. The refusal told the user to
+    "supply a key via CASHPILOT_ENCRYPTION_KEY" — which they already had.
+    """
+
+    def test_the_flag_is_conditional_on_where_the_key_came_from(self):
+        source = (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+        assert "_fernet_key_is_ephemeral = env_key is None" in source
+        assert "_fernet_key_is_ephemeral = True\n        _logger.error" not in source
+
+    def test_a_minted_key_is_still_ephemeral_when_unwritable(self):
+        """The guard must keep working for the case it was built for."""
+        source = (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+        assert "env_key is None" in source
+
+
+class TestTheSaladHintPointsAtAHostThatExists:
+    """CashPilot-ecc: app.salad.com does not resolve. The dashboard is app.salad.io."""
+
+    def test_the_hint_uses_the_working_host(self):
+        text = (ROOT / "services" / "compute" / "salad.yml").read_text(encoding="utf-8")
+        assert "app.salad.com" not in text
+        assert "app.salad.io" in text
+
+    def test_it_matches_the_dashboard_url_in_the_same_file(self):
+        """The right host was already in the file, three lines away."""
+        text = (ROOT / "services" / "compute" / "salad.yml").read_text(encoding="utf-8")
+        hint = re.search(r"credential_hint: \"(.*)\"", text)
+        assert hint and "app.salad.io" in hint.group(1)
+
+
+class TestTheDocsDescribeTheCodeThatExists:
+    """CashPilot-i5l: CLAUDE.md described a synthetic baseline row.
+
+    No such code exists — `grep -rni synthetic app/` returns nothing. The
+    documented outcome is delivered by the no-predecessor rule instead.
+    """
+
+    def test_no_synthetic_baseline_is_claimed(self):
+        text = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "insert synthetic baseline record" not in text
+
+    def test_no_synthetic_baseline_is_written(self):
+        """The doc was wrong, so the fix is to the doc — assert that stays true."""
+        for path in (ROOT / "app").rglob("*.py"):
+            assert "synthetic" not in path.read_text(encoding="utf-8").lower(), path.name
+
+
+def test_the_batch_touched_ten_beads():
+    """A count, so a silently dropped fix is visible in review."""
+    classes = [name for name, obj in globals().items() if name.startswith("Test") and isinstance(obj, type)]
+    assert len(classes) == 10, f"expected 10 bead classes, found {len(classes)}: {sorted(classes)}"


### PR DESCRIPTION
First of the bead batches. **Ten beads, all independently re-verified against this branch before being touched** — the audit's adversarial pass had already refuted 13 of 94 findings, so nothing here was taken on trust.

Targets `feat/payout-queue-ui`, not `main`, deliberately: `release.yml` fires on every push to main touching `app/**`, so merging batches straight to main would cut one release each. Stacking here yields a single release at the end.

| Bead | Defect |
|---|---|
| `c1q` + `i21` | Upgraded volumes reported every credential "fresh", including ones expired days earlier |
| `153` | `bool("false")` is True — the dedicated flag gave opposite advice |
| `a02` | Legacy tariff key worked on one endpoint, ignored on the other |
| `4ks` | `/docs`, `/redoc`, `/openapi.json` served unauthenticated |
| `0id` | One of two credentials showed "Configured" while collection silently never ran |
| `0rw` | Credential hints never reached the Settings page they were written for |
| `x2r` | Changing `entrypoint.sh` published no image |
| `w3g` | Startup refused with a supplied encryption key, telling the user to supply one |
| `ecc` | Salad hint pointed at a host that does not resolve |
| `i5l` | `CLAUDE.md` documented a synthetic baseline row that does not exist |

`c1q`/`i21` are the same defect filed from two audit areas — one fix closes both.

**Verification:** 2386 tests, 95.08% coverage, ruff clean, all JS parses. Negative controls run: reverting the docs and dedicated fixes turns four tests red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collector setup status to clearly identify incomplete credentials.
  - Sanitized credential guidance is now displayed safely in settings.
  - Preserved supplied encryption keys across restarts when persistence is unavailable.
  - Corrected tariff handling, boolean settings, and first-reading earnings behavior.
  - Updated Salad connection instructions to use the correct website.
  - Disabled interactive API documentation and schema endpoints for improved security.

- **Documentation**
  - Clarified earnings baseline behavior and updated collector setup guidance.

- **Release Improvements**
  - Changes to the application entrypoint now trigger the required builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->