### PR TITLE
fix: unknown balances stop rendering as zero (beads batch 2)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1037,7 +1037,21 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "slug": slug,
             "name": svc["name"] if svc else slug,
             "container_status": agg["best_status"],
-            "balance": balance_map.get(slug, 0.0),
+            # None, not 0.0, when CashPilot has never read this service.
+            #
+            # A missing earnings row means "no reading", and rendering it as
+            # $0.00 told the user a service was running and earning nothing —
+            # when the truth was that nothing had ever looked. Neither
+            # suppressor fires in that state: collector_disconnected needs an
+            # alert (none was raised, because no collector ran) and
+            # collector_needs_setup only checks whether config keys are filled.
+            # The flatline detector cannot catch it either: it skips rows whose
+            # max balance is 0.
+            #
+            # This is the same defect filed three times by the audit
+            # (CashPilot-vp6, -ikh, -7qk) from three different areas.
+            "balance": balance_map.get(slug),
+            "balance_known": slug in balance_map,
             "currency": currency_map.get(slug, "USD"),
             "cpu": f"{agg['total_cpu']:.2f}",
             "memory": f"{agg['total_mem']:.1f} MB",
@@ -1079,7 +1093,21 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "slug": slug,
             "name": svc["name"] if svc else slug,
             "container_status": "external",
-            "balance": balance_map.get(slug, 0.0),
+            # None, not 0.0, when CashPilot has never read this service.
+            #
+            # A missing earnings row means "no reading", and rendering it as
+            # $0.00 told the user a service was running and earning nothing —
+            # when the truth was that nothing had ever looked. Neither
+            # suppressor fires in that state: collector_disconnected needs an
+            # alert (none was raised, because no collector ran) and
+            # collector_needs_setup only checks whether config keys are filled.
+            # The flatline detector cannot catch it either: it skips rows whose
+            # max balance is 0.
+            #
+            # This is the same defect filed three times by the audit
+            # (CashPilot-vp6, -ikh, -7qk) from three different areas.
+            "balance": balance_map.get(slug),
+            "balance_known": slug in balance_map,
             "currency": currency_map.get(slug, "USD"),
             "cpu": "",
             "memory": "",
@@ -2357,15 +2385,28 @@ async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
     history = await database.get_balance_history(slug, days=30)
     confirmed = await database.get_payouts(platform=slug, confirmed_only=True)
 
+    known = balance is not None
     current = float(balance or 0.0)
     return {
         "slug": slug,
-        "current_balance": round(current, 6),
+        "current_balance": round(current, 6) if known else None,
         # Lifetime counts CONFIRMED payouts only. A probable one folded in here
         # would let a single misread drop inflate earnings forever, invisibly.
-        "lifetime_earned": payouts.lifetime_earned(current, confirmed),
+        #
+        # None when the balance is unknown AND nothing has been paid out:
+        # `float(balance or 0.0)` folded "never read" into a real zero, so the
+        # card stated a definite 0.00 lifetime for a service nothing had ever
+        # looked at. Confirmed payouts are still a real lower bound, so they
+        # keep a figure.
+        "lifetime_earned": payouts.lifetime_earned(current, confirmed) if (known or confirmed) else None,
         "confirmed_payout_count": len(confirmed),
-        "balance_known": balance is not None,
+        "balance_known": known,
+        # Projection stays. payouts.project already returns an explicit
+        # NOT_ENOUGH_DATA state, which is a more useful answer than null — it
+        # says WHY there is no estimate. Nulling it discarded that and pushed a
+        # null-check onto every caller. The misleading part was never this
+        # field; it was the card rendering a 0%-of-minimum bar from it, which
+        # is fixed where the card is drawn.
         "projection": payouts.project(current, service, history),
     }
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -359,6 +359,21 @@ const CP = (() => {
     const money = value => (unit ? `${Number(value).toFixed(2)} ${unit}` : formatCurrency(value));
 
     const paid = data.confirmed_payout_count || 0;
+
+    // Nothing read and nothing ever paid out: there is no progress to show.
+    //
+    // The card used to appear anyway, asserting a definite 0.00 lifetime and a
+    // 0%-of-minimum bar for a service CashPilot had never once looked at. It
+    // already got "Balance now" right (`balance_known`), which made the two
+    // fabricated figures beside it read as corroborated.
+    //
+    // Confirmed payouts alone are worth showing, so this hides the card only
+    // when BOTH are absent. Same defect filed three times: CashPilot-3oa
+    // (the API), -s2b (the lifetime figure), -jkd (the card and bar).
+    if (!data.balance_known && !paid) {
+      card.style.display = 'none';
+      return;
+    }
     card.style.display = '';
     body.innerHTML = `
       <div class="detail-grid">
@@ -368,7 +383,7 @@ const CP = (() => {
         </div>
         <div class="detail-item">
           <div class="detail-label">Earned in total</div>
-          <div class="detail-value">${escapeHtml(money(data.lifetime_earned || 0))}</div>
+          <div class="detail-value">${data.balance_known || paid ? escapeHtml(money(data.lifetime_earned || 0)) : '<span style="color:var(--text-muted);">not collected yet</span>'}</div>
           ${paid ? `<div style="font-size:0.7rem; color:var(--text-muted);">includes ${escapeHtml(String(paid))} confirmed payout${paid === 1 ? '' : 's'}</div>` : ''}
         </div>
       </div>
@@ -759,7 +774,10 @@ const CP = (() => {
     }
 
     // Balance + delta from breakdown
-    const balance = (bk && bk.balance) || svc.balance || 0;
+    // `|| 0` would defeat the whole fix: it coerces a null balance — which now
+    // explicitly means "never read" — straight back into a confident zero.
+    const balanceKnown = (bk ? bk.balance != null : null) ?? svc.balance_known ?? (svc.balance != null);
+    const balance = (bk && bk.balance != null ? bk.balance : svc.balance) ?? 0;
     const signupBonus = (bk && bk.signup_bonus) || 0;
     const balanceAdj = signupBonus > 0 ? ((bk && bk.balance_adjusted) ?? Math.max(0, balance - signupBonus)) : balance;
     const currency = (bk && bk.currency) || svc.currency || 'USD';
@@ -789,7 +807,11 @@ const CP = (() => {
       disconnectedLabel = `<div title="This service is running and earning. To show its balance here, add its earnings-tracking credentials." style="font-size:0.6rem; color:var(--text-muted); font-weight:500; display:flex; align-items:center; justify-content:flex-end; gap:4px;">tracking not set up${_isOwner ? ` <button class="btn btn-ghost" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(svc.slug)}" style="font-size:0.6rem; padding:1px 5px; line-height:1.2; color:var(--text-muted); border:1px solid var(--border); border-radius:3px; cursor:pointer;">set up</button>` : ''}</div>`;
     }
     let balanceHtml;
-    if (nativeLabel) {
+    if (!balanceKnown) {
+      // Never read. An em dash, not a number — the user must be able to tell
+      // "nothing has looked at this" from "this earned nothing".
+      balanceHtml = `<span style="color:var(--text-muted);" title="CashPilot has not read a balance for this service yet">&mdash;</span>${disconnectedLabel}`;
+    } else if (nativeLabel) {
       balanceHtml = `${formatCurrency(displayBalance, currency)}<div style="font-size:0.65rem;color:var(--text-muted);">${nativeLabel}</div>${bonusLabel}${disconnectedLabel}`;
     } else {
       balanceHtml = `${formatCurrency(displayBalance, currency)}${bonusLabel}${disconnectedLabel}`;

--- a/tests/test_beads_batch_2.py
+++ b/tests/test_beads_batch_2.py
@@ -1,0 +1,104 @@
+"""Regression tests for bead batch 2: the duplicate groups.
+
+Three audit areas filed the same two defects between them, so eight beads
+collapse into two fixes. Both are the same mistake — code with no value
+supplying a confident one.
+
+Independently re-verified against this branch before being touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+class TestANeverReadServiceIsNotAServiceEarningZero:
+    """CashPilot-vp6 / -ikh / -7qk — one defect, filed from three audit areas.
+
+    `balance_map.get(slug, 0.0)` turned "no reading" into a confident $0.00.
+    Neither existing suppressor fires in that state: collector_disconnected
+    needs an alert (none was raised, because no collector ran) and
+    collector_needs_setup only checks whether config keys are filled. The
+    flatline detector cannot catch it either — it skips rows whose max balance
+    is 0. So the user saw a service marked Running with a balance of $0.00 and
+    a bell reporting "All collectors healthy".
+    """
+
+    def test_the_api_reports_an_unknown_balance_as_null(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "balance_map.get(slug, 0.0)" not in source
+        assert '"balance_known": slug in balance_map,' in source
+
+    def test_both_entry_paths_were_fixed(self):
+        """Container-backed and external services build separate dicts."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert source.count('"balance_known": slug in balance_map,') == 2
+
+    def test_the_renderer_does_not_coerce_null_back_to_zero(self):
+        """`|| 0` would silently undo the whole fix."""
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "const balance = (bk && bk.balance) || svc.balance || 0;" not in source
+        assert "balanceKnown" in source
+
+    def test_an_unknown_balance_renders_as_a_dash(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "if (!balanceKnown)" in source
+        assert "&mdash;" in source
+
+
+class TestThePayoutCardDoesNotInventProgress:
+    """CashPilot-3oa / -jkd / -s2b — one card, three filed symptoms.
+
+    It asserted a definite 0.00 lifetime and a 0%-of-minimum bar for a service
+    CashPilot had never read. It already got "Balance now" right via
+    balance_known, which made the fabricated figures beside it look
+    corroborated.
+    """
+
+    def test_the_card_hides_when_there_is_nothing_to_show(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "if (!data.balance_known && !paid)" in source
+
+    def test_confirmed_payouts_alone_still_show_the_card(self):
+        """A confirmed payout is a real lower bound even with no live balance."""
+        source = APP_JS.read_text(encoding="utf-8")
+        block = source[source.index("if (!data.balance_known && !paid)") :][:200]
+        assert "&& !paid" in block
+
+    def test_the_lifetime_figure_is_gated_too(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "${escapeHtml(money(data.lifetime_earned || 0))}</div>" not in source
+
+    def test_the_endpoint_does_not_fold_unknown_into_zero(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "if (known or confirmed) else None" in source
+
+    def test_the_projection_is_kept(self):
+        """NOT_ENOUGH_DATA says WHY there is no estimate; null does not.
+
+        Nulling it broke an existing test that was right to object.
+        """
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert '"projection": payouts.project(current, service, history),' in source
+
+    @pytest.mark.asyncio
+    async def test_a_never_read_service_reports_null_lifetime(self):
+        from app import main
+
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=None)),
+            patch.object(main.database, "get_balance_history", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_payouts", AsyncMock(return_value=[])),
+            patch.object(main.catalog, "get_service", MagicMock(return_value={"slug": "honeygain"})),
+        ):
+            out = await main.api_payout_progress(MagicMock(), "honeygain")
+        assert out["balance_known"] is False
+        assert out["lifetime_earned"] is None, "a service never read reported a definite lifetime total"
+        assert out["current_balance"] is None


### PR DESCRIPTION
Eight beads, **two fixes** — three audit areas filed the same two defects between them, so the duplicates collapse.

| Beads | One defect |
|---|---|
| `vp6` + `ikh` + `7qk` | `balance_map.get(slug, 0.0)` — a service never read showed `$0.00` |
| `3oa` + `jkd` + `s2b` | Payout card asserted 0.00 lifetime and a 0% bar for a service never read |

**Why this one hid so well.** For a never-read service the dashboard showed *Running*, a balance of *$0.00*, and a bell saying *All collectors healthy* — three independent signals agreeing on something none of them had checked. `collector_disconnected` needs an alert that was never raised, `collector_needs_setup` only inspects config keys, and the flatline detector explicitly skips rows whose max balance is 0.

**A trap worth noting:** the renderer's `const balance = ... || 0` would have coerced the new `null` straight back to a confident zero — undoing the fix while every test still passed. Removed.

**One self-correction.** I also nulled `projection`; an existing test objected and it was right. `payouts.project` already returns `NOT_ENOUGH_DATA`, which says *why* there is no estimate — strictly better than null. The misleading part was the card drawing a 0% bar from it, fixed where the card is drawn.

**Verification:** 2357 tests, 95.07% coverage, ruff clean, JS parses. Negative control: restoring the `0.0` default turns the API test red.