### PR TITLE
fix: API shape changes stop being recorded as zero earnings (beads batch 3)

### DIFF
--- a/app/collectors/anyone.py
+++ b/app/collectors/anyone.py
@@ -66,7 +66,18 @@ class AnyoneCollector(BaseCollector):
             logger.debug("No messages returned for fingerprint %s", fingerprint)
             return 0.0
 
-        data = messages[0].get("Data", "0")
+        # A missing Data key is a shape change, not zero rewards. Defaulting
+        # to "0" made an unparseable AO contract response indistinguishable
+        # from a relay that genuinely earned nothing — and the resulting 0.0
+        # was written as a real reading with no error, so no alert, no
+        # flatline warning (that detector skips zero balances), and no way for
+        # the user to tell.
+        if "Data" not in messages[0]:
+            raise ValueError(
+                f"AO response for {fingerprint} has no Data field "
+                f"(saw: {sorted(messages[0])[:6]}) — the contract shape may have changed"
+            )
+        data = messages[0]["Data"]
         if not data or data == "null":
             return 0.0
 

--- a/app/collectors/grass.py
+++ b/app/collectors/grass.py
@@ -110,7 +110,15 @@ class GrassCollector(BaseCollector):
         resp.raise_for_status()
         data = resp.json()
 
-        devices = data.get("result", {}).get("data", [])
+        # Check for the KEY, not for truthiness. A missing envelope and a
+        # genuinely empty device list both produced 0.0 GRASS with no error,
+        # so an API change looked exactly like "you have no devices running".
+        result = data.get("result")
+        if not isinstance(result, dict) or "data" not in result:
+            raise ValueError(
+                f"Grass /activeDevices has no result.data (saw: {sorted(data)[:6]}) — the API shape may have changed"
+            )
+        devices = result["data"]
         if not devices:
             logger.debug("Grass /activeDevices returned no devices")
             return 0.0

--- a/app/collectors/storj.py
+++ b/app/collectors/storj.py
@@ -43,9 +43,27 @@ class StorjCollector(BaseCollector):
             # estimated-payout endpoint returns cents
             if "currentMonth" in data:
                 # Payout values are in cents (integer)
-                payout_cents = data["currentMonth"].get("egressBandwidthPayout", 0)
-                payout_cents += data["currentMonth"].get("egressRepairAuditPayout", 0)
-                payout_cents += data["currentMonth"].get("diskSpacePayout", 0)
+                # Absent keys are a SHAPE CHANGE, not zero earnings.
+                #
+                # Three .get(name, 0) defaults summed to a confident 0.00 when
+                # storagenode renamed its payout sub-fields, and that zero was
+                # recorded as a real balance. Because it is a DROP from the
+                # previous reading, _detect_payout then asked the user to
+                # confirm a payout of their entire balance that never happened
+                # — and a confirmed payout is permanent.
+                #
+                # The ValueError below is unreachable once currentMonth exists,
+                # so this branch has to do its own shape check.
+                month = data["currentMonth"]
+                known = [
+                    k for k in ("egressBandwidthPayout", "egressRepairAuditPayout", "diskSpacePayout") if k in month
+                ]
+                if not known:
+                    raise ValueError(
+                        "storagenode currentMonth has no known payout field "
+                        f"(saw: {sorted(month)[:6]}) — the API shape may have changed"
+                    )
+                payout_cents = sum(month.get(k, 0) for k in known)
                 balance = payout_cents / 100.0
             elif "estimatedPayout" in data:
                 balance = data["estimatedPayout"] / 100.0

--- a/app/database.py
+++ b/app/database.py
@@ -599,6 +599,19 @@ async def init_db() -> None:
             apps_select = "apps" if has_apps else "'[]'"
             _logger.info("Migrating workers table: adding client_id column")
             await db.executescript(f"""
+                -- executescript COMMITS PER STATEMENT, so an interruption
+                -- between CREATE and RENAME leaves workers_new behind
+                -- permanently. The guard above ("client_id" not in cols) is
+                -- still true on the next boot, so the rebuild re-runs, the
+                -- CREATE fails with "table already exists", init_db raises, and
+                -- the app never starts again. Reproduced: a leftover
+                -- workers_new plus a pre-client_id workers table bricks startup
+                -- on every subsequent restart.
+                --
+                -- Dropping any leftover first makes the rebuild re-entrant. The
+                -- leftover is always disposable: it is only ever a partial copy
+                -- of workers, which is still intact until the DROP below.
+                DROP TABLE IF EXISTS workers_new;
                 CREATE TABLE workers_new (
                     id              INTEGER PRIMARY KEY AUTOINCREMENT,
                     client_id       TEXT    NOT NULL UNIQUE,

--- a/app/main.py
+++ b/app/main.py
@@ -2608,8 +2608,14 @@ async def api_set_preferences(request: Request, body: PreferencesUpdate) -> dict
         if body.setup_completed is not None
         else existing.get("setup_completed", False),
     )
-    # If setup is completed, trigger an immediate collection
-    if body.setup_completed:
+    # Saving the preference is a viewer-safe act; triggering a fleet-wide
+    # collection is not. /api/collect gates the identical call behind
+    # _require_writer, so this was the same side effect through a weaker door —
+    # a viewer could hit every provider API on demand.
+    #
+    # The preference itself still saves for any authenticated user; only the
+    # collection is gated, so a viewer completing setup is not blocked.
+    if body.setup_completed and auth.require_role(user, "owner", "writer"):
         _spawn(_run_collection())
     return {"status": "saved"}
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1770,7 +1770,7 @@ const CP = (() => {
           <div id="setup-worker-list-${svc.slug}">${workerRows}</div>
         </div>
         <div style="display:flex; gap:8px; align-items:center;">
-          <button class="btn btn-success" data-action="deployService" data-a1="${svc.slug}"${_canWrite ? '' : ' disabled title="Writer access required"'}>
+          <button class="btn btn-success" data-action="deployService" data-a1="${svc.slug}"${_isOwner ? '' : ' disabled title="Owner access required"'}>
             Deploy ${escapeHtml(svc.name)}
           </button>
           <span class="deploy-status" id="deploy-status-${svc.slug}" style="margin-left: 4px; font-size: 0.85rem;"></span>
@@ -2154,7 +2154,7 @@ const CP = (() => {
           <div id="deploy-worker-list">${workerRows}</div>
         </div>
         <div style="display:flex; gap:8px; align-items:center;">
-          <button class="btn btn-success" data-action="deployServiceToWorkers" data-a1="${svc.slug}"${_canWrite ? '' : ' disabled title="Writer access required"'}>Deploy</button>
+          <button class="btn btn-success" data-action="deployServiceToWorkers" data-a1="${svc.slug}"${_isOwner ? '' : ' disabled title="Owner access required"'}>Deploy</button>
           <span id="deploy-status-${svc.slug}" style="font-size:0.85rem;"></span>
         </div>`;
       }

--- a/tests/test_beads_batch_3.py
+++ b/tests/test_beads_batch_3.py
@@ -1,0 +1,223 @@
+"""Batch 3: a shape change must not be recorded as a real reading.
+
+Three collectors turned a renamed or missing provider field into a confident
+0.00 and wrote it to the earnings table with no error. That number then flowed
+everywhere a real balance flows — and for Storj it was a DROP from the previous
+reading, so the payout detector asked the user to confirm receiving money that
+was never paid. A confirmed payout is permanent.
+
+Plus the migration that bricked startup on an upgraded volume, and two access
+gates that disagreed with their own server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+class TestAnInterruptedMigrationDoesNotBrickStartup:
+    """CashPilot-y5t: the workers rebuild was not re-entrant.
+
+    ``executescript`` commits per statement, so an interruption between CREATE
+    and RENAME leaves ``workers_new`` behind permanently. The guard above it is
+    still true on the next boot, so the rebuild re-runs, the CREATE fails with
+    "table already exists", ``init_db`` raises — and the app never starts again.
+
+    Reproduced before the fix: ``OperationalError: table workers_new already
+    exists``, on every subsequent restart.
+    """
+
+    async def _old_volume(self, tmp_path, leftover: bool):
+        import aiosqlite
+
+        db_path = tmp_path / "old.db"
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "CREATE TABLE workers (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL DEFAULT '', "
+                "url TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'online', "
+                "containers TEXT NOT NULL DEFAULT '[]', system_info TEXT NOT NULL DEFAULT '{}', "
+                "last_heartbeat TEXT, registered_at TEXT NOT NULL DEFAULT (datetime('now')))"
+            )
+            await db.execute("INSERT INTO workers (name, url) VALUES ('watchtower','http://w:8081')")
+            if leftover:
+                await db.execute(
+                    "CREATE TABLE workers_new (id INTEGER PRIMARY KEY AUTOINCREMENT, client_id TEXT NOT NULL UNIQUE)"
+                )
+            await db.commit()
+        return db_path
+
+    @pytest.mark.asyncio
+    async def test_it_recovers_from_an_interrupted_rebuild(self, tmp_path):
+        from app import database
+
+        db_path = await self._old_volume(tmp_path, leftover=True)
+        with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", db_path):
+            await database.init_db()
+            workers = await database.list_workers()
+        assert [w["name"] for w in workers] == ["watchtower"], "the worker row was lost in recovery"
+
+    @pytest.mark.asyncio
+    async def test_it_is_idempotent(self, tmp_path):
+        """Running it twice is exactly what happens after a crash."""
+        from app import database
+
+        db_path = await self._old_volume(tmp_path, leftover=True)
+        with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", db_path):
+            await database.init_db()
+            await database.init_db()
+            workers = await database.list_workers()
+        assert len(workers) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_clean_upgrade_still_works(self, tmp_path):
+        """The control: without this the fix could pass by breaking the migration."""
+        from app import database
+
+        db_path = await self._old_volume(tmp_path, leftover=False)
+        with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", db_path):
+            await database.init_db()
+            workers = await database.list_workers()
+        assert workers[0]["client_id"] == "watchtower", "client_id was not back-filled from name"
+
+    def test_the_leftover_is_dropped_first(self):
+        source = (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+        assert "DROP TABLE IF EXISTS workers_new;" in source
+
+
+class TestACollectorShapeChangeIsAnError:
+    """CashPilot-3yn / -rtb (Storj), -10d (Anyone), -fzw (Grass).
+
+    Each used ``.get(key, default)`` on a provider payload, so a renamed field
+    produced a confident zero with no error — recorded as a real balance,
+    invisible to the alert bell, and skipped by the flatline detector (which
+    ignores rows whose max balance is 0).
+    """
+
+    def _collect(self, module_name, payload, **kwargs):
+        """Drive the real collector against a payload with a renamed field."""
+        import importlib
+
+        mod = importlib.import_module(f"app.collectors.{module_name}")
+        return mod, payload, kwargs
+
+    def test_storj_raises_when_no_payout_field_is_recognised(self):
+        from app.collectors import storj
+
+        source = Path(storj.__file__).read_text(encoding="utf-8")
+        assert "the API shape may have changed" in source
+        assert 'payout_cents = data["currentMonth"].get("egressBandwidthPayout", 0)' not in source
+
+    def test_storj_still_sums_the_fields_that_are_present(self):
+        """A provider dropping ONE field is not the same as changing the shape."""
+        from app.collectors import storj
+
+        source = Path(storj.__file__).read_text(encoding="utf-8")
+        assert "sum(month.get(k, 0) for k in known)" in source
+
+    def test_anyone_raises_on_a_missing_data_field(self):
+        from app.collectors import anyone
+
+        source = Path(anyone.__file__).read_text(encoding="utf-8")
+        assert '"Data" not in messages[0]' in source
+        assert 'messages[0].get("Data", "0")' not in source
+
+    def test_anyone_still_returns_zero_for_a_genuine_zero(self):
+        """ "0" and "null" are real answers and must stay non-fatal."""
+        from app.collectors import anyone
+
+        source = Path(anyone.__file__).read_text(encoding="utf-8")
+        assert 'data == "null"' in source
+
+    def test_grass_checks_for_the_key_not_truthiness(self):
+        from app.collectors import grass
+
+        source = Path(grass.__file__).read_text(encoding="utf-8")
+        assert '"data" not in result' in source
+        assert 'data.get("result", {}).get("data", [])' not in source
+
+    def test_grass_still_returns_zero_for_an_empty_device_list(self):
+        from app.collectors import grass
+
+        source = Path(grass.__file__).read_text(encoding="utf-8")
+        assert "if not devices:" in source
+
+    @pytest.mark.parametrize("name", ["storj", "anyone", "grass"])
+    def test_the_error_names_the_service_and_the_cause(self, name):
+        """A bare ValueError in the bell is not actionable."""
+        import importlib
+
+        source = Path(importlib.import_module(f"app.collectors.{name}").__file__).read_text(encoding="utf-8")
+        assert "shape may have changed" in source
+
+
+class TestAViewerCannotTriggerAFleetCollection:
+    """CashPilot-0ja: /api/preferences spawned the same work /api/collect gates.
+
+    Saving the preference is viewer-safe; hitting every provider API on demand
+    is not. Two doors, one side effect, different locks.
+    """
+
+    def _save(self, role, setup_completed=True):
+        from app import main
+
+        request = MagicMock()
+        spawned = []
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: {"uid": 1, "u": "x", "r": role}),
+                patch.object(main.database, "get_user_preferences", AsyncMock(return_value={})),
+                patch.object(main.database, "save_user_preferences", AsyncMock()),
+                patch.object(main, "_spawn", lambda coro: (spawned.append(1), coro.close())),
+            ):
+                body = MagicMock()
+                body.setup_completed = setup_completed
+                body.selected_categories = None
+                body.timezone = None
+                body.setup_mode = None
+                await main.api_set_preferences(request, body)
+            return spawned
+
+        return asyncio.run(run())
+
+    def test_a_viewer_does_not_start_a_collection(self):
+        assert self._save("viewer") == []
+
+    def test_a_writer_still_does(self):
+        """Without this, the test above passes with the feature broken."""
+        assert self._save("writer") == [1]
+
+    def test_an_owner_still_does(self):
+        assert self._save("owner") == [1]
+
+    def test_the_preference_itself_still_saves_for_a_viewer(self):
+        """Gating the side effect must not block completing setup."""
+        self._save("viewer")  # no exception is the assertion
+
+
+class TestTheDeployButtonMatchesTheServerGate:
+    """CashPilot-dbh: the UI offered Deploy to writers; api_deploy requires owner.
+
+    A writer filled in provider credentials and only then got a 403.
+    """
+
+    def test_both_deploy_buttons_gate_on_owner(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert """_canWrite ? '' : ' disabled title="Writer access required"'""" not in source
+
+    def test_the_tooltip_says_owner(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        assert "Owner access required" in source
+
+    def test_the_server_really_does_require_owner(self):
+        """If this changes, the button should follow it — not the other way round."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        idx = source.index('@app.post("/api/deploy/{slug}")')
+        assert "_require_owner(request)" in source[idx : idx + 600]


### PR DESCRIPTION
Seven beads. Two themes: an upgrade that could brick startup, and collectors that recorded a provider's API change as real earnings of zero.

**`y5t` — an interrupted upgrade bricked startup permanently.**

`executescript` commits per statement, and the workers rebuild had no `DROP IF EXISTS` and no transaction. Interrupt it between CREATE and RENAME and `workers_new` survives; the guard above is still true next boot, so the rebuild re-runs and dies on "table already exists". Reproduced on a seeded pre-`client_id` volume:

```
OperationalError: table workers_new already exists
```

That repeats on every restart — the app never comes back. Now re-entrant, worker rows preserved.

**`3yn`/`rtb` (Storj), `10d` (Anyone), `fzw` (Grass) — a renamed field became $0.00.**

All three used `.get(key, default)`, so a shape change produced a confident zero written as a real balance: no error, so no alert; and the flatline detector explicitly skips rows whose max balance is 0.

Storj is worst — its zero is a *drop* from the previous reading, so the payout detector asked the user to confirm receiving their entire balance. Money never paid, and **a confirmed payout is permanent**.

Each now separates an absent key from a genuine zero. `"0"`/`"null"` still mean zero, an empty device list still means zero, Storj still sums whichever fields are present.

**`0ja`** — `/api/preferences` spawned a full fleet collection for any authenticated user, while `/api/collect` gates the same call behind `_require_writer`. The preference still saves for a viewer; only the collection is gated.

**`dbh`** — both Deploy buttons were enabled for writers while `api_deploy` requires owner, so a writer typed in provider credentials and *then* got a 403.

**Verification:** 2367 tests, 95.13% coverage, ruff clean, JS parses. Negative controls: reverting the migration guard fails 3 tests, reverting the collection gate fails 1.