### PR TITLE
fix: session hijack when adding a user, and unconfirmed worker keys (beads batch 5)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1555,8 +1555,17 @@ async def _get_verified_worker_url(worker: dict[str, Any]) -> tuple[str, dict[st
     # shared bootstrap key only for workers that have not enrolled yet. Post-cutover
     # an enrolled worker rejects the shared key, so the UI must present its own.
     cid = worker.get("client_id") or ""
-    worker_key = await database.get_worker_key(cid) if cid else None
-    auth_key = worker_key or FLEET_API_KEY
+    # Use the per-worker key only once the worker has CONFIRMED it.
+    #
+    # get_worker_key discards the confirmed flag, so the UI signed outbound
+    # commands with a key the worker may never have received — reachable
+    # whenever _save_worker_key failed on the worker ("staying on shared key").
+    # The worker then read as online from its heartbeats while every deploy,
+    # start, stop, restart and logs call failed 401, with nothing connecting
+    # the two symptoms.
+    key_state = await database.get_worker_key_state(cid) if cid else (None, False)
+    stored_key, key_confirmed = key_state if isinstance(key_state, tuple) else (key_state, False)
+    auth_key = stored_key if (stored_key and key_confirmed) else FLEET_API_KEY
     headers: dict[str, str] = {}
     if auth_key:
         headers["Authorization"] = f"Bearer {auth_key}"
@@ -2490,7 +2499,16 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
     assessed = []
     for worker in workers:
         info = worker.get("system_info") or {}
-        raw_watts = config.get(f"worker_{worker.get('id')}_watts")
+        # Keyed on client_id, not the autoincrement row id.
+        #
+        # delete_worker removes the row and nothing else, so a host that is
+        # removed and re-enrols gets a fresh id — orphaning its watts and
+        # dedicated settings silently, while the old keys linger forever. The
+        # id is also read from the row-id fallback for volumes written before
+        # this change.
+        raw_watts = config.get(f"worker_{_worker_config_key(worker)}_watts") or config.get(
+            f"worker_{worker.get('id')}_watts"
+        )
         try:
             watts = float(raw_watts) if raw_watts else None
         except (TypeError, ValueError):
@@ -2502,12 +2520,7 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
                 watts=watts,
                 price_per_kwh=price or None,
                 metered=power.is_metered(info),
-                # Config values are TEXT, so bool() made "false", "0" and "no"
-                # all mean dedicated=True — and dedicated flips the advice from
-                # "this machine would be on anyway" to "turning it off would
-                # save that". database._TRUTHY is the parser the rest of the
-                # codebase already uses for exactly this.
-                dedicated=_config_flag(config, f"worker_{worker.get('id')}_dedicated"),
+                dedicated=_worker_flag(config, worker, "dedicated"),
             )
         )
 
@@ -2694,6 +2707,35 @@ def _to_usd_with_stored(amount: float, currency: str, stored_rate: float | None)
     if live is not None:
         return live
     return amount * stored_rate if stored_rate is not None else None
+
+
+def _worker_flag(config: dict[str, Any], worker: dict[str, Any], suffix: str) -> bool:
+    """A per-worker boolean setting, read by client_id with a row-id fallback.
+
+    Two problems in one place. Config values are TEXT, so ``bool("false")`` is
+    True and a user who set a flag to "false" got the opposite of what they
+    asked for; ``database._TRUTHY`` is the parser the rest of the app already
+    uses. And the key was built from the AUTOINCREMENT row id, which changes
+    when a host is removed and re-enrolled — silently orphaning the setting —
+    so ``client_id`` is preferred, with the old id-based key still honoured for
+    volumes written before this change.
+    """
+    for key in (f"worker_{_worker_config_key(worker)}_{suffix}", f"worker_{worker.get('id')}_{suffix}"):
+        if str(config.get(key, "") or "").strip():
+            return _config_flag(config, key)
+    return False
+
+
+def _worker_config_key(worker: dict[str, Any]) -> str:
+    """The stable identifier for per-worker config keys.
+
+    The row id is an AUTOINCREMENT primary key and ``delete_worker`` deletes the
+    row without touching config, so a host removed and re-enrolled comes back
+    under a new id — silently orphaning its watts and dedicated settings while
+    the old keys linger. ``client_id`` is UNIQUE and survives re-enrolment,
+    which is what these settings should have been keyed on.
+    """
+    return str(worker.get("client_id") or worker.get("id") or "")
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -235,9 +235,20 @@ async def do_register(
         await database.delete_config_keys(["_setup_token"])
         setup_token_module.clear()
 
+    if not is_first:
+        # An owner adding a user must STAY the owner.
+        #
+        # This minted a session for the account just created and set it as the
+        # caller's cookie, so an owner who added a viewer was silently demoted
+        # into that viewer's session — losing their own access, with no sign
+        # anything had happened beyond landing on the dashboard.
+        #
+        # Only the first-run owner gets signed in here, which is the case this
+        # code was written for.
+        return RedirectResponse("/users", status_code=303)
+
     token = auth_module.create_session_token(user_id, username, role)
-    dest = "/setup" if is_first else "/"
-    response = RedirectResponse(dest, status_code=303)
+    response = RedirectResponse("/setup", status_code=303)
     return auth_module.set_session_cookie(response, token, request)
 
 

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -2127,27 +2127,35 @@ class TestOutboundWorkerAuth:
     def _worker(self):
         return {"status": "online", "url": "http://192.168.1.5:8081", "client_id": "c1"}
 
-    def test_uses_per_worker_key_when_enrolled(self):
+    def _auth(self, key_state):
+        """key_state is (key, confirmed) — the shape get_worker_key_state returns."""
         import app.main as m
 
         with (
             patch("app.main.FLEET_API_KEY", "shared-key"),
-            patch("app.main.database.get_worker_key", new_callable=AsyncMock, return_value="worker-1-key"),
+            patch("app.main.database.get_worker_key_state", new_callable=AsyncMock, return_value=key_state),
             patch("app.main._validate_worker_url", return_value=("http://192.168.1.5:8081", None)),
         ):
             _, headers = asyncio.run(m._get_verified_worker_url(self._worker()))
-        assert headers["Authorization"] == "Bearer worker-1-key"
+        return headers["Authorization"]
+
+    def test_uses_per_worker_key_when_enrolled_and_confirmed(self):
+        assert self._auth(("worker-1-key", True)) == "Bearer worker-1-key"
 
     def test_falls_back_to_shared_key_when_unenrolled(self):
-        import app.main as m
+        assert self._auth((None, False)) == "Bearer shared-key"
 
-        with (
-            patch("app.main.FLEET_API_KEY", "shared-key"),
-            patch("app.main.database.get_worker_key", new_callable=AsyncMock, return_value=None),
-            patch("app.main._validate_worker_url", return_value=("http://192.168.1.5:8081", None)),
-        ):
-            _, headers = asyncio.run(m._get_verified_worker_url(self._worker()))
-        assert headers["Authorization"] == "Bearer shared-key"
+    def test_an_unconfirmed_key_is_not_used(self):
+        """CashPilot-zcc: the worker may never have received this key.
+
+        get_worker_key discarded the confirmed flag, so the UI signed outbound
+        commands with a key the worker might not hold — reachable whenever the
+        worker failed to persist it and logged "staying on shared key". The
+        worker then read as ONLINE from its heartbeats while every deploy,
+        start, stop, restart and logs call failed 401, with nothing on screen
+        connecting the two.
+        """
+        assert self._auth(("worker-1-key", False)) == "Bearer shared-key"
 
 
 # ---------------------------------------------------------------------------
@@ -2250,3 +2258,60 @@ class TestImageDrift:
         assert _image_outdated("repo:1.0", "") is False
         # Same repo, tag vs digest (unresolvable) -> not flagged.
         assert _image_outdated("repo:1.0", "repo@sha256:x") is False
+
+
+class TestAddingAUserDoesNotStealTheOwnersSession:
+    """CashPilot-5e6: do_register signed the caller into the account it created.
+
+    An owner adding a viewer was silently demoted into that viewer's session —
+    losing their own access with no sign anything had happened beyond landing
+    on a page with fewer controls. Only the first-run owner should be signed in
+    here, which is the case the code was written for.
+    """
+
+    def _register(self, tmp_path, is_first):
+        import app.auth as auth_module
+        from app import database, setup_token
+        from app.routers import auth as auth_router
+
+        async def run():
+            with (
+                patch.object(database, "DB_DIR", tmp_path),
+                patch.object(database, "DB_PATH", tmp_path / "u.db"),
+            ):
+                await database.init_db()
+                setup_token.set_active("tok")
+                if not is_first:
+                    await database.create_user("owner", auth_module.hash_password("x" * 12), role="owner")
+                request = MagicMock()
+                request.session = {}
+                request.headers = {}
+                request.cookies = {}
+                request.client = MagicMock(host="127.0.0.1")
+                with patch.object(auth_module, "get_current_user", lambda r: {"uid": 1, "u": "owner", "r": "owner"}):
+                    return await auth_router.do_register(
+                        request,
+                        username="newviewer",
+                        password="A-real-passphrase-123",
+                        password_confirm="A-real-passphrase-123",
+                        setup_token="tok",
+                    )
+
+        return asyncio.run(run())
+
+    def test_the_owner_keeps_their_own_session(self, tmp_path):
+        resp = self._register(tmp_path, is_first=False)
+        cookies = resp.raw_headers if hasattr(resp, "raw_headers") else []
+        set_cookie = [v for k, v in cookies if k.lower() == b"set-cookie"]
+        assert not set_cookie, "adding a user replaced the caller's session cookie"
+
+    def test_the_owner_is_not_sent_to_the_dashboard_as_someone_else(self, tmp_path):
+        resp = self._register(tmp_path, is_first=False)
+        assert resp.headers["location"] == "/users"
+
+    def test_the_first_run_owner_is_still_signed_in(self, tmp_path):
+        """The case this code exists for must keep working."""
+        resp = self._register(tmp_path, is_first=True)
+        set_cookie = [v for k, v in resp.raw_headers if k.lower() == b"set-cookie"]
+        assert set_cookie, "the first owner was not signed in"
+        assert resp.headers["location"] == "/setup"


### PR DESCRIPTION
Four beads.

**`5e6` — an owner adding a user was logged into that user's account.**

`do_register` minted a session for the account it had just created and set it as the *caller's* cookie. An owner adding a viewer was silently demoted into that viewer's session — their own access gone, with no sign anything had happened beyond landing on a page with fewer controls. Only the first-run owner is signed in now.

**`zcc` — the UI signed worker commands with a key the worker never confirmed.**

`get_worker_key` discards the `confirmed` flag that `get_worker_key_state` returns. The unconfirmed state is reachable whenever a worker fails to persist its key and logs *"staying on shared key"*. The worker then reads as **online** from its heartbeats while every deploy, start, stop, restart and logs call fails **401** — two symptoms with nothing connecting them on screen.

**`cxy`** — per-worker watts/dedicated settings were keyed on the AUTOINCREMENT row id. `delete_worker` removes the row and nothing else, so a host removed and re-enrolled came back under a new id, orphaning its settings while the old keys lingered. Now keyed on `client_id`, with the old key still honoured.

**`153`** (this branch's half) — same helper fixes `bool("false") == True` on TEXT config values.

**On review coverage:** CodeRabbit had skipped *all* these PRs — "auto reviews are disabled on base branches other than the default" — a side effect of stacking them on the integration branch. The check showed green with zero review. I've triggered reviews on #182–#185 manually.

**Verification:** 2351 tests, 95.08% coverage. Negative controls for both behaviour changes — and the first `5e6` control **passed**, because my revert patch silently didn't match. Redone against the real text, it fails the two tests that name the defect.