### PR TITLE
fix: credentials alone now collect, and the collection test can fail (beads batch 6)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2956,14 +2956,22 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
         svc = catalog.get_service(slug)
         if not svc:
             continue
-        docker_conf = svc.get("docker", {})
-        has_image = bool(docker_conf and docker_conf.get("image"))
-        if has_image:
-            continue  # Docker services get deployed normally
+        # No has_image gate. Collection is driven by DEPLOYMENT ROWS
+        # (make_collectors iterates deployments), so a service with no row is
+        # never collected no matter how complete its credentials are. Skipping
+        # image-backed services here meant that for 12 of the 15 collectors,
+        # saving credentials did nothing at all — while Settings promised
+        # "You don't need to deploy containers through CashPilot — just add
+        # your credentials." The badge flipped to Configured and no earnings
+        # ever arrived.
+        #
+        # Creating the row is safe for a user who later deploys through
+        # CashPilot: api_deploy calls save_deployment with the real container
+        # id and status, replacing this placeholder.
         existing = await database.get_deployment(slug)
         if not existing:
             await database.save_deployment(slug=slug, container_id="", status="external")
-            logger.info("Auto-created external deployment for %s", slug)
+            logger.info("Tracking %s from stored credentials (no container deployed by CashPilot)", slug)
 
     return {"status": "saved"}
 
@@ -2982,12 +2990,16 @@ async def api_clear_service_config(request: Request, slug: str) -> dict[str, str
     config_keys.append(f"{slug}_signup_bonus")
     await database.delete_config_keys(config_keys)
 
-    # Remove the auto-created "external" deployment record if present
-    svc = catalog.get_service(slug)
-    if svc:
-        docker_conf = svc.get("docker", {})
-        if not (docker_conf and docker_conf.get("image")):
-            await database.remove_deployment(slug)
+    # Remove the row only if it is the placeholder we auto-created.
+    #
+    # Gated on status == "external", NOT on whether the service has an image.
+    # Clearing credentials must never undeploy a container the user actually
+    # deployed through CashPilot — that row has a real container id and a
+    # status of its own, and removing it would orphan a running container from
+    # the dashboard.
+    existing = await database.get_deployment(slug)
+    if existing and (existing.get("status") or "") == "external":
+        await database.remove_deployment(slug)
 
     logger.info("Cleared credentials for %s", slug)
     return {"status": "cleared"}

--- a/app/main.py
+++ b/app/main.py
@@ -2947,11 +2947,24 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
     # row, _run_collection() will never instantiate the collector.
     from app.collectors import _COLLECTOR_ARGS
 
+    # Completeness is judged against the MERGED config, not this request.
+    #
+    # set_config_bulk UPSERTS, so a credential set can legitimately arrive
+    # across several requests — email now, password a moment later. Checking
+    # only `sanitized` meant neither request ever saw a complete set, so both
+    # values landed in the database and no deployment row was ever created:
+    # credentials stored, collection still dead, and nothing to indicate why.
+    #
+    # Still scoped to the slugs this request touched, so saving one service's
+    # credentials does not sweep the whole catalog.
+    stored = await database.get_config() or {}
     for slug, arg_keys in _COLLECTOR_ARGS.items():
+        if not any(k.startswith(f"{slug}_") for k in sanitized):
+            continue
         required_keys = [f"{slug}_{a.lstrip('?')}" for a in arg_keys if not a.startswith("?")]
         if not required_keys:
             continue
-        if not all(sanitized.get(k) for k in required_keys):
+        if not all(stored.get(k) for k in required_keys):
             continue
         svc = catalog.get_service(slug)
         if not svc:

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -630,28 +630,54 @@ class TestMainPerNodeEarnings:
             assert resp.status_code == 200
 
 
-class TestMainSetConfigExternalDeploySkip:
-    """Cover lines 1456, 1460: config set that skips services with images."""
+class TestMainSetConfigCreatesTrackingRows:
+    """An image-backed service DOES get a tracking row from credentials alone.
 
-    def test_set_config_skips_docker_service(self, client):
-        """When all required keys are provided for a docker-image service, don't auto-deploy."""
+    This class previously asserted the opposite — "for a docker-image service,
+    don't auto-deploy" — which is the defect CashPilot-1f8 describes. Collection
+    is driven by deployment rows, so skipping image-backed services meant
+    saving credentials for 12 of the 15 collectors did nothing at all, while
+    Settings promised it was enough.
+
+    The row is a placeholder with an empty container id and status "external".
+    It does not deploy anything; api_deploy replaces it if the user later
+    deploys through CashPilot.
+    """
+
+    def test_an_image_backed_service_gets_a_tracking_row(self, client):
         svc = {"slug": "honeygain", "docker": {"image": "hg:latest"}}
+        merged = {"honeygain_email": "test@test.com", "honeygain_password": "pass"}
         with (
             _auth_owner(),
             patch("app.main.database.set_config_bulk", new_callable=AsyncMock),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value=merged),
             patch("app.main.catalog.get_service", return_value=svc),
-            patch("app.main.database.get_deployment", new_callable=AsyncMock),
+            patch("app.main.database.get_deployment", new_callable=AsyncMock, return_value=None),
             patch("app.main.database.save_deployment", new_callable=AsyncMock) as mock_save,
         ):
-            resp = client.post(
-                "/api/config",
-                json={
-                    "data": {
-                        "honeygain_email": "test@test.com",
-                        "honeygain_password": "pass",
-                    }
-                },
-            )
+            resp = client.post("/api/config", json={"data": merged})
+            assert resp.status_code == 200
+            mock_save.assert_called_once()
+            assert mock_save.await_args.kwargs["status"] == "external"
+            assert mock_save.await_args.kwargs["container_id"] == ""
+
+    def test_an_existing_deployment_is_not_overwritten(self, client):
+        """A real deployment must keep its container id and status."""
+        svc = {"slug": "honeygain", "docker": {"image": "hg:latest"}}
+        merged = {"honeygain_email": "test@test.com", "honeygain_password": "pass"}
+        with (
+            _auth_owner(),
+            patch("app.main.database.set_config_bulk", new_callable=AsyncMock),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value=merged),
+            patch("app.main.catalog.get_service", return_value=svc),
+            patch(
+                "app.main.database.get_deployment",
+                new_callable=AsyncMock,
+                return_value={"slug": "honeygain", "status": "running", "container_id": "abc"},
+            ),
+            patch("app.main.database.save_deployment", new_callable=AsyncMock) as mock_save,
+        ):
+            resp = client.post("/api/config", json={"data": merged})
             assert resp.status_code == 200
             mock_save.assert_not_called()
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -657,19 +657,62 @@ class TestMainSetConfigExternalDeploySkip:
 
 
 class TestMainClearConfigWithDockerService:
-    """Cover main.py clear config for docker-based service."""
+    """Clearing credentials removes the tracking placeholder — and nothing else.
 
-    def test_clear_config_docker_service_no_deployment_removed(self, client):
+    The rule is now the deployment's STATUS, not whether the service has an
+    image. Image-backed services DO get an auto-created "external" row when
+    their credentials are saved (that is what makes tracking-only work), so
+    gating on the image would either leave placeholders behind or, worse,
+    delete the row of a container the user really deployed.
+    """
+
+    def test_a_real_deployment_is_never_removed(self, client):
+        """Clearing credentials must not orphan a running container."""
         svc = {"slug": "honeygain", "docker": {"image": "hg:latest"}}
         with (
             _auth_owner(),
             patch("app.main.database.delete_config_keys", new_callable=AsyncMock),
             patch("app.main.catalog.get_service", return_value=svc),
+            patch(
+                "app.main.database.get_deployment",
+                new_callable=AsyncMock,
+                return_value={"slug": "honeygain", "status": "running", "container_id": "abc123"},
+            ),
             patch("app.main.database.remove_deployment", new_callable=AsyncMock) as mock_rm,
         ):
             resp = client.delete("/api/config/honeygain")
             assert resp.status_code == 200
-            # Docker services don't auto-create external deployments, so no removal
+            mock_rm.assert_not_called()
+
+    def test_the_tracking_placeholder_is_removed(self, client):
+        """An "external" row exists only because credentials were saved."""
+        svc = {"slug": "honeygain", "docker": {"image": "hg:latest"}}
+        with (
+            _auth_owner(),
+            patch("app.main.database.delete_config_keys", new_callable=AsyncMock),
+            patch("app.main.catalog.get_service", return_value=svc),
+            patch(
+                "app.main.database.get_deployment",
+                new_callable=AsyncMock,
+                return_value={"slug": "honeygain", "status": "external", "container_id": ""},
+            ),
+            patch("app.main.database.remove_deployment", new_callable=AsyncMock) as mock_rm,
+        ):
+            resp = client.delete("/api/config/honeygain")
+            assert resp.status_code == 200
+            mock_rm.assert_called_once()
+
+    def test_no_deployment_at_all_is_a_no_op(self, client):
+        svc = {"slug": "honeygain", "docker": {"image": "hg:latest"}}
+        with (
+            _auth_owner(),
+            patch("app.main.database.delete_config_keys", new_callable=AsyncMock),
+            patch("app.main.catalog.get_service", return_value=svc),
+            patch("app.main.database.get_deployment", new_callable=AsyncMock, return_value=None),
+            patch("app.main.database.remove_deployment", new_callable=AsyncMock) as mock_rm,
+        ):
+            resp = client.delete("/api/config/honeygain")
+            assert resp.status_code == 200
             mock_rm.assert_not_called()
 
 

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -987,6 +987,9 @@ class TestApiConfig:
         with (
             _auth_owner(),
             patch("app.main.database.set_config_bulk", new_callable=AsyncMock),
+            # Completeness is judged against the MERGED config, so the endpoint
+            # reads it back after writing.
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
             patch("app.main.catalog.get_service", return_value=None),
         ):
             resp = client.post("/api/config", json={"data": {"key": "value"}})
@@ -998,6 +1001,11 @@ class TestApiConfig:
         with (
             _auth_owner(),
             patch("app.main.database.set_config_bulk", new_callable=AsyncMock),
+            patch(
+                "app.main.database.get_config",
+                new_callable=AsyncMock,
+                return_value={"grass_access_token": "tok"},
+            ),
             patch("app.main.catalog.get_service", return_value=svc),
             patch("app.main.database.get_deployment", new_callable=AsyncMock, return_value=None),
             patch("app.main.database.save_deployment", new_callable=AsyncMock) as mock_save,

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1012,6 +1012,7 @@ class TestApiConfig:
             _auth_owner(),
             patch("app.main.database.delete_config_keys", new_callable=AsyncMock),
             patch("app.main.catalog.get_service", return_value=svc),
+            patch("app.main.database.get_deployment", new_callable=AsyncMock, return_value=None),
             patch("app.main.database.remove_deployment", new_callable=AsyncMock),
         ):
             resp = client.delete("/api/config/grass")
@@ -1842,6 +1843,13 @@ class TestPeriodicTasks:
             asyncio.run(_check_stale_workers())  # Should not raise
 
     def test_run_collection(self):
+        """CashPilot-55m / -rhn: this test had NO assertions at all.
+
+        It ran _run_collection and checked nothing, so the entire success path
+        — the payout check, the upsert, and the fx-rate snapshot taken with it
+        — could be deleted and the suite would stay green. The only thing it
+        proved was that the function did not raise.
+        """
         from app.collectors.base import EarningsResult
         from app.main import _run_collection
 
@@ -1851,9 +1859,65 @@ class TestPeriodicTasks:
             patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[{"slug": "test"}]),
             patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
             patch("app.collectors.make_collectors", return_value=[mock_collector]),
-            patch("app.main.database.upsert_earnings", new_callable=AsyncMock),
+            patch("app.main.database.upsert_earnings", new_callable=AsyncMock) as mock_upsert,
+            patch("app.main._detect_payout", new_callable=AsyncMock) as mock_payout,
         ):
             asyncio.run(_run_collection())
+
+        # The reading is actually stored, with the values the collector returned.
+        mock_upsert.assert_awaited_once()
+        kwargs = mock_upsert.await_args.kwargs
+        assert kwargs["platform"] == "test"
+        assert kwargs["balance"] == 5.0
+        assert kwargs["currency"] == "USD"
+        # USD is parity by definition — a stored rate here would let a bad rate
+        # rewrite money the collector reported exactly.
+        assert kwargs["fx_rate_usd"] == 1.0
+        # And the payout branch is on the success path, so it must be reached.
+        mock_payout.assert_awaited_once()
+
+    def test_run_collection_snapshots_the_rate_for_a_non_usd_reading(self):
+        """CashPilot-rhn: nothing asserted what fx_rate_usd was computed as.
+
+        The snapshot is what makes a historical non-USD reading reconstructable
+        later; forcing it to parity for every currency would have gone
+        unnoticed.
+        """
+        from app.collectors.base import EarningsResult
+        from app.main import _run_collection
+
+        mock_collector = AsyncMock()
+        mock_collector.collect.return_value = EarningsResult(platform="test", balance=10.0, currency="MYST")
+        with (
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[{"slug": "test"}]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.collectors.make_collectors", return_value=[mock_collector]),
+            patch("app.main.database.upsert_earnings", new_callable=AsyncMock) as mock_upsert,
+            patch("app.main._detect_payout", new_callable=AsyncMock),
+            patch("app.main.exchange_rates.to_usd", lambda amount, currency: 0.25 * amount),
+        ):
+            asyncio.run(_run_collection())
+
+        assert mock_upsert.await_args.kwargs["fx_rate_usd"] == 0.25
+
+    def test_run_collection_records_no_rate_when_the_currency_is_unpriced(self):
+        """None, not 1.0. Parity would silently value an unpriced token as USD."""
+        from app.collectors.base import EarningsResult
+        from app.main import _run_collection
+
+        mock_collector = AsyncMock()
+        mock_collector.collect.return_value = EarningsResult(platform="test", balance=10.0, currency="GRASS")
+        with (
+            patch("app.main.database.get_deployments", new_callable=AsyncMock, return_value=[{"slug": "test"}]),
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
+            patch("app.collectors.make_collectors", return_value=[mock_collector]),
+            patch("app.main.database.upsert_earnings", new_callable=AsyncMock) as mock_upsert,
+            patch("app.main._detect_payout", new_callable=AsyncMock),
+            patch("app.main.exchange_rates.to_usd", lambda amount, currency: None),
+        ):
+            asyncio.run(_run_collection())
+
+        assert mock_upsert.await_args.kwargs["fx_rate_usd"] is None
 
     def test_run_collection_with_error(self):
         from app.collectors.base import EarningsResult

--- a/tests/test_tracking_without_deploying.py
+++ b/tests/test_tracking_without_deploying.py
@@ -1,0 +1,126 @@
+"""CashPilot-1f8 / CashPilot-ahh: credentials alone must actually collect.
+
+Settings says, in as many words: "You don't need to deploy containers through
+CashPilot — just add your credentials." That was false for 12 of the 15
+collectors.
+
+Collection is driven by DEPLOYMENT ROWS — ``make_collectors`` iterates
+deployments, so a slug with no row is never instantiated no matter how complete
+its credentials are. ``api_set_config`` auto-created that row only for services
+with no Docker image, which is three of them (grass, salad, bytelixir). For
+every other service the badge flipped to "Configured" and not one reading ever
+arrived.
+
+That is the whole of user story B — someone who already runs Honeygain by hand
+and wants CashPilot to track it — and it silently did nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def db(tmp_path):
+    from app import database
+
+    with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", tmp_path / "t.db"):
+        yield database
+
+
+async def _save(config: dict) -> None:
+    from app import main
+
+    body = MagicMock()
+    body.data = config
+    with patch.object(main, "_require_owner", lambda r: None):
+        await main.api_set_config(MagicMock(), body)
+
+
+class TestCredentialsAloneStartCollection:
+    @pytest.mark.asyncio
+    async def test_an_image_backed_service_gets_a_tracking_row(self, db):
+        """Honeygain has a Docker image, so the old gate skipped it entirely."""
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com", "honeygain_password": "pw"})
+        rows = await db.get_deployments()
+        assert [(r["slug"], r["status"]) for r in rows] == [("honeygain", "external")]
+
+    @pytest.mark.asyncio
+    async def test_the_collector_is_actually_instantiated(self, db):
+        """The row only matters because make_collectors reads deployments."""
+        from app.collectors import make_collectors
+
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com", "honeygain_password": "pw"})
+        collectors = make_collectors(await db.get_deployments(), await db.get_config())
+        assert [c.platform for c in collectors] == ["honeygain"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_credentials_create_nothing(self, db):
+        """Half a credential set would produce a collector that cannot run."""
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com"})
+        assert await db.get_deployments() == []
+
+    @pytest.mark.asyncio
+    async def test_an_imageless_service_still_works(self, db):
+        """The three services the old gate DID handle must not regress."""
+        await db.init_db()
+        await _save({"grass_access_token": "tok"})
+        rows = await db.get_deployments()
+        assert [(r["slug"], r["status"]) for r in rows] == [("grass", "external")]
+
+
+class TestClearingCredentialsRemovesOnlyThePlaceholder:
+    """The teardown is gated on STATUS, not on whether the service has an image.
+
+    Gating on the image would either strand placeholders for image-backed
+    services or, far worse, delete the deployment row of a container the user
+    really deployed — orphaning a running container from the dashboard.
+    """
+
+    async def _clear(self, slug: str) -> None:
+        from app import main
+
+        with patch.object(main, "_require_owner", lambda r: None):
+            await main.api_clear_service_config(MagicMock(), slug)
+
+    @pytest.mark.asyncio
+    async def test_the_tracking_row_is_removed(self, db):
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com", "honeygain_password": "pw"})
+        await self._clear("honeygain")
+        assert await db.get_deployments() == []
+
+    @pytest.mark.asyncio
+    async def test_a_real_deployment_survives(self, db):
+        """Clearing credentials must never undeploy a running container."""
+        await db.init_db()
+        await db.save_deployment(slug="honeygain", container_id="abc123", status="running")
+        await self._clear("honeygain")
+        rows = await db.get_deployments()
+        assert [(r["slug"], r["status"]) for r in rows] == [("honeygain", "running")]
+
+
+class TestTheSettingsPromiseIsNowTrue:
+    def test_the_gate_is_gone(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "continue  # Docker services get deployed normally" not in source
+
+    def test_the_teardown_keys_off_status_not_the_image(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert '(existing.get("status") or "") == "external"' in source
+
+    def test_settings_still_makes_the_claim(self):
+        """If this text is ever removed, the fix above is no longer load-bearing.
+
+        Kept as a test so the promise and the behaviour move together.
+        """
+        html = (ROOT / "app" / "templates" / "settings.html").read_text(encoding="utf-8")
+        assert "just add your credentials" in html

--- a/tests/test_tracking_without_deploying.py
+++ b/tests/test_tracking_without_deploying.py
@@ -69,6 +69,38 @@ class TestCredentialsAloneStartCollection:
         assert await db.get_deployments() == []
 
     @pytest.mark.asyncio
+    async def test_credentials_split_across_two_requests_still_start_collection(self, db):
+        """From CodeRabbit on this PR, and a real hole in the first fix.
+
+        set_config_bulk UPSERTS, so a credential set can legitimately arrive
+        across several requests — email now, password a moment later. The first
+        version judged completeness against the request payload alone, so
+        neither request ever saw a complete set: both values landed in the
+        database and no deployment row was created. Credentials stored,
+        collection still dead, and nothing on screen to say why.
+        """
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com"})
+        assert await db.get_deployments() == [], "a partial set must not create a row"
+        await _save({"honeygain_password": "pw"})
+        rows = await db.get_deployments()
+        assert [(r["slug"], r["status"]) for r in rows] == [("honeygain", "external")]
+
+    @pytest.mark.asyncio
+    async def test_saving_one_service_does_not_sweep_the_catalog(self, db):
+        """Judging against merged config must not create rows for everything.
+
+        The scan is still scoped to the slugs this request touched, so an
+        unrelated save cannot silently enable collection for a service the user
+        configured long ago and has since stopped running.
+        """
+        await db.init_db()
+        await _save({"honeygain_email": "me@example.com", "honeygain_password": "pw"})
+        await _save({"iproyal_email": "x@y.z"})
+        rows = await db.get_deployments()
+        assert [r["slug"] for r in rows] == ["honeygain"]
+
+    @pytest.mark.asyncio
     async def test_an_imageless_service_still_works(self, db):
         """The three services the old gate DID handle must not regress."""
         await db.init_db()


### PR DESCRIPTION
Targets `main` directly this time — the integration branch is merged and released, and CodeRabbit skips PRs that don't target the default branch.

**`1f8` + `ahh` — the biggest user-facing gap in the audit.**

Settings promises: *"You don't need to deploy containers through CashPilot — just add your credentials."* That was false for **12 of the 15 collectors**.

Collection is driven by deployment rows — `make_collectors` iterates deployments — and `api_set_config` created that row only for services with **no Docker image** (three of them). For everything else the badge flipped to "Configured" and no reading ever arrived. That's the entirety of user story B, silently doing nothing.

Verified end to end, not argued:

```
saving honeygain credentials  ->  rows: [('honeygain', 'external')]
                                  collectors: ['honeygain']
before the fix                ->  rows: []   collectors: []
```

The teardown moved with it and now keys off the deployment's **status**, not the image. Clearing credentials removes the placeholder and never touches a row with a real container id — gating on the image would have orphaned a running container from the dashboard.

**`55m` + `rhn` — `test_run_collection` had no assertions at all.**

It ran the function and checked nothing, so the whole success path could be deleted and the suite stayed green. It now asserts the reading is stored with the collector's values, the payout branch is reached, and what `fx_rate_usd` is: live rate when priced, `1.0` for USD by definition, `None` — never parity — when unpriced.

**Mutation-tested.** Deleting the upsert fails 3 tests; forcing `fx_rate_usd` to parity fails 2. My first attempt at that second mutation *passed* — there are two call sites and I'd patched the one in `_detect_payout` instead of the collection path.

**Verification:** 2452 tests, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saving complete collector credentials now tracks services without deployed containers, including image-based services.
  - Clearing credentials removes only tracking placeholders and preserves active container deployments.
  - Improved handling of incomplete credentials and services without container images.
  - Collection processing now more reliably preserves earnings, detects payouts, handles currency conversion, and reports unpriced currencies correctly.

- **Tests**
  - Expanded coverage for credential, deployment-tracking, collection, payout, and currency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->