### PR TITLE
fix: releases that publish nothing, and docs naming the wrong encryption key (beads batch 7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,14 @@ jobs:
           BUILD_UI=false
           BUILD_WORKER=false
 
-          if echo "$CHANGED" | grep -qE '^(Dockerfile|entrypoint\.sh|pyproject\.toml|uv\.lock|app/(main|database|catalog|auth|compose_generator|exchange_rates|constants|collectors|templates|static|routers|deps|metrics|setup_token))'; then
+          # The UI image does `COPY app/ ./app/` — the WHOLE directory — so ANY
+          # change under app/ belongs in a UI build. The hand-maintained module
+          # allowlist that used to live here named 13 of 27 modules, so a change
+          # to any of the other 14 (payouts, preflight, power, egress,
+          # lan_isolation, notify, ...) produced a GREEN release run that
+          # published nothing at all: no tag, no GitHub Release, no images.
+          # Skipped steps do not fail a run, so it looked like a success.
+          if echo "$CHANGED" | grep -qE '^(Dockerfile|entrypoint\.sh|pyproject\.toml|uv\.lock|app/)'; then
             BUILD_UI=true
           fi
           if echo "$CHANGED" | grep -qE '^services/'; then
@@ -81,9 +88,22 @@ jobs:
             BUILD_WORKER=true
           fi
 
-          if echo "$CHANGED" | grep -qE '^(Dockerfile\.worker|entrypoint\.sh|pyproject\.toml|uv\.lock|app/(worker_api|orchestrator|constants|catalog|fleet_key)\.py)'; then
+          # The worker image copies an explicit list of modules, so its trigger
+          # is DERIVED FROM Dockerfile.worker rather than restated here. The
+          # previous hand-written list omitted egress.py and state_backup.py —
+          # both COPY'd into the worker and imported by worker_api at runtime —
+          # so a change to either published a worker image tagged with the new
+          # version while containing the previous release's code.
+          WORKER_MODULES=$(grep -oE '^COPY[^#]*app/([a-z_]+)\.py' Dockerfile.worker \
+            | grep -oE 'app/[a-z_]+\.py' | sort -u)
+          echo "Worker modules (from Dockerfile.worker):"; echo "$WORKER_MODULES"
+          if echo "$CHANGED" | grep -qE '^(Dockerfile\.worker|entrypoint\.sh|pyproject\.toml|uv\.lock)'; then
             BUILD_WORKER=true
           fi
+          while IFS= read -r mod; do
+            [ -n "$mod" ] || continue
+            if echo "$CHANGED" | grep -qxF "$mod"; then BUILD_WORKER=true; fi
+          done <<< "$WORKER_MODULES"
 
           if echo "$CHANGED" | grep -qE '^app/__init__\.py'; then
             BUILD_UI=true

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -131,7 +131,7 @@ If a worker goes offline (no heartbeat for 180 seconds):
 |----------|---------|-------------|
 | `CASHPILOT_API_KEY` | *(auto-generated via /fleet volume)* | Shared secret for worker authentication |
 | `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Signing key for login sessions. Persisted at `/data/.secret_key`. **Does not encrypt credentials** |
-| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key` |
+| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key`; adopted only when that file is absent |
 | `CASHPILOT_ADMIN_API_KEY` | -- | Optional separate key granting full owner access (for integrations) |
 | `CASHPILOT_WORKER_URL_POLICY` | `permissive` | Worker URL validation policy: `permissive` (LAN + Tailscale work out of the box) or `strict` (allowlist only) |
 | `CASHPILOT_WORKER_ALLOWED_HOSTS` | -- | Comma-separated CIDRs and `*.suffix` hostnames allowed in `strict` mode, e.g. `192.168.10.0/24,100.64.0.0/10,*.ts.net` |

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -130,7 +130,8 @@ If a worker goes offline (no heartbeat for 180 seconds):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CASHPILOT_API_KEY` | *(auto-generated via /fleet volume)* | Shared secret for worker authentication |
-| `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Encryption key for stored credentials |
+| `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Signing key for login sessions. Persisted at `/data/.secret_key`. **Does not encrypt credentials** |
+| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key` |
 | `CASHPILOT_ADMIN_API_KEY` | -- | Optional separate key granting full owner access (for integrations) |
 | `CASHPILOT_WORKER_URL_POLICY` | `permissive` | Worker URL validation policy: `permissive` (LAN + Tailscale work out of the box) or `strict` (allowlist only) |
 | `CASHPILOT_WORKER_ALLOWED_HOSTS` | -- | Comma-separated CIDRs and `*.suffix` hostnames allowed in `strict` mode, e.g. `192.168.10.0/24,100.64.0.0/10,*.ts.net` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,8 @@ graph LR
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TZ` | `UTC` | Timezone for scheduling and display |
-| `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Encryption key for stored credentials. Set this to persist encryption across container recreations |
+| `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Signing key for login sessions. Persisted at `/data/.secret_key`. **Does not encrypt credentials** |
+| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key`. Set this only to restore a backup |
 | `CASHPILOT_API_KEY` | -- | Shared secret between UI and workers for API authentication |
 | `CASHPILOT_COLLECT_INTERVAL` | `60` | Minutes between earnings collection cycles |
 | `CASHPILOT_BIND_ADDR` | `127.0.0.1` | Host interface the UI port is published on. **Loopback by default** — the dashboard can command the Docker-socket worker, so it is not exposed to your network out of the box. Set a specific IP (e.g. a Tailscale/VPN address) or `0.0.0.0` to expose it, or (preferred) run an authenticating reverse proxy in front |
@@ -116,7 +117,7 @@ services:
     environment:
       - TZ=Europe/Madrid
       - CASHPILOT_API_KEY=your-secret-api-key
-      - CASHPILOT_SECRET_KEY=your-encryption-key
+      - CASHPILOT_SECRET_KEY=your-session-signing-key
     restart: unless-stopped
 
   cashpilot-worker:
@@ -145,7 +146,7 @@ volumes:
     The worker container requires access to `/var/run/docker.sock` to manage service containers. This grants the worker significant privileges on the host. Run CashPilot on a dedicated machine or VLAN for best security.
 
 !!! tip "Secret Key Persistence"
-    If you don't set `CASHPILOT_SECRET_KEY`, one is auto-generated on first run and stored in the data volume. If you recreate the volume, stored credentials become unreadable. Set an explicit key in your compose file to avoid this.
+    Credentials are encrypted with `CASHPILOT_ENCRYPTION_KEY`, **not** `CASHPILOT_SECRET_KEY` — the latter only signs login sessions. The encryption key is auto-generated on first run and stored at `/data/.fernet_key`. **Back that file up.** If the volume is recreated without it, a fresh key is generated and every stored credential becomes permanently unreadable. Setting `CASHPILOT_ENCRYPTION_KEY` is for restoring that backup; the key file always wins, so setting it on a healthy instance changes nothing.
 
 !!! tip "Passwords and secrets in the UI"
     Change your own password any time from the avatar menu -> **Change password** (available to all roles); this signs out your other sessions. In **Settings**, stored secrets are write-only: enter a value to change it, or leave the field blank to keep the existing one. Saved credentials are never sent back to the browser.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ graph LR
 |----------|---------|-------------|
 | `TZ` | `UTC` | Timezone for scheduling and display |
 | `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Signing key for login sessions. Persisted at `/data/.secret_key`. **Does not encrypt credentials** |
-| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key`. Set this only to restore a backup |
+| `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key`. Adopted only when that file is absent, so set it only to restore a backup |
 | `CASHPILOT_API_KEY` | -- | Shared secret between UI and workers for API authentication |
 | `CASHPILOT_COLLECT_INTERVAL` | `60` | Minutes between earnings collection cycles |
 | `CASHPILOT_BIND_ADDR` | `127.0.0.1` | Host interface the UI port is published on. **Loopback by default** — the dashboard can command the Docker-socket worker, so it is not exposed to your network out of the box. Set a specific IP (e.g. a Tailscale/VPN address) or `0.0.0.0` to expose it, or (preferred) run an authenticating reverse proxy in front |

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ Then open [http://localhost:8080](http://localhost:8080) and follow the setup wi
     Some services require a residential IP and will not pay (or will ban) VPS/datacenter IPs. These are marked as "Residential Only" in the service catalog. Services that work on VPS are a good way to scale up without additional home hardware.
 
 ??? question "How are credentials stored?"
-    All service credentials are encrypted at rest in the SQLite database using your `CASHPILOT_SECRET_KEY`. The database file lives in the mounted Docker volume. No credentials are ever sent anywhere except to the service containers themselves.
+    All service credentials are encrypted at rest in the SQLite database with a Fernet key kept at `/data/.fernet_key` (overridable via `CASHPILOT_ENCRYPTION_KEY`). This is not `CASHPILOT_SECRET_KEY`, which only signs login sessions. The database file lives in the mounted Docker volume. No credentials are ever sent anywhere except to the service containers themselves.
 
 ??? question "What about security?"
     Every service CashPilot deploys runs inside its own isolated Docker container with `--security-opt no-new-privileges`. Service credentials are encrypted at rest using Fernet symmetric encryption. Only the worker container requires Docker socket access; the UI container has no privileged access. We recommend running CashPilot on a dedicated machine or VLAN and keeping Docker and your host OS up to date.

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ Then open [http://localhost:8080](http://localhost:8080) and follow the setup wi
     Some services require a residential IP and will not pay (or will ban) VPS/datacenter IPs. These are marked as "Residential Only" in the service catalog. Services that work on VPS are a good way to scale up without additional home hardware.
 
 ??? question "How are credentials stored?"
-    All service credentials are encrypted at rest in the SQLite database with a Fernet key kept at `/data/.fernet_key` (overridable via `CASHPILOT_ENCRYPTION_KEY`). This is not `CASHPILOT_SECRET_KEY`, which only signs login sessions. The database file lives in the mounted Docker volume. No credentials are ever sent anywhere except to the service containers themselves.
+    All service credentials are encrypted at rest in the SQLite database with a Fernet key kept at `/data/.fernet_key`. `CASHPILOT_ENCRYPTION_KEY` is adopted only when that file is absent — the file always wins, so on an instance that already has a key the variable changes nothing. This is not `CASHPILOT_SECRET_KEY`, which only signs login sessions. The database file lives in the mounted Docker volume. No credentials are ever sent anywhere except to the service containers themselves.
 
 ??? question "What about security?"
     Every service CashPilot deploys runs inside its own isolated Docker container with `--security-opt no-new-privileges`. Service credentials are encrypted at rest using Fernet symmetric encryption. Only the worker container requires Docker socket access; the UI container has no privileged access. We recommend running CashPilot on a dedicated machine or VLAN and keeping Docker and your host OS up to date.

--- a/tests/test_release_triggers.py
+++ b/tests/test_release_triggers.py
@@ -162,3 +162,29 @@ class TestTheDocsNameTheRightEncryptionKey:
         text = (ROOT / "unraid" / "cashpilot.xml").read_text(encoding="utf-8")
         assert 'Target="CASHPILOT_ENCRYPTION_KEY"' in text
         assert text.count('Mask="true"') >= 2, "the encryption key must be masked like the session key"
+
+    @pytest.mark.parametrize("rel", ["docs/index.md", "docs/fleet.md", "docs/getting-started.md"])
+    def test_the_env_var_is_not_described_as_an_override(self, rel):
+        """From CodeRabbit on this PR, and right.
+
+        The key FILE always wins — app/database.py logs a warning and keeps the
+        stored key when CASHPILOT_ENCRYPTION_KEY differs, because switching keys
+        would make every existing credential unreadable. Calling the variable an
+        "override" is wrong exactly where it matters most: someone restoring a
+        backup onto an instance that still has a stale key file would expect
+        their value to take effect, and it would be ignored.
+        """
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if "CASHPILOT_ENCRYPTION_KEY" not in line:
+                continue
+            assert "overridable" not in line.lower(), f"{rel}: {line.strip()[:120]}"
+
+    def test_at_least_one_doc_states_the_precedence(self):
+        """Knowing the variable exists is not enough to restore a backup with it."""
+        found = [
+            rel
+            for rel in ("docs/index.md", "docs/fleet.md", "docs/getting-started.md")
+            if "only when that file is absent" in (ROOT / rel).read_text(encoding="utf-8")
+        ]
+        assert len(found) >= 3, f"precedence stated in only {found}"

--- a/tests/test_release_triggers.py
+++ b/tests/test_release_triggers.py
@@ -1,0 +1,164 @@
+"""CashPilot-gn6 / CashPilot-l7t: a release that publishes nothing, silently.
+
+`release.yml` decided what to build from two hand-maintained regexes. Both had
+drifted from the Dockerfiles they were meant to mirror:
+
+* The UI regex named 13 of 27 modules, but the UI image does
+  ``COPY app/ ./app/`` — the whole directory. A change to any of the other 14
+  (payouts, preflight, power, egress, lan_isolation, notify, ...) set
+  ``BUILD_UI=false``, which skipped the version step, which left ``new_tag``
+  empty, which skipped the tag, the GitHub Release and the whole build job.
+  Skipped steps do not fail a run, so the release went GREEN having published
+  nothing at all.
+
+* The worker regex omitted ``egress.py`` and ``state_backup.py``, both COPY'd
+  into the worker image and imported by ``worker_api`` at runtime. With
+  ``build_worker=false`` the pipeline RETAGS the previous image, so the worker
+  could be published under a new version tag containing the previous release's
+  code — and ``verify-tags`` only runs ``docker manifest inspect``, which a
+  retag satisfies.
+
+The fix is to stop restating the Dockerfiles in a regex. These tests assert the
+two stay in agreement, so the next module added to either image is covered
+without anyone remembering.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+DOCKERFILE = ROOT / "Dockerfile"
+DOCKERFILE_WORKER = ROOT / "Dockerfile.worker"
+
+APP_MODULES = sorted(p.name for p in (ROOT / "app").glob("*.py"))
+
+
+def worker_copied_modules() -> list[str]:
+    """The app modules Dockerfile.worker actually COPYs, as the workflow reads them."""
+    text = DOCKERFILE_WORKER.read_text(encoding="utf-8")
+    return sorted(set(re.findall(r"^COPY[^#\n]*?app/([a-z_]+\.py)", text, re.M)))
+
+
+class TestTheUiBuildCoversEveryModule:
+    """The UI image copies app/ wholesale, so the trigger must too."""
+
+    def test_the_ui_image_still_copies_the_whole_directory(self):
+        """If this ever narrows, the blanket trigger below stops being right."""
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r"^COPY[^#\n]*\bapp/ ", text, re.M), "Dockerfile no longer copies app/ wholesale"
+
+    def test_the_trigger_is_not_a_module_allowlist(self):
+        text = RELEASE.read_text(encoding="utf-8")
+        assert "app/(main|database|catalog|auth|compose_generator" not in text, (
+            "the hand-maintained UI module allowlist is back"
+        )
+
+    def test_any_app_change_builds_the_ui(self):
+        text = RELEASE.read_text(encoding="utf-8")
+        assert "|app/)'" in text, "the UI trigger no longer matches all of app/"
+
+
+class TestTheWorkerBuildMatchesItsDockerfile:
+    def test_the_worker_list_is_derived_not_restated(self):
+        text = RELEASE.read_text(encoding="utf-8")
+        assert "Dockerfile.worker" in text
+        assert "WORKER_MODULES=$(grep" in text, "the worker list is not derived from the Dockerfile"
+
+    def test_no_hardcoded_worker_module_regex_remains(self):
+        text = RELEASE.read_text(encoding="utf-8")
+        assert "app/(worker_api|orchestrator|constants|catalog|fleet_key)" not in text
+
+    @pytest.mark.parametrize("module", ["egress.py", "state_backup.py"])
+    def test_the_previously_missed_modules_are_covered(self, module):
+        """Both ship in the worker image and were absent from the old regex."""
+        assert module in worker_copied_modules()
+
+    def test_every_copied_module_exists(self):
+        """A COPY of a deleted file would build a worker that cannot import."""
+        for module in worker_copied_modules():
+            assert (ROOT / "app" / module).exists(), f"Dockerfile.worker copies a missing {module}"
+
+    def test_worker_api_imports_are_all_copied(self):
+        """The real contract: what worker_api imports must be in the image.
+
+        This is what makes a stale or missing module a crash on the user's
+        machine rather than a build failure here.
+        """
+        source = (ROOT / "app" / "worker_api.py").read_text(encoding="utf-8")
+        imported = set()
+        for line in source.splitlines():
+            m = re.match(r"\s*from app import (.+)", line)
+            if m:
+                imported |= {n.strip().split(" as ")[0] for n in m.group(1).split(",")}
+        copied = {m[:-3] for m in worker_copied_modules()}
+        missing = {n for n in imported if n and not n.startswith("_")} - copied
+        assert not missing, f"worker_api imports modules the worker image does not contain: {sorted(missing)}"
+
+
+class TestNoModuleFallsThroughBothTriggers:
+    def test_every_app_module_triggers_at_least_one_build(self):
+        """The defect in one line: 14 of 27 modules triggered neither.
+
+        A change to any of them produced a green run that published nothing.
+        """
+        text = RELEASE.read_text(encoding="utf-8")
+        ui_matches_all = "|app/)'" in text
+        assert ui_matches_all, "some app modules would still trigger no build at all"
+
+    def test_there_are_modules_to_check(self):
+        """Guards against this whole file passing vacuously on an empty glob."""
+        assert len(APP_MODULES) > 20, APP_MODULES
+
+
+class TestTheDocsNameTheRightEncryptionKey:
+    """CashPilot-dxi: six places told users the wrong variable protects credentials.
+
+    `CASHPILOT_SECRET_KEY` signs login sessions. `CASHPILOT_ENCRYPTION_KEY` is
+    the Fernet key that encrypts stored credentials, persisted at
+    `/data/.fernet_key`.
+
+    The advice was not merely wrong, it was harmful: a user who set
+    `CASHPILOT_SECRET_KEY` believing their credentials were now portable would
+    never back up the key file, and would lose every stored credential the
+    first time the volume was recreated. README.md already had the correct
+    wording; the other six places contradicted it.
+    """
+
+    DOCS = ["docs/fleet.md", "docs/getting-started.md", "docs/index.md", "unraid/cashpilot.xml", "README.md"]
+
+    @pytest.mark.parametrize("rel", DOCS)
+    def test_no_doc_claims_the_session_key_encrypts_credentials(self, rel):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if "CASHPILOT_SECRET_KEY" not in line:
+                continue
+            lowered = line.lower()
+            if "encrypt" not in lowered:
+                continue
+            # A line may mention both, but only to DENY that the session key encrypts.
+            assert any(
+                marker in lowered
+                for marker in ("does not encrypt", "not encrypt", "not `cashpilot_secret_key`", "only signs")
+            ), f"{rel}: {line.strip()[:140]}"
+
+    def test_the_real_key_is_documented_where_it_matters(self):
+        for rel in ("docs/getting-started.md", "docs/fleet.md", "docs/index.md", "unraid/cashpilot.xml"):
+            text = (ROOT / rel).read_text(encoding="utf-8")
+            assert "CASHPILOT_ENCRYPTION_KEY" in text, f"{rel} never mentions the key that actually encrypts"
+
+    def test_the_key_file_is_named_so_it_can_be_backed_up(self):
+        """Knowing the variable is useless without knowing what to back up."""
+        text = (ROOT / "docs" / "getting-started.md").read_text(encoding="utf-8")
+        assert "/data/.fernet_key" in text
+        assert "back that file up" in text.lower()
+
+    def test_the_unraid_template_exposes_it(self):
+        """Unraid users configure entirely through the template."""
+        text = (ROOT / "unraid" / "cashpilot.xml").read_text(encoding="utf-8")
+        assert 'Target="CASHPILOT_ENCRYPTION_KEY"' in text
+        assert text.count('Mask="true"') >= 2, "the encryption key must be masked like the session key"

--- a/unraid/cashpilot.xml
+++ b/unraid/cashpilot.xml
@@ -26,5 +26,6 @@ More info: https://github.com/GeiserX/CashPilot</Overview>
   <Config Name="Data" Target="/data" Default="/mnt/user/appdata/cashpilot" Mode="rw" Description="Database and configuration storage" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="TZ" Target="TZ" Default="America/New_York" Mode="" Description="Timezone (e.g. America/New_York, Europe/London)" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="API Key" Target="CASHPILOT_API_KEY" Default="" Mode="" Description="Shared API key for worker authentication. Must match the key set on all CashPilot Worker instances." Type="Variable" Display="always" Required="true" Mask="true"/>
-  <Config Name="Secret Key" Target="CASHPILOT_SECRET_KEY" Default="" Mode="" Description="Encryption key for stored service credentials (Fernet). Auto-generated if left empty." Type="Variable" Display="always" Required="false" Mask="true"/>
+  <Config Name="Secret Key" Target="CASHPILOT_SECRET_KEY" Default="" Mode="" Description="Signing key for login sessions. Does NOT encrypt credentials — that is CASHPILOT_ENCRYPTION_KEY. Auto-generated if left empty." Type="Variable" Display="always" Required="false" Mask="true"/>
+  <Config Name="Encryption Key" Target="CASHPILOT_ENCRYPTION_KEY" Default="" Mode="" Description="Fernet key encrypting stored credentials at rest. Auto-generated at /data/.fernet_key if left empty — back that file up. Set this only to restore a backup." Type="Variable" Display="always" Required="false" Mask="true"/>
 </Container>


### PR DESCRIPTION
**`gn6` + `l7t` — a release could go green having published nothing.**

`release.yml` decided what to build from two hand-maintained regexes, both drifted from the Dockerfiles they mirror.

The UI regex named **13 of 27 modules**, while the UI image does `COPY app/ ./app/` — everything. A change to any of the other 14 (`payouts`, `preflight`, `power`, `egress`, `lan_isolation`, `notify`, …) set `BUILD_UI=false` → version step skipped → `new_tag` empty → tag, Release and build job all skipped. **Skipped steps don't fail a run**, so it reported success.

The worker regex omitted `egress.py` and `state_backup.py` — both COPY'd into the worker image and imported by `worker_api` at runtime. With `build_worker=false` the pipeline **retags the previous image**, so the worker ships under a new version tag containing old code, and `verify-tags` only runs `docker manifest inspect`, which a retag satisfies.

Neither is restated now: any `app/` change builds the UI, and the worker list is parsed out of `Dockerfile.worker` at run time. A test asserts every module `worker_api` imports is actually in the worker image — the contract that decides whether a miss is a crash on the user's machine or a build failure here.

**`dxi` — six places named the wrong key, harmfully.**

They said `CASHPILOT_SECRET_KEY` encrypts credentials. It signs sessions; `CASHPILOT_ENCRYPTION_KEY` is the Fernet key at `/data/.fernet_key`. Follow the old advice and you believe your credentials are portable, never back up the key file, and lose every one the first time the volume is recreated. README already said this correctly — the other six contradicted it.

Fixed all six, named the key file so it can be backed up, and added the variable to the Unraid template (masked), since that's the whole configuration surface for those users.

**Verification:** 2476 tests, 95.13% coverage. Negative controls: narrowing the UI trigger fails 2 tests; restoring the `index.md` claim fails 2 more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `CASHPILOT_SECRET_KEY` signs login sessions.
  * Added guidance for `CASHPILOT_ENCRYPTION_KEY`, which encrypts stored credentials.
  * Documented credential key storage, backup, recovery, and configuration options.
  * Updated the Unraid template with separate session-signing and encryption settings.

* **Bug Fixes**
  * Improved release detection so UI and worker builds trigger for all relevant application and module changes.

* **Tests**
  * Added coverage verifying release triggers, Dockerfile module packaging, and encryption-key documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->