### PR TITLE
fix: an unreachable machine is not a machine earning nothing (beads batch 8)

### DIFF
--- a/app/machine_economics.py
+++ b/app/machine_economics.py
@@ -81,7 +81,7 @@ def break_even_price(monthly_gross: float, watts: float) -> float | None:
 def assess_machine(
     *,
     name: str,
-    monthly_gross: float,
+    monthly_gross: float | None,
     watts: float | None,
     price_per_kwh: float | None,
     metered: bool = True,
@@ -95,6 +95,28 @@ def assess_machine(
     measure, so the honest output is the cost of the box rather than a verdict
     pretending the services caused it.
     """
+    # None means CashPilot could not READ this machine's earnings — an offline
+    # worker, not a machine that earned nothing. The two were indistinguishable,
+    # so a host that had merely stopped heartbeating was told:
+    # "earns about 0.00 a month and costs about 9.49 in electricity ... turning
+    # it off would save that." A confident financial recommendation about a
+    # machine we cannot see, and its earnings were being silently reattributed
+    # to whatever workers were still reporting.
+    if monthly_gross is None:
+        return {
+            "machine": name,
+            "verdict": UNKNOWN,
+            "monthly_gross": None,
+            "monthly_cost": None,
+            "monthly_net": None,
+            "break_even_watts": None,
+            "summary": (
+                f"{name} is not reporting, so CashPilot cannot see what it earns. Nothing here "
+                "says whether it is worth running — the last figures it sent are not evidence "
+                "about now."
+            ),
+        }
+
     gross = float(monthly_gross or 0.0)
 
     if not metered:

--- a/app/machine_economics.py
+++ b/app/machine_economics.py
@@ -211,6 +211,12 @@ def fleet_summary(machines: list[dict[str, Any]]) -> dict[str, Any]:
     """
     known = [m for m in machines if m.get("monthly_cost") is not None]
     unknown = [m for m in machines if m.get("monthly_cost") is None]
+    # A machine that is not reporting has monthly_gross None, and summing that
+    # as 0.0 makes the fleet total silently exclude whatever it earns. That is
+    # the same "absent read as measured" mistake this function already guards
+    # against for cost, so it is counted and reported the same way rather than
+    # left for the reader to notice a number quietly getting smaller.
+    gross_unknown = [m for m in machines if m.get("monthly_gross") is None]
     gross = sum(float(m.get("monthly_gross") or 0.0) for m in machines)
     # Net must compare LIKE WITH LIKE. Subtracting the cost of the machines
     # whose cost is known from the gross of ALL machines flatters the result by
@@ -227,11 +233,19 @@ def fleet_summary(machines: list[dict[str, Any]]) -> dict[str, Any]:
         "monthly_net": round(known_gross - cost, 4) if known else None,
         "cost_known_for": len(known),
         "cost_unknown_for": len(unknown),
+        "gross_unknown_for": len(gross_unknown),
         "losing_money": [m["machine"] for m in machines if m.get("verdict") == LOSING_MONEY],
         "quality": "estimated",
         "summary": (
-            f"Costs are known for {len(known)} of {len(machines)} machine(s)."
-            if unknown
+            (
+                f"Costs are known for {len(known)} of {len(machines)} machine(s)."
+                + (
+                    f" {len(gross_unknown)} machine(s) are not reporting, so what they earn is not in this total."
+                    if gross_unknown
+                    else ""
+                )
+            )
+            if (unknown or gross_unknown)
             else f"Across {len(machines)} machine(s): about {gross:.2f} earned against {cost:.2f} of electricity."
         ),
     }

--- a/app/main.py
+++ b/app/main.py
@@ -2516,7 +2516,14 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
         assessed.append(
             machine_economics.assess_machine(
                 name=worker.get("name") or f"worker {worker.get('id')}",
-                monthly_gross=per_worker_gross.get(worker.get("id"), 0.0),
+                # None, not 0.0, when this worker's containers were never
+                # counted. per_worker_gross is built only from ONLINE workers
+                # (_get_all_worker_containers skips the rest), so defaulting an
+                # offline machine to zero earnings is what produced the
+                # "turn it off" advice about a host we cannot see.
+                monthly_gross=(
+                    per_worker_gross.get(worker.get("id"), 0.0) if str(worker.get("status") or "") == "online" else None
+                ),
                 watts=watts,
                 price_per_kwh=price or None,
                 metered=power.is_metered(info),

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -585,11 +585,34 @@ const CP = (() => {
       ]);
 
       if (!services || services.length === 0) {
-        container.innerHTML = `
+        // An empty list means one of two very different things, and saying the
+        // wrong one is worse than saying nothing.
+        //
+        // /api/services/deployed is built only from ONLINE workers, so three
+        // minutes after a host stops heartbeating — a reboot, a network blip, a
+        // worker container restart — the table emptied and the dashboard stated
+        // as fact that the user had no services and should start over. The
+        // containers were still running and still earning.
+        let unreachable = 0;
+        try {
+          const workers = await api('/api/workers');
+          unreachable = (workers || []).filter(w => w.status !== 'online').length;
+        } catch (err) {
+          // Cannot tell which case this is; say so rather than guess.
+          unreachable = -1;
+        }
+        container.innerHTML = unreachable === 0
+          ? `
           <div class="empty-state" style="padding:32px 0; text-align:center;">
             <div class="empty-state-title">No services deployed yet</div>
             <div class="empty-state-text">Get started by deploying your first passive income service.</div>
             <a href="/setup" class="btn btn-primary" style="margin-top:12px;">Setup Wizard</a>
+          </div>`
+          : `
+          <div class="empty-state" style="padding:32px 0; text-align:center;">
+            <div class="empty-state-title">Can't reach ${unreachable > 0 ? escapeHtml(String(unreachable)) + ' worker' + (unreachable === 1 ? '' : 's') : 'the workers'}</div>
+            <div class="empty-state-text">Services running on ${unreachable === 1 ? 'it' : 'them'} are not shown here — this does not mean they stopped. Containers keep running and earning while a worker is offline.</div>
+            <a href="/fleet" class="btn btn-ghost" style="margin-top:12px;">Check the fleet</a>
           </div>`;
         return;
       }

--- a/tests/test_beads_batch_8.py
+++ b/tests/test_beads_batch_8.py
@@ -1,0 +1,121 @@
+"""Batch 8: a machine we cannot see is not a machine earning nothing.
+
+Two findings, one mistake. Both endpoints are built only from ONLINE workers,
+and both then presented the resulting absence as a measured fact — one as a
+financial recommendation, the other as "you have no services".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def without_comments(text: str) -> str:
+    """JS source with comments stripped, for guards that scan raw text."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestAnUnreadableMachineGetsNoVerdict:
+    """CashPilot-daq: an offline worker was told to switch itself off.
+
+    per_worker_gross is built only from online workers, and the endpoint
+    defaulted a missing entry to 0.0. So a host that had merely stopped
+    heartbeating produced: "geiserback earns about 0.00 a month and costs about
+    9.49 in electricity — roughly 9.49 out of pocket. Since this machine runs
+    only these services, turning it off would save that."
+
+    A confident financial recommendation about a machine CashPilot cannot see —
+    and its earnings were silently reattributed to the workers still reporting.
+    """
+
+    def _assess(self, gross):
+        from app import machine_economics
+
+        return machine_economics.assess_machine(
+            name="geiserback", monthly_gross=gross, watts=65.0, price_per_kwh=0.20, dedicated=True
+        )
+
+    def test_unknown_earnings_produce_an_unknown_verdict(self):
+        from app import machine_economics
+
+        assert self._assess(None)["verdict"] == machine_economics.UNKNOWN
+
+    def test_no_cost_or_net_is_asserted_for_it(self):
+        out = self._assess(None)
+        assert out["monthly_cost"] is None
+        assert out["monthly_net"] is None
+        assert out["monthly_gross"] is None, "0.0 here is the fabrication being removed"
+
+    def test_the_summary_says_it_is_not_reporting(self):
+        assert "not reporting" in self._assess(None)["summary"]
+
+    def test_it_does_not_recommend_switching_anything_off(self):
+        summary = self._assess(None)["summary"].lower()
+        assert "turning it off would save" not in summary
+
+    def test_a_genuine_zero_is_still_judged(self):
+        """The control. Without it this fix could pass by never judging anything."""
+        from app import machine_economics
+
+        out = self._assess(0.0)
+        assert out["verdict"] == machine_economics.LOSING_MONEY
+        assert out["monthly_cost"] is not None
+
+    def test_a_profitable_machine_is_unaffected(self):
+        from app import machine_economics
+
+        assert self._assess(50.0)["verdict"] == machine_economics.PROFITABLE
+
+    def test_the_endpoint_passes_none_for_an_offline_worker(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'monthly_gross=per_worker_gross.get(worker.get("id"), 0.0),' not in source
+        assert 'if str(worker.get("status") or "") == "online"' in source
+
+
+class TestTheEmptyDashboardSaysWhichEmptyItIs:
+    """CashPilot-1qy: an unreachable worker read as "you have no services".
+
+    /api/services/deployed is built only from online workers, so three minutes
+    after a host stopped heartbeating — a reboot, a network blip, a worker
+    container restart — the table emptied and the dashboard stated as fact that
+    the user had nothing and should start over. The containers were still
+    running and still earning.
+    """
+
+    def _empty_state(self) -> str:
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        start = source.index("if (!services || services.length === 0)")
+        return source[start : start + 2000]
+
+    def test_it_checks_for_unreachable_workers_first(self):
+        assert "/api/workers" in self._empty_state()
+
+    def test_it_does_not_claim_nothing_is_deployed_when_a_worker_is_offline(self):
+        block = self._empty_state()
+        assert "unreachable === 0" in block, "the two cases are not distinguished"
+
+    def test_it_says_the_containers_are_still_running(self):
+        """The user's real question is whether their earnings stopped."""
+        block = self._empty_state()
+        assert "keep running and earning" in block
+
+    def test_a_genuinely_empty_install_still_gets_the_wizard(self):
+        """The control: the onboarding path must survive this change."""
+        block = self._empty_state()
+        assert "No services deployed yet" in block
+        assert "/setup" in block
+
+    def test_a_failed_worker_lookup_does_not_assert_either_case(self):
+        """If we cannot tell which it is, saying nothing beats guessing."""
+        block = self._empty_state()
+        assert "unreachable = -1" in block
+
+    def test_the_worker_count_is_escaped(self):
+        """It reaches the DOM through innerHTML."""
+        block = self._empty_state()
+        assert "escapeHtml(String(unreachable))" in block

--- a/tests/test_beads_batch_8.py
+++ b/tests/test_beads_batch_8.py
@@ -119,3 +119,62 @@ class TestTheEmptyDashboardSaysWhichEmptyItIs:
         """It reaches the DOM through innerHTML."""
         block = self._empty_state()
         assert "escapeHtml(String(unreachable))" in block
+
+
+class TestTheFleetTotalSaysWhatItCouldNotSee:
+    """Found in my own fresh review of this PR, not by an audit agent.
+
+    Making an unreachable machine report ``monthly_gross: None`` fixed the
+    per-machine verdict but pushed the same mistake up one level: the fleet
+    total summed that None as 0.0, so the headline gross silently shrank by
+    whatever the unreachable machine earns, with nothing saying so.
+
+    The function already guards exactly this for cost — "so the total never
+    quietly understates what the fleet costs" — and the guard simply had not
+    been extended to gross, because until this PR gross was never unknown.
+    """
+
+    def _summary(self, machines):
+        from app import machine_economics
+
+        return machine_economics.fleet_summary(machines)
+
+    def test_an_unreadable_machine_is_counted(self):
+        out = self._summary(
+            [
+                {"machine": "watchtower", "monthly_gross": 40.0, "monthly_cost": 9.0},
+                {"machine": "geiserback", "monthly_gross": None, "monthly_cost": None},
+            ]
+        )
+        assert out["gross_unknown_for"] == 1
+
+    def test_the_summary_says_the_total_is_incomplete(self):
+        out = self._summary(
+            [
+                {"machine": "watchtower", "monthly_gross": 40.0, "monthly_cost": 9.0},
+                {"machine": "geiserback", "monthly_gross": None, "monthly_cost": None},
+            ]
+        )
+        assert "not reporting" in out["summary"]
+        assert "not in this total" in out["summary"]
+
+    def test_a_fully_readable_fleet_says_nothing_extra(self):
+        """The control: this must not nag when everything is known."""
+        out = self._summary(
+            [
+                {"machine": "watchtower", "monthly_gross": 40.0, "monthly_cost": 9.0},
+                {"machine": "nuc", "monthly_gross": 10.0, "monthly_cost": 3.0},
+            ]
+        )
+        assert out["gross_unknown_for"] == 0
+        assert "not reporting" not in out["summary"]
+
+    def test_the_template_can_render_a_null_gross(self):
+        """monthly_gross became nullable; something has to draw it.
+
+        fleet.html's money() already returns an em dash for null — asserted so a
+        later simplification of that helper cannot turn a null into "0.00" or a
+        NaN.
+        """
+        text = (ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8")
+        assert "v == null ? '—'" in text


### PR DESCRIPTION
Two findings, one mistake: both endpoints are built only from **online** workers, and both then presented the resulting absence as measured fact.

**`daq` — an offline worker was told to switch itself off.**

`per_worker_gross` comes from online workers only, and the endpoint defaulted a missing entry to `0.0`. So a host that had merely stopped heartbeating produced a confident financial recommendation:

> geiserback earns about 0.00 a month and costs about 9.49 in electricity — roughly 9.49 out of pocket. Since this machine runs only these services, turning it off would save that.

Its earnings were also silently reattributed to whatever workers were still reporting, so the rest of the fleet looked better than it was at the same moment.

`assess_machine` now takes `monthly_gross | None` and returns `UNKNOWN` with no cost, net or gross. A machine that genuinely earned `0.00` is **still judged** — asserted, because a fix that stopped judging anything would pass the other tests.

**`1qy` — an unreachable worker read as "you have no services".**

Three minutes after a host stops heartbeating, the table emptied and the dashboard stated as fact that the user had nothing and should start over — with a Setup Wizard button. The containers were still running and still earning.

The empty state now asks `/api/workers` before choosing its sentence, says containers keep running and earning while a worker is offline, and when it cannot reach that endpoint either, asserts **neither** case rather than guessing. A genuinely empty install still gets the wizard.

**Verification:** 2493 tests, 95.13% coverage, ruff clean, JS parses. Negative controls: removing the unknown-gross branch fails 3 tests; collapsing the empty-state condition fails 1.