### PR TITLE
test: guards that could not fail (beads batch 9)

### DIFF
--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -174,12 +174,68 @@ class TestGetAllWorkerContainers:
         assert result[0]["_is_android"] is True
 
     def test_offline_workers_skipped(self):
+        """CashPilot-1xg: this fed a worker with NO containers.
+
+        Removing the `status != "online"` skip therefore still produced [] and
+        the test passed — it asserted nothing about the skip it is named for.
+        The offline worker now HAS a container, so deleting the skip leaks it
+        into the result and the test fails.
+        """
         from app.main import _get_all_worker_containers
 
-        workers = [{"id": 1, "name": "w1", "status": "offline", "system_info": "{}", "containers": "[]", "apps": "[]"}]
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "offline",
+                "system_info": '{"docker_available": true}',
+                "containers": '[{"slug": "honeygain", "status": "running"}]',
+                "apps": "[]",
+            }
+        ]
         with patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers):
             result = asyncio.run(_get_all_worker_containers())
-        assert result == []
+        assert result == [], "an offline worker's containers leaked into the live view"
+
+    def test_online_workers_are_included(self):
+        """The control: without it the test above passes if NOTHING is returned."""
+        from app.main import _get_all_worker_containers
+
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": '{"docker_available": true}',
+                "containers": '[{"slug": "honeygain", "status": "running"}]',
+                "apps": "[]",
+            }
+        ]
+        with patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers):
+            result = asyncio.run(_get_all_worker_containers())
+        assert [c["slug"] for c in result] == ["honeygain"]
+
+    def test_a_container_with_no_status_reads_as_unknown(self):
+        """CashPilot-1xg, second half: no test supplied a container without a status.
+
+        `c.get("status", "unknown")` is the rule that stops an unreadable
+        container from rendering as running, and nothing exercised the default.
+        """
+        from app.main import _get_all_worker_containers
+
+        workers = [
+            {
+                "id": 1,
+                "name": "w1",
+                "status": "online",
+                "system_info": '{"docker_available": true}',
+                "containers": '[{"slug": "honeygain"}]',
+                "apps": "[]",
+            }
+        ]
+        with patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers):
+            result = asyncio.run(_get_all_worker_containers())
+        assert result[0]["status"] == "unknown", "a container with no status must not read as running"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -199,7 +199,20 @@ class TestEndpoints:
             patch.object(main, "_require_writer", lambda r: None),
             patch.object(main.database, "get_latest_balance", AsyncMock(return_value=patches.get("balance"))),
             patch.object(main.database, "get_balance_history", AsyncMock(return_value=patches.get("history", []))),
-            patch.object(main.database, "get_payouts", AsyncMock(return_value=patches.get("payouts", []))),
+            # Honours confirmed_only, because that filter is the thing under
+            # test. A plain return_value is blind to kwargs, so removing
+            # `confirmed_only=True` from the endpoint changed nothing
+            # observable and the flagship payout feature could silently start
+            # counting UNCONFIRMED payouts as lifetime earnings (CashPilot-lu9).
+            patch.object(
+                main.database,
+                "get_payouts",
+                AsyncMock(
+                    side_effect=lambda platform=None, confirmed_only=False: [
+                        p for p in patches.get("payouts", []) if not confirmed_only or p.get("confirmed")
+                    ]
+                ),
+            ),
             patch.object(main.database, "confirm_payout", AsyncMock(return_value=patches.get("ok", True))),
             patch.object(main.database, "reject_payout", AsyncMock(return_value=patches.get("ok", True))),
         ):
@@ -213,10 +226,22 @@ class TestEndpoints:
             "honeygain",
             balance=5.0,
             history=series(1.0, 2.0, 3.0, 4.0, 5.0),
-            payouts=[{"amount": 20.0, "confirmed": 1}],
+            # An UNCONFIRMED payout sits alongside the confirmed one. Lifetime
+            # must count only the confirmed 20.0 — a probable payout is a
+            # guess from a balance drop, and folding it in would let a single
+            # misread inflate lifetime earnings permanently.
+            payouts=[{"amount": 20.0, "confirmed": 1}, {"amount": 99.0, "confirmed": 0}],
         )
         assert out["current_balance"] == 5.0
-        assert out["lifetime_earned"] == 25.0, "lifetime must include the confirmed payout"
+        assert out["lifetime_earned"] == 25.0, "lifetime counted an unconfirmed payout"
+        # This is the field the endpoint's confirmed_only filter actually
+        # protects. CashPilot-lu9 claimed lifetime_earned was at risk; it is
+        # not — payouts.lifetime_earned has its own `if payout.get("confirmed")`
+        # guard, so the filter is defence in depth there. The COUNT has no such
+        # guard, and it is rendered to the user as "includes N confirmed
+        # payouts", so dropping the filter would state that an unconfirmed
+        # balance drop was money they received.
+        assert out["confirmed_payout_count"] == 1, "an unconfirmed payout was counted as confirmed"
         assert out["projection"]["state"] == payouts.PROJECTED
 
     def test_progress_for_a_never_collected_service_says_the_balance_is_unknown(self):


### PR DESCRIPTION
Two tests that existed, passed, and protected nothing.

**`1xg` — `test_offline_workers_skipped` fed a worker with no containers.**

Deleting the `status != "online"` skip still produced `[]`, so the test passed while asserting nothing about the rule it is named for. The offline worker now has a container, so removing the skip leaks it into the live view and the test fails.

Added the control it lacked — without an online-worker case, the test passes whenever *nothing* is returned — and the bead's second half: no test ever supplied a container with **no status**, so `c.get("status", "unknown")`, the rule that stops an unreadable container reading as running, was never exercised.

Mutation-tested: deleting the skip fails one, flipping the status default to `"running"` fails the other.

**`lu9` — the `get_payouts` mock was blind to its own filter.**

A plain `return_value` ignores kwargs, so removing `confirmed_only=True` changed nothing observable.

**Correction to the bead:** it claimed `lifetime_earned` would start counting unconfirmed payouts. It would not — `payouts.lifetime_earned` has its own `if payout.get("confirmed")` guard, so the endpoint filter is defence in depth there. My first negative control passed *because of that*, which is what surfaced it.

The field actually at risk is `confirmed_payout_count`, which has no such guard and is rendered as *"includes N confirmed payouts"* — so dropping the filter would tell the user an unconfirmed balance drop was money they received. That's what the test now asserts, and dropping the filter fails it.

**Verification:** 2501 tests, ruff clean. Every claim mutation-tested rather than asserted.