### PR TITLE
fix: a wizard that congratulated failed deploys, and a modal missing its own recommendation (beads batch 11)

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1147,8 +1147,20 @@ const CP = (() => {
       if (title) title.textContent = `${col.name} — Credentials`;
 
       const secrets = config._secrets || {};
-      const fieldsHtml = col.fields.filter(f => f.required).map(f => {
+      // EVERY field, not just the required ones.
+      //
+      // Filtering to required hid exactly the credentials this UI recommends.
+      // Bytelixir's session cookie expires in about two hours; its remember_web
+      // and xsrf_token cookies last a year and are what stop collection dying
+      // the same afternoon — and both are optional, so the credential-health
+      // panel said "a longer-lived credential exists for this service" while
+      // the modal it links to offered nowhere to put it.
+      //
+      // Storj is worse: its only field is optional, so the modal rendered no
+      // inputs at all.
+      const fieldsHtml = col.fields.map(f => {
         const inputType = f.secret ? 'password' : 'text';
+        const optionalSuffix = f.required ? '' : ' <span style="color:var(--text-muted); font-weight:400;">(optional)</span>';
         // Secret inputs are write-only: empty, with a placeholder that reflects
         // whether a value is already stored (per _secrets). Non-secret fields keep
         // their plain placeholder.
@@ -1157,7 +1169,7 @@ const CP = (() => {
           : escapeHtml(f.label);
         return `
         <div style="margin-bottom:10px;">
-          <label style="display:block; font-size:0.8rem; color:var(--text-secondary); margin-bottom:4px;">${escapeHtml(f.label)}</label>
+          <label style="display:block; font-size:0.8rem; color:var(--text-secondary); margin-bottom:4px;">${escapeHtml(f.label)}${optionalSuffix}</label>
           <input class="form-input cred-modal-input" type="${inputType}"
                  data-config="${escapeHtml(f.key)}"
                  value=""
@@ -1550,6 +1562,7 @@ const CP = (() => {
       if (wizardState.step === 2) loadWizardServices();
       if (wizardState.step === 3) loadWizardSetupForms();
       if (wizardState.step === 4) {
+        renderWizardOutcome();
         // Persist category/service selections
         api('/api/preferences', {
           method: 'POST',
@@ -1561,6 +1574,34 @@ const CP = (() => {
         }).catch(() => {});
       }
     }
+  }
+
+  function renderWizardOutcome() {
+    // Say what actually happened.
+    //
+    // The final screen was unconditional markup: "You're all set! Your services
+    // are being deployed." It said that whether five services deployed, or none
+    // did, or every deploy 403'd — wizardState.deployed was written twice and
+    // read nowhere. A user whose deploys all failed was congratulated and sent
+    // to an empty dashboard with no idea anything had gone wrong.
+    const title = document.getElementById('wizard-done-title');
+    const text = document.getElementById('wizard-done-text');
+    if (!title || !text) return;
+    const done = wizardState.deployed || [];
+    const wanted = wizardState.selectedServices || [];
+    if (done.length === 0) {
+      title.textContent = wanted.length ? 'Nothing was deployed' : 'Setup saved';
+      text.textContent = wanted.length
+        ? 'None of the selected services could be deployed. Your choices are saved — check the Fleet page for a worker that is online, then deploy from the catalog.'
+        : 'Your preferences are saved. Nothing was deployed, because no services were selected.';
+      return;
+    }
+    const missed = wanted.filter(s => !done.includes(s));
+    title.textContent = missed.length ? 'Partly deployed' : "You're all set!";
+    const names = done.map(escapeHtml).join(', ');
+    text.textContent = missed.length
+      ? `Deployed: ${names}. ${missed.length} service${missed.length === 1 ? '' : 's'} could not be deployed — check the Fleet page.`
+      : `Deployed: ${names}. Head to the dashboard to monitor status and earnings.`;
   }
 
   function wizardPrev() {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1507,10 +1507,11 @@ const CP = (() => {
     categories: [],
     selectedServices: [],
     deployed: [],
+    deployAttempted: false,
   };
 
   async function initWizard() {
-    wizardState = { step: 1, categories: [], selectedServices: [], deployed: [] };
+    wizardState = { step: 1, categories: [], selectedServices: [], deployed: [], deployAttempted: false };
 
     // Pre-populate from saved preferences
     try {
@@ -1590,10 +1591,21 @@ const CP = (() => {
     const done = wizardState.deployed || [];
     const wanted = wizardState.selectedServices || [];
     if (done.length === 0) {
-      title.textContent = wanted.length ? 'Nothing was deployed' : 'Setup saved';
-      text.textContent = wanted.length
-        ? 'None of the selected services could be deployed. Your choices are saved — check the Fleet page for a worker that is online, then deploy from the catalog.'
-        : 'Your preferences are saved. Nothing was deployed, because no services were selected.';
+      // Three different nothings, and only one is a failure. Skipping step 3
+      // reaches here with services selected and no deploy attempted, which is
+      // not the same as every deploy failing — telling someone their deploys
+      // failed when none were tried sends them hunting a problem that is not
+      // there.
+      if (!wizardState.deployAttempted) {
+        title.textContent = 'Setup saved';
+        text.textContent = wanted.length
+          ? 'Your choices are saved. Nothing was deployed yet — deploy them from the catalog whenever you are ready.'
+          : 'Your preferences are saved. Nothing was deployed, because no services were selected.';
+        return;
+      }
+      title.textContent = 'Nothing was deployed';
+      text.textContent =
+        'None of the selected services could be deployed. Your choices are saved — check the Fleet page for a worker that is online, then deploy from the catalog.';
       return;
     }
     const missed = wanted.filter(s => !done.includes(s));
@@ -1983,6 +1995,11 @@ const CP = (() => {
   }
 
   async function deployService(slug) {
+    // Record that a deploy was ATTEMPTED, separately from whether it worked.
+    // Step 3 offers "Skip to Summary", so a user can select services and reach
+    // the final screen having deployed nothing — and an empty `deployed` list
+    // then looks identical to every deploy having failed.
+    wizardState.deployAttempted = true;
     await _deployToWorkers(slug, _selectedWorkerIds(`.setup-deploy-worker-cb[data-slug="${slug}"]:checked:not(:disabled)`));
   }
 

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -106,9 +106,9 @@
     <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-bottom: 16px;">
       <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
     </svg>
-    <h2 class="section-title" style="margin-bottom: 8px;">You're all set!</h2>
-    <p style="color: var(--text-secondary); margin-bottom: 24px;">
-      Your services are being deployed. Head to the dashboard to monitor their status and earnings.
+    <h2 class="section-title" style="margin-bottom: 8px;" id="wizard-done-title">You're all set!</h2>
+    <p style="color: var(--text-secondary); margin-bottom: 24px;" id="wizard-done-text">
+      Head to the dashboard to monitor status and earnings.
     </p>
     <a href="/" class="btn btn-primary btn-lg">Go to Dashboard</a>
   </div>

--- a/tests/test_beads_batch_11.py
+++ b/tests/test_beads_batch_11.py
@@ -52,6 +52,35 @@ class TestTheWizardSaysWhatActuallyHappened:
         idx = source.index("if (wizardState.step === 4)")
         assert "renderWizardOutcome()" in source[idx : idx + 300]
 
+    def test_a_skipped_setup_is_not_reported_as_a_failure(self):
+        """From CodeRabbit on this PR, and a real gap in the first fix.
+
+        Step 3 offers "Skip to Summary", so a user can select services and reach
+        step 4 having deployed nothing. My first version keyed only on
+        `deployed.length === 0`, so it told them "None of the selected services
+        could be deployed" — sending them to hunt a failure that never happened.
+
+        The distinction is whether a deploy was ATTEMPTED, which is why
+        deployService now records it.
+        """
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "deployAttempted" in source, "the attempt is not tracked at all"
+        block = source[source.index("function renderWizardOutcome()") :][:1600]
+        assert "!wizardState.deployAttempted" in block, "the skip case is not distinguished"
+
+    def test_the_attempt_is_recorded_where_deploying_happens(self):
+        """A flag nothing sets is worse than no flag — it is always false."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        block = source[source.index("async function deployService(") :][:400]
+        assert "wizardState.deployAttempted = true" in block
+
+    def test_the_flag_starts_false_on_a_fresh_wizard(self):
+        """Otherwise a second run of the wizard inherits the first run's state."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert source.count("deployAttempted: false") >= 2, (
+            "deployAttempted must be initialised in both the declaration and the reset"
+        )
+
     def test_deployed_is_now_read_not_just_written(self):
         """The bead's core evidence: the field had no reader at all."""
         source = without_comments(APP_JS.read_text(encoding="utf-8"))

--- a/tests/test_beads_batch_11.py
+++ b/tests/test_beads_batch_11.py
@@ -1,0 +1,113 @@
+"""Batch 11: two screens that told the user something untrue.
+
+One congratulated them for deployments that never happened. The other
+recommended a credential and then offered nowhere to enter it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+SETUP_HTML = ROOT / "app" / "templates" / "setup.html"
+
+
+def without_comments(text: str) -> str:
+    """JS source with comments stripped, so prose cannot satisfy a code check."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestTheWizardSaysWhatActuallyHappened:
+    """CashPilot-4og: the final screen was unconditional markup.
+
+    "You're all set! Your services are being deployed." — shown whether five
+    deployed, none did, or every deploy returned 403. `wizardState.deployed`
+    was written twice and read nowhere, so a user whose deploys all failed was
+    congratulated and sent to an empty dashboard with no idea anything had gone
+    wrong.
+    """
+
+    def test_the_success_copy_is_no_longer_hardcoded(self):
+        html = SETUP_HTML.read_text(encoding="utf-8")
+        assert "Your services are being deployed." not in html
+
+    def test_the_copy_is_addressable(self):
+        html = SETUP_HTML.read_text(encoding="utf-8")
+        assert 'id="wizard-done-title"' in html
+        assert 'id="wizard-done-text"' in html
+
+    def test_the_outcome_is_rendered_from_what_deployed(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "function renderWizardOutcome()" in source
+        assert "wizardState.deployed" in source[source.index("function renderWizardOutcome()") :][:1400]
+
+    def test_it_runs_when_the_wizard_reaches_the_last_step(self):
+        """A renderer nothing calls is the same as no renderer."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        idx = source.index("if (wizardState.step === 4)")
+        assert "renderWizardOutcome()" in source[idx : idx + 300]
+
+    def test_deployed_is_now_read_not_just_written(self):
+        """The bead's core evidence: the field had no reader at all."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        reads = [
+            line
+            for line in source.splitlines()
+            if "wizardState.deployed" in line and ".push(" not in line and "= [" not in line
+        ]
+        assert reads, "wizardState.deployed is still write-only"
+
+
+class TestTheCredentialModalShowsWhatItRecommends:
+    """CashPilot-zr9: the modal filtered to required fields only.
+
+    Bytelixir's session cookie expires in about two hours. Its remember_web and
+    xsrf_token cookies last a year and are what stop collection dying the same
+    afternoon — and both are OPTIONAL, so the credential-health panel said "a
+    longer-lived credential exists for this service" while the modal it links to
+    offered nowhere to put it.
+
+    Storj was worse: its only field is optional, so the modal rendered no inputs
+    at all.
+    """
+
+    def _modal(self) -> str:
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        start = source.index("function openCredentialModal")
+        return source[start : start + 3000]
+
+    def test_every_field_is_rendered(self):
+        assert "col.fields.filter(f => f.required).map" not in self._modal()
+        assert "col.fields.map(f =>" in self._modal()
+
+    def test_optional_fields_are_labelled(self):
+        """Rendering them without saying so would imply they are required."""
+        assert "optionalSuffix" in self._modal()
+        assert "(optional)" in self._modal()
+
+    @pytest.mark.parametrize("slug,expected", [("storj", 1), ("bytelixir", 3)])
+    def test_the_affected_services_now_have_fields(self, slug, expected):
+        """storj showed ZERO inputs before this change."""
+        from app.collectors import _COLLECTOR_ARGS
+
+        assert len(_COLLECTOR_ARGS[slug]) == expected
+
+    def test_bytelixirs_durable_cookies_are_the_optional_ones(self):
+        """If these ever became required, the bug would have fixed itself.
+
+        Pinned so this test cannot pass for the wrong reason later.
+        """
+        from app.collectors import _COLLECTOR_ARGS
+
+        optional = {a.lstrip("?") for a in _COLLECTOR_ARGS["bytelixir"] if a.startswith("?")}
+        assert optional == {"remember_web", "xsrf_token"}
+
+    def test_the_health_panel_still_recommends_them(self):
+        """The recommendation is what made hiding the field a dead end."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "A longer-lived credential exists for this service" in source


### PR DESCRIPTION
Two screens that told the user something untrue.

**`4og` — the wizard congratulated you for deployments that never happened.**

The final screen was unconditional markup: *"You're all set! Your services are being deployed."* Shown whether five deployed, none did, or every deploy returned 403. `wizardState.deployed` was written twice and **read nowhere**, so a user whose deploys all failed was congratulated and sent to an empty dashboard with no idea anything had gone wrong.

Now rendered from what actually deployed, exercised in a real DOM across all four cases:

```
all deployed   -> You're all set!       Deployed: honeygain, earnapp. …
partial        -> Partly deployed       Deployed: honeygain. 1 service could not be deployed …
none deployed  -> Nothing was deployed  None of the selected services could be deployed …
nothing chosen -> Setup saved           Nothing was deployed, because no services were selected.
```

**`zr9` — the modal hid exactly the credentials the app recommends.**

Bytelixir's session cookie expires in ~2 hours; its `remember_web` and `xsrf_token` cookies last a year and are what stop collection dying the same afternoon. Both are **optional**, so the credential-health panel said *"a longer-lived credential exists for this service"* while the modal it links to offered nowhere to put it.

Storj was worse — its only field is optional, so the modal rendered **no inputs at all**.

```
storj      0 fields -> 1
bytelixir  1 field  -> 3
```

Optional fields are labelled so they aren't mistaken for required.

**Verification:** 2521 tests, 95.14% coverage, ruff clean, JS parses. Negative controls: reverting the field filter fails 1 test; reverting the wizard copy and its render call fails 2 more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential setup dialogs now display all available fields, including clearly labeled optional inputs.
  * Setup completion now summarizes deployment outcomes, distinguishing saved, failed, partial, and complete results.
  * Completion messaging now directs users to monitor status and earnings.

* **Bug Fixes**
  * Corrected misleading deployment-success messaging.
  * Restored missing optional credential fields in setup dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->