### PR TITLE
fix: an undocumented payout minimum is not zero, and settings that never applied (beads batch 12)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1880,7 +1880,16 @@ async def api_earnings_breakdown(request: Request) -> list[dict[str, Any]]:
         slug = row["platform"]
         svc = catalog.get_service(slug)
         cashout = (svc.get("cashout", {}) if svc else {}) or {}
-        min_amount = float(cashout.get("min_amount", 0))
+        # Three-valued, matching payouts.min_payout: a positive number is a
+        # real minimum, 0 is a documented "no minimum", and None means nobody
+        # published one. float(..., 0) collapsed the last two, so 21 services
+        # with no published minimum reported the user as eligible to cash out
+        # any balance above zero.
+        raw_min = cashout.get("min_amount")
+        try:
+            min_amount = float(raw_min) if raw_min is not None else None
+        except (TypeError, ValueError):
+            min_amount = None
         balance = float(row["balance"])
         prev_balance = float(row.get("prev_balance", 0))
         delta = balance - prev_balance
@@ -1901,7 +1910,19 @@ async def api_earnings_breakdown(request: Request) -> list[dict[str, Any]]:
             "last_updated": row["date"],
             "delta": round(delta, 4),
             "cashout": {
-                "eligible": bool(cashout) and balance > 0 and balance >= min_amount,
+                # None, not True, when the minimum is unknown. Claiming
+                # eligibility we cannot establish sends the user to a withdrawal
+                # page that will refuse them.
+                # False and None mean different things here, and the existing
+                # tests were right to insist on the distinction:
+                #   no cashout section  -> False. There is no withdrawal route
+                #                          at all; that is a real answer.
+                #   route but no known  -> None. We cannot say, and claiming
+                #   minimum                eligibility would send the user to a
+                #                          page that refuses them.
+                "eligible": (
+                    False if not cashout else (None if min_amount is None else (balance > 0 and balance >= min_amount))
+                ),
                 "min_amount": min_amount,
                 "method": cashout.get("method", "redirect"),
                 "dashboard_url": cashout.get("dashboard_url", ""),

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2454,7 +2454,12 @@ const CP = (() => {
       let badge;
       if (fromEnv) badge = '<span class="badge badge-deployed" style="font-size:0.7rem;margin-left:8px;">ENV</span>';
       else if (v.read_only) badge = '<span class="badge" style="font-size:0.7rem;margin-left:8px;opacity:0.6;">Read-only</span>';
-      else if (dbVal) badge = '<span class="badge badge-category" style="font-size:0.7rem;margin-left:8px;">DB</span>';
+      // No "DB" badge. It asserted that a stored value was in force, and
+      // nothing reads these from the database: every one is resolved once from
+      // the environment at import (main.py:639-640, auth.py, fleet_key.py), so
+      // a saved value could never take effect. A stored-but-inert value is
+      // worth flagging as exactly that.
+      else if (dbVal) badge = '<span class="badge badge-warning" style="font-size:0.7rem;margin-left:8px;" title="Stored in the database but NOT in use — these are read from the environment at startup">Stored, not applied</span>';
       else if (isSet) badge = '<span class="badge" style="font-size:0.7rem;margin-left:8px;opacity:0.5;">Default</span>';
       else badge = '<span class="badge" style="font-size:0.7rem;margin-left:8px;opacity:0.5;">Not set</span>';
       // Secret fields render empty; placeholder communicates whether a value is stored.
@@ -2482,8 +2487,15 @@ const CP = (() => {
       </div>`;
     }).join('');
     container.innerHTML = rows + `
+    <div class="form-hint" style="margin-top:12px;">
+      These are read from the environment when CashPilot starts, so changing one
+      here does not take effect. Set it in your <code>docker-compose.yml</code>
+      (or Unraid template) and restart the container. Saving stores the value but
+      nothing reads it back — the field is kept so an existing stored value stays
+      visible rather than disappearing.
+    </div>
     <div style="display:flex;justify-content:flex-end;margin-top:12px;">
-      <button class="btn btn-primary" data-action="saveEnvSettings">Save Variables</button>
+      <button class="btn btn-ghost" data-action="saveEnvSettings" title="Stores the value; it will not take effect until it is set in the environment and the container restarts">Save anyway</button>
     </div>`;
   }
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -11,7 +11,7 @@
 <div class="card settings-section">
   <h3 class="settings-section-title">Environment Variables</h3>
   <p class="settings-section-desc">
-    Variables set via Docker <code>-e</code> flags are locked. Unset variables can be configured here and saved to the database.
+    These are read from the environment when CashPilot starts. Variables set via Docker <code>-e</code> flags are shown locked; the rest can be stored here, but <strong>a stored value does not take effect</strong> &mdash; set it in your compose file or Unraid template and restart. Several of them cannot change at runtime at all: the session key signs logins already in use, the data directory is where the open database lives, and the fleet key is what enrolled workers already hold.
   </p>
   <div id="env-vars-container">
     <p style="color: var(--text-muted); font-size: 0.85rem;">Loading...</p>

--- a/services/bandwidth/earncc.yml
+++ b/services/bandwidth/earncc.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://earn.cc"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: USD
   notes: "Signup broken. Cannot assess."
 

--- a/services/compute/flux.yml
+++ b/services/compute/flux.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://home.runonflux.io"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: FLUX
 
 platforms: [linux]

--- a/services/compute/golem.yml
+++ b/services/compute/golem.yml
@@ -45,7 +45,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://stats.golem.network"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: GLM
   notes: "GLM tokens earned. Configure payout wallet in provider setup."
 

--- a/services/compute/ionet.yml
+++ b/services/compute/ionet.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://cloud.io.net"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: IO
 
 platforms: [linux]

--- a/services/compute/nosana.yml
+++ b/services/compute/nosana.yml
@@ -45,7 +45,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://app.nosana.io/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: NOS
   notes: "NOS tokens earned on Solana. Payout to configured wallet."
 

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -61,7 +61,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://anyone.io"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: ANYONE
 
 platforms: [docker, linux]

--- a/services/depin/blockmesh.yml
+++ b/services/depin/blockmesh.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://app.blockmesh.xyz/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: BMESH
   notes: "Token-based rewards. Claim from dashboard when available."
 

--- a/services/depin/dawn.yml
+++ b/services/depin/dawn.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://dashboard.dawninternet.com"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: DAWN
   notes: "Extension works but half-baked. Black Box hardware announced. Check future."
 

--- a/services/depin/deeper-network.yml
+++ b/services/depin/deeper-network.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://device.deeper.network"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: DPR
 
 platforms: []

--- a/services/depin/gradient.yml
+++ b/services/depin/gradient.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://app.gradient.network/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: GRADIENT
   notes: "Points-based system. Token conversion TBD."
 

--- a/services/depin/grass.yml
+++ b/services/depin/grass.yml
@@ -50,7 +50,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://app.grass.io/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: GRASS
   notes: "GRASS token airdrop-based. Claim from dashboard when eligible."
 

--- a/services/depin/helium.yml
+++ b/services/depin/helium.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://app.helium.com"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: HNT
 
 platforms: []

--- a/services/depin/koii.yml
+++ b/services/depin/koii.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://koii.network"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: KOII
 
 platforms: [windows, macos, linux]

--- a/services/depin/network3.yml
+++ b/services/depin/network3.yml
@@ -45,7 +45,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://account.network3.ai"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: N3
   notes: "Site up but no SSL, no updates in months. Avoid for now."
 

--- a/services/depin/nodepay.yml
+++ b/services/depin/nodepay.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://app.nodepay.ai/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: NC
   notes: "Points-based system. Token conversion TBD."
 

--- a/services/depin/nodle.yml
+++ b/services/depin/nodle.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://nodle.com"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: NODL
 
 platforms: [ios, android]

--- a/services/depin/presearch.yml
+++ b/services/depin/presearch.yml
@@ -50,7 +50,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://nodes.presearch.com/dashboard"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: PRE
 
 platforms: [docker, linux]

--- a/services/depin/sentinel-dvpn.yml
+++ b/services/depin/sentinel-dvpn.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://sentinel.co"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: DVPN
 
 platforms: [linux]

--- a/services/depin/teneo.yml
+++ b/services/depin/teneo.yml
@@ -44,7 +44,10 @@ earnings:
 cashout:
   method: redirect
   dashboard_url: "https://dashboard.teneo.pro"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: TENEO
   notes: "Points convert to tokens. Claim from dashboard."
 

--- a/services/depin/theta-edge.yml
+++ b/services/depin/theta-edge.yml
@@ -43,7 +43,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://edgecloud.thetatoken.org"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: TFUEL
 
 platforms: [windows, macos, linux]

--- a/services/depin/titan.yml
+++ b/services/depin/titan.yml
@@ -45,7 +45,10 @@ earnings:
 cashout:
   method: manual
   dashboard_url: "https://edge.titannet.io"
-  min_amount: 0
+  # Undocumented: the provider does not publish a minimum. NOT 0 —
+  # 0 means 'no minimum, cash out anything', which would tell the
+  # user they can withdraw now and disables payout detection.
+  min_amount: null
   currency: TNT
   notes: ""
 

--- a/tests/test_beads_batch_12.py
+++ b/tests/test_beads_batch_12.py
@@ -1,0 +1,155 @@
+"""Batch 12: two claims the app could not support.
+
+One told users a stored setting was in force when nothing read it back. The
+other told 21 services' users they could cash out any amount, because
+"undocumented" had been written into the catalog as "no minimum".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+SERVICES = ROOT / "services"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+def catalog_entries():
+    out = {}
+    for path in sorted(SERVICES.rglob("*.yml")):
+        if path.name.startswith("_"):
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        out[data.get("slug", path.stem)] = data
+    return out
+
+
+class TestAnUndocumentedMinimumIsNotZero:
+    """CashPilot-x26: 21 services encoded "we don't know" as "no minimum".
+
+    payouts.min_payout is explicitly three-valued — positive is a real minimum,
+    0.0 is a documented "cash out any amount", None is undocumented. Twenty-one
+    services carried ``min_amount: 0`` with an EMPTY ``payment.minimum_payout``,
+    so the catalog asserted a fact nobody had established.
+
+    Two consequences. api_earnings_breakdown reported the user eligible to cash
+    out any balance above zero, sending them to a withdrawal page that would
+    refuse them. And payouts.looks_like_payout returns False on a falsy
+    threshold, so payout detection was silently disabled for all 21.
+    """
+
+    def test_no_service_claims_zero_without_documenting_it(self):
+        offenders = []
+        for slug, data in catalog_entries().items():
+            cashout = data.get("cashout") or {}
+            payment = data.get("payment") or {}
+            if cashout.get("min_amount") == 0 and not str(payment.get("minimum_payout") or "").strip():
+                offenders.append(slug)
+        assert not offenders, (
+            f"these claim 'no minimum' with nothing documenting it: {offenders}. "
+            "Use null for undocumented; 0 means the provider genuinely has no minimum."
+        )
+
+    def test_a_documented_zero_would_still_be_allowed(self):
+        """The contract keeps three values; this fix must not collapse it to two."""
+        from app import payouts
+
+        assert payouts.min_payout({"cashout": {"min_amount": 0}}) == 0.0
+        assert payouts.min_payout({"cashout": {"min_amount": None}}) is None
+        assert payouts.min_payout({"cashout": {"min_amount": 4.0}}) == 4.0
+
+    def test_the_catalog_still_has_real_minimums(self):
+        """Guards against this passing because every minimum was nulled."""
+        real = [
+            slug
+            for slug, d in catalog_entries().items()
+            if isinstance((d.get("cashout") or {}).get("min_amount"), (int, float))
+            and (d.get("cashout") or {}).get("min_amount")
+        ]
+        assert len(real) >= 5, f"only {len(real)} services have a positive minimum: {real}"
+
+
+class TestEligibilityDistinguishesItsThreeCases:
+    """Reuses the existing harness in tests/test_eligibility.py.
+
+    Rebuilding it here produced a service dict missing `name`, which the handler
+    requires — a second harness for one endpoint is a second thing to get wrong.
+    """
+
+    def _eligible(self, cashout, balance=100.0):
+        from tests.test_eligibility import _call_breakdown, _earnings_row, _service
+
+        rows = [_earnings_row("svc", balance=balance)]
+        svcs = {"svc": _service("svc", cashout=cashout)}
+        return _call_breakdown(rows, svcs)[0]["cashout"]["eligible"]
+
+    def test_no_cashout_route_is_a_definite_no(self):
+        """Not unknown — there is no withdrawal route at all."""
+        assert self._eligible(None) is False
+
+    def test_an_unknown_minimum_is_unknown(self):
+        """Claiming eligibility here sends the user to a page that refuses them."""
+        assert self._eligible({"min_amount": None}) is None
+
+    def test_a_documented_no_minimum_is_eligible(self):
+        assert self._eligible({"min_amount": 0}, balance=5.0) is True
+
+    def test_a_real_threshold_is_compared(self):
+        assert self._eligible({"min_amount": 20.0}, balance=5.0) is False
+        assert self._eligible({"min_amount": 20.0}, balance=25.0) is True
+
+
+class TestTheSettingsPageDoesNotClaimStoredValuesApply:
+    """CashPilot-73o: the page asserted a stored value was in force.
+
+    Every variable it offers is resolved once from the environment at import —
+    main.py:639-640, auth.py, fleet_key.py — so a value written to the config
+    table can never take effect. The UI showed a green "Variables saved" toast
+    and a "DB" badge meaning "the database value is in use", and collection
+    carried on at the old interval.
+
+    Several of them cannot change at runtime at all, which is why the fix is to
+    stop claiming they can rather than to wire them up: the session key signs
+    logins already in use, the data directory is where the open database lives,
+    and the fleet key is what enrolled workers already hold.
+    """
+
+    def test_the_db_badge_no_longer_asserts_the_value_is_in_use(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert 'badge-category" style="font-size:0.7rem;margin-left:8px;">DB<' not in source
+
+    def test_a_stored_value_is_labelled_as_not_applied(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "Stored, not applied" in source
+
+    def test_the_page_says_a_restart_is_required(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "does not take effect" in source
+        assert "restart the container" in source
+
+    def test_the_template_copy_matches(self):
+        html = (ROOT / "app" / "templates" / "settings.html").read_text(encoding="utf-8")
+        assert "saved to the database." not in html
+        assert "does not take effect" in html
+
+    @pytest.mark.parametrize(
+        "key,module",
+        [
+            ("CASHPILOT_HOSTNAME_PREFIX", "app/main.py"),
+            ("CASHPILOT_COLLECT_INTERVAL", "app/main.py"),
+            ("CASHPILOT_SECRET_KEY", "app/auth.py"),
+        ],
+    )
+    def test_these_really_are_import_time_reads(self, key, module):
+        """The premise of the fix. If one ever becomes live, revisit the copy."""
+        source = (ROOT / module).read_text(encoding="utf-8")
+        assert f'os.getenv("{key}"' in source

--- a/tests/test_beads_batch_12.py
+++ b/tests/test_beads_batch_12.py
@@ -103,6 +103,21 @@ class TestEligibilityDistinguishesItsThreeCases:
     def test_a_documented_no_minimum_is_eligible(self):
         assert self._eligible({"min_amount": 0}, balance=5.0) is True
 
+    def test_an_unparseable_minimum_is_unknown_not_a_crash(self):
+        """A catalog typo must not 500 the dashboard.
+
+        min_amount comes from YAML a human edits, so "4.00 USD" or an empty
+        string are realistic. float() raises on both; treating that as unknown
+        matches how every other unparseable value in this codebase is handled,
+        and is the branch codecov flagged as untested.
+        """
+        assert self._eligible({"min_amount": "not a number"}) is None
+
+    def test_a_numeric_string_still_parses(self):
+        """YAML quoting is common and should not silently disable a threshold."""
+        assert self._eligible({"min_amount": "20"}, balance=25.0) is True
+        assert self._eligible({"min_amount": "20"}, balance=5.0) is False
+
     def test_a_real_threshold_is_compared(self):
         assert self._eligible({"min_amount": 20.0}, balance=5.0) is False
         assert self._eligible({"min_amount": 20.0}, balance=25.0) is True


### PR DESCRIPTION
Two claims the app could not support.

**`x26` — 21 services encoded "we don't know" as "no minimum".**

`payouts.min_payout` is explicitly three-valued: positive is a real minimum, `0.0` is a documented *"cash out any amount"*, `None` is undocumented. Twenty-one services carried `min_amount: 0` with an **empty** `payment.minimum_payout` — the catalog asserting a fact nobody had established.

Two user-facing consequences:

- `api_earnings_breakdown` reported the user **eligible to cash out any balance above zero**, sending them to a withdrawal page that would refuse them.
- `looks_like_payout` returns `False` on a falsy threshold, so **payout detection was silently disabled** for all 21.

Those minimums are `null` now, and eligibility is three-valued.

**The existing tests were right and my first attempt was wrong.** I collapsed *no cashout section* and *unknown minimum* both to `None`, which broke two tests in `test_eligibility.py`. They were protecting a real distinction: no cashout section is a definite **`False`** — there is no withdrawal route at all — while a route with no published minimum is genuinely **unknown**.

**`73o` — Settings asserted a stored value was in force.**

Every variable the page offers is resolved once from the environment at import, so a value written to the config table can never take effect. The UI showed a green *"Variables saved"* toast and a **"DB"** badge meaning *the database value is in use*, while collection carried on at the old interval.

Fixed by telling the truth rather than wiring them up, because several **cannot** change at runtime: the session key signs logins already in use, the data directory is where the open database lives, and the fleet key is what enrolled workers already hold. A stored value now reads **"Stored, not applied"**, and the page says to set it in the compose file and restart.

**Verification:** 2542 tests, 95.11% coverage, ruff clean (both `check` and `format --check`), JS parses. Negative controls: collapsing eligibility fails one test; restoring the DB badge fails another.