### PR TITLE
fix: net earnings subtracted a EUR cost from a USD gross (beads batch 13)

### DIFF
--- a/app/exchange_rates.py
+++ b/app/exchange_rates.py
@@ -160,6 +160,25 @@ def get_all() -> dict[str, Any]:
     }
 
 
+def from_usd(amount: float, currency: str) -> float | None:
+    """Convert a USD amount into *currency*. The inverse of :func:`to_usd`.
+
+    ``_fiat_rates`` stores USD->X rates, so this MULTIPLIES where ``to_usd``
+    divides. Getting that backwards would be worse than not converting at all,
+    which is why the two live next to each other.
+
+    Fiat only: a USD figure has no meaningful expression in a provider's token,
+    and inventing one would put a crypto amount where a currency belongs.
+    Returns None when no rate is available.
+    """
+    if currency == "USD":
+        return amount
+    rate = _fiat_rates.get(currency)
+    if rate and rate > 0:
+        return amount * rate
+    return None
+
+
 def to_usd(amount: float, currency: str) -> float | None:
     """Convert an amount in *currency* to USD.
 

--- a/app/main.py
+++ b/app/main.py
@@ -2195,32 +2195,41 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
             }
         )
 
-    # Put gross into the SAME currency as the cost before subtracting.
+    # Convert the TARIFF into USD, rather than the gross into the tariff currency.
     #
-    # gross comes from get_earned_by_platform, which is USD by contract; cost is
-    # computed from a tariff the user entered in power_currency. Subtracting one
-    # from the other produced a number in neither, labelled with the tariff
-    # currency — at ~1.08 USD/EUR that is an 8% error in the direction that
-    # flatters the result, on the figure that decides whether a machine is worth
-    # running.
+    # gross comes from get_earned_by_platform, which is USD by contract, while
+    # the tariff is whatever power_currency says. Subtracting one from the other
+    # produced a number in neither, labelled with the tariff currency — at
+    # ~1.08 USD/EUR an 8% error, in the direction that flatters the result, on
+    # the figure that decides whether a machine is worth running.
     #
-    # When no rate is available the gross is left in USD and the response says
-    # the two could not be reconciled, rather than quietly mixing them.
+    # Converting the PRICE keeps this endpoint canonical USD like every other
+    # money figure in the API, and the frontend's display-currency layer renders
+    # it in whatever the user reads in. Converting the gross the other way would
+    # have made this one endpoint the exception.
+    price_usd = price
     fx_ok = True
-    if currency != "USD":
-        for row in rows:
-            converted = exchange_rates.from_usd(float(row.get("gross") or 0.0), currency)
-            if converted is None:
-                fx_ok = False
-                break
-            row["gross"] = converted
+    if price and currency != "USD":
+        converted = exchange_rates.to_usd(price, currency)
+        if converted is None:
+            fx_ok = False
+        else:
+            price_usd = converted
 
-    result = power.summarise(
-        rows, price_per_kwh=price, currency=(currency if fx_ok else "USD")
-    )
+    # No rate means the tariff cannot be expressed in the same unit as the
+    # earnings, so there is no honest net. Reporting gross alone is what this
+    # module already does when no tariff is set at all: "a zero cost would
+    # render gross as net and quietly overstate earnings."
+    result = power.summarise(rows, price_per_kwh=(price_usd if fx_ok else 0.0), currency="USD")
     if not fx_ok:
+        result["cost_known"] = False
         result["fx_unavailable"] = True
         result["tariff_currency"] = currency
+        result["cost_unavailable_reason"] = (
+            f"Your tariff is in {currency} and earnings are recorded in USD. No "
+            f"{currency}-to-USD rate is available right now, so a net figure would be "
+            "two different currencies subtracted from each other."
+        )
     result["window_days"] = max(1, int(days))
     result["host_tdp_watts"] = host_tdp
     return result

--- a/app/main.py
+++ b/app/main.py
@@ -2195,7 +2195,32 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
             }
         )
 
-    result = power.summarise(rows, price_per_kwh=price, currency=currency)
+    # Put gross into the SAME currency as the cost before subtracting.
+    #
+    # gross comes from get_earned_by_platform, which is USD by contract; cost is
+    # computed from a tariff the user entered in power_currency. Subtracting one
+    # from the other produced a number in neither, labelled with the tariff
+    # currency — at ~1.08 USD/EUR that is an 8% error in the direction that
+    # flatters the result, on the figure that decides whether a machine is worth
+    # running.
+    #
+    # When no rate is available the gross is left in USD and the response says
+    # the two could not be reconciled, rather than quietly mixing them.
+    fx_ok = True
+    if currency != "USD":
+        for row in rows:
+            converted = exchange_rates.from_usd(float(row.get("gross") or 0.0), currency)
+            if converted is None:
+                fx_ok = False
+                break
+            row["gross"] = converted
+
+    result = power.summarise(
+        rows, price_per_kwh=price, currency=(currency if fx_ok else "USD")
+    )
+    if not fx_ok:
+        result["fx_unavailable"] = True
+        result["tariff_currency"] = currency
     result["window_days"] = max(1, int(days))
     result["host_tdp_watts"] = host_tdp
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,34 @@ def schema_path():
 
 
 @pytest.fixture(autouse=True)
+def _seed_fiat_rates():
+    """Give every test the exchange rates a RUNNING CashPilot always has.
+
+    ``exchange_rates.refresh()`` populates these at startup and every 15
+    minutes, so in production a fiat rate is available essentially always. The
+    test process never calls it, so ``_fiat_rates`` was empty everywhere.
+
+    That mattered once ``/api/earnings/net`` started converting the tariff into
+    USD before subtracting it from a USD gross: ten tests configure a EUR tariff
+    and expect a cost, and with no rate the endpoint correctly refuses to
+    produce a net — so they failed for a reason that had nothing to do with what
+    they were testing.
+
+    Seeded rather than mocked per-test, because "a rate exists" is the normal
+    state of the system. Tests that need the no-rate path clear this themselves.
+    """
+    from app import exchange_rates
+
+    saved = dict(exchange_rates._fiat_rates)
+    exchange_rates._fiat_rates.update({"EUR": 0.92, "GBP": 0.79, "USD": 1.0})
+    try:
+        yield
+    finally:
+        exchange_rates._fiat_rates.clear()
+        exchange_rates._fiat_rates.update(saved)
+
+
+@pytest.fixture(autouse=True)
 def _reset_shared_db():
     """Drain the per-loop shared SQLite connections after every test.
 

--- a/tests/test_currency_correctness.py
+++ b/tests/test_currency_correctness.py
@@ -8,7 +8,7 @@ movement into fabricated earnings.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -105,3 +105,77 @@ class TestACryptoPriceMoveCannotFabricateEarnings:
 
         assert "ANYONE" in exchange_rates.CRYPTO_IDS
         assert exchange_rates.CRYPTO_IDS["ANYONE"] == "airtor-protocol"
+
+
+class TestNetEarningsSubtractLikeFromLike:
+    """CashPilot-dlr: an electricity cost in EUR taken off a gross in USD.
+
+    ``gross`` comes from ``get_earned_by_platform``, which is USD by contract.
+    ``cost`` is computed from a tariff the user entered in ``power_currency``.
+    Subtracting one from the other produced a number in neither, labelled with
+    the tariff currency.
+
+    At roughly 1.08 USD/EUR that is an ~8% error, in the direction that flatters
+    the result, on the single figure that decides whether a machine is worth
+    keeping powered on.
+    """
+
+    def _net(self, rate, currency="EUR", gross=100.0):
+        import asyncio
+
+        from app import exchange_rates as fx
+        from app import main
+
+        fx._fiat_rates.clear()
+        if rate is not None:
+            fx._fiat_rates[currency] = rate
+        cfg = {"power_price_per_kwh": "0.20", "power_currency": currency}
+        workers = [{"id": 1, "name": "w", "status": "online", "system_info": '{"network_type":"residential"}'}]
+        conts = [{"slug": "honeygain", "status": "running", "cpu_percent": 4.0, "_worker_id": 1}]
+
+        async def run():
+            with (
+                patch.object(main, "_require_auth_api", lambda r: None),
+                patch.object(main.database, "get_config", AsyncMock(return_value=cfg)),
+                patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=conts)),
+                patch.object(main.database, "list_workers", AsyncMock(return_value=workers)),
+                patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"honeygain": gross})),
+            ):
+                return await main.api_earnings_net(MagicMock(), days=30)
+
+        return asyncio.run(run())
+
+    def test_gross_is_converted_into_the_tariff_currency(self):
+        out = self._net(rate=0.92)
+        assert out["total_gross"] == pytest.approx(92.0), "gross was not converted, so net mixes two currencies"
+        assert out["currency"] == "EUR"
+
+    def test_net_is_then_a_real_subtraction(self):
+        out = self._net(rate=0.92)
+        assert out["total_net"] == pytest.approx(out["total_gross"] - out["total_cost"])
+
+    def test_without_a_rate_it_stays_in_usd_and_says_so(self):
+        """Mixing silently is the failure; reporting one currency honestly is not."""
+        out = self._net(rate=None)
+        assert out["total_gross"] == pytest.approx(100.0)
+        assert out["currency"] == "USD"
+        assert out["fx_unavailable"] is True
+        assert out["tariff_currency"] == "EUR"
+
+    def test_a_usd_tariff_needs_no_conversion(self):
+        out = self._net(rate=None, currency="USD")
+        assert out["currency"] == "USD"
+        assert "fx_unavailable" not in out
+
+    def test_the_inverse_rate_direction_is_right(self):
+        """_fiat_rates holds USD->X, so from_usd multiplies where to_usd divides.
+
+        Inverting this would be worse than the bug: at 0.92 it would report 109
+        EUR for 100 USD and flatter the result further.
+        """
+        from app import exchange_rates as fx
+
+        fx._fiat_rates.clear()
+        fx._fiat_rates["EUR"] = 0.92
+        assert fx.from_usd(100.0, "EUR") == pytest.approx(92.0)
+        assert fx.to_usd(92.0, "EUR") == pytest.approx(100.0)

--- a/tests/test_currency_correctness.py
+++ b/tests/test_currency_correctness.py
@@ -15,6 +15,26 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 
 
+@pytest.fixture(autouse=True)
+def _isolate_fiat_rates():
+    """Save and restore exchange_rates._fiat_rates around every test here.
+
+    These tests set a rate to exercise the conversion. Without restoring it the
+    rate leaks into the rest of the suite, where unrelated endpoints then
+    convert a gross they were never meant to convert — test_power.py started
+    seeing 6.44 where it expected 7.0, failing for a reason that had nothing to
+    do with it.
+    """
+    from app import exchange_rates as fx
+
+    saved = dict(fx._fiat_rates)
+    try:
+        yield
+    finally:
+        fx._fiat_rates.clear()
+        fx._fiat_rates.update(saved)
+
+
 class TestACryptoPriceMoveCannotFabricateEarnings:
     """anyone-protocol priced a CUMULATIVE balance before the delta was taken.
 
@@ -145,12 +165,22 @@ class TestNetEarningsSubtractLikeFromLike:
 
         return asyncio.run(run())
 
-    def test_gross_is_converted_into_the_tariff_currency(self):
+    def test_the_tariff_is_converted_into_usd(self):
+        """The TARIFF moves, not the gross.
+
+        My first attempt converted gross into the tariff currency. Converting
+        the price instead keeps this endpoint canonical USD like every other
+        money figure in the API, and the frontend's display-currency layer
+        renders it in whatever the user reads in — converting the other way
+        would have made this one endpoint the exception.
+        """
         out = self._net(rate=0.92)
-        assert out["total_gross"] == pytest.approx(92.0), "gross was not converted, so net mixes two currencies"
-        assert out["currency"] == "EUR"
+        assert out["currency"] == "USD"
+        assert out["total_gross"] == pytest.approx(100.0), "gross is USD by contract and should not move"
+        assert out["cost_known"] is True
 
     def test_net_is_then_a_real_subtraction(self):
+        """Both sides in USD, so the subtraction means something."""
         out = self._net(rate=0.92)
         assert out["total_net"] == pytest.approx(out["total_gross"] - out["total_cost"])
 
@@ -158,13 +188,15 @@ class TestNetEarningsSubtractLikeFromLike:
         """Mixing silently is the failure; reporting one currency honestly is not."""
         out = self._net(rate=None)
         assert out["total_gross"] == pytest.approx(100.0)
-        assert out["currency"] == "USD"
+        assert out["cost_known"] is False, "a net here would subtract EUR from USD"
         assert out["fx_unavailable"] is True
         assert out["tariff_currency"] == "EUR"
+        assert "no" in out["cost_unavailable_reason"].lower()
 
     def test_a_usd_tariff_needs_no_conversion(self):
         out = self._net(rate=None, currency="USD")
         assert out["currency"] == "USD"
+        assert out["cost_known"] is True
         assert "fx_unavailable" not in out
 
     def test_the_inverse_rate_direction_is_right(self):

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -234,7 +234,11 @@ class TestNetEndpoint:
             [{"service": "svc", "status": "running", "cpu_percent": 5.0}],
         )
         assert out["cost_known"] is True
-        assert out["currency"] == "EUR"
+        # USD, not EUR. The tariff is converted into USD before it is subtracted
+        # from a USD gross (CashPilot-dlr); labelling the result EUR while the
+        # gross stayed in USD is exactly the mixing that was fixed. The frontend
+        # renders it in the user's display currency.
+        assert out["currency"] == "USD"
         assert out["services"][0]["net"] is not None
         assert out["window_days"] == 30
 


### PR DESCRIPTION
**`dlr`** — `gross` is USD by contract; `cost` comes from a tariff in `power_currency`. Subtracting one from the other produced a number in neither, labelled with the tariff currency.

At ~1.08 USD/EUR that's an **8% error, in the direction that flatters the result**, on the single figure that decides whether a machine is worth keeping powered on.

**The tariff is converted into USD, not the gross into the tariff currency.** My first attempt did the latter and it was wrong: every other money figure in this API is canonical USD and the frontend has a display-currency layer, so converting the gross would have made this endpoint the exception. Converting the price keeps the convention and needs no new rate direction.

With no rate available it reports `cost_known: false` and says why, rather than inventing a net. That mirrors what the module already does with no tariff at all — *"a zero cost would render gross as net and quietly overstate earnings."* Passing `"USD"` as a label while the price stayed EUR-denominated (my second attempt) only **moves** the mixing.

**`conftest` now seeds the fiat rates a running system always has.** `exchange_rates.refresh()` populates them at startup and every 15 minutes, but the test process never calls it, so `_fiat_rates` was empty everywhere. Ten tests configure a EUR tariff and expect a cost; with no rate the endpoint correctly refuses, so they failed for reasons unrelated to what they test.

Two existing assertions changed, both encoding the defect — `test_power` expected `currency == "EUR"` on a figure whose gross was USD.

**Verification:** 2533 tests, 95.12% coverage, both ruff gates, JS parses. Negative control: restoring the mixing fails four tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Net earnings now support electricity tariffs priced in non-USD currencies by converting them to USD.
  * Responses identify the tariff currency and explain when conversion rates are unavailable.
* **Bug Fixes**
  * Prevented misleading net earnings when currency conversion data is missing.
  * Corrected exchange-rate direction and preserved gross earnings in USD.
  * Improved handling of native-currency earnings and pricing scenarios.
* **Tests**
  * Added coverage for currency transitions, tariff conversion, missing rates, and related earnings calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->