### PR TITLE
fix(worker): removing a worker no longer locks the host out permanently

### DIFF
--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -343,7 +343,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
   };
 
   async function removeWorker(workerId, name) {
-    if (!confirm(`Remove worker "${name}"? This will unregister it from the fleet.`)) return;
+    if (!confirm(`Remove worker "${name}"?\n\nIt is removed from the fleet here, but the worker itself keeps running. It will re-enrol on its own after a few minutes of rejected heartbeats. To bring it back immediately, delete /data/.worker_key on that host and restart the container.`)) return;
     try {
       await CP.api(`/api/workers/${workerId}`, { method: 'DELETE' });
       CP.toast(`Worker "${name}" removed`, 'success');

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -70,6 +70,9 @@ _last_error: str = ""
 # may be restarting); a run of them means our identity no longer matches our key.
 _consecutive_auth_failures = 0
 _AUTH_FAILURE_ALARM_AFTER = 3
+# Well above the alarm: the operator is told first, and a key is only discarded
+# after the rejection has clearly persisted rather than on a flaky link.
+_AUTH_FAILURE_DISCARD_AFTER = 10
 
 # Per-worker fleet key. On first contact the UI enrolls this worker and hands back
 # a key unique to us, which we persist here (in our own private /data, never the
@@ -105,6 +108,40 @@ def _save_worker_key(key: str) -> bool:
     global _worker_key
     _worker_key = key
     return True
+
+
+def _discard_worker_key(reason: str) -> None:
+    """Forget our per-worker key so the next heartbeat re-enrols.
+
+    Removing a worker in the fleet dashboard deletes its row and its key on the
+    UI side, but the worker keeps sending the key it persisted — so it 401s
+    forever, on a host whose containers are still running and still earning.
+    Nothing on either side says why: the UI shows one fewer worker, the worker
+    logs a bare 401. The documented recovery ("remove it and the shared key is
+    accepted again") could not work, and the real fix was SSHing in to delete a
+    file that is documented nowhere.
+
+    Bounded on purpose. Discarding after a single failure would re-enrol on any
+    transient blip and widen the window in which the shared key is accepted; it
+    takes sustained rejection, which is what a deleted row actually looks like.
+    """
+    global _worker_key, _consecutive_auth_failures
+    try:
+        _WORKER_KEY_FILE.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.error(
+            "Could not remove the stale per-worker key at %s: %s. Delete it by hand "
+            "and restart this container to re-enrol.",
+            _WORKER_KEY_FILE,
+            exc,
+        )
+        return
+    _worker_key = None
+    _consecutive_auth_failures = 0
+    logger.warning(
+        "Discarded this worker's per-worker key (%s). Re-enrolling with the shared key on the next heartbeat.",
+        reason,
+    )
 
 
 _worker_key: str | None = _load_worker_key()
@@ -426,6 +463,11 @@ async def _send_heartbeat() -> None:
                     CLIENT_ID,
                     _WORKER_ID_FILE,
                 )
+            elif _consecutive_auth_failures >= _AUTH_FAILURE_DISCARD_AFTER:
+                # Sustained rejection of our own key is what a worker REMOVED in
+                # the dashboard looks like from here. Re-enrol rather than 401
+                # forever on a host that is still running containers.
+                _discard_worker_key(f"rejected {_consecutive_auth_failures} times; the UI no longer has this enrolment")
         else:
             # Any other outcome breaks the run. "Consecutive" has to mean it:
             # 401 -> timeout -> 401 -> 500 -> 401 is a flaky link, not an

--- a/docs/upgrade-v1.md
+++ b/docs/upgrade-v1.md
@@ -45,11 +45,15 @@ survives restarts.
 ## Recovery & rollback
 
 - **A worker's `/data` was wiped** (lost its key): it will try the shared key, which
-  the UI now rejects for an enrolled worker. Re-enroll it by removing the worker in
-  the fleet dashboard — it re-registers and enrolls fresh on its next heartbeat.
-- **Rolling a worker back to a 0.x image:** first remove that worker in the dashboard
-  (clears its enrollment) so the shared key is accepted again, then redeploy the old
-  image.
+  the UI now rejects for an enrolled worker. Remove the worker in the fleet
+  dashboard and it re-enrols on its own: the worker keeps sending the key it
+  persisted, and after roughly ten consecutive rejections it discards that key
+  and re-enrols with the shared one. Expect a few minutes of 401s in the worker
+  log while that plays out. To skip the wait, delete `/data/.worker_key` on that
+  host and restart the container.
+- **Rolling a worker back to a 0.x image:** remove that worker in the dashboard,
+  wait for it to re-enrol (or delete `/data/.worker_key` on the host), then
+  redeploy the old image.
 
 ---
 

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -420,3 +420,145 @@ class TestTheAlarmActuallyFires(TestAuthFailureAlarmCounter):
     def test_a_broken_run_never_raises_it(self, caplog):
         """A flaky link is not a lockout, and must not be reported as one."""
         assert self._alarms([401, None, 401, 500, 401], caplog) == []
+
+
+class TestRemovingAWorkerDoesNotLockTheHostOut(TestAuthFailureAlarmCounter):
+    """CashPilot-u10: "remove it and it re-enrols" was not true of any code.
+
+    Removing a worker in the fleet dashboard deletes its row and its key on the
+    UI side. The worker keeps sending the key it persisted at /data/.worker_key
+    — _active_key() returns `_worker_key or API_KEY`, so once that file exists
+    the shared key is never used again — and 401s forever, on a host whose
+    service containers are still running and still earning. docs/upgrade-v1.md
+    promised removal "clears its enrollment so the shared key is accepted
+    again"; nothing cleared anything. The only real recovery was SSHing in to
+    delete a file documented nowhere.
+    """
+
+    def _run_with_real_key_file(self, statuses, tmp_path):
+        """Like _run, but with a key that can actually be discarded.
+
+        The inherited harness patches _worker_key with patch.object, which
+        restores the global when the block exits — so a discard inside the
+        heartbeat would be silently undone and this whole class would pass
+        against unmodified code.
+        """
+        key_file = tmp_path / ".worker_key"
+        key_file.write_text("own")
+        saved = w._worker_key
+        w._worker_key = "own"
+        w._consecutive_auth_failures = 0
+        try:
+            for st in statuses:
+                request = httpx.Request("POST", "http://ui:8080/api/workers/heartbeat")
+                response = httpx.Response(st, request=request, json={})
+                client = MagicMock()
+                client.__aenter__ = AsyncMock(return_value=client)
+                client.__aexit__ = AsyncMock(return_value=False)
+                client.post = AsyncMock(return_value=response)
+                with (
+                    patch.object(w, "_WORKER_KEY_FILE", key_file),
+                    patch.object(w, "UI_URL", "http://ui:8080"),
+                    patch("app.worker_api.orchestrator.get_status", return_value=[]),
+                    patch("app.worker_api.orchestrator.docker_available", return_value=True),
+                    patch("app.worker_api.httpx.AsyncClient", return_value=client),
+                ):
+                    asyncio.run(w._send_heartbeat())
+            return {"key": w._worker_key, "file_exists": key_file.exists()}
+        finally:
+            w._worker_key = saved
+            w._consecutive_auth_failures = 0
+
+    def test_sustained_rejection_discards_the_stale_key(self, tmp_path):
+        out = self._run_with_real_key_file([401] * w._AUTH_FAILURE_DISCARD_AFTER, tmp_path)
+        assert out["key"] is None, "the worker is still sending the key the UI deleted"
+        assert not out["file_exists"], "the stale key survives a restart"
+
+    def test_it_then_re_enrols_with_the_shared_key(self, tmp_path):
+        """Discarding is only useful if the next heartbeat can authenticate."""
+        self._run_with_real_key_file([401] * w._AUTH_FAILURE_DISCARD_AFTER, tmp_path)
+        with patch.object(w, "_worker_key", None), patch.object(w, "API_KEY", "shared"):
+            assert w._active_key() == "shared"
+
+    def test_a_few_401s_do_not_discard_anything(self, tmp_path):
+        """The control that keeps this bounded.
+
+        Discarding on the first failure would re-enrol on any blip and widen the
+        window in which the shared key is accepted — the exact weakening that
+        per-worker keys exist to close.
+        """
+        out = self._run_with_real_key_file([401] * (w._AUTH_FAILURE_DISCARD_AFTER - 1), tmp_path)
+        assert out["key"] == "own"
+        assert out["file_exists"]
+
+    def test_the_discard_threshold_is_above_the_alarm(self):
+        """The operator is told first, and only then does the key go."""
+        assert w._AUTH_FAILURE_DISCARD_AFTER > w._AUTH_FAILURE_ALARM_AFTER
+
+    def test_a_flaky_link_never_discards(self, tmp_path):
+        """Non-consecutive failures are a network problem, not a deleted row."""
+        statuses = [401, 500] * w._AUTH_FAILURE_DISCARD_AFTER
+        out = self._run_with_real_key_file(statuses, tmp_path)
+        assert out["key"] == "own"
+        assert out["file_exists"]
+
+    def test_a_success_before_the_threshold_saves_the_key(self, tmp_path):
+        statuses = [401] * (w._AUTH_FAILURE_DISCARD_AFTER - 1) + [200, 401]
+        out = self._run_with_real_key_file(statuses, tmp_path)
+        assert out["key"] == "own"
+        assert out["file_exists"]
+
+    def test_it_says_why_in_the_log(self, tmp_path, caplog):
+        """A key vanishing without explanation is its own support ticket."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="app.worker_api"):
+            caplog.clear()
+            self._run_with_real_key_file([401] * w._AUTH_FAILURE_DISCARD_AFTER, tmp_path)
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Discarded" in m and "Re-enrolling" in m for m in messages)
+
+    def test_an_undeletable_key_keeps_the_key_rather_than_pretending(self, tmp_path, caplog):
+        """A read-only /data must not leave us believing we re-enrolled.
+
+        Zeroing _worker_key while the file survives would re-enrol now and then
+        load the stale key back on the next restart, which is worse than not
+        trying: the same lockout returns with no failures leading up to it.
+        """
+        import logging
+
+        key_file = tmp_path / ".worker_key"
+        key_file.write_text("own")
+        saved = w._worker_key
+        w._worker_key = "own"
+        try:
+            with (
+                patch.object(w, "_WORKER_KEY_FILE", key_file),
+                patch.object(w.Path, "unlink", side_effect=OSError("read-only file system")),
+                caplog.at_level(logging.ERROR, logger="app.worker_api"),
+            ):
+                caplog.clear()
+                w._discard_worker_key("test")
+            assert w._worker_key == "own", "we claimed to re-enrol while the key is still on disk"
+            assert key_file.exists()
+            assert any("Delete it by hand" in r.getMessage() for r in caplog.records)
+        finally:
+            w._worker_key = saved
+
+
+class TestTheRecoveryIsDocumentedWhereItIsNeeded:
+    """The bead is as much about the two false promises as about the code."""
+
+    def test_the_upgrade_doc_no_longer_promises_the_shared_key_is_accepted(self):
+        from pathlib import Path
+
+        text = Path(__file__).resolve().parents[1].joinpath("docs/upgrade-v1.md").read_text(encoding="utf-8")
+        assert "so the shared key is accepted again" not in text
+        assert "/data/.worker_key" in text, "the manual recovery must be written down somewhere"
+
+    def test_the_confirm_dialog_says_the_worker_keeps_running(self):
+        from pathlib import Path
+
+        text = Path(__file__).resolve().parents[1].joinpath("app/templates/fleet.html").read_text(encoding="utf-8")
+        assert "This will unregister it from the fleet." not in text
+        assert "re-enrol on its own" in text


### PR DESCRIPTION
## The defect

Removing a worker in the fleet dashboard deletes its row and its per-worker key on the UI side. The worker never learned that.

`app/worker_api.py` `_active_key()` returns `_worker_key or API_KEY` — once `/data/.worker_key` exists, the shared key is **never sent again**. So the host 401s forever, while its service containers keep running and keep earning. Nothing on either side explains it: the UI shows one fewer worker, the worker logs a bare 401.

Both places that described this promised a recovery no code performed:

- `docs/upgrade-v1.md:51` — removing the worker "(clears its enrollment) so the shared key is accepted again". Nothing cleared anything.
- `app/templates/fleet.html:346` — `Remove worker "${name}"? This will unregister it from the fleet.`

The only real recovery was SSHing in to delete a file documented nowhere.

## The fix

After **ten consecutive** rejections of our own key, the worker discards it and re-enrols with the shared key.

Bounded deliberately. Discarding on the first failure would re-enrol on any transient blip and widen the window in which the shared key is accepted — the exact weakening per-worker keys exist to close. The threshold sits above the existing `_AUTH_FAILURE_ALARM_AFTER = 3`, so the operator is told before anything is deleted. A key that cannot be removed from disk is **kept**, not zeroed in memory: believing we re-enrolled while the stale key survives a restart brings the same lockout back with no failures leading up to it.

The docs and the confirm dialog now describe what actually happens, including the manual shortcut.

## Evidence

- `ruff check .` + `ruff format --check .` clean; `node --check` on all JS
- 2558 tests pass
- **Negative control:** removing the five-line discard branch (module still imports — a behaviour change, not a syntax break) fails `test_sustained_rejection_discards_the_stale_key` and `test_it_says_why_in_the_log`, and nothing else. Reverting the two doc changes fails their two tests.
- Controls that keep the fix bounded: 9 consecutive 401s discard nothing; a flaky link (`401, 500` alternating) discards nothing; a success before the threshold saves the key.

Closes CashPilot-u10
