### PR TITLE
fix: fleet running costs subtracted a EUR tariff from a USD gross

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2529,6 +2529,21 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
     except (TypeError, ValueError):
         price = 0.0
 
+    # The tariff is in the user's own currency; every gross here comes from
+    # get_earned_by_platform, which is USD by contract. Subtracting one from the
+    # other produced a "losing money — turning it off would save that" verdict
+    # off by the whole FX spread, on a payload that carried no currency label at
+    # all. Convert the TARIFF, so the endpoint stays canonical USD like the rest
+    # of the API and the frontend's display-currency layer can render it.
+    tariff_currency = str(config.get("power_currency") or "EUR")
+    fx_ok = True
+    if price and tariff_currency != "USD":
+        converted = exchange_rates.to_usd(price, tariff_currency)
+        if converted is None:
+            fx_ok = False
+        else:
+            price = converted
+
     # Fetched once and reused: this used to query the worker table here and
     # then again inside _get_all_worker_containers, decoding every row twice
     # to build the same list in a single request.
@@ -2580,13 +2595,30 @@ async def api_fleet_economics(request: Request) -> dict[str, Any]:
                     per_worker_gross.get(worker.get("id"), 0.0) if str(worker.get("status") or "") == "online" else None
                 ),
                 watts=watts,
-                price_per_kwh=price or None,
+                # No rate means the tariff cannot be expressed in the same unit
+                # as the earnings, so there is no honest cost. None is already
+                # this module's "unknown", and it reports that rather than
+                # inventing a net.
+                price_per_kwh=(price or None) if fx_ok else None,
                 metered=power.is_metered(info),
                 dedicated=_worker_flag(config, worker, "dedicated"),
             )
         )
 
-    return machine_economics.fleet_summary(assessed)
+    summary = machine_economics.fleet_summary(assessed)
+    # Every figure in this payload is USD. It previously carried no currency at
+    # all, so fleet.html printed bare numbers the user could not attribute to a
+    # unit — and the numbers themselves mixed two.
+    summary["currency"] = "USD"
+    if not fx_ok:
+        summary["fx_unavailable"] = True
+        summary["tariff_currency"] = tariff_currency
+        summary["cost_unavailable_reason"] = (
+            f"Your electricity tariff is in {tariff_currency} and earnings are recorded in "
+            f"USD. No {tariff_currency}-to-USD rate is available right now, so a running "
+            "cost would be two different currencies subtracted from each other."
+        )
+    return summary
 
 
 @app.get("/api/services/{slug}/deploy-risk")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3054,5 +3054,10 @@ const CP = (() => {
     loadDeployRisk,
     confirmPayout,
     rejectPayout,
+    // Exposed for fleet.html, which rendered running costs with a bare
+    // Number(v).toFixed(2) — no unit at all, on figures that mixed USD earnings
+    // with a tariff in the user's own currency. The API is canonical USD now,
+    // and this is the one place that knows the viewer's display currency.
+    formatCurrency,
   };
 })();

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -176,7 +176,10 @@ CASHPILOT_WORKER_NAME=server-name</code>
 
     const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c =>
       ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]);
-    const money = v => (v == null ? '—' : Number(v).toFixed(2));
+    // null is genuinely unknown (a machine not reporting, or no tariff), and an
+    // em dash says so. Everything else is USD from the API and is rendered in
+    // whatever currency the viewer reads in.
+    const money = v => (v == null ? '—' : CP.formatCurrency(v));
 
     const rows = machines.map(m => {
       const losing = m.verdict === 'losing_money';

--- a/tests/test_beads_batch_16.py
+++ b/tests/test_beads_batch_16.py
@@ -1,0 +1,160 @@
+"""CashPilot-dlr: the fleet running-costs card subtracted EUR from USD.
+
+Every gross in /api/fleet/economics comes from ``get_earned_by_platform``,
+which is USD by contract (database.py: "USD earned per platform"). The
+electricity price came straight from the tariff config, in whatever currency
+the user set. ``machine_economics`` then did ``net = gross - cost``.
+
+Live, that rendered gross 5.00 (USD) minus cost 14.24 (EUR, 65 W at €0.30/kWh)
+= net −9.24, verdict "losing money", with "turning it off would save that" — a
+recommendation to switch off hardware, wrong by the whole FX spread. At the
+live rate the true net is about −$11.35, not −9.24 of any currency. With a
+weaker tariff currency the error is not 15% but orders of magnitude.
+
+The payload also carried no currency field at all, and fleet.html printed
+``Number(v).toFixed(2)``, so the user saw bare numbers they could not attribute
+to a unit — while those numbers silently mixed two.
+
+Fixed the same way /api/earnings/net was: convert the TARIFF to USD, so the
+endpoint stays canonical USD like the rest of the API and the frontend's
+display-currency layer renders it in whatever the viewer reads in.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+async def _economics(config, *, rate=0.92, rate_available=True):
+    """Drive api_fleet_economics with one online worker drawing 100 W.
+
+    machine_economics bills a month as 730 hours (365 * 24 / 12), so 100 W is
+    73 kWh and a €0.30 tariff is €21.90 — large enough that a missing conversion
+    cannot hide inside rounding.
+    """
+    from app import main
+
+    worker = {
+        "id": 1,
+        "client_id": "abc",
+        "name": "watchtower",
+        "status": "online",
+        "system_info": {},
+    }
+
+    def to_usd(amount, currency):
+        if currency == "USD":
+            return amount
+        return amount * rate if rate_available else None
+
+    with (
+        patch.object(main, "_require_auth_api", lambda r: None),
+        patch.object(main.database, "get_config", AsyncMock(return_value=config)),
+        patch.object(main.database, "list_workers", AsyncMock(return_value=[worker])),
+        patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"honeygain": 5.0})),
+        patch.object(
+            main,
+            "_get_all_worker_containers",
+            AsyncMock(return_value=[{"slug": "honeygain", "_worker_id": 1}]),
+        ),
+        patch.object(main, "_decoded_worker", lambda w: w),
+        patch.object(main.exchange_rates, "to_usd", to_usd),
+    ):
+        return await main.api_fleet_economics(MagicMock())
+
+
+CONFIG = {"power_price_per_kwh": "0.30", "power_currency": "EUR", "worker_abc_watts": "100"}
+
+
+class TestTheCostIsConvertedBeforeItIsSubtracted:
+    @pytest.mark.asyncio
+    async def test_the_cost_is_the_tariff_in_usd_not_the_raw_number(self):
+        out = await _economics(CONFIG)
+        machine = out["machines"][0]
+        # 100 W * 730 h = 73 kWh; 73 * 0.30 = EUR 21.90; * 0.92 = USD 20.15.
+        assert machine["monthly_cost"] == pytest.approx(20.15, abs=0.05), (
+            f"cost {machine['monthly_cost']} — EUR 21.90 was subtracted from a USD gross"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_net_is_a_like_for_like_subtraction(self):
+        out = await _economics(CONFIG)
+        machine = out["machines"][0]
+        assert machine["monthly_net"] == pytest.approx(5.0 - 20.15, abs=0.05)
+
+    @pytest.mark.asyncio
+    async def test_a_usd_tariff_is_left_alone(self):
+        """The control: converting when no conversion is needed is its own bug."""
+        out = await _economics({**CONFIG, "power_currency": "USD"})
+        assert out["machines"][0]["monthly_cost"] == pytest.approx(21.90, abs=0.05)
+
+    @pytest.mark.asyncio
+    async def test_the_payload_says_what_currency_it_is_in(self):
+        """It carried none, so the card printed numbers with no unit."""
+        assert (await _economics(CONFIG))["currency"] == "USD"
+
+
+class TestNoRateMeansNoCostRatherThanAWrongOne:
+    """Absent is not zero. A zero cost renders gross as net and overstates it."""
+
+    @pytest.mark.asyncio
+    async def test_the_cost_is_unknown_when_the_rate_is_missing(self):
+        out = await _economics(CONFIG, rate_available=False)
+        machine = out["machines"][0]
+        assert machine["monthly_cost"] is None
+        assert machine["monthly_net"] is None
+
+    @pytest.mark.asyncio
+    async def test_it_does_not_advise_switching_the_machine_off(self):
+        out = await _economics(CONFIG, rate_available=False)
+        assert "turning it off would save" not in out["machines"][0]["summary"].lower()
+
+    @pytest.mark.asyncio
+    async def test_the_payload_explains_why(self):
+        out = await _economics(CONFIG, rate_available=False)
+        assert out["fx_unavailable"] is True
+        assert out["tariff_currency"] == "EUR"
+        assert "two different currencies" in out["cost_unavailable_reason"]
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_flagged_when_the_rate_is_there(self):
+        """The control: this must not nag on a healthy install."""
+        out = await _economics(CONFIG)
+        assert "fx_unavailable" not in out
+        assert "cost_unavailable_reason" not in out
+
+    @pytest.mark.asyncio
+    async def test_a_usd_tariff_never_needs_a_rate(self):
+        """A USD user must not lose their cost figure when CoinGecko is down."""
+        out = await _economics({**CONFIG, "power_currency": "USD"}, rate_available=False)
+        assert out["machines"][0]["monthly_cost"] is not None
+        assert "fx_unavailable" not in out
+
+
+class TestTheCardRendersAUnit:
+    def test_the_fleet_card_no_longer_prints_a_bare_number(self):
+        text = without_comments((ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8"))
+        assert "Number(v).toFixed(2)" not in text, "running costs still render with no currency"
+        assert "CP.formatCurrency(v)" in text
+
+    def test_unknown_still_renders_as_a_dash_not_zero(self):
+        """The distinction the endpoint works to preserve must survive display."""
+        text = without_comments((ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8"))
+        assert "v == null ? '—'" in text
+
+    def test_format_currency_is_actually_exported(self):
+        """fleet.html calls it through CP; an unexported helper is a dead card."""
+        source = (ROOT / "app" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+        public_api = source[source.rindex("  return {") :]
+        assert "formatCurrency," in public_api


### PR DESCRIPTION
## The defect

Every gross in `/api/fleet/economics` comes from `get_earned_by_platform`, which is **USD by contract**. The electricity price came straight from the tariff config, in **whatever currency the user set**. `machine_economics` then does `net = gross - cost`.

Live, that rendered:

> gross 5.00 (USD) − cost 14.24 (EUR, 65 W at €0.30/kWh) = net **−9.24**, verdict *"losing money"*, with *"turning it off would save that"*

Advice to switch off hardware, wrong by the whole FX spread — the true net was about **−$11.35**, not −9.24 of any currency. With a weaker tariff currency the error is not 15% but orders of magnitude.

The payload also carried **no currency field at all**, and `fleet.html` rendered `Number(v).toFixed(2)` — bare numbers the user could not attribute to a unit, while those numbers silently mixed two.

## The fix

Same design `/api/earnings/net` settled on in #196: **convert the tariff to USD**, so the endpoint stays canonical USD like the rest of the API and the frontend's display-currency layer renders it in whatever the viewer reads in.

When no rate is available the cost is `None`, not zero — a zero cost renders gross as net and overstates earnings, the mistake this module already guards against when no tariff is set at all. The payload says so explicitly (`fx_unavailable`, `tariff_currency`, `cost_unavailable_reason`).

`formatCurrency` is now exported on `CP` so `fleet.html` can reach the one function that knows the viewer's display currency. `null` still renders as an em dash, so "not reporting" stays distinct from "earns nothing".

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` clean, 2636 passed.

Negative control, each part of the fix separately:

| reverted | tests that fail |
|---|---|
| don't convert the tariff (the original bug) | 2 |
| treat a missing rate as a usable price | 1 |
| drop the `currency` label | 1 |
| restore the bare-number renderer | 1 |

No overlap — each part is independently load-bearing.

Closes CashPilot-dlr