### PR TITLE
fix: a dollar balance was compared against a token minimum at 1:1

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2515,7 +2515,11 @@ async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
         # What the numbers above are actually in, so nothing has to assume.
         "balance_currency": balance_currency,
         "min_amount": minimum,
-        "min_amount_currency": balance_currency if minimum is not None else declared_currency,
+        # Falls back to the DECLARED unit when nothing has been collected: with
+        # no balance currency, min_payout_in returns the catalog figure at face
+        # value, and labelling that with None leaves the consumer holding a
+        # threshold it cannot attribute to any unit.
+        "min_amount_currency": (balance_currency if (minimum is not None and balance_currency) else declared_currency),
         # False only when a real minimum exists and could not be brought into
         # the balance's unit. The card hides the comparison rather than drawing
         # a bar out of two different currencies.

--- a/app/main.py
+++ b/app/main.py
@@ -1891,6 +1891,12 @@ async def api_earnings_breakdown(request: Request) -> list[dict[str, Any]]:
         except (TypeError, ValueError):
             min_amount = None
         balance = float(row["balance"])
+        # The minimum in the same unit as this balance. The catalog declares it
+        # in whatever the provider cashes out in, which for Storj (USD balance,
+        # STORJ minimum) and anyone-protocol is not what the collector reports —
+        # so `balance >= min_amount` was comparing two different currencies at
+        # 1:1, and told the user they were eligible when they were not.
+        comparable_min = payouts.min_payout_in(svc, row.get("currency"))
         prev_balance = float(row.get("prev_balance", 0))
         delta = balance - prev_balance
 
@@ -1921,9 +1927,17 @@ async def api_earnings_breakdown(request: Request) -> list[dict[str, Any]]:
                 #   minimum                eligibility would send the user to a
                 #                          page that refuses them.
                 "eligible": (
-                    False if not cashout else (None if min_amount is None else (balance > 0 and balance >= min_amount))
+                    False
+                    if not cashout
+                    else (None if comparable_min is None else (balance > 0 and balance >= comparable_min))
                 ),
                 "min_amount": min_amount,
+                # The threshold in the same unit as the balance above, or None
+                # when the two cannot be reconciled. Eligibility is decided on
+                # this one; min_amount stays as the catalog declares it so the
+                # provider's own wording is still available to the UI.
+                "min_amount_comparable": comparable_min,
+                "min_amount_currency": payouts.min_payout_currency(svc),
                 "method": cashout.get("method", "redirect"),
                 "dashboard_url": cashout.get("dashboard_url", ""),
                 "notes": cashout.get("notes", ""),
@@ -2476,13 +2490,36 @@ async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
 
     balance = await database.get_latest_balance(slug)
     history = await database.get_balance_history(slug, days=30)
+    # The unit the balance is recorded in, taken from the newest reading we
+    # already fetched rather than a second query. None when nothing has ever
+    # been collected, which min_payout_in reads as "cannot reconcile" and so
+    # leaves the declared minimum alone.
+    balance_currency = (history[-1].get("currency") if history else None) or None
     confirmed = await database.get_payouts(platform=slug, confirmed_only=True)
 
     known = balance is not None
     current = float(balance or 0.0)
+    # The card renders every figure here in ONE unit and asks the user to compare
+    # them against the provider's minimum. The balance is in whatever the
+    # collector reports and the minimum in whatever the provider cashes out in;
+    # for Storj and anyone-protocol those differ, so "3.50 STORJ" was really
+    # $3.50 and "0.50 to go" counted down to a threshold in another unit.
+    # Expressing the minimum in the BALANCE's unit keeps the comparison honest
+    # and leaves the balance itself untouched.
+    minimum = payouts.min_payout_in(service, balance_currency)
+    declared_currency = payouts.min_payout_currency(service)
+    comparable = minimum is not None or payouts.min_payout(service) is None
     return {
         "slug": slug,
         "current_balance": round(current, 6) if known else None,
+        # What the numbers above are actually in, so nothing has to assume.
+        "balance_currency": balance_currency,
+        "min_amount": minimum,
+        "min_amount_currency": balance_currency if minimum is not None else declared_currency,
+        # False only when a real minimum exists and could not be brought into
+        # the balance's unit. The card hides the comparison rather than drawing
+        # a bar out of two different currencies.
+        "comparable": comparable,
         # Lifetime counts CONFIRMED payouts only. A probable one folded in here
         # would let a single misread drop inflate earnings forever, invisibly.
         #
@@ -2500,7 +2537,7 @@ async def api_payout_progress(request: Request, slug: str) -> dict[str, Any]:
         # null-check onto every caller. The misleading part was never this
         # field; it was the card rendering a 0%-of-minimum bar from it, which
         # is fixed where the card is drawn.
-        "projection": payouts.project(current, service, history),
+        "projection": payouts.project(current, service, history, balance_currency),
     }
 
 

--- a/app/payouts.py
+++ b/app/payouts.py
@@ -78,6 +78,56 @@ def min_payout(service: dict[str, Any] | None) -> float | None:
     return value
 
 
+def min_payout_currency(service: dict[str, Any] | None) -> str | None:
+    """The unit ``min_payout`` is expressed in, straight from the catalog."""
+    if not service:
+        return None
+    raw = (service.get("cashout") or {}).get("currency")
+    text = str(raw or "").strip().upper()
+    return text or None
+
+
+def min_payout_in(service: dict[str, Any] | None, currency: str | None) -> float | None:
+    """The provider's minimum, expressed in ``currency``.
+
+    The minimum is declared in whatever unit the provider cashes out in, and the
+    balance is recorded in whatever unit the collector reports. For thirteen of
+    the fifteen collectors those agree, which is why nothing noticed. For Storj
+    the collector reports USD (its API gives cents) while the catalog declares
+    ``currency: STORJ, min_amount: 4.0``, and for anyone-protocol it is USD
+    against ANYONE — so a $3.50 balance was compared against 4 STORJ as though
+    the two were the same number, and the card told the user they had "0.50 to
+    go" toward a threshold in a different unit entirely.
+
+    ``None`` when the minimum is undocumented, when either unit is unknown, or
+    when no rate is available. Unknown is not zero and not "eligible": a guess
+    here sends someone to a withdrawal page that refuses them.
+    """
+    minimum = min_payout(service)
+    if minimum is None:
+        return None
+    declared = min_payout_currency(service)
+    target = str(currency or "").strip().upper()
+    # No declared unit is the common case — most catalog entries omit it because
+    # the provider pays in the same unit the collector reports. Taking the
+    # minimum at face value is what the code already did, and is right whenever
+    # the two agree; there is nothing better available when one is unstated.
+    if not declared or not target or declared == target:
+        return minimum
+    if minimum == 0:
+        # A documented "no minimum" is unit-free: zero of anything is zero.
+        return 0.0
+
+    # Imported here, not at module scope: this module is otherwise pure and is
+    # imported by tests that must not reach for a rate table.
+    from app import exchange_rates
+
+    in_usd = minimum if declared == "USD" else exchange_rates.to_usd(minimum, declared)
+    if in_usd is None:
+        return None
+    return in_usd if target == "USD" else exchange_rates.from_usd(in_usd, target)
+
+
 def looks_like_payout(previous: float, current: float, threshold: float | None) -> bool:
     """Did this balance fall far enough to look like a cashout?
 
@@ -175,6 +225,7 @@ def project(
     current_balance: float,
     service: dict[str, Any] | None,
     history: list[dict[str, Any]] | None,
+    balance_currency: str | None = None,
 ) -> dict[str, Any]:
     """How long until this can be cashed out?
 
@@ -182,7 +233,13 @@ def project(
     and "this is not earning" are different problems with different fixes, and
     collapsing them into one shrug helps nobody.
     """
-    threshold = min_payout(service)
+    # The threshold has to be in the BALANCE's unit, not the provider's. For
+    # Storj the collector records USD and the catalog declares the minimum in
+    # STORJ, so `remaining = 4.0 - 3.50` produced "0.50 to go" where the two
+    # numbers were dollars and tokens. min_payout_in returns None when they
+    # cannot be reconciled, which every branch below already treats as "no
+    # documented minimum" — no estimate rather than a wrong one.
+    threshold = min_payout_in(service, balance_currency)
     balance = float(current_balance or 0.0)
 
     if threshold is None:

--- a/app/payouts.py
+++ b/app/payouts.py
@@ -125,7 +125,19 @@ def min_payout_in(service: dict[str, Any] | None, currency: str | None) -> float
     in_usd = minimum if declared == "USD" else exchange_rates.to_usd(minimum, declared)
     if in_usd is None:
         return None
-    return in_usd if target == "USD" else exchange_rates.from_usd(in_usd, target)
+    if target == "USD":
+        return in_usd
+    # The inverse is DERIVED from to_usd rather than taken from from_usd, for
+    # two reasons. from_usd is deliberately fiat-only ("a USD figure has no
+    # meaningful expression in a provider's token"), which is right for
+    # displaying earnings but wrong here: expressing a threshold in the token
+    # the balance is counted in is exactly the comparison the card needs. And
+    # deriving it means the direction cannot be inverted by mistake — one unit
+    # of the target is worth `unit_in_usd`, so a USD figure is that many units.
+    unit_in_usd = exchange_rates.to_usd(1.0, target)
+    if not unit_in_usd:
+        return None
+    return in_usd / unit_in_usd
 
 
 def looks_like_payout(previous: float, current: float, threshold: float | None) -> bool:

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -348,14 +348,18 @@ const CP = (() => {
         </div>`;
     }
 
-    // Everything in this card is stated in the CASHOUT currency — the unit the
-    // provider's own minimum is declared in — and deliberately not converted to
-    // the dashboard's display currency. A browser check caught why: the balance
-    // rendered as "£3.73" directly above "to the 20 minimum", so the two halves
-    // of a single comparison were in different units and the progress bar
-    // agreed with neither. Here the numbers exist to be compared against that
-    // threshold, so they have to share its unit.
-    const unit = card.dataset.currency || '';
+    // Everything in this card shares ONE unit, and it is the unit the balance is
+    // actually recorded in — deliberately not the dashboard's display currency.
+    // A browser check caught why: the balance rendered as "£3.73" directly above
+    // "to the 20 minimum", so the two halves of a single comparison were in
+    // different units and the progress bar agreed with neither.
+    //
+    // It used to be the CASHOUT currency from the catalog, which is right only
+    // while the collector reports that same unit. Storj records USD and declares
+    // its minimum in STORJ, so a $3.50 balance rendered as "3.50 STORJ" and
+    // counted down to a threshold in tokens. The endpoint now converts the
+    // minimum into the balance's unit and states what that unit is.
+    const unit = data.balance_currency || card.dataset.currency || '';
     const money = value => (unit ? `${Number(value).toFixed(2)} ${unit}` : formatCurrency(value));
 
     const paid = data.confirmed_payout_count || 0;
@@ -555,8 +559,10 @@ const CP = (() => {
           const coB = b.cashout || {};
           const balA = (breakdownMap[a.slug] && breakdownMap[a.slug].balance) || a.balance || 0;
           const balB = (breakdownMap[b.slug] && breakdownMap[b.slug].balance) || b.balance || 0;
-          va = coA.min_amount > 0 ? (balA / coA.min_amount) : -1;
-          vb = coB.min_amount > 0 ? (balB / coB.min_amount) : -1;
+          // Sorting by "closest to payout" needs the same like-for-like ratio;
+          // otherwise a USD balance over a token minimum sorts nonsensically.
+          va = coA.min_amount_comparable > 0 ? (balA / coA.min_amount_comparable) : -1;
+          vb = coB.min_amount_comparable > 0 ? (balB / coB.min_amount_comparable) : -1;
           break;
         }
         default:
@@ -858,7 +864,12 @@ const CP = (() => {
 
     // Payout progress
     const co = svc.cashout || {};
-    const minAmount = co.min_amount || 0;
+    // The minimum in the SAME unit as the balance beside it. co.min_amount is
+    // whatever the provider declared — STORJ for a Storj balance recorded in USD
+    // — so comparing against it directly rated a $3.50 balance as 87% of the way
+    // to "4", and the tooltip printed 4 STORJ as "$4.00". null means the two
+    // units cannot be reconciled right now, and no bar is better than a wrong one.
+    const minAmount = co.min_amount_comparable ?? 0;
     const eligible = balance > 0 && balance >= minAmount;
     const pctToMin = minAmount > 0 ? Math.min(100, (balance / minAmount) * 100) : 0;
     const progressBar = minAmount > 0 ? `
@@ -1336,7 +1347,9 @@ const CP = (() => {
 
       const co = svc.cashout || {};
       const eligible = co.eligible;
-      const minAmount = co.min_amount || 0;
+      // Same reconciliation as the service row: compare and render in the unit
+      // the balance is in, never the catalog's declared cashout unit.
+      const minAmount = co.min_amount_comparable ?? 0;
       const currency = svc.currency || 'USD';
 
       if (title) title.textContent = `Claim — ${svc.name}`;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -869,10 +869,18 @@ const CP = (() => {
     // — so comparing against it directly rated a $3.50 balance as 87% of the way
     // to "4", and the tooltip printed 4 STORJ as "$4.00". null means the two
     // units cannot be reconciled right now, and no bar is better than a wrong one.
-    const minAmount = co.min_amount_comparable ?? 0;
-    const eligible = balance > 0 && balance >= minAmount;
-    const pctToMin = minAmount > 0 ? Math.min(100, (balance / minAmount) * 100) : 0;
-    const progressBar = minAmount > 0 ? `
+    // `?? 0` here would defeat the endpoint's own three-valued answer: null
+    // means the threshold could not be brought into the balance's unit, and
+    // coercing it to zero rates EVERY positive balance as eligible — the exact
+    // "unknown read as a definite yes" this whole change exists to remove.
+    const minAmount = co.min_amount_comparable;
+    const comparable = typeof minAmount === 'number';
+    // Eligibility is the endpoint's to decide; it is the only side that knows
+    // whether a rate was available. Recomputing it here is what let the two
+    // disagree.
+    const eligible = co.eligible === true;
+    const pctToMin = comparable && minAmount > 0 ? Math.min(100, (balance / minAmount) * 100) : 0;
+    const progressBar = comparable && minAmount > 0 ? `
       <div class="payout-progress" title="${formatCurrency(balance, currency)} / ${formatCurrency(minAmount, currency)}" style="min-width:60px;">
         <div class="payout-progress-bar ${eligible ? 'eligible' : ''}" style="width:${pctToMin.toFixed(0)}%"></div>
       </div>
@@ -1346,26 +1354,42 @@ const CP = (() => {
       }
 
       const co = svc.cashout || {};
+      // Three-valued, exactly as the endpoint reports it. `eligible` false and
+      // `eligible` null are different answers — "you are below the minimum" and
+      // "we cannot tell" — and rendering the second as the first tells the user
+      // something we do not know.
       const eligible = co.eligible;
+      const eligibilityUnknown = eligible == null;
       // Same reconciliation as the service row: compare and render in the unit
       // the balance is in, never the catalog's declared cashout unit.
-      const minAmount = co.min_amount_comparable ?? 0;
+      const minAmount = co.min_amount_comparable;
+      const comparable = typeof minAmount === 'number';
       const currency = svc.currency || 'USD';
 
       if (title) title.textContent = `Claim — ${svc.name}`;
 
-      const statusIcon = eligible
+      const unknownIcon = '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="8" y1="12" x2="16" y2="12"/></svg>';
+      const statusIcon = eligibilityUnknown
+        ? unknownIcon
+        : eligible
         ? '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="16 8 10 16 7 13"/></svg>'
         : '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>';
 
-      const statusText = eligible
+      const statusText = eligibilityUnknown
+        ? `<span style="color:var(--text-muted); font-weight:600; font-size:1.1rem;">Cannot tell yet</span>
+           <div style="color:var(--text-muted); font-size:0.85rem; margin-top:6px;">
+             This provider's minimum is set in ${escapeHtml(String(co.min_amount_currency || 'another currency'))} and the balance is
+             recorded in ${escapeHtml(String(currency))}. Without an exchange rate the two cannot be compared, so
+             CashPilot will not guess. Check the provider's own dashboard.
+           </div>`
+        : eligible
         ? `<span style="color:var(--success); font-weight:600; font-size:1.1rem;">Eligible for payout!</span>`
         : `<span style="color:var(--warning); font-weight:600; font-size:1.1rem;">Below minimum payout</span>`;
 
-      const pctToMin = minAmount > 0 ? Math.min(100, (svc.balance / minAmount) * 100) : 0;
-      const remaining = Math.max(0, minAmount - svc.balance);
+      const pctToMin = comparable && minAmount > 0 ? Math.min(100, (svc.balance / minAmount) * 100) : 0;
+      const remaining = comparable ? Math.max(0, minAmount - svc.balance) : 0;
 
-      const progressSection = minAmount > 0 ? `
+      const progressSection = comparable && minAmount > 0 ? `
         <div style="margin: 20px 0;">
           <div style="display:flex; justify-content:space-between; font-size:0.85rem; margin-bottom:6px;">
             <span>Current: <strong>${formatCurrency(svc.balance, currency)}</strong></span>

--- a/tests/test_beads_batch_17.py
+++ b/tests/test_beads_batch_17.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import yaml
@@ -89,12 +89,50 @@ class TestTheMinimumIsBroughtIntoTheBalancesUnit:
         assert payouts.min_payout_in({"cashout": {}}, "USD") is None
 
     def test_it_converts_the_other_way_too(self):
-        """A USD minimum against a token balance is the mirror case."""
-        from app import payouts
+        """A USD minimum against a token balance is the mirror case.
 
-        with patch("app.exchange_rates.from_usd", lambda amount, currency: amount * 4.0):
+        Driven through the REAL rate table, not a patched helper. The first
+        version of this test replaced exchange_rates.from_usd with a lambda and
+        passed while production returned None for every token target: from_usd
+        is deliberately fiat-only, so nothing here exercised the path it claimed
+        to. Seeding the rate is the difference between testing the conversion
+        and testing the mock. (CodeRabbit caught this on PR #200.)
+        """
+        from app import exchange_rates, payouts
+
+        saved = dict(exchange_rates._crypto_usd)
+        try:
+            exchange_rates._crypto_usd["GRASS"] = 0.25  # 1 GRASS = $0.25
             got = payouts.min_payout_in({"cashout": {"min_amount": 5.0, "currency": "USD"}}, "GRASS")
-            assert got == pytest.approx(20.0)
+            assert got == pytest.approx(20.0), "a $5 minimum is 20 GRASS at $0.25"
+        finally:
+            exchange_rates._crypto_usd.clear()
+            exchange_rates._crypto_usd.update(saved)
+
+    def test_an_unpriced_token_target_is_unknown_not_zero(self):
+        """No rate for the token means no comparison, not a threshold of 0."""
+        from app import exchange_rates, payouts
+
+        saved = dict(exchange_rates._crypto_usd)
+        try:
+            exchange_rates._crypto_usd.pop("NOSUCHTOKEN", None)
+            assert payouts.min_payout_in({"cashout": {"min_amount": 5.0, "currency": "USD"}}, "NOSUCHTOKEN") is None
+        finally:
+            exchange_rates._crypto_usd.clear()
+            exchange_rates._crypto_usd.update(saved)
+
+    def test_a_fiat_target_still_works(self):
+        """The conversion is derived from to_usd, which handles both kinds."""
+        from app import exchange_rates, payouts
+
+        saved = dict(exchange_rates._fiat_rates)
+        try:
+            exchange_rates._fiat_rates["EUR"] = 0.80  # USD -> EUR
+            got = payouts.min_payout_in({"cashout": {"min_amount": 10.0, "currency": "USD"}}, "EUR")
+            assert got == pytest.approx(8.0), "a $10 minimum is EUR 8 at 0.80"
+        finally:
+            exchange_rates._fiat_rates.clear()
+            exchange_rates._fiat_rates.update(saved)
 
 
 class TestTheProjectionCountsDownInOneUnit:
@@ -186,7 +224,12 @@ class TestTheCardsRenderTheUnitTheyAreIn:
     def test_no_site_still_divides_by_the_raw_declared_minimum(self):
         source = without_comments(APP_JS.read_text(encoding="utf-8"))
         assert "/ coA.min_amount)" not in source
-        assert "balance >= minAmount" in source, "the comparison itself should still exist"
+        # The row no longer recomputes eligibility at all — it reads the
+        # endpoint's three-valued answer, which is the only side that knows
+        # whether a rate was available. This assertion used to require the local
+        # `balance >= minAmount`; keeping it would have blocked the better fix.
+        assert "co.eligible === true" in source, "the row must still state eligibility from somewhere"
+        assert "min_amount_comparable" in source, "the reconciled threshold is still what the bar uses"
 
 
 class TestTheCatalogStillContainsTheCaseThisIsAbout:
@@ -203,3 +246,84 @@ class TestTheCatalogStillContainsTheCaseThisIsAbout:
     def test_the_storj_collector_still_reports_usd(self):
         source = (ROOT / "app" / "collectors" / "storj.py").read_text(encoding="utf-8")
         assert 'currency="USD"' in source
+
+
+class TestTheThresholdAlwaysNamesItsUnit:
+    """CodeRabbit, PR #200: min_amount without a currency cannot be attributed.
+
+    With nothing collected there is no balance currency, so min_payout_in hands
+    back the catalog figure at face value — and the response labelled it with
+    None, leaving a consumer holding a number in no stated unit.
+    """
+
+    async def _progress(self, history):
+        from app import main
+
+        service = {"name": "Storj", "cashout": {"min_amount": 4.0, "currency": "STORJ"}}
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main.catalog, "get_service", lambda slug: service),
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=None if not history else 3.5)),
+            patch.object(main.database, "get_balance_history", AsyncMock(return_value=history)),
+            patch.object(main.database, "get_payouts", AsyncMock(return_value=[])),
+        ):
+            return await main.api_payout_progress(MagicMock(), "storj")
+
+    @pytest.mark.asyncio
+    async def test_a_never_collected_service_reports_the_declared_unit(self):
+        out = await self._progress([])
+        assert out["min_amount"] == 4.0
+        assert out["min_amount_currency"] == "STORJ", "the threshold has no attributable unit"
+
+    @pytest.mark.asyncio
+    async def test_a_collected_service_reports_the_balances_unit(self):
+        """The control: once there is a balance, the unit is the balance's."""
+        from app import exchange_rates
+
+        saved = dict(exchange_rates._crypto_usd)
+        try:
+            exchange_rates._crypto_usd["STORJ"] = 0.25
+            out = await self._progress([{"date": "2026-08-01", "balance": 3.5, "currency": "USD"}])
+            assert out["min_amount_currency"] == "USD"
+            assert out["min_amount"] == pytest.approx(1.0)
+        finally:
+            exchange_rates._crypto_usd.clear()
+            exchange_rates._crypto_usd.update(saved)
+
+
+class TestUnknownEligibilityStaysUnknownInTheUI:
+    """CodeRabbit, PR #200: my own fix reintroduced the bug it was removing.
+
+    The endpoint answers three-valued — True, False, or null when no rate makes
+    the comparison possible. The service row did `co.min_amount_comparable ?? 0`
+    and then `balance >= 0`, rating EVERY positive balance as eligible; the
+    claim modal rendered the same null as "Below minimum payout". Two opposite
+    wrong answers from one unknown.
+    """
+
+    def _js(self):
+        return without_comments(APP_JS.read_text(encoding="utf-8"))
+
+    def test_the_row_does_not_coerce_a_null_threshold_to_zero(self):
+        assert "co.min_amount_comparable ?? 0" not in self._js()
+
+    def test_the_row_takes_eligibility_from_the_endpoint(self):
+        """Recomputing it locally is what let the two sides disagree."""
+        assert "co.eligible === true" in self._js()
+
+    def test_the_row_hides_the_bar_when_the_units_cannot_be_reconciled(self):
+        assert "comparable && minAmount > 0" in self._js()
+
+    def test_the_modal_has_a_third_state(self):
+        js = self._js()
+        assert "eligibilityUnknown" in js
+        assert "Cannot tell yet" in js
+
+    def test_the_modal_explains_why_rather_than_guessing(self):
+        js = self._js()
+        assert "cannot be compared" in js
+        assert "will not guess" in js
+
+    def test_the_modal_still_says_below_minimum_when_it_knows(self):
+        """The control: the ordinary negative answer must survive."""
+        assert "Below minimum payout" in self._js()

--- a/tests/test_beads_batch_17.py
+++ b/tests/test_beads_batch_17.py
@@ -1,0 +1,205 @@
+"""CashPilot-c50: a dollar balance compared against a token minimum at 1:1.
+
+The balance is recorded in whatever the collector reports; the payout minimum
+is declared in whatever the provider cashes out in. For thirteen of the fifteen
+registered collectors those agree, which is why nothing noticed. Two disagree:
+
+* Storj — the collector reports USD (its API gives cents), the catalog declares
+  ``currency: STORJ, min_amount: 4.0``;
+* anyone-protocol — USD against ANYONE.
+
+So a real $3.50 balance rendered as "Balance now: 3.50 STORJ", the card said
+"0.50 to go" toward a threshold in a different unit, and the service-row
+tooltip printed 4 STORJ as "$4.00". Every number the user was asked to compare
+was in a unit it was not in.
+
+Fixed by reconciling once, in payouts.min_payout_in, and using it everywhere the
+two are compared: eligibility, the projection, the progress card, the service
+row, the claim modal, and the "closest to payout" sort.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+STORJ = {"cashout": {"min_amount": 4.0, "currency": "STORJ"}}
+
+
+class TestTheMinimumIsBroughtIntoTheBalancesUnit:
+    def test_a_token_minimum_becomes_dollars(self):
+        """4 STORJ at $0.25 is $1.00 — not "4", and not "$4.00"."""
+        from app import payouts
+
+        with patch("app.exchange_rates.to_usd", lambda amount, currency: amount * 0.25):
+            assert payouts.min_payout_in(STORJ, "USD") == pytest.approx(1.0)
+
+    def test_matching_units_are_left_exactly_alone(self):
+        """The thirteen collectors that already agree must not move at all."""
+        from app import payouts
+
+        assert payouts.min_payout_in({"cashout": {"min_amount": 20.0, "currency": "USD"}}, "USD") == 20.0
+
+    def test_an_undeclared_cashout_currency_is_taken_at_face_value(self):
+        """Most catalog entries omit it because the two agree.
+
+        Refusing to compare here would disable the payout bar for almost every
+        service in the catalog — a far worse answer than the existing behaviour,
+        which is correct whenever the units match.
+        """
+        from app import payouts
+
+        assert payouts.min_payout_in({"cashout": {"min_amount": 20.0}}, "USD") == 20.0
+
+    def test_an_unknown_balance_currency_is_taken_at_face_value(self):
+        from app import payouts
+
+        assert payouts.min_payout_in(STORJ, None) == 4.0
+
+    def test_no_rate_means_no_comparison_rather_than_a_guess(self):
+        """Unknown is not zero and not "eligible"."""
+        from app import payouts
+
+        with patch("app.exchange_rates.to_usd", lambda amount, currency: None):
+            assert payouts.min_payout_in(STORJ, "USD") is None
+
+    def test_a_documented_no_minimum_needs_no_rate(self):
+        """Zero of anything is zero — refusing here would hide a real answer."""
+        from app import payouts
+
+        with patch("app.exchange_rates.to_usd", lambda amount, currency: None):
+            assert payouts.min_payout_in({"cashout": {"min_amount": 0, "currency": "STORJ"}}, "USD") == 0.0
+
+    def test_an_undocumented_minimum_stays_unknown(self):
+        from app import payouts
+
+        assert payouts.min_payout_in({"cashout": {}}, "USD") is None
+
+    def test_it_converts_the_other_way_too(self):
+        """A USD minimum against a token balance is the mirror case."""
+        from app import payouts
+
+        with patch("app.exchange_rates.from_usd", lambda amount, currency: amount * 4.0):
+            got = payouts.min_payout_in({"cashout": {"min_amount": 5.0, "currency": "USD"}}, "GRASS")
+            assert got == pytest.approx(20.0)
+
+
+class TestTheProjectionCountsDownInOneUnit:
+    def _remaining(self, balance, currency, rate=0.25):
+        from app import payouts
+
+        history = [
+            {"date": "2026-07-01", "balance": balance - 1.0, "currency": currency},
+            {"date": "2026-07-31", "balance": balance, "currency": currency},
+        ]
+        with patch("app.exchange_rates.to_usd", lambda amount, cur: amount * rate):
+            return payouts.project(balance, STORJ, history, currency)
+
+    def test_remaining_is_in_the_balances_unit(self):
+        """$3.50 against 4 STORJ at $0.25 is already PAST the $1.00 minimum."""
+        out = self._remaining(3.50, "USD")
+        assert out.get("remaining") == 0.0, f"still counting down to a token threshold: {out}"
+
+    def test_a_matching_unit_is_unaffected(self):
+        """The control: the ordinary case must keep its countdown."""
+        from app import payouts
+
+        history = [
+            {"date": "2026-07-01", "balance": 1.0, "currency": "USD"},
+            {"date": "2026-07-31", "balance": 3.50, "currency": "USD"},
+        ]
+        out = payouts.project(3.50, {"cashout": {"min_amount": 20.0, "currency": "USD"}}, history, "USD")
+        assert out.get("remaining") == pytest.approx(16.50)
+
+    def test_no_rate_gives_no_estimate_rather_than_a_wrong_one(self):
+        from app import payouts
+
+        history = [
+            {"date": "2026-07-01", "balance": 1.0, "currency": "USD"},
+            {"date": "2026-07-31", "balance": 3.50, "currency": "USD"},
+        ]
+        with patch("app.exchange_rates.to_usd", lambda amount, cur: None):
+            out = payouts.project(3.50, STORJ, history, "USD")
+        assert out.get("remaining") is None
+
+
+class TestEligibilityUsesTheReconciledThreshold:
+    def _eligible(self, cashout, balance, currency):
+        from tests.test_eligibility import _call_breakdown, _earnings_row, _service
+
+        row = _earnings_row("storj", balance=balance)
+        row["currency"] = currency
+        return _call_breakdown([row], {"storj": _service("storj", cashout=cashout)})[0]["cashout"]
+
+    def test_a_dollar_balance_is_judged_against_the_dollar_minimum(self):
+        """$3.50 vs 4 STORJ at $0.25 = $1.00: eligible, and it was not."""
+        with patch("app.exchange_rates.to_usd", lambda amount, cur: amount * 0.25):
+            out = self._eligible({"min_amount": 4.0, "currency": "STORJ"}, 3.50, "USD")
+        assert out["eligible"] is True
+        assert out["min_amount_comparable"] == pytest.approx(1.0)
+
+    def test_the_catalogs_own_figure_is_still_reported(self):
+        """The provider's wording stays available; only the comparison changed."""
+        with patch("app.exchange_rates.to_usd", lambda amount, cur: amount * 0.25):
+            out = self._eligible({"min_amount": 4.0, "currency": "STORJ"}, 3.50, "USD")
+        assert out["min_amount"] == 4.0
+        assert out["min_amount_currency"] == "STORJ"
+
+    def test_no_rate_makes_eligibility_unknown_not_true(self):
+        with patch("app.exchange_rates.to_usd", lambda amount, cur: None):
+            out = self._eligible({"min_amount": 4.0, "currency": "STORJ"}, 3.50, "USD")
+        assert out["eligible"] is None
+
+    def test_the_ordinary_matching_case_is_unchanged(self):
+        """The control that would catch this breaking every other service."""
+        out = self._eligible({"min_amount": 20.0}, 25.0, "USD")
+        assert out["eligible"] is True
+        assert self._eligible({"min_amount": 20.0}, 5.0, "USD")["eligible"] is False
+
+
+class TestTheCardsRenderTheUnitTheyAreIn:
+    def test_the_progress_card_labels_with_the_balances_currency(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "data.balance_currency" in source, "the card still assumes the cashout unit"
+
+    @pytest.mark.parametrize("count", [3])
+    def test_every_comparison_site_uses_the_reconciled_minimum(self, count):
+        """Service row, claim modal, and the closest-to-payout sort."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert source.count("min_amount_comparable") >= count, (
+            "a comparison site still divides a balance by the catalog's declared minimum"
+        )
+
+    def test_no_site_still_divides_by_the_raw_declared_minimum(self):
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "/ coA.min_amount)" not in source
+        assert "balance >= minAmount" in source, "the comparison itself should still exist"
+
+
+class TestTheCatalogStillContainsTheCaseThisIsAbout:
+    """If Storj's YAML is ever normalised, this fix stops being exercised."""
+
+    def _cashout(self, slug):
+        for path in ROOT.joinpath("services").rglob(f"{slug}.yml"):
+            return (yaml.safe_load(path.read_text(encoding="utf-8")) or {}).get("cashout") or {}
+        return {}
+
+    def test_storj_still_declares_a_token_minimum(self):
+        assert self._cashout("storj").get("currency") == "STORJ"
+
+    def test_the_storj_collector_still_reports_usd(self):
+        source = (ROOT / "app" / "collectors" / "storj.py").read_text(encoding="utf-8")
+        assert 'currency="USD"' in source

--- a/tests/test_beads_batch_2.py
+++ b/tests/test_beads_batch_2.py
@@ -85,7 +85,12 @@ class TestThePayoutCardDoesNotInventProgress:
         Nulling it broke an existing test that was right to object.
         """
         source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
-        assert '"projection": payouts.project(current, service, history),' in source
+        # Matched on the CALL, not its full argument list. Pinning the arguments
+        # made this fail when project() gained the balance's currency — a change
+        # that has nothing to do with what this test is protecting, which is
+        # that the field is populated rather than nulled.
+        assert '"projection": payouts.project(current, service, history' in source
+        assert '"projection": None' not in source
 
     @pytest.mark.asyncio
     async def test_a_never_read_service_reports_null_lifetime(self):


### PR DESCRIPTION
## The defect

The balance is recorded in whatever **the collector** reports. The payout minimum is declared in whatever **the provider** cashes out in. Thirteen of the fifteen registered collectors agree — which is why nothing noticed. Two do not:

| service | collector reports | catalog declares |
|---|---|---|
| storj | `USD` (its API gives cents) | `4.0 STORJ` |
| anyone-protocol | `USD` | `ANYONE` |

So a real **$3.50** Storj balance rendered as `Balance now: 3.50 STORJ`, the card said **"0.50 to go"** toward a threshold in a different unit, and the service-row tooltip printed 4 STORJ as **"$4.00"**. Every number the user was asked to compare was in a unit it was not in.

The same 1:1 comparison decided `eligible`, so a user could be told they can cash out and sent to a page that refuses them.

## The fix

Reconciled **once**, in `payouts.min_payout_in`, and used everywhere the two meet:

- eligibility (`/api/earnings/breakdown`)
- the projection countdown (`payouts.project`)
- the payout-progress card
- the service row + its tooltip
- the claim modal
- the "closest to payout" sort

`/api/services/{slug}/payout-progress` now also states what unit its figures are in, instead of leaving the frontend to assume the catalog's.

Three-valued throughout, matching the rest of the codebase:

- **no rate → `None`**, no comparison and no estimate. Unknown is not zero and not "eligible".
- **a documented `0` minimum needs no rate** — zero of anything is zero; refusing there would hide a real answer.
- **an undeclared cashout currency is taken at face value** — correct whenever the units match, which is almost every catalog entry. Refusing there would disable the payout bar catalog-wide, a far worse answer than the behaviour being fixed.

`payouts.project` gained the balance's currency as a **defaulted** argument, so no existing caller changes behaviour.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and the currency harness clean, **2644 passed**.

Negative control — five parts, no overlap:

| reverted | tests that fail |
|---|---|
| `min_payout_in` never converts (the original behaviour) | 7 |
| eligibility compares against the declared minimum | 2 |
| the projection counts down to the declared minimum | 2 |
| the card labels with the cashout unit | 1 |
| the rows divide by the declared minimum | 2 |

Two tests also pin the catalog case itself (Storj still declares STORJ, its collector still reports USD), so a later YAML tidy-up cannot quietly stop exercising this.

Closes CashPilot-c50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payout eligibility and progress now correctly compare thresholds across different currencies.
  * Added currency-aware payout projections, remaining-balance calculations, and countdowns.
  * Unconvertible currency mismatches no longer produce misleading threshold estimates.
  * Updated payout sorting and eligibility displays to use comparable amounts.

* **Tests**
  * Added coverage for cross-currency payout thresholds and projections.
  * Improved resilience of projection-related validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->