### PR TITLE
fix: an unreachable host reported its containers as running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Currency formatting behaviour
         run: node scripts/currency_check.mjs
 
+      # Also behaviour pytest cannot reach, and for the same reason: these
+      # renderers live in a <script> block inside a Jinja template, so a Python
+      # assertion could only prove the source mentions a variable — never what
+      # colour a given worker actually produces.
+      - name: Fleet staleness behaviour
+        run: node scripts/fleet_staleness_check.mjs
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -266,8 +266,8 @@ CASHPILOT_WORKER_NAME=server-name</code>
               <span>${esc(sysInfo.arch || '-')}</span>
               <span>Last seen: ${w.last_heartbeat || 'never'}</span>
             </div>
-            ${isAndroid && items.length > 0 ? renderApps(items) : ''}
-            ${!isAndroid && items.length > 0 ? renderContainers(w) : ''}
+            ${isAndroid && items.length > 0 ? renderApps(items, isOnline, w.last_heartbeat) : ''}
+            ${!isAndroid && items.length > 0 ? renderContainers(w, isOnline) : ''}
           </div>
         </div>`;
       }
@@ -282,31 +282,55 @@ CASHPILOT_WORKER_NAME=server-name</code>
     return (b / 1073741824).toFixed(2) + ' GB';
   }
 
-  function renderApps(apps) {
+  function renderApps(apps, isOnline, lastSeen) {
     let html = '<div style="margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-color);">';
+    if (isOnline === false) {
+      html += `<div style="font-size:0.7rem; color:var(--text-muted); margin-bottom:6px;">Last known state — not reachable</div>`;
+    }
     html += '<div style="display: flex; gap: 6px; flex-wrap: wrap;">';
     for (const a of apps) {
-      const isRunning = a.running;
+      // Same rule as the containers: an unreachable device cannot be reporting
+      // an app as running, whatever its last heartbeat said.
+      const isRunning = isOnline !== false && a.running;
       const color = isRunning ? 'var(--success)' : 'var(--text-muted)';
       const bg = isRunning ? 'var(--success-soft)' : 'var(--bg-hover)';
       const tx = a.net_tx_24h || 0;
       const rx = a.net_rx_24h || 0;
-      const netTip = (tx || rx) ? ` title="24h: ↑${fmtBytes(tx)} ↓${fmtBytes(rx)}"` : '';
-      html += `<span style="font-size:0.75rem; padding:3px 8px; border-radius:4px; background:${bg}; color:${color}; font-weight:500;"${netTip}>${esc(a.slug)}</span>`;
+      const staleTip = isOnline === false ? esc(staleNote(lastSeen)) : '';
+      const trafficTip = (tx || rx) ? `24h: ↑${fmtBytes(tx)} ↓${fmtBytes(rx)}` : '';
+      const tipText = [staleTip, trafficTip].filter(Boolean).join(' — ');
+      const netTip = tipText ? ` title="${tipText}"` : '';
+      const appStyle = isOnline === false ? ' border:1px dashed var(--border-color); opacity:0.75;' : '';
+      html += `<span style="font-size:0.75rem; padding:3px 8px; border-radius:4px; background:${bg}; color:${color}; font-weight:500;${appStyle}"${netTip}>${esc(a.slug)}</span>`;
     }
     html += '</div></div>';
     return html;
   }
 
-  function renderContainers(worker) {
+  // A container's colour is a claim about RIGHT NOW, and it can only be made
+  // while the worker is reachable. When it is not, every chip stayed the colour
+  // frozen into the last heartbeat — so a host that is powered off rendered a
+  // row of success-green containers next to a grey dot, and green is the louder
+  // signal. The state is still shown, because "what was running when we last
+  // heard" is useful, but it is shown as a memory rather than a measurement.
+  function staleNote(lastSeen) {
+    return `Last reported ${lastSeen || 'never'}. This host is not reachable, so this is the last known state, not the current one.`;
+  }
+
+  function renderContainers(worker, isOnline) {
     let html = '<div style="margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-color);">';
+    if (!isOnline) {
+      html += `<div style="font-size:0.7rem; color:var(--text-muted); margin-bottom:6px;">Last known state — not reachable</div>`;
+    }
     html += '<div style="display: flex; gap: 6px; flex-wrap: wrap;">';
     for (const c of worker.containers) {
       const status = (c.status || 'stopped').toLowerCase();
-      const isRunning = status === 'running';
+      const isRunning = isOnline && status === 'running';
       const color = isRunning ? 'var(--success)' : 'var(--text-muted)';
       const bg = isRunning ? 'var(--success-soft)' : 'var(--bg-hover)';
-      html += `<span style="font-size:0.75rem; padding:3px 8px; border-radius:4px; background:${bg}; color:${color}; font-weight:500;">${esc(c.slug || c.name)}</span>`;
+      const style = isOnline ? '' : ' border:1px dashed var(--border-color); opacity:0.75;';
+      const tip = isOnline ? '' : ` title="${esc(staleNote(worker.last_heartbeat))}"`;
+      html += `<span style="font-size:0.75rem; padding:3px 8px; border-radius:4px; background:${bg}; color:${color}; font-weight:500;${style}"${tip}>${esc(c.slug || c.name)}</span>`;
     }
     html += '</div></div>';
     return html;

--- a/scripts/fleet_staleness_check.mjs
+++ b/scripts/fleet_staleness_check.mjs
@@ -1,0 +1,94 @@
+// Run the REAL fleet.html chip renderers and check what colour they claim.
+//
+// CashPilot-1m8: a worker whose host is powered off still rendered a row of
+// success-green container chips, coloured from the status frozen into its last
+// heartbeat. The only counter-signal was a grey dot elsewhere on the card, and
+// green is the louder signal — the user reads "honeygain, traffmonetizer" as
+// running on a machine CashPilot has not heard from in hours.
+//
+// pytest cannot see this. The renderers live inside a <script> block in a Jinja
+// template, and a text assertion on the template would only prove the source
+// contains a variable name, not what colour a given worker produces. So the
+// functions are extracted and run for real, on both an online and an offline
+// worker, and the OUTPUT is inspected.
+//
+// No browser needed: these renderers build strings and touch no DOM.
+//   node scripts/fleet_staleness_check.mjs
+// Exits non-zero on any mismatch.
+import {readFileSync} from 'node:fs';
+
+const html = readFileSync('app/templates/fleet.html', 'utf8');
+
+function extract(name) {
+  const start = html.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`fleet.html no longer defines ${name}() — this check is stale`);
+  // Walk braces from the first { after the signature to find the real end.
+  let i = html.indexOf('{', start), depth = 0;
+  for (let j = i; j < html.length; j++) {
+    if (html[j] === '{') depth++;
+    else if (html[j] === '}' && --depth === 0) return html.slice(start, j + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name}()`);
+}
+
+const esc = s => String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+const fmtBytes = b => `${b}B`;
+const source = [extract('staleNote'), extract('renderContainers'), extract('renderApps')].join('\n');
+const build = new Function('esc', 'fmtBytes', `${source}; return {renderContainers, renderApps, staleNote};`);
+const {renderContainers, renderApps} = build(esc, fmtBytes);
+
+const WORKER = {
+  name: 'geiserback',
+  last_heartbeat: '2026-08-04 09:12',
+  containers: [{slug: 'honeygain', status: 'running'}, {slug: 'traffmonetizer', status: 'running'}],
+};
+const APPS = [{slug: 'honeygain', running: true, net_tx_24h: 10, net_rx_24h: 20}];
+
+const failures = [];
+const check = (name, ok, detail) => { if (!ok) failures.push(`${name}: ${detail}`); };
+
+// 1. The defect itself. An unreachable host must not paint anything success-green.
+const offline = renderContainers(WORKER, false);
+check('offline containers are not green', !offline.includes('var(--success)'),
+  'a powered-off host still reports its containers as running');
+
+// 2. The control. Without this, the check above passes if the chips never go
+//    green at all — which would be a different bug, not a fix.
+const online = renderContainers(WORKER, true);
+check('online containers stay green', online.includes('var(--success)'),
+  'a reachable host stopped reporting running containers');
+
+// 3. The state is still shown — it is useful, it just is not a measurement.
+check('offline still lists the containers', offline.includes('honeygain'),
+  'the container list vanished instead of being marked stale');
+check('offline says so in words', offline.includes('Last known state'),
+  'nothing on the card says the state is not current');
+check('offline names when it was last seen', offline.includes('2026-08-04 09:12'),
+  'the chip tooltip does not say when this was last true');
+
+// 4. A stopped container on a LIVE host must still read as stopped, not stale.
+const stoppedLive = renderContainers({...WORKER, containers: [{slug: 'grass', status: 'exited'}]}, true);
+check('a stopped container on a live host is not green', !stoppedLive.includes('var(--success)'),
+  'an exited container rendered as running');
+check('a live host carries no staleness note', !stoppedLive.includes('Last known state'),
+  'a reachable host is being described as unreachable');
+
+// 5. Android apps take the same rule — the bead named only containers, but the
+//    same frozen-heartbeat colour was applied one function above.
+const appsOffline = renderApps(APPS, false, '2026-08-04 09:12');
+const appsOnline = renderApps(APPS, true, '2026-08-04 09:12');
+check('offline apps are not green', !appsOffline.includes('var(--success)'),
+  'an unreachable phone still reports its apps as running');
+check('online apps stay green', appsOnline.includes('var(--success)'),
+  'a reachable phone stopped reporting running apps');
+check('app traffic tooltip survives', appsOnline.includes('24h:'),
+  'the traffic tooltip was lost while adding the staleness one');
+check('offline apps keep both tooltips', appsOffline.includes('Last reported') && appsOffline.includes('24h:'),
+  'the staleness note replaced the traffic figures instead of joining them');
+
+if (failures.length) {
+  console.error('fleet staleness check FAILED:');
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`fleet staleness check passed (${11} assertions)`);

--- a/tests/test_javascript_is_parsed.py
+++ b/tests/test_javascript_is_parsed.py
@@ -87,3 +87,32 @@ class TestTheCommittedBrowserHarnessesStillRun:
         )
         assert result.returncode == 0, f"currency harness failed:\n{result.stdout}\n{result.stderr}"
         assert "RESULT: PASS" in result.stdout
+
+
+class TestTheBrowserHarnessesActuallyRun:
+    """The .mjs checks are only worth having if something runs them.
+
+    CI runs them as separate steps, which is right — but a harness that only
+    ever runs on CI is one a local `pytest` run will not catch before a push.
+    Shelling out here keeps them in the same gate as everything else.
+    """
+
+    @pytest.mark.parametrize("script", ["currency_check.mjs", "fleet_staleness_check.mjs"])
+    def test_the_harness_passes(self, script):
+        node = shutil.which("node")
+        if node is None:
+            pytest.skip("node is not installed; CI runs these as their own step")
+        result = subprocess.run(
+            [node, f"scripts/{script}"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, f"{script} failed:\n{result.stdout}\n{result.stderr}"
+
+    def test_ci_runs_every_browser_free_harness(self):
+        """A new harness that CI never invokes is decoration."""
+        workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+        for script in ("currency_check.mjs", "fleet_staleness_check.mjs"):
+            assert script in workflow, f"scripts/{script} is never run by CI"


### PR DESCRIPTION
## The defect

The Fleet page coloured every container chip from the status **frozen into the last heartbeat**, with no staleness input:

```js
const isRunning = status === 'running';
const color = isRunning ? 'var(--success)' : 'var(--text-muted)';
```

So a host that is powered off rendered a row of success-green chips — "honeygain, traffmonetizer" — next to a machine CashPilot had not heard from in hours. The only counter-signal was a grey dot and a "Last seen" line elsewhere on the card, and green is the louder signal.

`renderApps` had the same defect one function above. The bead named only the containers.

## The fix

A colour is a claim about **right now**, and it can only be made while the worker is reachable.

The state is still shown — "what was running when we last heard" is genuinely useful — but as a memory rather than a measurement: muted, dashed, headed *"Last known state — not reachable"*, with a tooltip naming when it was last true.

## Evidence

Proof is a **node harness**, not a Python assertion, because these renderers live in a `<script>` block inside a Jinja template — a text assertion could only show the source mentions a variable, never what colour a given worker actually produces. The harness extracts the real functions and inspects their output (11 assertions).

CI runs it as its own step, and pytest shells out to it so a local run catches it too. A test also asserts CI invokes every browser-free harness, so a new one can't sit unrun.

Negative control:

| reverted | result |
|---|---|
| containers coloured from the frozen status | ✗ "a powered-off host still reports its containers as running" |
| apps coloured from the frozen status | ✗ "an unreachable phone still reports its apps as running" |
| hide the list entirely instead of marking it (the lazy fix) | ✗ "nothing on the card says the state is not current" |

The third matters: the obvious shortcut — just don't render the chips — fails a *different* assertion, so it can't pass by accident.

Controls also pin the ordinary cases: a reachable host still goes green, an exited container on a live host still reads stopped, and the app traffic tooltip survives alongside the new staleness one.

Closes CashPilot-1m8
