### PR TITLE
fix: the dashboard asserted $0.00 before anything had ever looked

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1849,6 +1849,13 @@ async def api_earnings_summary(request: Request) -> dict[str, Any]:
     # A total that silently omits holdings is indistinguishable from a correct
     # one. The count was already being computed in database.py and only logged;
     # it now reaches the caller so the card can say the figure is partial.
+    # Whether anything has ever been read at all. Without this the payload is
+    # identical on a fresh install and on an install whose collection has
+    # silently stopped — an expired cookie, deleted credentials, a wedged
+    # scheduler — and the dashboard states "$0.00" as a measurement in both.
+    # A new user's very first view of CashPilot asserted three zero balances in
+    # the same typeface those cards will later carry real money in.
+    summary["has_readings"] = bool(all_earnings)
     summary["unpriced_platforms"] = sorted(set(unpriced_platforms))
     summary["total_bonus"] = round(total_bonus_usd, 2)
     summary["total_adjusted"] = round(total_adjusted, 2)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -475,10 +475,19 @@ const CP = (() => {
       const data = await api('/api/earnings/summary');
       const totalBonus = data.total_bonus || 0;
       const displayTotal = totalBonus > 0 ? (data.total_adjusted || 0) : (data.total || 0);
-      setTextContent('total-earnings', formatCurrency(displayTotal));
-      setTextContent('today-earnings', formatCurrency(data.today || 0));
-      setTextContent('month-earnings', formatCurrency(data.month || 0));
+      // "Nothing has been read yet" and "we read it and it was zero" are
+      // different facts, and only one of them is a measurement. Rendering both
+      // as $0.00 told a brand-new user their balance was zero before anything
+      // had ever looked, and said exactly the same thing on an install whose
+      // collection had silently stopped.
+      const money = value => (data.has_readings === false ? '\u2014' : formatCurrency(value));
+      setTextContent('total-earnings', money(displayTotal));
+      setTextContent('today-earnings', money(data.today || 0));
+      setTextContent('month-earnings', money(data.month || 0));
       setTextContent('active-services', data.active_services || 0);
+
+      const nothingYet = document.getElementById('no-readings-note');
+      if (nothingYet) nothingYet.style.display = data.has_readings === false ? '' : 'none';
 
       // Show promo offset footnote under total
       const bonusNote = document.getElementById('total-bonus-note');
@@ -492,7 +501,7 @@ const CP = (() => {
       }
 
       // Update topbar
-      setTextContent('topbar-total', formatCurrency(displayTotal));
+      setTextContent('topbar-total', money(displayTotal));
 
       // Change indicators
       if (data.today_change !== undefined) {

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -9,17 +9,18 @@
 <div class="stats-grid">
   <div class="stat-card">
     <div class="stat-label">Total Balance</div>
-    <div class="stat-value highlight" id="total-earnings">$0.00</div>
+    <div class="stat-value highlight" id="total-earnings">—</div>
     <div id="total-bonus-note" style="display:none; font-size:0.7rem; color:var(--text-muted); margin-top:2px;"></div>
+    <div id="no-readings-note" style="display:none; font-size:0.7rem; color:var(--text-muted); margin-top:2px;">Nothing collected yet</div>
   </div>
   <div class="stat-card">
     <div class="stat-label">Today</div>
-    <div class="stat-value" id="today-earnings">$0.00</div>
+    <div class="stat-value" id="today-earnings">—</div>
     <div class="stat-change" id="today-change"></div>
   </div>
   <div class="stat-card">
     <div class="stat-label">This Month</div>
-    <div class="stat-value" id="month-earnings">$0.00</div>
+    <div class="stat-value" id="month-earnings">—</div>
     <div class="stat-change" id="month-change"></div>
   </div>
   <div class="stat-card">

--- a/tests/test_beads_batch_19.py
+++ b/tests/test_beads_batch_19.py
@@ -1,0 +1,130 @@
+"""CashPilot-93t: the dashboard asserted $0.00 before anything had ever looked.
+
+A brand-new user's first view of CashPilot was "Total Balance $0.00 / Today
+$0.00 / This Month $0.00" — stated as measurements, in the same typeface those
+cards will later carry real money in. The three cards rendered identically when
+collection had silently STOPPED: an expired cookie, deleted credentials, a
+wedged scheduler. Nothing in the payload let the page tell "nothing measured
+yet" from "measured, and it was zero".
+
+Verified against a live empty install: /api/earnings/summary returned
+{"total":0,"today":0.0,"month":0,...} with no field separating the two, while
+/api/earnings and /api/earnings/history?period=week both returned [].
+
+This is the same rule the rest of the codebase already follows for balances,
+costs and payout minimums — absent is not zero — applied to the first screen a
+new user ever sees.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+DASHBOARD = ROOT / "app" / "templates" / "dashboard.html"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+async def _summary(earnings_rows):
+    from app import main
+
+    with (
+        patch.object(main, "_require_auth_api", lambda r: None),
+        patch.object(
+            main.database,
+            "get_earnings_dashboard_summary",
+            AsyncMock(return_value={"total": 0, "today": 0.0, "month": 0}),
+        ),
+        patch.object(main.database, "get_config", AsyncMock(return_value={})),
+        patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=earnings_rows)),
+        patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=[])),
+    ):
+        return await main.api_earnings_summary(MagicMock())
+
+
+class TestThePayloadSaysWhetherAnythingHasBeenRead:
+    @pytest.mark.asyncio
+    async def test_a_fresh_install_reports_no_readings(self):
+        assert (await _summary([]))["has_readings"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_collected_install_reports_readings(self):
+        """The control: this must not claim "nothing yet" once data exists."""
+        rows = [{"platform": "honeygain", "balance": 3.5, "currency": "USD"}]
+        assert (await _summary(rows))["has_readings"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_measured_zero_still_counts_as_read(self):
+        """The distinction that makes this worth having.
+
+        A service read at exactly 0.00 HAS been measured. Folding it back into
+        "nothing yet" would replace one wrong answer with another.
+        """
+        rows = [{"platform": "honeygain", "balance": 0.0, "currency": "USD"}]
+        out = await _summary(rows)
+        assert out["has_readings"] is True
+        assert out["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_existing_fields_are_untouched(self):
+        """Nothing else about the payload changes."""
+        out = await _summary([])
+        for key in ("total", "today", "month", "active_services", "total_bonus", "total_adjusted"):
+            assert key in out, f"{key} disappeared from the summary payload"
+
+
+class TestTheCardsDoNotStateMoneyTheyDoNotHave:
+    def test_the_static_page_no_longer_ships_hardcoded_zeroes(self):
+        """These render before any request is made, so they are an assertion."""
+        html = DASHBOARD.read_text(encoding="utf-8")
+        for element in ("total-earnings", "today-earnings", "month-earnings"):
+            assert f'id="{element}">$0.00<' not in html, f"{element} still ships a hardcoded balance"
+
+    def test_the_static_page_uses_a_neutral_placeholder(self):
+        html = DASHBOARD.read_text(encoding="utf-8")
+        assert html.count('">—<') >= 3
+
+    def test_the_renderer_checks_has_readings(self):
+        """Pinned to the MONEY path, not just the string.
+
+        The first version asserted `data.has_readings === false` appeared
+        anywhere in the file — which the note-toggling line satisfies on its own.
+        Removing the conditional from the figures left this passing, so it was
+        testing nothing about the three cards it names.
+        """
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "const money = value => (data.has_readings === false" in source, (
+            "the stat cards render currency unconditionally again"
+        )
+
+    @pytest.mark.parametrize("element", ["total-earnings", "today-earnings", "month-earnings"])
+    def test_each_card_goes_through_the_conditional_formatter(self, element):
+        """All three, not just whichever one was checked."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert f"setTextContent('{element}', money(" in source, f"{element} bypasses the has_readings check"
+
+    def test_the_topbar_total_gets_the_same_treatment(self):
+        """It sits beside the cards; one of them saying $0.00 undoes the other."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "setTextContent('topbar-total', money(displayTotal));" in source
+
+    def test_there_is_a_note_saying_which_case_it_is(self):
+        """An em dash alone is ambiguous — it needs a word."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        html = DASHBOARD.read_text(encoding="utf-8")
+        assert "no-readings-note" in source
+        assert "Nothing collected yet" in html
+
+    def test_real_figures_still_render_as_currency(self):
+        """The control: this must not em-dash a working dashboard."""
+        source = without_comments(APP_JS.read_text(encoding="utf-8"))
+        assert "formatCurrency(value)" in source, "the money path was removed rather than made conditional"


### PR DESCRIPTION
## The defect

A brand-new user's first view of CashPilot:

> **Total Balance** $0.00 — **Today** $0.00 — **This Month** $0.00

Stated as measurements, in the same typeface those cards will later carry real money in. Worse, the same three cards render **identically** when collection has silently stopped — an expired cookie, deleted credentials, a wedged scheduler.

Verified live on an empty install: `/api/earnings/summary` returns `{"total":0,"today":0.0,"month":0,...}` with **no field** separating "no earnings rows exist" from "balances summed to zero". And `dashboard.html` shipped the zeroes hardcoded, so they were on screen before any request was made.

## The fix

`/api/earnings/summary` now reports `has_readings`, computed from the earnings rows it was **already fetching** — no extra query. The cards render an em dash plus "Nothing collected yet" until something has actually been read. The topbar total gets the same treatment, since one of them saying $0.00 would undo the other.

A service read at exactly **0.00 still counts as read**. Folding a genuine measured zero back into "nothing yet" would replace one wrong answer with another, and a control pins it.

This is the rule the codebase already applies to balances, running costs and payout minimums — *absent is not zero* — applied to the first screen a new user ever sees.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` clean, **95.12% coverage**, 2644 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| endpoint stops reporting `has_readings` | 3 |
| derive it from the total instead of the rows | 2 |
| cards render currency unconditionally | 1 |
| one hardcoded `$0.00` restored to the template | 2 |

One note worth recording: the third control initially **passed**. My renderer assertion matched `data.has_readings === false` anywhere in the file, and the note-toggling line satisfies it on its own — so it proved nothing about the three cards it named. Strengthened to pin the money path, and each card is now separately asserted to go through it.

Closes CashPilot-93t
