### PR TITLE
fix(ci): the release workflow could not pass its own test suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The same tags test.yml needs. tests/test_compose_image_pins.py
+          # compares the pinned image tag against the newest RELEASED version,
+          # and fails loudly rather than skipping when it finds no tags — so
+          # without this the whole release is blocked by a test that is working
+          # exactly as designed. It blocked v1.11.4 after six merges.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'

--- a/tests/test_compose_image_pins.py
+++ b/tests/test_compose_image_pins.py
@@ -124,3 +124,68 @@ class TestTheComposePinTracksReleases:
         text = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
         header = text[: text.index("services:")]
         assert "PINNED" in header or "pinned" in header
+
+
+class TestEveryWorkflowThatRunsTheSuiteFetchesTags:
+    """The drift test above fails loudly when it finds no tags. That is right —
+    a silent skip is how the pin rotted to 1.4 in the first place — but it means
+    any workflow running pytest without tags cannot pass.
+
+    test.yml was given `fetch-tags: true` when the drift test was written.
+    release.yml was not, so its "Verify CI passes" job failed and blocked the
+    release of six merged fixes. The test was working exactly as designed; the
+    workflow was the thing that was wrong. This makes the requirement explicit
+    so a third workflow cannot repeat it.
+    """
+
+    @staticmethod
+    def _runs_the_drift_test(command: str) -> bool:
+        """Whether a pytest invocation would actually collect the drift test.
+
+        A marker or keyword filter means it would not. collector-live-check.yml
+        runs `pytest tests/ -m live`, and no test here carries that marker — so
+        requiring tags there would be a rule about a problem that workflow
+        cannot have. The first version of this guard flagged it, which is how
+        the distinction got noticed.
+        """
+        if "pytest" not in command:
+            return False
+        return " -m " not in command and " -k " not in command
+
+    def _workflows_running_pytest(self):
+        import yaml
+
+        out = []
+        for path in sorted((PROJECT_ROOT / ".github" / "workflows").glob("*.yml")):
+            text = path.read_text(encoding="utf-8")
+            if "pytest" not in text:
+                continue
+            out.append((path.name, yaml.safe_load(text)))
+        return out
+
+    def test_at_least_two_workflows_run_the_suite(self):
+        """Guards against this passing because the glob found nothing."""
+        names = [n for n, _ in self._workflows_running_pytest()]
+        assert len(names) >= 2, f"only {names} appear to run pytest — the scan is not seeing the workflows"
+
+    def test_a_marker_filtered_run_is_not_required_to_fetch_tags(self):
+        """The control that keeps this rule honest rather than merely strict."""
+        assert not self._runs_the_drift_test("python -m pytest tests/ -m live -q")
+        assert self._runs_the_drift_test("uv run pytest")
+        assert self._runs_the_drift_test("pytest tests/ -v --tb=short")
+
+    def test_each_such_job_checks_out_with_tags(self):
+        offenders = []
+        for name, doc in self._workflows_running_pytest():
+            for job_name, job in (doc.get("jobs") or {}).items():
+                steps = job.get("steps") or []
+                if not any(self._runs_the_drift_test(str(step.get("run", ""))) for step in steps):
+                    continue
+                checkouts = [s for s in steps if str(s.get("uses", "")).startswith("actions/checkout")]
+                for step in checkouts:
+                    if not (step.get("with") or {}).get("fetch-tags"):
+                        offenders.append(f"{name}:{job_name}")
+        assert not offenders, (
+            f"these run pytest without fetching tags, so the compose-pin drift test fails: {offenders}. "
+            "Add `fetch-depth: 0` and `fetch-tags: true` to the checkout."
+        )


### PR DESCRIPTION
## What happened

**Auto Release failed on `main` after the six merges, so v1.11.4 was never cut.**

The failing job was `Verify CI passes`, and the failure was:

```
Failed: no semver tags in this checkout — CI must fetch tags (fetch-tags: true),
otherwise this drift test silently passes and the pin can rot again
tests/test_compose_image_pins.py:88
```

The test was working **exactly as designed**. It compares the pinned compose image tag against the newest *released* version, and fails loudly rather than skipping — because a silent skip is precisely how the pin rotted to `1.4` and shipped issue #188.

`test.yml` was given `fetch-depth: 0` + `fetch-tags: true` when that test was written. `release.yml` was not, and nothing connected the two.

## The fix

`release.yml` fetches tags, and a guard asserts **every workflow job that runs the unfiltered suite** checks out with them — so a third workflow can't repeat this.

The guard is narrowed to invocations that would actually *collect* the drift test. Its first version flagged `collector-live-check.yml`, which runs `pytest tests/ -m live`; no test carries that marker, so the drift test never executes there and requiring tags would have been a rule about a problem that workflow cannot have. A control pins that distinction rather than leaving the rule merely strict.

## Evidence

`ruff check` + `ruff format --check` clean, 95.17% coverage, 2706 passed.

Negative control: removing `fetch-tags` from `release.yml` fails the guard; a marker-filtered invocation is asserted *not* to require it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and validation workflows to retrieve complete repository history and tags, ensuring image tag checks run reliably.

* **Tests**
  * Added automated checks confirming workflows that run compose-image validation also check out repository tags.
  * Added coverage for correctly handling marker-filtered test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->