### PR TITLE
fix: the one credential needing a shell command had no hint on screen

### DIFF
--- a/services/bandwidth/traffmonetizer.yml
+++ b/services/bandwidth/traffmonetizer.yml
@@ -71,6 +71,5 @@ platforms: [docker, windows, macos, android]
 
 collector:
   type: api
-  auth: browser_jwt
   notes: "reCAPTCHA blocks programmatic login. Token extracted from browser Local Storage at app.traffmonetizer.com (same as deployment token)."
   credential_hint: "Log in at <a href='https://app.traffmonetizer.com' target='_blank'>app.traffmonetizer.com</a>, press F12 → Application → Local Storage → <b>token</b> value (a long JWT starting with <code>eyJ</code>)."

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -71,14 +71,18 @@ platforms: [docker, linux]
 
 collector:
   type: auto
-  credentials:
-    - key: fingerprints
-      label: "Relay Fingerprints"
-      hint: >
-        Comma-separated relay fingerprints. Find yours with:
-        docker exec cashpilot-anyone-protocol anon --list-fingerprint
-        or check https://api.ec.anyone.tech/relays/{fingerprint}
-      type: text
+  # Under credential_hint, which is the field the UI actually reads
+  # (app/main.py: `(svc.get("collector") or {}).get("credential_hint")`) and the
+  # one services/_schema.yml documents. This text previously sat in a
+  # `credentials:` list that nothing anywhere reads, so the ONE credential in the
+  # catalog that cannot be found in a provider dashboard — it needs a shell
+  # command against the running container — was the one credential with no
+  # guidance on screen.
+  credential_hint: >
+    Comma-separated relay fingerprints. This one is not in a web dashboard:
+    run <b>docker exec cashpilot-anyone-protocol anon --list-fingerprint</b> on
+    the host running the relay, or look the relay up at
+    <a href="https://api.ec.anyone.tech/relays/">api.ec.anyone.tech/relays/</a>.
   notes: "Queries AO relay-rewards contract by fingerprint, converts ANYONE tokens to USD via CoinGecko."
 
 # What this service does with the user's machine (CashPilot-66x).

--- a/tests/test_beads_batch_24.py
+++ b/tests/test_beads_batch_24.py
@@ -1,0 +1,141 @@
+"""CashPilot-eat / CashPilot-izt: the one credential needing a shell command had no hint.
+
+``app/main.py`` reads credential guidance from ``collector.credential_hint``, and
+``services/_schema.yml`` documents exactly that field. Thirteen services use it.
+anyone-protocol alone carried its guidance in ``collector.credentials`` — a list
+of ``{key, label, hint, type}`` dicts that nothing in the codebase reads.
+
+That is the worst possible service to lose a hint on. Every other credential is
+findable in a provider's web dashboard; this one is a relay fingerprint that
+exists only on the operator's own machine and needs
+
+    docker exec cashpilot-anyone-protocol anon --list-fingerprint
+
+So the single credential that genuinely cannot be guessed was the single
+credential with nothing on screen explaining where to get it. The input rendered
+(``_COLLECTOR_ARGS["anyone-protocol"] = ["fingerprints"]``) with no hint beside
+it — the user saw an empty box labelled "fingerprints".
+
+Two beads, one cause: -eat filed the missing hint, -izt filed the unread field.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES = ROOT / "services"
+
+# Every key services/_schema.yml defines under `collector:`. A key outside this
+# set is not a schema violation the app rejects — it is worse, because it is
+# silently ignored, which is exactly how the anyone-protocol hint disappeared.
+DOCUMENTED_COLLECTOR_KEYS = {
+    "type",
+    "notes",
+    "per_node_earnings",
+    "credential_hint",
+    "credential_lifetime",
+    "durable_alternative",
+}
+
+
+def catalog():
+    out = {}
+    for path in sorted(SERVICES.rglob("*.yml")):
+        if path.name.startswith("_"):
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        out[data.get("slug", path.stem)] = data
+    return out
+
+
+class TestTheHintReachesTheFieldTheUIReads:
+    def test_anyone_protocol_has_a_hint_at_all(self):
+        collector = catalog()["anyone-protocol"]["collector"]
+        assert collector.get("credential_hint"), "the fingerprint credential still has no guidance"
+
+    def test_the_hint_still_carries_the_command(self):
+        """The whole value of this hint: the credential is not in any dashboard."""
+        hint = catalog()["anyone-protocol"]["collector"]["credential_hint"]
+        assert "anon --list-fingerprint" in hint
+        assert "docker exec" in hint
+
+    def test_the_unread_field_is_gone(self):
+        collector = catalog()["anyone-protocol"]["collector"]
+        assert "credentials" not in collector, "guidance is back in a field nothing reads"
+
+    def test_the_handler_reads_the_field_this_now_uses(self):
+        """The premise. If main.py ever reads something else, this hint dies again."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert '.get("credential_hint")' in source
+
+    def test_the_credential_input_is_still_declared(self):
+        """A hint with no input beside it would be equally useless."""
+        from app.collectors import _COLLECTOR_ARGS
+
+        assert _COLLECTOR_ARGS["anyone-protocol"] == ["fingerprints"]
+
+
+class TestNoServiceHidesGuidanceInAFieldNothingReads:
+    """The general rule. Two beads were filed for one instance of it.
+
+    An undocumented key under `collector:` is not rejected anywhere — it is
+    silently ignored, so the author sees their YAML accepted and the user sees
+    nothing. That is the failure mode worth a test.
+    """
+
+    def test_every_collector_key_is_one_the_schema_defines(self):
+        offenders = []
+        for slug, data in catalog().items():
+            collector = data.get("collector") or {}
+            unknown = set(collector) - DOCUMENTED_COLLECTOR_KEYS
+            if unknown:
+                offenders.append((slug, sorted(unknown)))
+        assert not offenders, (
+            f"these declare collector keys nothing reads: {offenders}. "
+            "Undocumented keys are silently ignored — put user-facing guidance in "
+            "credential_hint (see services/_schema.yml)."
+        )
+
+    def test_the_allowlist_matches_what_the_schema_documents(self):
+        """Guards the guard: an allowlist that drifts from the schema proves nothing."""
+        schema = (SERVICES / "_schema.yml").read_text(encoding="utf-8")
+        start = schema.index("# collector:")
+        block = schema[start : start + 2000]
+        for key in ("type", "notes", "credential_hint", "per_node_earnings"):
+            assert f"#   {key}:" in block, f"{key} is in the allowlist but not documented in _schema.yml"
+
+    def test_the_documented_field_is_actually_used(self):
+        """Guards against this passing because every hint was deleted."""
+        with_hint = [slug for slug, d in catalog().items() if (d.get("collector") or {}).get("credential_hint")]
+        assert len(with_hint) >= 10, f"only {len(with_hint)} services carry a credential hint"
+
+    @pytest.mark.parametrize("slug", ["honeygain", "earnapp", "anyone-protocol"])
+    def test_named_services_keep_their_hint(self, slug):
+        assert (catalog()[slug].get("collector") or {}).get("credential_hint")
+
+
+class TestTheHintSurvivesTheSanitiser:
+    """A hint is inserted as markup, and the sanitiser strips what it does not keep.
+
+    A previous fix found that a `rel` written into a hint is removed on its way
+    to the DOM. The tags used here have to be ones that survive, or the guidance
+    renders as stripped text with the command mangled.
+    """
+
+    def test_it_uses_only_tags_the_sanitiser_keeps(self):
+        import re
+
+        hint = catalog()["anyone-protocol"]["collector"]["credential_hint"]
+        tags = {t.lower() for t in re.findall(r"<\s*([a-zA-Z]+)", hint)}
+        allowed = {"a", "b", "code", "br", "i", "strong", "em"}
+        assert tags <= allowed, f"hint uses tags the sanitiser will strip: {sorted(tags - allowed)}"
+
+    def test_the_command_is_not_inside_a_link(self):
+        """A shell command rendered as an anchor invites clicking, not copying."""
+        hint = catalog()["anyone-protocol"]["collector"]["credential_hint"]
+        anchor_start = hint.find("<a ")
+        assert anchor_start == -1 or "anon --list-fingerprint" not in hint[anchor_start:]

--- a/tests/test_catalog_is_the_source_of_truth.py
+++ b/tests/test_catalog_is_the_source_of_truth.py
@@ -116,8 +116,16 @@ class TestCredentialHintsLiveInTheCatalog:
             if not p.name.startswith("_")
             and ((yaml.safe_load(p.read_text(encoding="utf-8")) or {}).get("collector") or {}).get("credential_hint")
         ]
-        assert len(with_hint) == 13, (
-            f"expected 13 services with a credential hint, found {len(with_hint)}: {sorted(with_hint)}"
+        # A FLOOR at the current count, not equality. Equality made ADDING a
+        # hint look like a regression — anyone-protocol's fingerprint hint
+        # (CashPilot-eat) broke this test by existing. A floor below the current
+        # count would be worse: at >= 13 with 14 present, losing one still
+        # passed, which is the exact regression this guards. So the number
+        # tracks the current total and is bumped deliberately when a hint is
+        # added, which is a one-line edit with a message saying so.
+        assert len(with_hint) >= 14, (
+            f"a credential hint was lost: found {len(with_hint)}, expected at least 14: {sorted(with_hint)}. "
+            "If you ADDED one, raise this floor."
         )
 
     @pytest.mark.parametrize("slug", ["bytelixir", "earnapp", "grass", "packetstream", "proxyrack"])
@@ -338,7 +346,8 @@ class TestTheCatalogDrivenPathsActuallyRun:
         with patch.object(main, "_require_owner", lambda r: None):
             meta = asyncio.run(main.api_collectors_meta(MagicMock()))
         hints = {e["slug"]: e.get("hint") for e in meta if e.get("hint")}
-        assert len(hints) == 13, f"expected 13 services to serve a hint, got {sorted(hints)}"
+        # Floor at the current count — see the note in test_the_hints_survived_the_move.
+        assert len(hints) >= 14, f"a hint stopped being served: got {sorted(hints)}. If you added one, raise this."
         assert "F12" in hints["earnapp"], "the hint text itself did not survive the move to YAML"
 
     def test_a_service_without_a_hint_simply_omits_the_key(self):
@@ -436,7 +445,10 @@ class TestCredentialHintLinksCannotBeUsedForTabnabbing:
             for p in SERVICES.rglob("*.yml")
             if not p.name.startswith("_") and "credential_hint" in p.read_text(encoding="utf-8")
         ]
-        assert len(hints) == 13, f"expected 13 hint-bearing services, found {len(hints)}"
+        # Floor at the current count. The rule this class protects is enforced
+        # per-file by test_every_hint_anchor_is_covered_by_that_rule, which
+        # iterates them all; this count guards against the set shrinking.
+        assert len(hints) >= 14, f"hint-bearing services disappeared: found {len(hints)}. If you added one, raise this."
 
     def test_every_hint_anchor_is_covered_by_that_rule(self):
         """If a hint ever uses target without the sanitiser seeing it, this fails."""


### PR DESCRIPTION
## The defect

`app/main.py` reads credential guidance from `collector.credential_hint`, and `services/_schema.yml` documents exactly that field. **Thirteen services use it.** anyone-protocol alone carried its guidance in `collector.credentials` — a list of `{key, label, hint, type}` dicts that **nothing in the codebase reads**.

That's the worst possible service to lose a hint on. Every other credential is findable in a provider's web dashboard. This one is a relay fingerprint that exists only on the operator's own machine:

```
docker exec cashpilot-anyone-protocol anon --list-fingerprint
```

So the single credential that genuinely **cannot be guessed** was the single credential with nothing on screen explaining where to get it. The input rendered fine (`_COLLECTOR_ARGS["anyone-protocol"] = ["fingerprints"]`) — the user just saw an empty box labelled `fingerprints`.

Two beads, one cause: **-eat** filed the missing hint, **-izt** filed the unread field.

## The general rule

An undocumented key under `collector:` isn't rejected anywhere — it's **silently ignored**, so the author sees their YAML accepted and the user sees nothing. A catalog test now rejects any collector key the schema doesn't define.

It immediately found a second instance: traffmonetizer's `auth: browser_jwt`, read by nothing and already stated in words in its own `notes`. Removed — its `credential_hint` and `notes` are untouched.

## A test-quality note worth reading

Three existing tests pinned **"exactly 13 hint-bearing services"**, so they failed simply because a 14th hint now exists — equality made *documenting a credential* look like a regression.

My first fix was `>= 13`. That was **measurably worse**: with 14 present, deleting one still passed, defeating the loss-guard those tests exist to be. Caught by actually removing honeygain's hint and watching them *not* fail. They're now floors at the current count, and three of them fail on that same deletion.

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.23% coverage**, 2767 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| hint back under the unread field | 7 |
| shell command stripped from the hint | 1 |
| honeygain's hint deleted (floor check) | 3 |

Every revert prints its byte count — an earlier control this session silently failed to apply and "passed", so that's now the standard.

Closes CashPilot-eat
Closes CashPilot-izt
