### PR TITLE
fix: a correct balance was thrown away and reported as a collector failure

### DIFF
--- a/app/collectors/base.py
+++ b/app/collectors/base.py
@@ -21,6 +21,13 @@ class EarningsResult:
     balance: float
     currency: str = "USD"
     error: str | None = None
+    # A caveat about a reading that SUCCEEDED. `error` used to carry both, and
+    # the collection loop stores a balance only when `error` is unset — so a
+    # collector reporting a real figure with a note attached had that figure
+    # silently discarded and the user was told the collector had failed.
+    # Bytelixir's API fallback did exactly this: a valid withdrawable balance,
+    # thrown away, reported as a failure.
+    warning: str | None = None
 
 
 class BaseCollector(abc.ABC):

--- a/app/collectors/bytelixir.py
+++ b/app/collectors/bytelixir.py
@@ -213,7 +213,11 @@ class BytelixirCollector(BaseCollector):
                 platform=self.platform,
                 balance=round(balance, 4),
                 currency="USD",
-                error="Withdrawable balance only (HTML scrape failed, using API fallback)",
+                # A WARNING, not an error: this reading is real and worth
+                # storing. Reported as an error, the balance was discarded by
+                # the collection loop and the user saw "collector failed" for a
+                # collector that had just returned a correct number.
+                warning="Withdrawable balance only (HTML scrape failed, using API fallback)",
             )
         except Exception as exc:
             base.log_failure(logger, "Bytelixir", exc)

--- a/app/main.py
+++ b/app/main.py
@@ -534,6 +534,13 @@ async def _run_collection() -> None:
                             )
                         )
                 else:
+                    # A caveat on a SUCCESSFUL reading. It is shown, because the
+                    # figure is partial and the user should know, but it is not
+                    # a failure: the balance below is stored exactly as any other.
+                    if getattr(result, "warning", None):
+                        safe_warning = notify.redact(result.warning)
+                        logger.info("Collector notice for %s: %s", result.platform, safe_warning)
+                        alerts.append({"kind": "notice", "platform": result.platform, "error": safe_warning})
                     # Compare against the last reading BEFORE writing the new one:
                     # a payout is only visible as the step between two snapshots.
                     payout_alert = await _detect_payout(result)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2858,18 +2858,26 @@ const CP = (() => {
       // something is broken at the exact moment they got paid.
       const WARNING_ICON = '<path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>';
       const PAYOUT_ICON = '<circle cx="12" cy="12" r="10"/><path d="M12 6v12M15 9.5a2.5 2.5 0 00-2.5-1.5h-1a2 2 0 000 4h1a2 2 0 010 4h-1A2.5 2.5 0 019 14.5"/>';
+      // A notice is a caveat about a reading that WORKED — "this figure is
+      // withdrawable balance only", not "this is broken". Same reasoning as the
+      // payout case above: the warning triangle and an "Update credentials"
+      // button would tell the user something is wrong and point them at the one
+      // action that cannot help.
+      const NOTICE_ICON = '<circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>';
       list.innerHTML = alerts.map(a => {
         const isPayout = a.kind === 'payout';
+        const isNotice = a.kind === 'notice';
+        const icon = isPayout ? PAYOUT_ICON : isNotice ? NOTICE_ICON : WARNING_ICON;
         return `
         <div class="notify-item" data-platform="${escapeHtml(a.platform)}" data-kind="${escapeHtml(a.kind || 'collector')}">
-          <div class="notify-item-icon">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${isPayout ? PAYOUT_ICON : WARNING_ICON}</svg>
+          <div class="notify-item-icon"${isNotice ? ' style="color:var(--text-muted);"' : ''}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${icon}</svg>
           </div>
           <div class="notify-item-body">
-            <div class="notify-item-platform">${escapeHtml(a.platform)}${isPayout ? ' — payout?' : ''}</div>
+            <div class="notify-item-platform">${escapeHtml(a.platform)}${isPayout ? ' — payout?' : ''}${isNotice ? ' — note' : ''}</div>
             <div class="notify-item-msg" title="${escapeHtml(a.error)}">${escapeHtml(a.error)}</div>
           </div>
-          ${!isPayout && _isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
+          ${!isPayout && !isNotice && _isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
         </div>
       `;
       }).join('');

--- a/tests/test_beads_batch_25.py
+++ b/tests/test_beads_batch_25.py
@@ -1,0 +1,167 @@
+"""CashPilot-qul: a correct balance was thrown away and reported as a failure.
+
+``EarningsResult.error`` was doing two jobs — "this collection failed" and "this
+succeeded, with a caveat" — and ``_run_collection`` stores a balance only in the
+``else`` branch of ``if result.error:``.
+
+Bytelixir's API fallback returns a real, valid withdrawable balance together
+with an informational note ("Withdrawable balance only (HTML scrape failed,
+using API fallback)"). Because that note went in ``error``, the balance was
+discarded, no earnings row was written, and the user was told the collector had
+failed — with an "Update credentials" button whose credentials were fine.
+
+A caveat now has its own field. The reading is stored like any other, and the
+note is surfaced as a `notice`, which the bell renders as a note rather than a
+fault: the same reasoning already written for payouts, where the warning
+triangle and the Update button "would tell the user something is broken at the
+exact moment they got paid".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestACaveatIsNotAFailure:
+    def test_the_result_type_can_hold_one(self):
+        from app.collectors.base import EarningsResult
+
+        result = EarningsResult(platform="bytelixir", balance=1.5, warning="partial")
+        assert result.warning == "partial"
+        assert result.error is None, "a caveat must not present as a failure"
+
+    def test_a_plain_result_carries_neither(self):
+        """The control: the new field must not appear on ordinary readings."""
+        from app.collectors.base import EarningsResult
+
+        result = EarningsResult(platform="honeygain", balance=3.0)
+        assert result.warning is None
+        assert result.error is None
+
+    def test_bytelixirs_fallback_no_longer_reports_an_error(self):
+        source = (ROOT / "app" / "collectors" / "bytelixir.py").read_text(encoding="utf-8")
+        assert 'error="Withdrawable balance only' not in source, "the fallback still reports a failure"
+        assert 'warning="Withdrawable balance only' in source
+
+    def test_a_real_bytelixir_failure_is_still_an_error(self):
+        """The control: this must not turn genuine failures into notes.
+
+        An expired session is the common Bytelixir failure and needs the exact
+        "Update credentials" affordance a notice deliberately withholds.
+        """
+        source = (ROOT / "app" / "collectors" / "bytelixir.py").read_text(encoding="utf-8")
+        assert 'error="Session expired' in source
+
+
+class TestTheBalanceIsStoredAndTheNoteIsShown:
+    async def _collect(self, result):
+        """Drive the part of _run_collection that decides store-or-alert."""
+        from app import main
+        from app.collectors.base import EarningsResult
+
+        assert isinstance(result, EarningsResult)
+        stored: list[dict] = []
+        alerts: list[dict] = []
+
+        async def fake_upsert(**kwargs):
+            stored.append(kwargs)
+
+        with (
+            patch.object(main.database, "get_deployments", AsyncMock(return_value=[{"slug": "bytelixir"}])),
+            patch.object(main.database, "get_config", AsyncMock(return_value={})),
+            patch.object(main.database, "upsert_earnings", AsyncMock(side_effect=fake_upsert)),
+            patch.object(main.database, "record_alert", AsyncMock(return_value=False)),
+            patch.object(main.database, "list_alerts", AsyncMock(return_value=[])),
+            patch.object(main, "_detect_payout", AsyncMock(return_value=None)),
+            patch.object(main, "_flatline_check", AsyncMock(return_value=[])),
+            patch.object(main, "_pending_payout_alerts", AsyncMock(return_value=[])),
+            patch.object(main, "_collect_bounded", AsyncMock(return_value=result)),
+            patch("app.collectors.make_collectors", lambda deployments, config: [object()]),
+            patch("app.collectors._close_stale", AsyncMock()),
+            patch.object(main, "_spawn", lambda coro: coro.close()),
+        ):
+            await main._run_collection()
+            alerts = list(main._collector_alerts)
+        return stored, alerts
+
+    @pytest.mark.asyncio
+    async def test_a_reading_with_a_caveat_is_stored(self):
+        from app.collectors.base import EarningsResult
+
+        stored, _ = await self._collect(
+            EarningsResult(platform="bytelixir", balance=1.2345, currency="USD", warning="partial figure")
+        )
+        assert stored, "the balance was discarded again"
+        assert stored[0]["balance"] == pytest.approx(1.2345)
+
+    @pytest.mark.asyncio
+    async def test_the_caveat_is_surfaced_as_a_notice(self):
+        from app.collectors.base import EarningsResult
+
+        _, alerts = await self._collect(EarningsResult(platform="bytelixir", balance=1.2345, warning="partial figure"))
+        notices = [a for a in alerts if a.get("kind") == "notice"]
+        assert len(notices) == 1
+        assert notices[0]["platform"] == "bytelixir"
+        assert "partial figure" in notices[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_it_is_not_reported_as_a_collector_failure(self):
+        from app.collectors.base import EarningsResult
+
+        _, alerts = await self._collect(EarningsResult(platform="bytelixir", balance=1.2345, warning="partial figure"))
+        assert not [a for a in alerts if a.get("kind") == "collector"], (
+            "a successful reading is still being reported as a broken collector"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_error_still_stores_nothing(self):
+        """The control. Without it this could pass by storing everything."""
+        from app.collectors.base import EarningsResult
+
+        stored, alerts = await self._collect(EarningsResult(platform="bytelixir", balance=0.0, error="Session expired"))
+        assert not stored, "a failed collection wrote an earnings row"
+        assert [a for a in alerts if a.get("kind") == "collector"]
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_reading_produces_no_notice(self):
+        """The control: the bell must not gain an entry per successful collection."""
+        from app.collectors.base import EarningsResult
+
+        stored, alerts = await self._collect(EarningsResult(platform="honeygain", balance=5.0))
+        assert stored
+        assert not [a for a in alerts if a.get("kind") == "notice"]
+
+
+class TestTheBellRendersANoteRatherThanAFault:
+    def _js(self):
+        return without_comments(APP_JS.read_text(encoding="utf-8"))
+
+    def test_a_notice_is_recognised(self):
+        assert "a.kind === 'notice'" in self._js()
+
+    def test_a_notice_does_not_offer_update_credentials(self):
+        """The button points at the one action that cannot help here."""
+        assert "!isPayout && !isNotice && _isOwner" in self._js()
+
+    def test_a_notice_does_not_use_the_warning_triangle(self):
+        js = self._js()
+        assert "NOTICE_ICON" in js
+        assert "isNotice ? NOTICE_ICON : WARNING_ICON" in js
+
+    def test_a_collector_failure_still_gets_the_triangle_and_the_button(self):
+        """The control: the fault path must survive intact."""
+        js = self._js()
+        assert "WARNING_ICON" in js
+        assert "openCredentialModal" in js


### PR DESCRIPTION
## The defect

`EarningsResult.error` was doing two jobs — *"this collection failed"* and *"this succeeded, with a caveat"* — and `_run_collection` stores a balance only in the `else` branch:

```python
if result.error:
    ...alert, no storage...
else:
    await database.upsert_earnings(...)   # ← the only path that stores
```

Bytelixir's API fallback returns a **real, valid withdrawable balance** together with an informational note (`"Withdrawable balance only (HTML scrape failed, using API fallback)"`). Because that note went in `error`:

- the balance was **discarded** — no earnings row written
- the user was told the **collector had failed**
- beside an **"Update credentials"** button whose credentials were fine

## The fix

A caveat gets its own field. The reading is stored like any other, and the note is surfaced as a `notice`, which the bell renders as a note rather than a fault — the same reasoning already written into the payout case:

> A payout is a question, not a fault. Rendering it with the warning triangle and an "Update credentials" button would tell the user something is broken at the exact moment they got paid.

A notice keeps the informative text and drops the affordance that cannot help.

**A notice is not persisted** through `record_alert`, so it doesn't survive a restart. That's deliberate: it describes the *latest reading*, and the next collection regenerates it if it still applies.

Bytelixir's genuine failures — an expired session above all — are untouched and still errors, with the Update button they need. A control pins that.

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.25% coverage**, 2780 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| caveat reported as an error again (the original bug) | 1 |
| loop ignores warnings entirely | 1 |
| bell treats a notice as a fault | 1 |

Each revert prints its byte count before the tests run. Controls also pin that a genuine error still stores nothing and still raises a collector alert, and that an ordinary reading produces no notice — so the bell doesn't gain an entry per successful collection.

Closes CashPilot-qul
