### PR TITLE
fix: the credential checker was correct, complete, and had no caller

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1238,7 +1238,7 @@ const CP = (() => {
         ${fieldsHtml}
         ${bonusHtml}
         <div style="display:flex; gap:8px; margin-top:14px;">
-          <button class="btn btn-primary btn-sm" data-action="saveCredentialModal">Save</button>
+          <button class="btn btn-primary btn-sm" data-action="saveCredentialModal" data-a1="${escapeHtml(slug)}">Save</button>
           <button class="btn btn-ghost btn-sm" data-action="closeModal" data-a1="cred-modal">Cancel</button>
           <button class="btn btn-ghost btn-sm" style="color:var(--error); margin-left:auto;" data-action="clearServiceCredentials" data-a1="${escapeHtml(slug)}" data-a2="${escapeHtml(col.name)}">Clear</button>
         </div>`;
@@ -1247,7 +1247,7 @@ const CP = (() => {
     }
   }
 
-  async function saveCredentialModal() {
+  async function saveCredentialModal(slug) {
     const inputs = document.querySelectorAll('.cred-modal-input');
     const data = {};
     inputs.forEach(input => {
@@ -1261,8 +1261,36 @@ const CP = (() => {
     }
     try {
       await api('/api/config', { method: 'POST', body: { data } });
-      toast('Credentials saved — collecting now\u2026', 'success');
       closeModal('cred-modal');
+
+      // Say whether the credentials WORK, not just that they were stored.
+      //
+      // app/credential_test.py exists to end the "paste a token, wait up to an
+      // hour, learn from the notification bell" loop, and it produces the
+      // actionable sentence ("... most likely expired — copy a fresh one and try
+      // again"). Nothing called it. What a user with a mistyped password got
+      // instead was the next hourly run's alert, rendered verbatim: "Client
+      // error '401 Unauthorized' for url 'https://.../api/v1/users/tokens' For
+      // more information check: https://developer.mozilla.org/...".
+      //
+      // The endpoint deliberately returns no field that could carry a secret,
+      // so its message is safe to show as-is.
+      if (slug) {
+        toast('Credentials saved — checking them\u2026', 'success');
+        try {
+          const verdict = await api(`/api/services/${encodeURIComponent(slug)}/test-credentials`, { method: 'POST' });
+          toast(verdict.message || (verdict.ok ? 'Credentials work.' : 'Could not verify these credentials.'),
+                verdict.ok ? 'success' : 'error');
+        } catch (err) {
+          // The CHECK failed, which is not the same as the credentials failing.
+          // Saying "rejected" here would send someone to re-copy a token that
+          // was fine.
+          toast(`Saved, but could not check them right now: ${err.message}`, 'warning');
+        }
+      } else {
+        toast('Credentials saved — collecting now\u2026', 'success');
+      }
+
       // Trigger a collection so it picks up new creds immediately
       api('/api/collect', { method: 'POST' }).catch(() => {});
       // Silently refresh the dashboard after collection has time to finish

--- a/tests/test_beads_batch_27.py
+++ b/tests/test_beads_batch_27.py
@@ -1,0 +1,133 @@
+"""CashPilot-3hf: the credential checker was correct, complete, and dead.
+
+``app/credential_test.py`` exists to end the "paste a token, wait up to an hour,
+learn from the notification bell" loop. It classifies outcomes and produces
+genuinely actionable sentences:
+
+    Honeygain rejected these credentials. If they are a browser cookie or
+    token, they have most likely expired — copy a fresh one and try again.
+
+``/api/services/{slug}/test-credentials`` serves that. **No UI ever called it.**
+
+What a user with a mistyped password actually got was the next scheduled run's
+alert, rendered verbatim in the bell:
+
+    Client error '401 Unauthorized' for url
+    'https://dashboard.honeygain.com/api/v1/users/tokens' For more information
+    check: https://developer.mozilla.org/…
+
+Up to an hour later, and pointing at MDN.
+
+The Save button on the credential modal now calls it and reports the verdict.
+The endpoint deliberately returns no field that could carry a secret, so its
+message is safe to show as-is.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+def js():
+    return without_comments(APP_JS.read_text(encoding="utf-8"))
+
+
+class TestTheCheckerIsReachableFromTheUI:
+    def test_something_calls_the_endpoint(self):
+        assert "/test-credentials" in js(), "the credential checker still has no caller"
+
+    def test_the_save_button_passes_its_slug(self):
+        """Without the slug the caller cannot name a service to test."""
+        source = js()
+        assert 'data-action="saveCredentialModal" data-a1="${escapeHtml(slug)}"' in source
+
+    def test_the_handler_accepts_it(self):
+        assert "async function saveCredentialModal(slug)" in js()
+
+    def test_the_slug_is_url_encoded(self):
+        """Slugs are catalog-controlled, but building a path by concatenation is
+        the habit that eventually meets a value that needs escaping."""
+        assert "encodeURIComponent(slug)" in js()
+
+    def test_the_verdict_message_is_shown(self):
+        source = js()
+        assert "verdict.message" in source
+
+    def test_success_and_failure_are_styled_differently(self):
+        """A red toast for a working credential would be worse than silence."""
+        assert "verdict.ok ? 'success' : 'error'" in js()
+
+
+class TestAFailedCheckIsNotAFailedCredential:
+    """The distinction that keeps this honest.
+
+    If the CHECK itself cannot run — the app is unreachable, the provider times
+    out, the endpoint 500s — saying "rejected" sends someone to re-copy a token
+    that was fine. The two are reported differently.
+    """
+
+    def test_a_check_that_errors_says_so(self):
+        source = js()
+        assert "could not check them right now" in source
+
+    def test_it_is_not_reported_as_an_error(self):
+        source = js()
+        i = source.index("could not check them right now")
+        assert "'warning'" in source[i : i + 200], "an unavailable check is being reported as a rejection"
+
+    def test_the_credentials_are_still_saved(self):
+        """The save already succeeded; a failed check must not imply otherwise."""
+        source = js()
+        i = source.index("could not check them right now")
+        assert "Saved, but" in source[i - 60 : i + 40]
+
+
+class TestTheEndpointItCallsStillBehaves:
+    """The UI is only worth wiring if what it calls is still correct."""
+
+    def test_the_route_exists(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert '@app.post("/api/services/{slug}/test-credentials")' in source
+
+    def test_the_response_carries_a_message(self):
+        from app import credential_test
+
+        out = credential_test.result(credential_test.OK, "Honeygain", balance=3.5, currency="USD")
+        assert out["ok"] is True
+        assert out["message"]
+
+    def test_a_rejection_is_actionable(self):
+        """The sentence this whole bead is about."""
+        from app import credential_test
+
+        outcome = credential_test.classify("Client error '401 Unauthorized' for url 'https://x/api'")
+        message = credential_test.message(outcome, "Honeygain", None, "")
+        assert "Honeygain" in message
+        assert "expired" in message.lower() or "reject" in message.lower()
+
+    def test_the_response_cannot_carry_a_secret(self):
+        """Deliberate, and worth pinning now that the message reaches a toast."""
+        from app import credential_test
+
+        out = credential_test.result(credential_test.OK, "Honeygain", balance=1.0, currency="USD", password="hunter2")
+        assert "password" not in out
+        assert "hunter2" not in str(out)
+
+    @pytest.mark.parametrize("raw", ["", "connection timed out", "Client error '403 Forbidden' for url 'https://x'"])
+    def test_classification_never_raises(self, raw):
+        """It is now on the interactive path; a crash here is a broken Save."""
+        from app import credential_test
+
+        outcome = credential_test.classify(raw)
+        assert credential_test.message(outcome, "Honeygain", None, "")


### PR DESCRIPTION
## The defect

`app/credential_test.py` exists to end the *"paste a token, wait up to an hour, learn from the notification bell"* loop. It classifies outcomes and produces genuinely actionable sentences:

> Honeygain rejected these credentials. If they are a browser cookie or token, they have most likely expired — copy a fresh one and try again.

`/api/services/{slug}/test-credentials` serves exactly that. **Nothing called it.**

What a user with a mistyped password actually got was the next scheduled run's alert, rendered verbatim in the bell:

> Client error '401 Unauthorized' for url 'https://dashboard.honeygain.com/api/v1/users/tokens' For more information check: https://developer.mozilla.org/…

Up to an hour later, and pointing at MDN. The classification existed, was correct, and was dead.

## The fix

Saving credentials now reports whether they **work**, not just that they were stored.

The endpoint deliberately returns no field that could carry a secret, so its message is safe to show as-is — now pinned by a test, since that property matters a great deal more once something actually displays the response.

**A check that cannot run is reported differently from a credential that was rejected.** If the app is unreachable or the provider times out, saying "rejected" would send someone off to re-copy a token that was fine. That path says the save succeeded and the check couldn't be made — a warning, not an error.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.26% coverage**, 2810 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| remove the call entirely (the original state) | 6 |
| report an unavailable check as a rejection | 3 |
| drop the slug from the Save button | 1 |

Controls also pin that classification never raises on odd input (it's on the interactive path now — a crash there is a broken Save button) and that the response still can't carry a secret.

Closes CashPilot-3hf
