### PR TITLE
fix: a container you started yourself got live buttons that 404

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -204,7 +204,16 @@ async def _get_all_worker_containers(workers: list[dict[str, Any]] | None = None
                             "net_rx_bytes": c.get("net_rx_bytes"),
                             "net_tx_bytes": c.get("net_tx_bytes"),
                             "category": "",
-                            "deployed_by": worker_name,
+                            # The WORKER's answer, not the node name. The image
+                            # matcher sets "external" for a container it found by
+                            # image rather than by CashPilot's own label — one the
+                            # user started themselves. Overwriting it here meant
+                            # that container appeared as an ordinary managed
+                            # service with live Restart/Stop/Logs buttons, and
+                            # every one of them answered "404 Container not
+                            # found" for a row the same screen called Running.
+                            # The node name is already carried by _node.
+                            "deployed_by": c.get("deployed_by") or worker_name,
                             "_node": worker_name,
                             "_worker_id": w.get("id"),
                             "_has_docker": worker_has_docker,
@@ -227,6 +236,9 @@ async def _get_all_worker_containers(workers: list[dict[str, Any]] | None = None
                             "cpu_percent": 0,
                             "memory_mb": 0,
                             "category": "",
+                            # Android apps are enumerated by the worker itself and
+                            # are never CashPilot-managed containers, so there is
+                            # no external/managed distinction to preserve here.
                             "deployed_by": worker_name,
                             "_node": worker_name,
                             "_worker_id": w.get("id"),
@@ -1079,6 +1091,10 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
                 "container_name": inst.get("name", ""),
                 "has_docker": inst.get("_has_docker", False),
                 "is_android": inst.get("_is_android", False),
+                # Started outside CashPilot: it has no CashPilot label, so the
+                # container commands cannot target it and the UI must not offer
+                # them.
+                "unmanaged": inst.get("deployed_by") == "external",
             }
             if inst.get("_is_android"):
                 detail["net_tx_24h"] = inst.get("_net_tx_24h", 0)
@@ -1091,6 +1107,10 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "slug": slug,
             "name": svc["name"] if svc else slug,
             "container_status": agg["best_status"],
+            # True only when EVERY instance was started outside CashPilot. With
+            # a mix, the managed one can still be controlled, so the row keeps
+            # its buttons and the per-instance flag marks the odd one out.
+            "unmanaged": bool(agg["instances"]) and all(i.get("deployed_by") == "external" for i in agg["instances"]),
             # None, not 0.0, when CashPilot has never read this service.
             #
             # A missing earnings row means "no reading", and rendering it as

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -990,7 +990,17 @@ const CP = (() => {
         const nodeLabel = inst.node === 'local' ? 'Local' : escapeHtml(inst.node);
         const wParam = inst.worker_id != null ? `', ${inst.worker_id}` : `'`;
         const iNoDocker = !inst.has_docker || inst.is_android;
-        const disabledAttr = iNoDocker ? ' disabled title="No Docker access"' : '';
+        // The mixed case this whole change is built around. The ROW keeps its
+        // buttons because a managed instance can still be controlled — but the
+        // external instance in that same row cannot, and its sub-row was still
+        // offering Restart/Stop/Logs that answer 404. The per-instance flag has
+        // to be READ here; marking it in the payload and ignoring it at the one
+        // place a mixed service is drawn left the bug exactly where it was.
+        // (CodeRabbit, PR #212.)
+        const iUnmanaged = inst.unmanaged || svc.unmanaged;
+        const disabledAttr = iUnmanaged
+          ? ' disabled title="Started outside CashPilot — manage it where you started it"'
+          : (iNoDocker ? ' disabled title="No Docker access"' : '');
         const subLabel = inst.is_android ? '' : escapeHtml(inst.container_name);
         const cpuCell = inst.is_android ? `↑ ${fmtNetBytes(inst.net_tx_24h)}` : `${inst.cpu || '0'}%`;
         const memCell = inst.is_android ? `↓ ${fmtNetBytes(inst.net_rx_24h)}` : (inst.memory || '0 MB');

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -917,6 +917,11 @@ const CP = (() => {
       ? ` <span class="badge badge-instances" title="${instances} instance${instances > 1 ? 's' : ''}">${instances}x</span>`
       : '';
 
+    // Say why the buttons are dead rather than leaving the user to click one.
+    const unmanagedLabel = svc.unmanaged
+      ? ` <span class="badge badge-category" title="This container was started outside CashPilot, so CashPilot cannot stop, restart or read the logs of it.">Unmanaged</span>`
+      : '';
+
     // Settings gear (owner-only) — opens credential + bonus modal
     const settingsBtn = _isOwner
       ? `<button class="btn btn-icon" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(svc.slug)}" title="Credentials &amp; settings">
@@ -938,7 +943,15 @@ const CP = (() => {
       const inst = details[0] || {};
       const wParam = inst.worker_id != null ? `', ${inst.worker_id}` : `'`;
       const noDocker = !inst.has_docker || inst.is_android;
-      const disabledAttr = noDocker ? ' disabled title="No Docker access"' : '';
+      // Started outside CashPilot — matched by IMAGE, not by a CashPilot label,
+      // so every container command targets a name that does not exist and
+      // answers "404 Container not found" for a row this same screen calls
+      // Running. Offering the button at all is the bug; the disabled title says
+      // why rather than leaving it looking broken.
+      const unmanaged = inst.unmanaged || svc.unmanaged;
+      const disabledAttr = unmanaged
+        ? ' disabled title="Started outside CashPilot — manage it where you started it"'
+        : (noDocker ? ' disabled title="No Docker access"' : '');
       actionBtns = `<div class="action-btns">
           ${claimBtn}
           ${settingsBtn}
@@ -959,7 +972,7 @@ const CP = (() => {
     let html = `
     <tr class="breakdown-row${isMulti ? ' expandable' : ''}" data-slug="${escapeHtml(svc.slug)}"${isMulti ? ` data-action="toggleInstances" data-a1="${escapeHtml(svc.slug)}" data-a2="event" style="cursor:pointer;"` : ''}>
       <td>${nameHtml}<div style="font-size:0.7rem; color:var(--text-muted);">${subtitle}</div></td>
-      <td style="text-align:center;"><span class="badge badge-${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span>${instanceLabel}${outdatedBadge}</td>
+      <td style="text-align:center;"><span class="badge badge-${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span>${instanceLabel}${unmanagedLabel}${outdatedBadge}</td>
       <td style="text-align:center;">${healthBadge}</td>
       <td style="text-align:right; font-weight:600;">${balanceHtml}</td>
       <td style="text-align:right;"><span class="stat-change ${deltaClass}">${deltaStr}</span></td>

--- a/tests/test_beads_batch_28.py
+++ b/tests/test_beads_batch_28.py
@@ -181,3 +181,61 @@ class TestTheWorkerStillComputesIt:
     def test_labelled_containers_report_their_label(self):
         source = (ROOT / "app" / "orchestrator.py").read_text(encoding="utf-8")
         assert 'c.labels.get(LABEL_DEPLOYED_BY, "unknown")' in source
+
+
+class TestTheMixedServiceSubRowsHonourTheFlag:
+    """CodeRabbit, PR #212: the case this change was designed around was unfixed.
+
+    A row with one managed and one external instance deliberately KEEPS its
+    buttons, because the managed instance can still be controlled — and the
+    per-instance flag was supposed to mark the odd one out. The sub-row renderer
+    never read that flag, so the external instance inside a mixed service still
+    offered Restart / Stop / Logs, and every one still answered 404.
+
+    Marking a thing in the payload and ignoring it at the one place it matters
+    leaves the bug exactly where it was.
+    """
+
+    def _js(self):
+        return without_comments(APP_JS.read_text(encoding="utf-8"))
+
+    def test_the_sub_row_reads_the_per_instance_flag(self):
+        """Declared AND used — declaring it alone changes no behaviour."""
+        source = self._js()
+        assert "const iUnmanaged = inst.unmanaged || svc.unmanaged;" in source
+        i = source.index("const iUnmanaged")
+        assert "iUnmanaged" in source[i + 20 : i + 300], "the flag is declared but never read"
+
+    def test_the_sub_row_disables_on_it(self):
+        source = self._js()
+        i = source.index("const iUnmanaged")
+        block = source[i : i + 300]
+        assert "disabled" in block
+        assert "Started outside CashPilot" in block
+
+    def test_the_sub_rows_no_docker_reason_survives(self):
+        """The control: the pre-existing disable must not be swallowed."""
+        source = self._js()
+        i = source.index("const iUnmanaged")
+        assert "iNoDocker ? ' disabled title=\"No Docker access\"'" in source[i : i + 400]
+
+    def test_both_render_paths_now_check_it(self):
+        """Single-instance and multi-instance are separate code paths.
+
+        Fixing one and not the other is exactly what happened the first time.
+
+        Asserted on the USE, not the declaration. The first version counted
+        `unmanaged || svc.unmanaged` occurrences, which a revert that deleted
+        only the disabledAttr ternary still satisfied — the variable stayed,
+        unused, and the test passed against the broken state. Every
+        disabledAttr assignment must mention the reason.
+        """
+        source = self._js()
+        assignments = [line for line in source.splitlines() if "const disabledAttr" in line]
+        assert len(assignments) >= 2, f"expected both render paths to build disabledAttr, found {assignments}"
+        # The ternary wraps, so check the block after each assignment.
+        for line in assignments:
+            i = source.index(line)
+            assert "Started outside CashPilot" in source[i : i + 300], (
+                f"a render path builds disabledAttr without the unmanaged reason: {line.strip()}"
+            )

--- a/tests/test_beads_batch_28.py
+++ b/tests/test_beads_batch_28.py
@@ -1,0 +1,183 @@
+"""CashPilot-ljx: a container you started yourself got live buttons that 404.
+
+The worker's image matcher already answers this. ``app/orchestrator.py`` sets
+``"deployed_by": "external"`` for a container matched by IMAGE rather than by
+CashPilot's own label — one the user started themselves with ``docker run``.
+
+``_get_all_worker_containers`` then rebuilt each container dict from scratch and
+hardcoded ``"deployed_by": worker_name``, so the worker's answer was read
+nowhere. ``grep -rn deployed_by app/`` showed the only readers were the two
+writers in orchestrator.py and these two overwrites.
+
+The result: that container appeared as an ordinary managed service — "Running"
+badge, instance count, CPU/memory, and enabled Restart / Stop / Logs. Clicking
+any of them returned ``404 Container for honeygain not found``, which reads as a
+CashPilot bug on a service the same screen had just called Running.
+
+The node name was never lost by preserving the flag: ``_node`` already carries
+it, and is what the UI uses for per-instance labels.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+def _worker(containers, name="watchtower"):
+    return {
+        "id": 1,
+        "client_id": f"cid-{name}",
+        "name": name,
+        "status": "online",
+        "containers": json.dumps(containers),
+        "apps": "[]",
+        "system_info": json.dumps({"docker_available": True}),
+    }
+
+
+async def _containers(rows):
+    from app import main
+
+    with patch.object(main.database, "list_workers", AsyncMock(return_value=rows)):
+        return await main._get_all_worker_containers()
+
+
+MANAGED = {"slug": "honeygain", "name": "cashpilot-honeygain", "status": "running", "deployed_by": "watchtower"}
+EXTERNAL = {"slug": "honeygain", "name": "honeygain", "status": "running", "deployed_by": "external"}
+
+
+class TestTheWorkersAnswerSurvives:
+    @pytest.mark.asyncio
+    async def test_an_externally_started_container_stays_external(self):
+        out = await _containers([_worker([EXTERNAL])])
+        assert out[0]["deployed_by"] == "external", "the worker's answer is still being overwritten"
+
+    @pytest.mark.asyncio
+    async def test_a_managed_container_is_unaffected(self):
+        """The control: this must not mark everything external."""
+        out = await _containers([_worker([MANAGED])])
+        assert out[0]["deployed_by"] != "external"
+
+    @pytest.mark.asyncio
+    async def test_a_container_with_no_answer_falls_back_to_the_node(self):
+        """An older worker sends no deployed_by; the previous value is the sane default."""
+        row = {"slug": "honeygain", "name": "x", "status": "running"}
+        out = await _containers([_worker([row], name="geiserback")])
+        assert out[0]["deployed_by"] == "geiserback"
+
+    @pytest.mark.asyncio
+    async def test_the_node_name_is_still_carried(self):
+        """_node is what the UI labels instances with; it must not be collateral."""
+        out = await _containers([_worker([EXTERNAL], name="geiserback")])
+        assert out[0]["_node"] == "geiserback"
+
+
+class TestTheEndpointReportsIt:
+    async def _deployed(self, containers):
+        from app import main
+
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
+            patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_config", AsyncMock(return_value={})),
+            patch.object(main.database, "get_health_scores", AsyncMock(return_value={})),
+            patch.object(main.catalog, "get_service", lambda slug: {"name": "Honeygain", "slug": slug}),
+        ):
+            from unittest.mock import MagicMock
+
+            return await main.api_services_deployed(MagicMock())
+
+    def _instance(self, deployed_by):
+        return {
+            "slug": "honeygain",
+            "name": "honeygain",
+            "status": "running",
+            "cpu_percent": 0,
+            "memory_mb": 0,
+            "deployed_by": deployed_by,
+            "_node": "watchtower",
+            "_worker_id": 1,
+            "_has_docker": True,
+            "_is_android": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_an_external_only_service_is_flagged(self):
+        rows = await self._deployed([self._instance("external")])
+        assert rows[0]["unmanaged"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_managed_service_is_not(self):
+        rows = await self._deployed([self._instance("watchtower")])
+        assert rows[0]["unmanaged"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_mixed_service_keeps_its_buttons(self):
+        """One managed instance can still be controlled.
+
+        Flagging the whole row would remove the buttons that DO work; the
+        per-instance flag marks the odd one out instead.
+        """
+        rows = await self._deployed([self._instance("external"), self._instance("watchtower")])
+        assert rows[0]["unmanaged"] is False
+        flags = [i["unmanaged"] for i in rows[0]["instance_details"]]
+        assert sorted(flags) == [False, True]
+
+    @pytest.mark.asyncio
+    async def test_each_instance_carries_the_flag(self):
+        rows = await self._deployed([self._instance("external")])
+        assert rows[0]["instance_details"][0]["unmanaged"] is True
+
+
+class TestTheUIStopsOfferingButtonsThatCannotWork:
+    def _js(self):
+        return without_comments(APP_JS.read_text(encoding="utf-8"))
+
+    def test_the_row_reads_the_flag(self):
+        assert "inst.unmanaged || svc.unmanaged" in self._js()
+
+    def test_the_buttons_are_disabled(self):
+        source = self._js()
+        assert "Started outside CashPilot" in source
+        i = source.index("const unmanaged = inst.unmanaged")
+        assert "disabled" in source[i : i + 400]
+
+    def test_the_reason_is_stated_rather_than_left_blank(self):
+        """A dead button with no explanation reads as a broken app."""
+        assert "manage it where you started it" in self._js()
+
+    def test_the_row_is_labelled(self):
+        source = self._js()
+        assert "unmanagedLabel" in source
+        assert ">Unmanaged<" in source
+
+    def test_the_no_docker_case_still_has_its_own_message(self):
+        """The control: this must not swallow the pre-existing disable reason."""
+        assert 'title="No Docker access"' in self._js()
+
+
+class TestTheWorkerStillComputesIt:
+    """The premise. If orchestrator stops setting it, everything above is inert."""
+
+    def test_the_image_matcher_marks_external_containers(self):
+        source = (ROOT / "app" / "orchestrator.py").read_text(encoding="utf-8")
+        assert source.count('"deployed_by": "external"') >= 2
+
+    def test_labelled_containers_report_their_label(self):
+        source = (ROOT / "app" / "orchestrator.py").read_text(encoding="utf-8")
+        assert 'c.labels.get(LABEL_DEPLOYED_BY, "unknown")' in source


### PR DESCRIPTION
## The defect

The worker **already answers this**. `app/orchestrator.py` sets `"deployed_by": "external"` for a container matched by **image** rather than by CashPilot's own label — one the user started themselves with `docker run`.

Then `_get_all_worker_containers` rebuilt each container dict from scratch:

```python
"deployed_by": worker_name,     # ← the worker's answer, discarded
```

`grep -rn deployed_by app/` showed the only readers were the two writers in `orchestrator.py` and these two overwrites.

So a container you started yourself appeared as an ordinary managed service — "Running" badge, instance count, CPU/memory, and enabled **Restart / Stop / Logs**. Clicking any of them returned:

> 404 Container for honeygain not found

…which reads as a CashPilot bug on a service the same screen had just called Running.

## The fix

The worker's answer survives. The node name was never at risk — `_node` already carries it, and that's what the UI labels instances with.

**A row is flagged only when *every* instance was started outside CashPilot.** With a mix, the managed one can still be controlled, so the row keeps its buttons and the per-instance flag marks the odd one out. Flagging the whole row would remove the buttons that *do* work.

The UI disables the three container actions and **says why**. A dead button with no explanation reads as a broken app — the same complaint as the 404, just quieter. The pre-existing "No Docker access" reason is preserved, pinned by a control.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.26% coverage**, 2825 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| overwrite `deployed_by` again (the original bug) | 1 |
| flag the row on *any* external instance rather than all | 1 |
| leave the buttons enabled | 2 |

Controls also pin that a managed container is unaffected, an older worker sending no `deployed_by` still falls back to the node name, and the worker still computes the flag at all — without that last one, everything here is inert.

Closes CashPilot-ljx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service listings now identify containers started outside CashPilot with an “Unmanaged” badge.
  * Deployment status now reports unmanaged state for individual instances and entire services.
* **Improvements**
  * Controls for restarting, stopping, or viewing logs are disabled for unmanaged single-instance services, with explanatory guidance.
  * Container deployment classifications are preserved more accurately, including Android app deployments.
* **Bug Fixes**
  * Improved detection and reporting of externally deployed containers across workers and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->