### PR TITLE
fix(test): two more route sweeps were quietly shrinking on Starlette 1.3

### DIFF
--- a/tests/route_enumeration.py
+++ b/tests/route_enumeration.py
@@ -1,0 +1,64 @@
+"""One way to enumerate the app's routes, for every test that needs to.
+
+``app.routes`` is NOT a complete enumeration. Under Starlette 1.3 — which CI
+installs, because requirements.txt pins only ``fastapi>=0.136.1`` —
+``include_router`` stops adding its routes there. Measured: re-including a
+6-route ``APIRouter`` grew ``app.routes`` by ONE, and ``/login`` never appeared
+at all. Routing itself is unaffected; every one of those paths still serves.
+
+Anything that ENUMERATES routes therefore sees a subset, and the failure is
+silent in the worst possible direction:
+
+* a sweep that asserts something about every route quietly stops covering the
+  ones it cannot see, while still reporting a large number and passing;
+* a NEGATIVE assertion — "no route serves /docs" — becomes trivially true the
+  moment the enumeration is incomplete.
+
+Three test modules independently walked ``app.routes``. The first was caught
+because a PUBLIC-list staleness check failed on CI and nowhere else
+(CashPilot-zfd); the other two would have shrunk in silence (CashPilot-33h).
+Hence one helper rather than three copies of the workaround.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def all_routes() -> list[Any]:
+    """Every route the app serves, on any supported Starlette version.
+
+    The app's own routes, unioned with the routes of each ``APIRouter`` reached
+    through ``app.main``. Deduplicated on (path, methods), so a version where
+    ``include_router`` still populates ``app.routes`` yields the same list.
+    """
+    from fastapi import APIRouter
+
+    from app import main
+
+    # Starlette 1.3 puts a pathless `_IncludedRouter` placeholder in app.routes
+    # for each include_router call — that is the "+1 per include" measured when
+    # this was diagnosed. It is not a route anyone can call, and leaving it in
+    # makes every consumer filter it out again.
+    routes = [r for r in main.app.routes if getattr(r, "path", "")]
+    seen = {(getattr(r, "path", ""), frozenset(getattr(r, "methods", None) or ())) for r in routes}
+    for value in vars(main).values():
+        # main binds them as MODULES (`from app.routers import auth as
+        # auth_router`), so the APIRouter is one attribute further in.
+        candidate = value if isinstance(value, APIRouter) else getattr(value, "router", None)
+        if isinstance(candidate, APIRouter):
+            for route in candidate.routes:
+                key = (getattr(route, "path", ""), frozenset(getattr(route, "methods", None) or ()))
+                if key not in seen:
+                    seen.add(key)
+                    routes.append(route)
+    return routes
+
+
+def all_paths() -> set[str]:
+    """Every path the app serves. For negative assertions, which need this most.
+
+    "No route serves /docs" is only meaningful if the set being searched is
+    complete: an incomplete one makes the claim true by omission.
+    """
+    return {getattr(r, "path", "") for r in all_routes()}

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -260,11 +260,19 @@ class TestNoRouteIsShadowedByAnEarlierParameterisedOne:
     def test_every_literal_path_resolves_to_its_own_handler(self):
         from fastapi.routing import APIRoute
 
-        from app.main import app
+        from tests.route_enumeration import all_routes
 
-        literals = [
-            r for r in app.routes if isinstance(r, APIRoute) and "{" not in r.path and r.path.startswith("/api/")
-        ]
+        # all_routes(), not app.routes: on Starlette 1.3 the latter omits every
+        # route added by include_router, so this shadowing sweep silently
+        # covered fewer paths than it claimed. (CashPilot-33h)
+        #
+        # BOTH sides have to use it. Widening only the literals made /api/users
+        # report "shadowed by None" — the route was now being checked, but the
+        # list searched for its winner still could not see it. The order is the
+        # real one either way: main.py includes its routers last, and all_routes
+        # appends them last.
+        registered = [r for r in all_routes() if isinstance(r, APIRoute)]
+        literals = [r for r in registered if "{" not in r.path and r.path.startswith("/api/")]
         for route in literals:
             method = next(iter(route.methods - {"HEAD", "OPTIONS"}), "GET")
             scope = {
@@ -277,7 +285,7 @@ class TestNoRouteIsShadowedByAnEarlierParameterisedOne:
                 "root_path": "",
             }
             winner = next(
-                (r for r in app.routes if isinstance(r, APIRoute) and r.matches(scope)[0].name == "FULL"),
+                (r for r in registered if r.matches(scope)[0].name == "FULL"),
                 None,
             )
             assert winner is route, (

--- a/tests/test_beads_batch_1.py
+++ b/tests/test_beads_batch_1.py
@@ -148,9 +148,14 @@ class TestTheAdminSchemaIsNotPublished:
         assert app.openapi_url is None
 
     def test_no_route_serves_them(self):
-        from app.main import app
+        # A NEGATIVE assertion over an incomplete set is true by omission. On
+        # Starlette 1.3 app.routes drops every include_router route, so this
+        # would have kept passing while enumerating less and less.
+        # (CashPilot-33h)
+        from tests.route_enumeration import all_paths
 
-        paths = {getattr(r, "path", "") for r in app.routes}
+        paths = all_paths()
+        assert paths, "no routes enumerated at all — this assertion would pass vacuously"
         assert not paths & {"/docs", "/redoc", "/openapi.json"}
 
 

--- a/tests/test_beads_batch_31.py
+++ b/tests/test_beads_batch_31.py
@@ -1,0 +1,132 @@
+"""CashPilot-33h: two more route sweeps were quietly shrinking.
+
+``app.routes`` is not a complete enumeration on Starlette 1.3 — the version CI
+installs, because requirements.txt pins only ``fastapi>=0.136.1``.
+``include_router`` stops adding its routes there: re-including a 6-route
+APIRouter grew ``app.routes`` by ONE, and ``/login`` never appeared at all.
+
+Three test modules walked ``app.routes`` independently. The first was caught
+only because a PUBLIC-list staleness check failed on CI and nowhere else. The
+other two would have shrunk in silence, and one of them is the shape that breaks
+worst: ``assert not paths & {"/docs", "/redoc", "/openapi.json"}`` is a NEGATIVE
+assertion, true by omission the moment the set is incomplete.
+
+One helper now, rather than a third copy of the same workaround.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+
+
+class TestTheEnumerationSeesTheWholeApp:
+    def test_it_finds_the_router_routes(self):
+        from tests.route_enumeration import all_paths
+
+        paths = all_paths()
+        for path in ("/", "/login", "/logout", "/register", "/onboarding"):
+            assert path in paths, f"{path} is served but not enumerated"
+
+    def test_it_finds_the_directly_registered_routes(self):
+        """The control: the union must not lose what app.routes already had."""
+        from tests.route_enumeration import all_paths
+
+        paths = all_paths()
+        assert "/api/workers" in paths
+        assert "/api/earnings/summary" in paths
+
+    def test_it_does_not_duplicate(self):
+        """Deduplicated on (path, methods), so a version where include_router
+        still populates app.routes yields the same list rather than doubles."""
+        from tests.route_enumeration import all_routes
+
+        keys = [(getattr(r, "path", ""), frozenset(getattr(r, "methods", None) or ())) for r in all_routes()]
+        assert len(keys) == len(set(keys)), "the union produced duplicate routes"
+
+    def test_it_sees_more_than_app_routes_alone(self):
+        """The premise. If this ever stops being true the helper is harmless,
+        but the comment explaining it would be wrong, so it is asserted."""
+        from app.main import app
+        from tests.route_enumeration import all_routes
+
+        real = [r for r in app.routes if getattr(r, "path", "")]
+        assert len(all_routes()) > len(real), (
+            "the union found nothing app.routes was missing — either Starlette changed back, "
+            "or the helper stopped reaching the routers"
+        )
+
+
+class TestEverySweepUsesIt:
+    """A fourth copy of the workaround is the thing to prevent."""
+
+    SWEEPS = {
+        "test_audit_guards.py": "the shadowing check",
+        "test_beads_batch_1.py": "the docs-disabled check",
+        "test_every_route_rejects_anonymous.py": "the anonymous sweep",
+    }
+
+    @pytest.mark.parametrize("filename", sorted(SWEEPS))
+    def test_it_does_not_walk_app_routes_directly(self, filename):
+        """Checked against the AST, not the text.
+
+        Two earlier versions were wrong in opposite directions. Matching the
+        literal "in app.routes" let a control reverting via
+        `__import__("app.main").app.routes` sail straight past. Matching any
+        mention then flagged the DOCSTRINGS that explain why the helper exists.
+
+        An attribute access is the thing that actually matters, and it is what
+        the parser can see: prose cannot trip it and no spelling can hide from
+        it.
+        """
+        import ast
+
+        tree = ast.parse((TESTS / filename).read_text(encoding="utf-8"))
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "routes"
+            and getattr(node.value, "id", getattr(node.value, "attr", None)) == "app"
+        ]
+        assert not offenders, (
+            f"{filename} ({self.SWEEPS[filename]}) reaches for app.routes at line(s) {offenders}, "
+            "which is incomplete on Starlette 1.3 — use tests/route_enumeration.py"
+        )
+
+    @pytest.mark.parametrize("filename", sorted(SWEEPS))
+    def test_it_imports_the_helper(self, filename):
+        source = (TESTS / filename).read_text(encoding="utf-8")
+        assert "route_enumeration" in source, f"{filename} does not use the shared enumeration"
+
+
+class TestTheNegativeAssertionCannotPassVacuously:
+    """`assert not paths & {...}` is true when paths is empty.
+
+    That is the failure mode an incomplete enumeration produces, so the test
+    that makes the claim now also asserts it enumerated anything at all.
+    """
+
+    def test_the_docs_check_guards_against_an_empty_set(self):
+        source = (TESTS / "test_beads_batch_1.py").read_text(encoding="utf-8")
+        i = source.index("def test_no_route_serves_them")
+        block = source[i : i + 900]
+        assert "assert paths," in block, "an empty enumeration would satisfy this test"
+
+    def test_the_docs_are_still_actually_disabled(self):
+        """The control: the guard above must not be the only thing left."""
+        from tests.route_enumeration import all_paths
+
+        assert not all_paths() & {"/docs", "/redoc", "/openapi.json"}
+
+
+def test_the_helper_explains_why_it_exists():
+    """A workaround with no recorded reason gets 'simplified' back out."""
+    source = (TESTS / "route_enumeration.py").read_text(encoding="utf-8")
+    assert "Starlette 1.3" in source
+    assert re.search(r"include_router", source)

--- a/tests/test_every_route_rejects_anonymous.py
+++ b/tests/test_every_route_rejects_anonymous.py
@@ -83,37 +83,15 @@ def _body_for(route):
 
 
 def _routes():
-    """Every route the app serves, on any supported Starlette version.
+    """Delegates to tests/route_enumeration.py.
 
-    ``app.routes`` is NOT a complete enumeration. Under Starlette 1.3 (which CI
-    installs, because requirements.txt pins only ``fastapi>=0.136.1``)
-    ``include_router`` stops adding its routes there: re-including a 6-route
-    router grew ``app.routes`` by one, and /login never appeared at all. Routing
-    itself is unaffected — every one of those paths still serves — but anything
-    that ENUMERATES routes silently sees 65 of 76.
-
-    That is exactly the failure this file exists to prevent, reappearing as a
-    quiet under-count, and it is why the page routes are unioned back in from
-    the routers themselves. test_the_page_routes_are_enumerated below fails if
-    this ever stops working, rather than letting the sweep shrink in silence.
+    This function was written here first, for CashPilot-zfd. Two other modules
+    then turned out to walk app.routes with the same blind spot, so the logic
+    moved to one place rather than being copied a third time. (CashPilot-33h)
     """
-    from fastapi import APIRouter
+    from tests.route_enumeration import all_routes
 
-    from app import main
-
-    routes = list(main.app.routes)
-    seen = {(getattr(r, "path", ""), frozenset(getattr(r, "methods", None) or ())) for r in routes}
-    for value in vars(main).values():
-        # main binds them as MODULES (`from app.routers import auth as
-        # auth_router`), so the APIRouter is one attribute further in.
-        candidate = value if isinstance(value, APIRouter) else getattr(value, "router", None)
-        if isinstance(candidate, APIRouter):
-            for route in candidate.routes:
-                key = (getattr(route, "path", ""), frozenset(getattr(route, "methods", None) or ()))
-                if key not in seen:
-                    seen.add(key)
-                    routes.append(route)
-    return routes
+    return all_routes()
 
 
 def _requests():


### PR DESCRIPTION
## The defect

`app.routes` is not a complete enumeration on Starlette 1.3 — the version CI installs, because `requirements.txt` pins only `fastapi>=0.136.1`. `include_router` stops adding its routes there: re-including a 6-route `APIRouter` grew `app.routes` by **one**, and `/login` never appeared at all.

**Three** test modules walked `app.routes` independently. The first was caught only because a PUBLIC-list staleness check failed on CI and nowhere else (#198). The other two would have shrunk in silence — and one is the shape that breaks worst:

```python
assert not paths & {"/docs", "/redoc", "/openapi.json"}
```

A **negative** assertion is true by omission the moment the set is incomplete. It now also asserts the enumeration found anything at all.

## The fix

One helper — `tests/route_enumeration.py` — rather than a third copy of the workaround. It also drops the pathless `_IncludedRouter` placeholders Starlette 1.3 leaves in `app.routes` (the "+1 per include" measured when this was diagnosed), so consumers don't each filter them out again.

Widening the shadowing sweep immediately reported **"/api/users is shadowed by None"**: the literals were now being checked, but the list searched for their *winner* still couldn't see them. Both sides use the same enumeration. The order is the real one either way — `main.py` includes its routers last, and the union appends them last.

## The guard took three attempts, and the control caught each one

| attempt | why it was wrong |
|---|---|
| match the literal `"in app.routes"` | a revert via `__import__("app.main").app.routes` sailed past it |
| match *any* mention | flagged the **docstrings** explaining why the helper exists |
| **AST check for the attribute access** | prose can't trip it, no spelling can hide from it |

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.26% coverage**, 2867 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| shadowing sweep walks `app.routes` again | 1 |
| docs check drops its non-empty guard | 1 |
| helper stops reaching the routers | 2 |

Closes CashPilot-33h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added shared route-enumeration coverage for application and router-defined endpoints.
  - Improved route-related tests to include nested and directly registered routes while avoiding duplicates.
  - Added safeguards ensuring route checks cannot pass with incomplete or empty route sets.
  - Updated anonymous-access, audit, and documentation-disabled checks to use comprehensive route discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->