### PR TITLE
fix(ci): the test suite ran against a resolution nothing else used

### DIFF
--- a/.github/workflows/collector-live-check.yml
+++ b/.github/workflows/collector-live-check.yml
@@ -33,11 +33,13 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Same lockfile as the test job and the shipped image. A live check that
+      # runs against a different resolution than production can pass or fail for
+      # reasons that have nothing to do with the provider it is checking.
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-asyncio
+          python -m pip install --upgrade pip uv
+          uv sync --frozen --extra dev
 
       - name: Run live collector checks
         id: live
@@ -49,7 +51,7 @@ jobs:
           # marker yet, so without this the job fails EVERY night and files a
           # false drift alert — which trains the maintainer to ignore the one
           # alert designed to catch a real provider change.
-          python -m pytest tests/ -m live -q 2>&1 | tee live.log || [ "${PIPESTATUS[0]}" = "5" ]
+          uv run pytest tests/ -m live -q 2>&1 | tee live.log || [ "${PIPESTATUS[0]}" = "5" ]
 
       - name: Open an issue when a provider's shape changed
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,16 +51,24 @@ jobs:
       - name: Fleet staleness behaviour
         run: node scripts/fleet_staleness_check.mjs
 
+      # From the LOCKFILE, which is what Docker ships (`uv sync --frozen` in the
+      # Dockerfile) and what release.yml verifies against. Installing from the
+      # unpinned requirements.txt meant the suite ran against a resolution
+      # nobody else had: locally fastapi 0.136.1 / starlette 1.0.1, here
+      # 0.141.1 / 1.3.1. On the newer one `include_router` stops adding routes
+      # to `app.routes`, so a route sweep silently covered 65 of 76 — a real
+      # behaviour difference that only ever appeared on CI (CashPilot-de1).
+      - name: Install uv
+        run: pip install uv --quiet
+
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-asyncio pyyaml tzdata docker
+        run: uv sync --frozen --extra dev
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: uv run pytest tests/ -v --tb=short
 
       - name: Run tests with coverage
-        run: pytest tests/ --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=90
+        run: uv run pytest tests/ --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=90
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.13",
+    # Imported by the suite and previously installed ad hoc in test.yml, which
+    # meant the test environment was assembled by hand rather than resolved from
+    # the lockfile that ships.
+    "docker>=7.1.0",
+    "tzdata>=2025.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,109 @@
-# NOTE: pyproject.toml + uv.lock are now the primary source of truth for dependencies.
-# Docker builds use `uv sync --frozen` from the lockfile.
-# This file is kept for backward compatibility with local development.
-fastapi>=0.136.1
-uvicorn>=0.47.0
-uvloop>=0.22.1
-httptools>=0.6
-jinja2>=3.1.6
-pyyaml>=6.0.3
-aiosqlite>=0.22.1
-httpx>=0.28.1
-apscheduler>=3.11.2
-python-multipart>=0.0.31
-cryptography>=50.0.0
-bcrypt>=5.0.0
-itsdangerous>=2.2
-prometheus_client>=0.22.0
+# GENERATED — do not edit by hand.
+#
+# pyproject.toml + uv.lock are the source of truth. This file is a pinned export
+# of the lockfile's runtime dependencies, regenerated with:
+#
+#     uv export --no-dev --no-hashes --format requirements-txt > requirements.txt
+#
+# It used to list unpinned lower bounds (fastapi>=0.136.1, ...), which meant
+# anyone installing from it resolved something different from what ships: CI got
+# fastapi 0.141.1 / starlette 1.3.1 while local development sat on 0.136.1 /
+# 1.0.1. On the newer one include_router stops adding routes to app.routes, so a
+# route sweep silently covered 65 of 76 — a real behaviour difference that only
+# ever showed up on CI. A test asserts this file still matches the lockfile.
+aiosqlite==0.22.1
+    # via cashpilot
+annotated-doc==0.0.4
+    # via fastapi
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.13.0
+    # via
+    #   httpx
+    #   starlette
+apscheduler==3.11.2
+    # via cashpilot
+bcrypt==5.0.0
+    # via cashpilot
+certifi==2026.5.20
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
+    # via cryptography
+charset-normalizer==3.4.7
+    # via requests
+click==8.4.1
+    # via uvicorn
+colorama==0.4.6 ; sys_platform == 'win32'
+    # via click
+cryptography==50.0.0
+    # via cashpilot
+docker==7.1.0
+    # via cashpilot
+fastapi==0.136.1
+    # via cashpilot
+h11==0.16.0
+    # via
+    #   httpcore
+    #   uvicorn
+httpcore==1.0.9
+    # via httpx
+httptools==0.7.1
+    # via cashpilot
+httpx==0.28.1
+    # via cashpilot
+idna==3.16
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+itsdangerous==2.2.0
+    # via cashpilot
+jinja2==3.1.6
+    # via cashpilot
+markupsafe==3.0.3
+    # via jinja2
+prometheus-client==0.25.0
+    # via cashpilot
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
+    # via cffi
+pydantic==2.13.4
+    # via fastapi
+pydantic-core==2.46.4
+    # via pydantic
+python-multipart==0.0.31
+    # via cashpilot
+pywin32==311 ; sys_platform == 'win32'
+    # via docker
+pyyaml==6.0.3
+    # via cashpilot
+requests==2.34.2
+    # via docker
+starlette==1.3.1
+    # via fastapi
+typing-extensions==4.15.0
+    # via
+    #   anyio
+    #   fastapi
+    #   pydantic
+    #   pydantic-core
+    #   starlette
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   fastapi
+    #   pydantic
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via tzlocal
+tzlocal==5.3.1
+    # via apscheduler
+urllib3==2.7.0
+    # via
+    #   docker
+    #   requests
+uvicorn==0.47.0
+    # via cashpilot
+uvloop==0.22.1
+    # via cashpilot

--- a/tests/route_enumeration.py
+++ b/tests/route_enumeration.py
@@ -1,10 +1,17 @@
 """One way to enumerate the app's routes, for every test that needs to.
 
-``app.routes`` is NOT a complete enumeration. Under Starlette 1.3 — which CI
-installs, because requirements.txt pins only ``fastapi>=0.136.1`` —
-``include_router`` stops adding its routes there. Measured: re-including a
-6-route ``APIRouter`` grew ``app.routes`` by ONE, and ``/login`` never appeared
-at all. Routing itself is unaffected; every one of those paths still serves.
+``app.routes`` is NOT a complete enumeration on every supported version.
+FastAPI 0.141.1 drops routes from ``app.routes``. Measured by holding
+Starlette at 1.3.1 and moving FastAPI alone: on 0.136.1 the app reports all 76
+routes including /login; on 0.141.1 it reports 62 and /login is absent, with
+``include_router`` leaving only a pathless placeholder behind. Routing itself is
+unaffected — every one of those paths still serves.
+
+It surfaced because requirements.txt pinned only ``fastapi>=0.136.1`` while the
+lockfile pins 0.136.1, so CI resolved a version nobody developed against
+(CashPilot-de1). CI now installs from the lock, which closes that gap — this
+helper is what keeps a future FastAPI bump from silently shrinking a sweep
+again.
 
 Anything that ENUMERATES routes therefore sees a subset, and the failure is
 silent in the worst possible direction:
@@ -36,10 +43,10 @@ def all_routes() -> list[Any]:
 
     from app import main
 
-    # Starlette 1.3 puts a pathless `_IncludedRouter` placeholder in app.routes
-    # for each include_router call — that is the "+1 per include" measured when
-    # this was diagnosed. It is not a route anyone can call, and leaving it in
-    # makes every consumer filter it out again.
+    # FastAPI 0.141.1 puts a pathless `_IncludedRouter` placeholder in
+    # app.routes for each include_router call — the "+1 per include" measured
+    # when this was diagnosed. It is not a route anyone can call, and leaving it
+    # in makes every consumer filter it out again.
     routes = [r for r in main.app.routes if getattr(r, "path", "")]
     seen = {(getattr(r, "path", ""), frozenset(getattr(r, "methods", None) or ())) for r in routes}
     for value in vars(main).values():

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -262,8 +262,8 @@ class TestNoRouteIsShadowedByAnEarlierParameterisedOne:
 
         from tests.route_enumeration import all_routes
 
-        # all_routes(), not app.routes: on Starlette 1.3 the latter omits every
-        # route added by include_router, so this shadowing sweep silently
+        # all_routes(), not app.routes: on FastAPI 0.141.1 the latter omits
+        # every route added by include_router, so this shadowing sweep silently
         # covered fewer paths than it claimed. (CashPilot-33h)
         #
         # BOTH sides have to use it. Widening only the literals made /api/users

--- a/tests/test_beads_batch_1.py
+++ b/tests/test_beads_batch_1.py
@@ -149,7 +149,7 @@ class TestTheAdminSchemaIsNotPublished:
 
     def test_no_route_serves_them(self):
         # A NEGATIVE assertion over an incomplete set is true by omission. On
-        # Starlette 1.3 app.routes drops every include_router route, so this
+        # FastAPI 0.141.1 app.routes drops every include_router route, so this
         # would have kept passing while enumerating less and less.
         # (CashPilot-33h)
         from tests.route_enumeration import all_paths

--- a/tests/test_beads_batch_31.py
+++ b/tests/test_beads_batch_31.py
@@ -1,9 +1,14 @@
 """CashPilot-33h: two more route sweeps were quietly shrinking.
 
-``app.routes`` is not a complete enumeration on Starlette 1.3 — the version CI
-installs, because requirements.txt pins only ``fastapi>=0.136.1``.
-``include_router`` stops adding its routes there: re-including a 6-route
-APIRouter grew ``app.routes`` by ONE, and ``/login`` never appeared at all.
+``app.routes`` is not a complete enumeration on every version. Measured by
+holding Starlette at 1.3.1 and moving FastAPI alone: on 0.136.1 the app reports
+all 76 routes including ``/login``; on 0.141.1 it reports 62, with
+``include_router`` leaving only a pathless placeholder behind.
+
+It surfaced because requirements.txt pinned only ``fastapi>=0.136.1`` while the
+lockfile pins 0.136.1, so CI resolved a version nobody developed against. CI now
+installs from the lock (CashPilot-de1), which closes that gap; these sweeps go
+through one helper so a future FastAPI bump cannot shrink them again.
 
 Three test modules walked ``app.routes`` independently. The first was caught
 only because a PUBLIC-list staleness check failed on CI and nowhere else. The
@@ -49,17 +54,23 @@ class TestTheEnumerationSeesTheWholeApp:
         keys = [(getattr(r, "path", ""), frozenset(getattr(r, "methods", None) or ())) for r in all_routes()]
         assert len(keys) == len(set(keys)), "the union produced duplicate routes"
 
-    def test_it_sees_more_than_app_routes_alone(self):
-        """The premise. If this ever stops being true the helper is harmless,
-        but the comment explaining it would be wrong, so it is asserted."""
-        from app.main import app
-        from tests.route_enumeration import all_routes
+    def test_it_is_a_superset_of_app_routes(self):
+        """A SUPERSET, never strictly larger.
 
-        real = [r for r in app.routes if getattr(r, "path", "")]
-        assert len(all_routes()) > len(real), (
-            "the union found nothing app.routes was missing — either Starlette changed back, "
-            "or the helper stopped reaching the routers"
-        )
+        The first version asserted the union finds MORE than app.routes, which
+        encoded a wrong diagnosis. The under-enumeration comes from FastAPI
+        0.141.1, and the lockfile pins 0.136.1 — where app.routes is already
+        complete. On the version that ships the two are equal, and that is the
+        healthy state rather than a failure.
+
+        What must hold on every version is that the union never sees LESS.
+        """
+        from app.main import app
+        from tests.route_enumeration import all_paths
+
+        union = all_paths()
+        direct = {getattr(r, "path", "") for r in app.routes if getattr(r, "path", "")}
+        assert direct <= union, f"the union lost routes app.routes had: {sorted(direct - union)}"
 
 
 class TestEverySweepUsesIt:
@@ -128,5 +139,5 @@ class TestTheNegativeAssertionCannotPassVacuously:
 def test_the_helper_explains_why_it_exists():
     """A workaround with no recorded reason gets 'simplified' back out."""
     source = (TESTS / "route_enumeration.py").read_text(encoding="utf-8")
-    assert "Starlette 1.3" in source
+    assert "0.141.1" in source, "the helper should name the version that motivated it"
     assert re.search(r"include_router", source)

--- a/tests/test_beads_batch_32.py
+++ b/tests/test_beads_batch_32.py
@@ -1,0 +1,153 @@
+"""CashPilot-de1: CI and local development tested different code.
+
+``pyproject.toml`` + ``uv.lock`` are the source of truth, and the Dockerfile
+installs with ``uv sync --frozen`` — so what SHIPS is pinned. But the test
+workflow installed from ``requirements.txt``, which listed unpinned lower bounds
+(``fastapi>=0.136.1``, ...), and then pip-installed pytest and friends by hand
+on top.
+
+The consequence is not theoretical. Local development sat on fastapi 0.136.1 /
+starlette 1.0.1; CI resolved 0.141.1 / 1.3.1. On the newer pair
+``include_router`` stops adding its routes to ``app.routes``, so a route sweep
+silently covered 65 of 76 — a real behaviour difference that appeared only on
+CI, and only because one test happened to assert something that noticed.
+
+A green local suite was not evidence about what CI would do, nor about what a
+user installing today would get.
+
+Now every workflow that runs the suite resolves from the same lockfile the image
+ships, and requirements.txt is a pinned export of it rather than a second,
+looser opinion.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _workflow(name):
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _run_steps(doc):
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            run = step.get("run")
+            if run:
+                yield run
+
+
+class TestEveryWorkflowResolvesFromTheLockfile:
+    SUITE_WORKFLOWS = ["test.yml", "collector-live-check.yml", "release.yml"]
+
+    @pytest.mark.parametrize("name", SUITE_WORKFLOWS)
+    def test_it_does_not_pip_install_requirements(self, name):
+        commands = " ".join(_run_steps(_workflow(name)))
+        assert "pip install -r requirements.txt" not in commands, (
+            f"{name} installs from requirements.txt instead of the lockfile the image ships"
+        )
+
+    @pytest.mark.parametrize("name", SUITE_WORKFLOWS)
+    def test_it_syncs_from_the_lock(self, name):
+        commands = " ".join(_run_steps(_workflow(name)))
+        assert "uv sync --frozen" in commands, f"{name} does not resolve from uv.lock"
+
+    @pytest.mark.parametrize("name", ["test.yml", "collector-live-check.yml"])
+    def test_it_runs_pytest_inside_that_environment(self, name):
+        """`uv sync` then a bare `pytest` would run whatever pip left on PATH."""
+        commands = [c for c in _run_steps(_workflow(name)) if "pytest" in c]
+        assert commands, f"{name} does not run pytest at all"
+        for command in commands:
+            assert "uv run pytest" in command, f"{name} runs pytest outside the synced environment: {command.strip()}"
+
+    def test_nothing_installs_test_deps_by_hand(self):
+        """Hand-assembling the test environment is how it diverged.
+
+        Checked per STEP. Joining every run block into one string let the
+        pattern span two unrelated commands — "pip install uv" in one step and
+        "uv run pytest" three steps later — and reported a violation that did
+        not exist.
+        """
+        offenders = [
+            command.strip()
+            for command in _run_steps(_workflow("test.yml"))
+            for line in command.splitlines()
+            if re.search(r"pip install\b.*\bpytest\b", line)
+            for command in [line]
+        ]
+        assert not offenders, f"test.yml still pip-installs pytest directly; put it in the dev extra: {offenders}"
+
+
+class TestTheDevExtraCoversWhatTheSuiteNeeds:
+    def _dev(self):
+        data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        return {re.split(r"[><=\[]", d)[0].strip().lower() for d in data["project"]["optional-dependencies"]["dev"]}
+
+    @pytest.mark.parametrize("package", ["pytest", "pytest-asyncio", "pytest-cov", "docker", "tzdata"])
+    def test_it_is_declared(self, package):
+        assert package in self._dev(), f"{package} is imported by the suite but not in the dev extra"
+
+    def test_pyyaml_comes_from_the_runtime_deps(self):
+        """It is a real runtime dependency, not a test-only one."""
+        data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        runtime = {re.split(r"[><=\[]", d)[0].strip().lower() for d in data["project"]["dependencies"]}
+        assert "pyyaml" in runtime
+
+
+class TestRequirementsTxtIsAPinnedExport:
+    def _text(self):
+        return (ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+    def test_every_requirement_is_pinned(self):
+        loose = [
+            line.strip()
+            for line in self._text().splitlines()
+            if line.strip() and not line.startswith((" ", "#")) and "==" not in line
+        ]
+        assert not loose, f"these are not pinned, so they can resolve differently from the lock: {loose}"
+
+    def test_it_says_it_is_generated(self):
+        """A hand-edit is how it drifts back apart."""
+        assert "GENERATED" in self._text()
+        assert "uv export" in self._text()
+
+    def test_it_matches_the_lockfile(self):
+        """The whole point: one resolution, not two.
+
+        Regenerate with:
+            uv export --no-dev --no-hashes --format requirements-txt > requirements.txt
+        """
+        result = subprocess.run(
+            ["uv", "export", "--no-dev", "--no-hashes", "--format", "requirements-txt"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.skip("uv is not available here; CI resolves from the lock directly")
+        exported = {
+            line.strip() for line in result.stdout.splitlines() if line.strip() and not line.startswith(("#", " "))
+        }
+        committed = {
+            line.strip() for line in self._text().splitlines() if line.strip() and not line.startswith(("#", " "))
+        }
+        assert committed == exported, (
+            "requirements.txt has drifted from uv.lock. Regenerate it with "
+            "`uv export --no-dev --no-hashes --format requirements-txt > requirements.txt` "
+            f"(only in committed: {sorted(committed - exported)}; only in lock: {sorted(exported - committed)})"
+        )
+
+    def test_it_still_lists_the_real_dependencies(self):
+        """Guards against this passing because the file was emptied."""
+        text = self._text().lower()
+        for package in ("fastapi", "uvicorn", "cryptography", "httpx"):
+            assert package in text, f"{package} disappeared from requirements.txt"

--- a/tests/test_every_route_rejects_anonymous.py
+++ b/tests/test_every_route_rejects_anonymous.py
@@ -88,6 +88,9 @@ def _routes():
     This function was written here first, for CashPilot-zfd. Two other modules
     then turned out to walk app.routes with the same blind spot, so the logic
     moved to one place rather than being copied a third time. (CashPilot-33h)
+
+    The blind spot is FastAPI 0.141.1, not Starlette 1.3 as first recorded —
+    measured by moving FastAPI alone with Starlette held at 1.3.1.
     """
     from tests.route_enumeration import all_routes
 
@@ -156,12 +159,12 @@ class TestEveryRegisteredRouteRefusesAnAnonymousCaller:
     def test_the_page_routes_are_enumerated(self, path):
         """The under-count guard, and it has already fired once.
 
-        On Starlette 1.3 — what CI installs, since requirements.txt pins only
-        fastapi>=0.136.1 — include_router stops adding its routes to app.routes.
-        The whole HTML surface silently dropped out of this sweep while it still
-        reported 65 routes and passed. A sweep that quietly stops sweeping is
-        worse than the hand-written list it replaced, because it still looks
-        thorough.
+        On FastAPI 0.141.1 — which CI resolved, because requirements.txt
+        pinned only fastapi>=0.136.1 — include_router stops adding its routes to
+        app.routes. The whole HTML surface silently dropped out of this sweep
+        while it still reported 62 routes and passed. A sweep that quietly stops
+        sweeping is worse than the hand-written list it replaced, because it
+        still looks thorough.
         """
         assert path in {p for _m, p, _u, _b in ALL_REQUESTS}, (
             f"{path} is served but not enumerated — the sweep is missing a whole router"

--- a/uv.lock
+++ b/uv.lock
@@ -144,10 +144,12 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "docker" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tzdata" },
 ]
 
 [package.metadata]
@@ -157,6 +159,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "httptools", specifier = ">=0.6" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -169,6 +172,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.13" },
+    { name = "tzdata", marker = "extra == 'dev'", specifier = ">=2025.1" },
     { name = "uvicorn", specifier = ">=0.47.0" },
     { name = "uvloop", specifier = ">=0.22.1" },
 ]


### PR DESCRIPTION
## The defect

`pyproject.toml` + `uv.lock` are the source of truth, and the Dockerfile installs with `uv sync --frozen` — so **what ships is pinned**. But `test.yml` and `collector-live-check.yml` installed from `requirements.txt` (unpinned lower bounds) and then pip-installed pytest and friends by hand on top.

A green local suite was not evidence about what CI would do, nor about what a user installing today would get.

## The fix

Both workflows sync from the lockfile and run pytest inside that environment, so the suite exercises exactly what the image contains. `requirements.txt` becomes a **pinned export** of the lock rather than a second, looser opinion — with a test asserting the two still agree. `docker` and `tzdata` move into the dev extra; they're imported by the suite and were installed ad hoc.

## This also corrects a diagnosis I got wrong in six files

I attributed the `app.routes` under-enumeration to **Starlette 1.3**. That's wrong. Holding Starlette at 1.3.1 and moving FastAPI alone:

| fastapi | starlette | routes in `app.routes` | `/login` present |
|---|---|---|---|
| 0.136.1 | 1.3.1 | 76 | yes |
| 0.141.1 | 1.3.1 | 62 | **no** |

It's FastAPI 0.141.1. And since the lock pins **0.136.1**, once CI installs from the lock the exposure disappears — the shared enumeration helper from #215 stays as protection for the next bump, not as a workaround for today.

One test encoded the wrong diagnosis directly: it asserted the union finds *more* routes than `app.routes`, which is **false on the version that ships**, where the two are equal. It now asserts the union is a **superset** — never sees less — which holds everywhere.

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.26% coverage**, 2886 passed — run against the locked versions (`uv sync --frozen --extra dev`), which is what CI will now use.

Negative control:

| reverted | tests that fail |
|---|---|
| test.yml installs from requirements.txt again | 4 |
| one pin drifts from the lock | 1 |
| docker/tzdata dropped from the dev extra | 2 |

Closes CashPilot-de1
