### PR TITLE
fix: neither image knew what version it was, so skew was undetectable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            CASHPILOT_VERSION=${{ needs.resolve-tags.outputs.version }}
           tags: ${{ needs.resolve-tags.outputs.ui_tags }}
           cache-from: type=gha,scope=ui
           cache-to: type=gha,mode=max,scope=ui
@@ -175,6 +177,8 @@ jobs:
           file: Dockerfile.worker
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            CASHPILOT_VERSION=${{ needs.resolve-tags.outputs.version }}
           tags: ${{ needs.resolve-tags.outputs.worker_tags }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ RUN uv sync --frozen --no-dev --no-install-project \
 # -- Runtime stage --
 FROM python:3.14-alpine
 
+# The release tag this image was built from, so the app can report what it is.
+# Both apps used to hardcode "0.1.0" while releases were tag-driven and past
+# 1.11, which made UI/worker skew undetectable (CashPilot-l6c). Defaults to dev
+# so a local `docker build` says so rather than claiming a release.
+ARG CASHPILOT_VERSION=dev
+ENV CASHPILOT_VERSION=$CASHPILOT_VERSION
+
 LABEL maintainer="Sergio Fernandez <9169332+GeiserX@users.noreply.github.com>"
 LABEL org.opencontainers.image.description="CashPilot - Self-hosted passive income orchestrator"
 LABEL org.opencontainers.image.url="https://github.com/GeiserX/CashPilot"

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -18,6 +18,13 @@ RUN uv sync --frozen --no-dev --no-install-project \
 # -- Runtime stage --
 FROM python:3.14-alpine
 
+# The release tag this image was built from, so the app can report what it is.
+# Both apps used to hardcode "0.1.0" while releases were tag-driven and past
+# 1.11, which made UI/worker skew undetectable (CashPilot-l6c). Defaults to dev
+# so a local `docker build` says so rather than claiming a release.
+ARG CASHPILOT_VERSION=dev
+ENV CASHPILOT_VERSION=$CASHPILOT_VERSION
+
 LABEL maintainer="Sergio Fernandez <9169332+GeiserX@users.noreply.github.com>"
 LABEL org.opencontainers.image.description="CashPilot Worker - Lightweight Docker container orchestration agent"
 LABEL org.opencontainers.image.url="https://github.com/GeiserX/CashPilot"
@@ -46,6 +53,10 @@ COPY --chown=cashpilot:root app/egress.py ./app/
 # Encrypted state export: encryption happens on the WORKER so the UI only
 # ever handles ciphertext.
 COPY --chown=cashpilot:root app/state_backup.py ./app/
+# worker_api imports this to report which release it is; without it the worker
+# crashes on import. The two tests that caught the omission compare this list
+# against worker_api's actual imports.
+COPY --chown=cashpilot:root app/version.py ./app/
 COPY --chown=cashpilot:root app/worker_api.py ./app/
 COPY --chown=cashpilot:root app/orchestrator.py ./app/
 COPY --chown=cashpilot:root app/catalog.py ./app/

--- a/app/main.py
+++ b/app/main.py
@@ -49,6 +49,7 @@ from app import (
     preflight,
     producer_state,
     setup_token,
+    version,
 )
 from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
 
@@ -837,7 +838,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="CashPilot",
-    version="0.1.0",
+    version=version.current(),
     lifespan=lifespan,
     # Off by default. FastAPI serves these unauthenticated, and this app's
     # schema is a map of its own admin surface — every route, parameter and
@@ -3411,8 +3412,16 @@ async def api_list_workers(request: Request) -> list[dict[str, Any]]:
     """List all registered workers."""
     _require_auth_api(request)
     workers = await database.list_workers()
+    ui_version = version.current()
     for w in workers:
         _parse_worker_json(w)
+        # Skew is judged here, where the UI's own version is known, rather than
+        # in the browser: the fleet page would otherwise have to learn what the
+        # UI is running and re-implement the comparison. Both sides must be
+        # known releases for this to be True, so an older worker that predates
+        # version reporting reads as unknown, not as a mismatch.
+        w["ui_version"] = ui_version
+        w["version_skew"] = version.skewed(ui_version, (w.get("system_info") or {}).get("version"))
     return workers
 
 

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -268,6 +268,9 @@ CASHPILOT_WORKER_NAME=server-name</code>
               <span>${esc(sysInfo.os || '-')}${sysInfo.os_version ? ' ' + esc(sysInfo.os_version) : ''}</span>
               <span>${esc(sysInfo.arch || '-')}</span>
               <span>Last seen: ${w.last_heartbeat || 'never'}</span>
+              ${sysInfo.version
+                ? `<span${w.version_skew ? ` style="color:var(--warning); font-weight:600;" title="This worker is on a different release series from the UI (${esc(w.ui_version || '?')}). Update whichever is behind — on Unraid the UI and the worker are two separate apps, so updating one leaves the other."` : ''}>v${esc(sysInfo.version)}${w.version_skew ? ` \u2260 UI v${esc(w.ui_version || '?')}` : ''}</span>`
+                : `<span title="This worker predates version reporting, so CashPilot cannot tell which release it is. Update it to find out.">version unknown</span>`}
             </div>
             ${isAndroid && items.length > 0 ? renderApps(items, isOnline, w.last_heartbeat) : ''}
             ${!isAndroid && items.length > 0 ? renderContainers(w, isOnline) : ''}

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,62 @@
+"""The version this image was built as.
+
+Both apps hardcoded ``version="0.1.0"`` while releases are tag-driven and had
+reached 1.11.x, so neither image knew or reported what it was. That made UI /
+worker skew completely undetectable: an Unraid user updating the CashPilot app
+but not the CashPilot Worker app — two separate Community Applications entries,
+each on ``:latest`` — ends up running a 1.11 UI against a 1.4 worker, and
+nothing in the fleet page, the workers table, the heartbeat or any log says so.
+The symptoms surface as unexplained missing data (a worker that never reports an
+egress IP, a button that 404s) with no way for the user or a support thread to
+identify the cause.
+
+The value is baked in at build time from the release tag. ``dev`` is the honest
+answer anywhere else — a checkout, a local ``docker build``, the test suite —
+because claiming a release number there would be worse than admitting ignorance.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: What an image reports when it was not built from a release tag.
+UNKNOWN = "dev"
+
+
+def current() -> str:
+    """The running version, or ``dev`` outside a release build."""
+    return (os.getenv("CASHPILOT_VERSION") or "").strip() or UNKNOWN
+
+
+def is_release(value: str | None = None) -> bool:
+    """Whether a version string names an actual release rather than ``dev``."""
+    return (value if value is not None else current()) not in ("", UNKNOWN, "latest", None)
+
+
+def series(value: str | None) -> str | None:
+    """The MAJOR.MINOR of a version, which is what skew is judged on.
+
+    Patch releases inside a series are meant to interoperate; a difference in
+    major or minor is the one worth telling somebody about.
+    """
+    text = (value or "").strip().lstrip("v")
+    if not is_release(text):
+        return None
+    parts = text.split(".")
+    if len(parts) < 2 or not all(p.isdigit() for p in parts[:2]):
+        return None
+    return f"{parts[0]}.{parts[1]}"
+
+
+def skewed(ui: str | None, worker: str | None) -> bool:
+    """True only when both sides are known releases AND their series differ.
+
+    Deliberately conservative. An unknown version on either side is not
+    evidence of skew — an older worker that predates version reporting sends
+    nothing at all, and calling that "skewed" would light a warning on every
+    fleet during the upgrade that introduces this.
+    """
+    ui_series, worker_series = series(ui), series(worker)
+    if ui_series is None or worker_series is None:
+        return False
+    return ui_series != worker_series

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -34,7 +34,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from app import egress, fleet_key, orchestrator, state_backup
+from app import egress, fleet_key, orchestrator, state_backup, version
 
 try:
     from app.catalog import get_services as _catalog_get_services
@@ -412,6 +412,10 @@ async def _send_heartbeat() -> None:
             "arch": platform.machine(),
             "hostname": socket.gethostname(),
             "docker_available": await asyncio.to_thread(orchestrator.docker_available),
+            # So the UI can tell an operator when the two halves are different
+            # releases. An older worker sends nothing here, which reads as
+            # unknown rather than as a mismatch (CashPilot-l6c).
+            "version": version.current(),
             # Providers count devices per public IP, so the UI needs the address
             # the provider sees — not this container's LAN or tailnet address.
             "egress_ip": await _detect_egress_ip(),
@@ -546,7 +550,7 @@ async def lifespan(app: FastAPI):
     logger.info("CashPilot Worker stopped")
 
 
-app = FastAPI(title="CashPilot Worker", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="CashPilot Worker", version=version.current(), lifespan=lifespan)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_beads_batch_33.py
+++ b/tests/test_beads_batch_33.py
@@ -1,0 +1,159 @@
+"""CashPilot-l6c: neither image knew what version it was.
+
+Both apps hardcoded ``version="0.1.0"`` while releases are tag-driven and had
+reached 1.11.x. The heartbeat carried no version, the workers table had no
+column for one, and nothing in the fleet page, the logs or any payload said what
+either half was running.
+
+That makes UI/worker skew undetectable. On Unraid the UI and the worker are two
+separate Community Applications entries, each on ``:latest``, so updating one
+and not the other is a single click — and the result is a 1.11 UI against a 1.4
+worker with no indication anywhere. The symptoms are unexplained missing data: a
+worker that never reports an egress IP, a button that 404s.
+
+The version is baked in at build time from the release tag and travels in the
+heartbeat, which needs no migration because ``system_info`` is already a stored
+JSON blob.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestTheVersionIsHonestAboutWhatItKnows:
+    def test_outside_a_release_build_it_says_dev(self, monkeypatch):
+        from app import version
+
+        monkeypatch.delenv("CASHPILOT_VERSION", raising=False)
+        assert version.current() == "dev"
+
+    def test_a_release_build_reports_its_tag(self, monkeypatch):
+        from app import version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", "1.11.15")
+        assert version.current() == "1.11.15"
+
+    def test_an_empty_value_is_not_a_version(self, monkeypatch):
+        """An unset build arg must not read as a release called ''."""
+        from app import version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", "   ")
+        assert version.current() == "dev"
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("1.11.15", "1.11"), ("v1.4.4", "1.4"), ("dev", None), ("latest", None), ("", None), (None, None)],
+    )
+    def test_the_series_is_what_skew_is_judged_on(self, value, expected):
+        from app import version
+
+        assert version.series(value) == expected
+
+
+class TestSkewIsOnlyClaimedWhenItIsKnown:
+    @pytest.mark.parametrize(
+        ("ui", "worker", "skewed"),
+        [
+            ("1.11.15", "1.4.4", True),  # the bead's exact case
+            ("1.11.15", "1.11.2", False),  # same series: patches interoperate
+            ("1.11.15", None, False),  # an older worker sends nothing
+            ("1.11.15", "dev", False),  # a locally built worker
+            ("dev", "1.11.15", False),  # a locally built UI
+            (None, None, False),
+        ],
+    )
+    def test_it(self, ui, worker, skewed):
+        from app import version
+
+        assert version.skewed(ui, worker) is skewed
+
+    def test_an_unknown_worker_is_not_a_mismatch(self):
+        """The upgrade that introduces this must not light up every fleet.
+
+        Every worker predating this change sends no version at all. Reporting
+        that as skew would put a warning on every card in the fleet on the day
+        the UI is updated, which is exactly the false alarm that teaches people
+        to ignore warnings.
+        """
+        from app import version
+
+        assert version.skewed("1.11.15", None) is False
+
+
+class TestBothImagesLearnTheirVersion:
+    @pytest.mark.parametrize("dockerfile", ["Dockerfile", "Dockerfile.worker"])
+    def test_it_takes_a_build_arg(self, dockerfile):
+        text = (ROOT / dockerfile).read_text(encoding="utf-8")
+        assert "ARG CASHPILOT_VERSION" in text
+        assert "ENV CASHPILOT_VERSION=$CASHPILOT_VERSION" in text
+
+    @pytest.mark.parametrize("dockerfile", ["Dockerfile", "Dockerfile.worker"])
+    def test_it_defaults_to_dev(self, dockerfile):
+        """A local `docker build` must not claim to be a release."""
+        text = (ROOT / dockerfile).read_text(encoding="utf-8")
+        assert "ARG CASHPILOT_VERSION=dev" in text
+
+    def test_the_build_passes_the_resolved_version_to_both(self):
+        import yaml
+
+        doc = yaml.safe_load((ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8"))
+        builds = [
+            step
+            for job in doc["jobs"].values()
+            for step in job.get("steps") or []
+            if str(step.get("uses", "")).startswith("docker/build-push-action")
+        ]
+        assert len(builds) >= 2, f"expected a build step per image, found {len(builds)}"
+        for step in builds:
+            args = (step.get("with") or {}).get("build-args") or ""
+            assert "CASHPILOT_VERSION=" in args, (
+                f"a build step passes no version: {(step.get('with') or {}).get('file')}"
+            )
+
+    def test_the_worker_image_ships_the_module(self):
+        """It is imported at worker startup; omitting it crashes the worker.
+
+        Two existing tests caught this when the module was first added — the
+        assertion is repeated here because it is what makes the rest reachable.
+        """
+        text = (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")
+        assert re.search(r"^COPY .*app/version\.py \./app/", text, re.M)
+
+    @pytest.mark.parametrize("module", ["app/main.py", "app/worker_api.py"])
+    def test_neither_app_hardcodes_a_placeholder(self, module):
+        text = (ROOT / module).read_text(encoding="utf-8")
+        assert 'version="0.1.0"' not in text, f"{module} still reports the 0.1.0 placeholder"
+        assert "version.current()" in text
+
+
+class TestTheWorkerReportsItAndTheUISurfacesIt:
+    def test_the_heartbeat_carries_the_version(self):
+        text = (ROOT / "app" / "worker_api.py").read_text(encoding="utf-8")
+        i = text.index('"docker_available"')
+        assert '"version": version.current()' in text[i : i + 600], "the heartbeat payload has no version"
+
+    def test_the_workers_endpoint_reports_skew(self):
+        text = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'w["version_skew"] = version.skewed(' in text
+        assert 'w["ui_version"] = ui_version' in text
+
+    def test_the_fleet_card_shows_it(self):
+        text = (ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8")
+        assert "sysInfo.version" in text
+        assert "version_skew" in text
+
+    def test_an_unknown_version_says_so_rather_than_nothing(self):
+        """Blank space would read as "no problem" for a worker too old to say."""
+        text = (ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8")
+        assert "version unknown" in text
+
+    def test_the_warning_says_what_to_do(self):
+        """ "Different versions" without the Unraid detail is not actionable."""
+        text = (ROOT / "app" / "templates" / "fleet.html").read_text(encoding="utf-8")
+        assert "two separate apps" in text


### PR DESCRIPTION
## The defect

Both apps hardcoded `version="0.1.0"` while releases are tag-driven and had reached **1.11.x**. The heartbeat carried no version, the workers table had no column for one, and nothing in the fleet page, the logs, or any payload said what either half was running.

On Unraid the UI and the worker are **two separate Community Applications entries, each on `:latest`** — so updating one and not the other is a single click. The result is a 1.11 UI against a 1.4 worker with no indication anywhere. The symptoms are unexplained missing data: a worker that never reports an egress IP, a button that 404s, and nothing to point a support thread at.

## The fix

The version is baked in at build time from the release tag `build.yml` **already resolves**, and travels in the heartbeat — which needs no migration, because `system_info` is already a stored JSON blob. The fleet card shows it, and the workers endpoint computes skew where the UI's own version is known, rather than making the browser re-implement the comparison.

Three deliberate limits:

- **`dev` outside a release build.** A local `docker build` claiming a release number would be worse than admitting ignorance.
- **Skew is judged on MAJOR.MINOR.** Patch releases inside a series are meant to interoperate; flagging them would be noise.
- **An unknown version is not skew.** Every worker predating this change sends nothing. Reporting that as a mismatch would put a warning on *every card in the fleet* the day the UI is updated — the false alarm that teaches people to ignore warnings. Those workers are labelled "version unknown", which says what's missing without claiming a fault.

## The existing suite caught a real bug

`app/version.py` is imported by `worker_api.py`, and I hadn't added it to `Dockerfile.worker`'s COPY list — which would have **crashed the worker at startup**. Two existing tests (`test_every_imported_module_is_copied_into_the_image`, `test_worker_api_imports_are_all_copied`) failed immediately. Exactly what they're for.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, `build.yml` parses, **95.26% coverage**, 2927 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| treat an unknown version as skew | 4 |
| judge on the full version rather than the series | 3 |
| drop the version from the heartbeat | 1 |
| stop shipping the module in the worker image | 1 |

Closes CashPilot-l6c
