### PR TITLE
fix: the running-costs feature had no way to configure it

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3412,6 +3412,7 @@ async def api_list_workers(request: Request) -> list[dict[str, Any]]:
     """List all registered workers."""
     _require_auth_api(request)
     workers = await database.list_workers()
+    config = await database.get_config() or {}
     ui_version = version.current()
     for w in workers:
         _parse_worker_json(w)
@@ -3422,6 +3423,14 @@ async def api_list_workers(request: Request) -> list[dict[str, Any]]:
         # version reporting reads as unknown, not as a mismatch.
         w["ui_version"] = ui_version
         w["version_skew"] = version.skewed(ui_version, (w.get("system_info") or {}).get("version"))
+        # The per-machine power settings the running-costs card needs, read the
+        # SAME way api_fleet_economics reads them — client_id first, row id as
+        # the fallback for values written before that changed. Returning them
+        # here is what lets the fleet page show the current value in its input
+        # rather than an empty box that silently overwrites what is stored.
+        raw_watts = config.get(f"worker_{_worker_config_key(w)}_watts") or config.get(f"worker_{w.get('id')}_watts")
+        w["watts"] = raw_watts or ""
+        w["dedicated"] = _worker_flag(config, w, "dedicated")
     return workers
 
 

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -60,15 +60,33 @@ CASHPILOT_WORKER_NAME=server-name</code>
 </div>
 
 <!-- Is this fleet worth running?
-     Hidden until there is a tariff to answer it with: with no electricity price
-     configured the honest answer is "unknown", and a card saying so on every
-     visit is noise. The backend computes all of this and, until now, nothing
-     asked it. -->
+     The card needs an electricity price to answer that, and until now there was
+     no way to enter one: the keys existed, the backend read them, and nothing
+     in the app ever wrote them. A user who only uses the app saw "unknown"
+     forever with no route out of it (CashPilot-jm6). The inputs below are that
+     route. The verdict area stays hidden until there is something to say. -->
 <div class="card" style="margin-bottom: 24px; display:none;" id="fleet-economics-card">
   <div class="card-header">
     <span class="card-title">Running costs</span>
     <span style="font-size:0.72rem; color:var(--text-muted);" id="fleet-economics-quality"></span>
   </div>
+
+  <div id="power-settings" style="display:flex; gap:12px; flex-wrap:wrap; align-items:flex-end; padding:12px 0; border-bottom:1px solid var(--border-color); margin-bottom:12px;">
+    <div>
+      <label for="power-price" style="display:block; font-size:0.7rem; color:var(--text-muted); margin-bottom:4px;">Electricity price per kWh</label>
+      <input id="power-price" class="form-input" type="number" step="0.001" min="0" style="width:9rem;"
+             placeholder="0.30" aria-describedby="power-help">
+    </div>
+    <div>
+      <label for="power-currency" style="display:block; font-size:0.7rem; color:var(--text-muted); margin-bottom:4px;">Currency</label>
+      <input id="power-currency" class="form-input" type="text" maxlength="4" style="width:5.5rem;" placeholder="EUR">
+    </div>
+    <button class="btn btn-primary btn-sm" id="power-save">Save</button>
+    <span id="power-help" style="font-size:0.7rem; color:var(--text-muted);">
+      Your tariff, as it appears on your bill. Figures below are converted to USD.
+    </span>
+  </div>
+
   <div id="fleet-economics-body"></div>
 </div>
 
@@ -140,6 +158,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
 
       renderWorkers(workers);
       loadFleetEconomics();
+      loadPowerSettings();
     } catch (err) {
       const msg = (err.message || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]);
       document.getElementById('fleet-workers').innerHTML =
@@ -173,6 +192,9 @@ CASHPILOT_WORKER_NAME=server-name</code>
 
     const machines = (economics && economics.machines) || [];
     if (!machines.length) { card.style.display = 'none'; return; }
+    // Shown as soon as there are machines, not once a tariff exists. Hiding it
+    // until configured made the one control that configures it unreachable.
+    card.style.display = '';
 
     const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c =>
       ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]);
@@ -268,6 +290,19 @@ CASHPILOT_WORKER_NAME=server-name</code>
               <span>${esc(sysInfo.os || '-')}${sysInfo.os_version ? ' ' + esc(sysInfo.os_version) : ''}</span>
               <span>${esc(sysInfo.arch || '-')}</span>
               <span>Last seen: ${w.last_heartbeat || 'never'}</span>
+              <span>
+                <label for="watts-${esc(w.client_id || w.id)}" style="color:var(--text-muted);">Draw</label>
+                <input id="watts-${esc(w.client_id || w.id)}" class="power-watts form-input" type="number" min="0" step="1"
+                       data-client-id="${esc(w.client_id || w.id)}" value="${esc(w.watts ?? '')}"
+                       placeholder="65" style="width:5rem; padding:2px 6px; font-size:0.78rem;"
+                       title="Wall power this machine draws, in watts. Without it CashPilot cannot say what the machine costs to run.">W
+                <label style="color:var(--text-muted); margin-left:8px;">
+                  <input type="checkbox" class="power-dedicated" data-client-id="${esc(w.client_id || w.id)}" ${w.dedicated ? 'checked' : ''}>
+                  dedicated
+                </label>
+                <button class="btn btn-ghost btn-sm power-save-worker" data-client-id="${esc(w.client_id || w.id)}"
+                        style="font-size:0.7rem; padding:1px 6px;">Save</button>
+              </span>
               ${sysInfo.version
                 ? `<span${w.version_skew ? ` style="color:var(--warning); font-weight:600;" title="This worker is on a different release series from the UI (${esc(w.ui_version || '?')}). Update whichever is behind — on Unraid the UI and the worker are two separate apps, so updating one leaves the other."` : ''}>v${esc(sysInfo.version)}${w.version_skew ? ` \u2260 UI v${esc(w.ui_version || '?')}` : ''}</span>`
                 : `<span title="This worker predates version reporting, so CashPilot cannot tell which release it is. Update it to find out.">version unknown</span>`}
@@ -383,7 +418,84 @@ CASHPILOT_WORKER_NAME=server-name</code>
     }
   }
 
-  document.getElementById('fleet-workers').addEventListener('click', function(e) {
+  // The tariff the running-costs card needs. These keys were read by
+  // app/main.py and written by nothing: no field, no docs, no route short of
+  // hand-crafting a POST /api/config (CashPilot-jm6).
+  async function loadPowerSettings() {
+    const price = document.getElementById('power-price');
+    const currency = document.getElementById('power-currency');
+    if (!price || !currency) return;
+    try {
+      const config = await CP.api('/api/config');
+      // power_price_per_kwh is canonical; electricity_price_per_kwh is the older
+      // name main.py still honours, so an existing setting shows up here rather
+      // than looking unset and being silently overwritten.
+      const stored = config.power_price_per_kwh ?? config.electricity_price_per_kwh;
+      if (stored != null && stored !== '') price.value = stored;
+      if (config.power_currency) currency.value = config.power_currency;
+    } catch (err) {
+      console.warn('Could not read the power settings:', err);
+    }
+  }
+
+  async function savePowerSettings() {
+    const price = document.getElementById('power-price');
+    const currency = document.getElementById('power-currency');
+    const raw = (price.value || '').trim();
+    if (raw === '') {
+      CP.toast('Enter your price per kWh first', 'warning');
+      return;
+    }
+    const value = Number(raw);
+    if (!Number.isFinite(value) || value < 0) {
+      CP.toast('That is not a price per kWh', 'error');
+      return;
+    }
+    const code = (currency.value || 'EUR').trim().toUpperCase();
+    try {
+      await CP.api('/api/config', { method: 'POST', body: { data: {
+        power_price_per_kwh: String(value),
+        power_currency: code,
+      } } });
+      CP.toast('Electricity price saved', 'success');
+      loadFleetEconomics();
+    } catch (err) {
+      CP.toast('Could not save: ' + err.message, 'error');
+    }
+  }
+
+  document.getElementById('power-save').addEventListener('click', savePowerSettings);
+
+  document.getElementById('fleet-workers').addEventListener('click', async function(e) {
+    // Per-machine power. machine_economics needs BOTH a tariff and a wattage;
+    // with either missing every machine reports UNKNOWN, which is what the card
+    // did forever because neither had an input (CashPilot-jm6).
+    const powerBtn = e.target.closest('.power-save-worker');
+    if (powerBtn) {
+      const id = powerBtn.dataset.clientId;
+      const watts = document.querySelector(`.power-watts[data-client-id="${CSS.escape(id)}"]`);
+      const dedicated = document.querySelector(`.power-dedicated[data-client-id="${CSS.escape(id)}"]`);
+      const raw = (watts?.value || '').trim();
+      const value = Number(raw);
+      if (raw !== '' && (!Number.isFinite(value) || value < 0)) {
+        CP.toast('That is not a wattage', 'error');
+        return;
+      }
+      try {
+        await CP.api('/api/config', { method: 'POST', body: { data: {
+          // Keyed on client_id, which survives re-enrolment — the row id does
+          // not, and settings keyed on it are orphaned when a host re-enrols.
+          [`worker_${id}_watts`]: raw,
+          [`worker_${id}_dedicated`]: dedicated?.checked ? 'true' : 'false',
+        } } });
+        CP.toast('Machine power saved', 'success');
+        loadFleetEconomics();
+      } catch (err) {
+        CP.toast('Could not save: ' + err.message, 'error');
+      }
+      return;
+    }
+
     const btn = e.target.closest('.btn-remove-worker');
     if (!btn) return;
     const id = parseInt(btn.dataset.workerId, 10);

--- a/tests/test_beads_batch_34.py
+++ b/tests/test_beads_batch_34.py
@@ -1,0 +1,150 @@
+"""CashPilot-jm6: the running-costs feature had no way to configure it.
+
+Every key the feature reads — the electricity price, its currency, the
+per-machine wattage, the dedicated flag — was read by app/main.py and written by
+nothing. No field, no documentation, no route short of hand-crafting a
+POST /api/config with key names that appear nowhere the user can see.
+
+So a user who only uses the app saw the card hidden, or saw "Without your
+electricity price CashPilot cannot say whether that covers the electricity",
+forever. machine_economics returns UNKNOWN for every machine when the price and
+the watts are unset, and both were unsettable.
+
+The card was also hidden until a tariff existed, which made the one control that
+could set a tariff unreachable — so it is now shown as soon as there are
+machines to talk about.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+FLEET = ROOT / "app" / "templates" / "fleet.html"
+
+
+def fleet_html() -> str:
+    return FLEET.read_text(encoding="utf-8")
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.S)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestTheTariffCanBeEntered:
+    def test_there_is_a_price_field(self):
+        assert 'id="power-price"' in fleet_html()
+
+    def test_there_is_a_currency_field(self):
+        """Reading the price without its unit is how the EUR/USD mixing began."""
+        assert 'id="power-currency"' in fleet_html()
+
+    def test_it_writes_the_key_main_py_reads(self):
+        """Asserted together with the CONTROL that triggers the write.
+
+        Checking only for the key names left this passing when the inputs and
+        the save button were removed — the handler still mentioned them. A key
+        name in a function nobody can reach is the bug, not the fix.
+        """
+        source = without_comments(fleet_html())
+        assert "power_price_per_kwh" in source
+        assert "power_currency" in source
+        assert 'id="power-save"' in source, "the key is written by a control the user cannot reach"
+        assert "getElementById('power-save').addEventListener" in source, "the save button is not wired up"
+
+    def test_main_py_still_reads_that_key(self):
+        """The premise. A field writing a key nobody reads is the same bug."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "power_price_per_kwh" in source
+
+    def test_the_legacy_key_is_honoured_when_loading(self):
+        """main.py accepts electricity_price_per_kwh; an existing setting must
+        show in the field rather than looking unset and being overwritten."""
+        assert "electricity_price_per_kwh" in without_comments(fleet_html())
+
+    def test_a_blank_price_is_refused_rather_than_stored(self):
+        source = without_comments(fleet_html())
+        assert "Enter your price per kWh first" in source
+
+    def test_a_nonsense_price_is_refused(self):
+        source = without_comments(fleet_html())
+        assert "Number.isFinite" in source
+
+
+class TestPerMachinePowerCanBeEntered:
+    def test_there_is_a_watts_field(self):
+        assert "power-watts" in fleet_html()
+
+    def test_there_is_a_dedicated_toggle(self):
+        assert "power-dedicated" in fleet_html()
+
+    def test_it_writes_the_keys_main_py_reads(self):
+        source = without_comments(fleet_html())
+        assert "_watts`]" in source or "_watts`" in source
+        assert "_dedicated`" in source
+
+    def test_it_keys_on_client_id_not_the_row_id(self):
+        """The row id does not survive re-enrolment; main.py keys on client_id.
+
+        Writing under the row id would orphan the setting the moment a host is
+        removed and comes back, which is the exact trap _worker_config_key
+        exists to document.
+        """
+        source = without_comments(fleet_html())
+        assert "clientId" in source
+        assert "worker_${id}_watts" in source
+
+    def test_the_endpoint_returns_the_current_values(self):
+        """An empty box that silently overwrites what is stored is worse than
+        no box, so the field has to be able to show what is set."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'w["watts"]' in source
+        assert 'w["dedicated"]' in source
+
+    def test_it_reads_them_the_same_way_the_economics_endpoint_does(self):
+        """Two readers of one setting is how they drift apart."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert source.count("_worker_config_key(") >= 2
+        assert '_worker_flag(config, w, "dedicated")' in source
+
+
+class TestTheCardIsReachable:
+    def test_it_is_shown_once_there_are_machines(self):
+        """It was hidden until a tariff existed, which hid the tariff control."""
+        source = without_comments(fleet_html())
+        i = source.index("if (!machines.length)")
+        assert "card.style.display = ''" in source[i : i + 400]
+
+    def test_an_empty_fleet_still_hides_it(self):
+        """The control: it must not appear on an install with no workers."""
+        source = without_comments(fleet_html())
+        assert "if (!machines.length) { card.style.display = 'none'; return; }" in source
+
+
+class TestTheBackendStillNeedsBoth:
+    """The reason both inputs exist rather than just the tariff."""
+
+    @pytest.mark.parametrize(
+        ("watts", "price", "known"),
+        [(65.0, 0.30, True), (None, 0.30, False), (65.0, None, False), (None, None, False)],
+    )
+    def test_a_cost_needs_a_wattage_and_a_tariff(self, watts, price, known):
+        from app import machine_economics
+
+        out = machine_economics.assess_machine(
+            name="watchtower", monthly_gross=5.0, watts=watts, price_per_kwh=price, dedicated=True
+        )
+        assert (out["monthly_cost"] is not None) is known
+
+    def test_the_unknown_verdict_is_what_the_user_was_stuck_on(self):
+        from app import machine_economics
+
+        out = machine_economics.assess_machine(
+            name="watchtower", monthly_gross=5.0, watts=None, price_per_kwh=None, dedicated=True
+        )
+        assert out["verdict"] == machine_economics.UNKNOWN

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1545,9 +1545,14 @@ class TestApiFleet:
         with (
             _auth_owner(),
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            # The endpoint reads config for the per-machine power settings the
+            # running-costs card shows (CashPilot-jm6).
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
         ):
             resp = client.get("/api/workers")
             assert resp.status_code == 200
+            body = resp.json()
+            assert "watts" in body[0] and "dedicated" in body[0]
 
     def test_api_get_worker(self, client):
         worker = {"id": 1, "name": "w1", "status": "online", "containers": "[]", "apps": "[]", "system_info": "{}"}

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -281,6 +281,9 @@ class TestWorkerList:
         ]
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            # api_list_workers reads config for the per-machine power settings
+            # the running-costs card shows (CashPilot-jm6).
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
             patch("app.main.auth.get_current_user", return_value={"uid": 1, "u": "t", "r": "owner"}),
         ):
             result = _run(api_list_workers(_request()))
@@ -303,6 +306,9 @@ class TestWorkerList:
         ]
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
+            # api_list_workers reads config for the per-machine power settings
+            # the running-costs card shows (CashPilot-jm6).
+            patch("app.main.database.get_config", new_callable=AsyncMock, return_value={}),
             patch("app.main.auth.get_current_user", return_value={"uid": 1, "u": "t", "r": "owner"}),
         ):
             result = _run(api_list_workers(_request()))


### PR DESCRIPTION
## The defect

Every key the running-costs feature reads — electricity price, its currency, per-machine wattage, the dedicated flag — was **read by `app/main.py` and written by nothing**. No field, no documentation, no route short of hand-crafting a `POST /api/config` with key names that appear nowhere the user can see.

So a user who only uses the app saw the card hidden, or saw *"Without your electricity price CashPilot cannot say whether that covers the electricity"*, forever. `machine_economics` returns `UNKNOWN` for every machine when price and watts are unset — and both were unsettable.

The card was also **hidden until a tariff existed**, which made the one control that could set a tariff unreachable.

## The fix

A tariff (price + currency) on the card, and per-machine watts + dedicated on each worker card. All through the existing `POST /api/config`.

- **Both inputs are needed**, not just the tariff: a cost requires a wattage *and* a price, either missing gives `UNKNOWN`. A parametrised test pins that so the reason the per-machine field exists stays visible.
- **Keyed on `client_id`**, matching how `main.py` reads them. The row id doesn't survive re-enrolment, so writing under it would orphan the setting the moment a host is removed and comes back — the trap `_worker_config_key` already documents.
- **`/api/workers` returns the stored values** so the fields show what's set. An empty box that silently overwrites what's stored is worse than no box.
- The legacy `electricity_price_per_kwh` key is honoured when loading, so an existing setting appears rather than looking unset.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.26% coverage**, 2947 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| remove the tariff inputs (the original state) | 3 |
| key per-machine settings on the row id | 1 |
| hide the card until a tariff exists | 1 |
| endpoint stops returning the current values | 1 |

That first control initially failed only **2** — the JS handler survived removing the inputs and still mentioned the key names, so tests looking for those names passed. They now require the save button and its listener too: a key name in a function nobody can reach is the bug, not the fix.

Closes CashPilot-jm6