### PR TITLE
fix: two worker rows, one name, and no way to tell them apart

### DIFF
--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -259,6 +259,18 @@ CASHPILOT_WORKER_NAME=server-name</code>
     const container = document.getElementById('fleet-workers');
     if (!container) return;
 
+    // A worker redeployed with a new or empty /data registers under a fresh
+    // client_id, and the old row stays forever — offline, same display name,
+    // last-known container pills. The operator then picks one to Remove by
+    // guesswork, and removing the LIVE one used to lock that host out
+    // permanently. Naming the duplicates and showing the id is what makes that
+    // choice safe (CashPilot-3fr).
+    const nameCounts = {};
+    for (const w of workers) {
+      const key = String(w.name || '');
+      nameCounts[key] = (nameCounts[key] || 0) + 1;
+    }
+
     let html = '';
 
     if (workers.length === 0) {
@@ -282,8 +294,10 @@ CASHPILOT_WORKER_NAME=server-name</code>
                 <span class="status-dot ${statusClass}"></span>
                 <span style="font-weight: 600; color: var(--text-primary);">${esc(w.name)}</span>
                 ${isAndroid ? '<span style="font-size:0.7rem; padding:2px 6px; border-radius:4px; background:var(--bg-hover); color:var(--text-muted);">Android</span>' : ''}
+                ${nameCounts[String(w.name || '')] > 1 ? `<span style="font-size:0.7rem; padding:2px 6px; border-radius:4px; background:var(--warning-soft, var(--bg-hover)); color:var(--warning);" title="More than one worker is registered under this name. That usually means this host was redeployed with a new or empty /data, so it re-registered under a new id and the old row stayed behind. Compare the ids and the last-seen times before removing one.">duplicate name</span>` : ''}
+                <code style="font-size:0.68rem; color:var(--text-muted); background:var(--bg-hover); padding:1px 5px; border-radius:3px;" title="This worker's client_id — the id CashPilot keys it on. Two rows with the same name always have different ids; this is how to tell which is which.">${esc(w.client_id || ('#' + w.id))}</code>
               </div>
-              ${_isOwner ? `<button class="btn btn-danger btn-sm btn-remove-worker" data-worker-id="${w.id}" data-worker-name="${esc(w.name)}" title="Remove worker">Remove</button>` : ''}
+              ${_isOwner ? `<button class="btn btn-danger btn-sm btn-remove-worker" data-worker-id="${w.id}" data-worker-name="${esc(w.name)}" data-worker-client="${esc(w.client_id || '')}" title="Remove worker">Remove</button>` : ''}
             </div>
             <div style="display: flex; gap: 16px; flex-wrap: wrap; font-size: 0.82rem; color: var(--text-muted);">
               <span>${esc(w.url || '-')}</span>
@@ -407,8 +421,12 @@ CASHPILOT_WORKER_NAME=server-name</code>
     }
   };
 
-  async function removeWorker(workerId, name) {
-    if (!confirm(`Remove worker "${name}"?\n\nIt is removed from the fleet here, but the worker itself keeps running. It will re-enrol on its own after a few minutes of rejected heartbeats. To bring it back immediately, delete /data/.worker_key on that host and restart the container.`)) return;
+  async function removeWorker(workerId, name, clientId) {
+    // The id is in the prompt because two rows can share a display name — a
+    // host redeployed with a new /data leaves its old row behind — and picking
+    // the wrong one takes the LIVE host out of the fleet (CashPilot-3fr).
+    const which = clientId ? `\n\nId: ${clientId}` : '';
+    if (!confirm(`Remove worker "${name}"?${which}\n\nIt is removed from the fleet here, but the worker itself keeps running. It will re-enrol on its own after a few minutes of rejected heartbeats. To bring it back immediately, delete /data/.worker_key on that host and restart the container.`)) return;
     try {
       await CP.api(`/api/workers/${workerId}`, { method: 'DELETE' });
       CP.toast(`Worker "${name}" removed`, 'success');
@@ -501,7 +519,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
     const id = parseInt(btn.dataset.workerId, 10);
     if (isNaN(id)) return;
     const name = btn.dataset.workerName;
-    removeWorker(id, name);
+    removeWorker(id, name, btn.dataset.workerClient);
   });
 
   window.copyWorkerEnv = async function() {

--- a/tests/test_beads_batch_35.py
+++ b/tests/test_beads_batch_35.py
@@ -1,0 +1,134 @@
+"""CashPilot-3fr: two rows, one name, no way to tell them apart.
+
+A worker redeployed with a new or empty ``/data`` — the appdata path changed,
+the volume was recreated — registers under a fresh random ``client_id``. The old
+row stays in the fleet list forever: offline, with its last-known container
+pills, inflating the worker count.
+
+Both rows carry the same display name, and the page rendered no id at all. So
+the operator picked one to Remove by guesswork, and removing the LIVE one takes
+that host out of the fleet.
+
+The automatic purge cannot help here and should not be widened to. It only
+deletes rows with no ``api_key_enc``, and the first heartbeat of every worker
+sets that — so no row that ever heartbeated is eligible. The reason is written
+into ``_check_stale_workers``: a host persists its key locally and re-presents
+it, so deleting an enrolled row leaves no match for that key. Auto-deleting
+enrolled rows trades a cosmetic duplicate for an outage.
+
+What was actually missing is the information needed to choose correctly, so the
+fix is to show it: the id on every card, a flag when a name is duplicated, and
+the id in the removal prompt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FLEET = ROOT / "app" / "templates" / "fleet.html"
+
+
+def fleet_html() -> str:
+    return FLEET.read_text(encoding="utf-8")
+
+
+def without_comments(text: str) -> str:
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.S)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestTheIdIsVisible:
+    """Asserted on the DISPLAYED element, not on the expression.
+
+    The first version looked for `w.client_id ||` anywhere in the file. That
+    expression also appears six times in the per-machine power inputs
+    (CashPilot-jm6), which are data attributes the user never reads — so
+    deleting the visible id left the test passing. What matters here is that
+    something RENDERS it.
+    """
+
+    def _id_element(self) -> str:
+        source = without_comments(fleet_html())
+        marker = '<code style="font-size:0.68rem'
+        assert marker in source, "no element renders the worker id on the card"
+        start = source.index(marker)
+        return source[start : source.index("</code>", start)]
+
+    def test_every_card_renders_the_client_id(self):
+        assert "w.client_id" in self._id_element()
+
+    def test_it_falls_back_to_the_row_id(self):
+        """A worker from before client_id existed still needs to be identifiable."""
+        assert "'#' + w.id" in self._id_element()
+
+    def test_the_id_is_escaped(self):
+        """It reaches the DOM through innerHTML like everything else here."""
+        assert "esc(" in self._id_element()
+
+    def test_it_says_what_the_id_is_for(self):
+        """A bare hex string with no explanation is not usable information."""
+        assert "how to tell which is which" in fleet_html()
+
+
+class TestDuplicateNamesAreFlagged:
+    def test_the_page_counts_names(self):
+        source = without_comments(fleet_html())
+        assert "nameCounts" in source
+
+    def test_it_marks_a_duplicated_name(self):
+        source = without_comments(fleet_html())
+        assert "duplicate name" in source
+
+    def test_the_flag_explains_the_cause(self):
+        """ "Duplicate" without the reason invites deleting the wrong row."""
+        source = fleet_html()
+        assert "redeployed with a new or empty /data" in source
+
+    def test_it_tells_the_operator_what_to_compare(self):
+        source = fleet_html()
+        assert "Compare the ids and the last-seen times" in source
+
+    def test_a_unique_name_is_not_flagged(self):
+        """The control: the badge is conditional, not always rendered."""
+        source = without_comments(fleet_html())
+        assert "> 1 ?" in source, "the duplicate badge is not gated on a count"
+
+
+class TestTheRemovalPromptNamesWhichOne:
+    def test_it_takes_the_client_id(self):
+        source = without_comments(fleet_html())
+        assert "function removeWorker(workerId, name, clientId)" in source
+
+    def test_the_handler_passes_it(self):
+        source = without_comments(fleet_html())
+        assert "removeWorker(id, name, btn.dataset.workerClient)" in source
+
+    def test_the_button_carries_it(self):
+        source = without_comments(fleet_html())
+        assert "data-worker-client=" in source
+
+    def test_the_prompt_shows_it(self):
+        source = without_comments(fleet_html())
+        assert "Id: ${clientId}" in source
+
+    def test_the_existing_warning_survives(self):
+        """The control: the re-enrolment explanation must not be lost."""
+        source = fleet_html()
+        assert "delete /data/.worker_key on that host" in source
+
+
+class TestTheAutomaticPurgeIsDeliberatelyUnchanged:
+    """Widening it would trade a cosmetic duplicate for a real outage."""
+
+    def test_enrolled_rows_are_still_never_auto_deleted(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'not w.get("api_key_enc")' in source, (
+            "the purge now deletes enrolled workers; a host that persists its key would be dropped"
+        )
+
+    def test_the_reason_is_still_recorded(self):
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert "permanent fleet lockout" in source


### PR DESCRIPTION
## The defect

A worker redeployed with a new or empty `/data` — appdata path changed, volume recreated — registers under a **fresh random `client_id`**. The old row stays in the fleet list forever: offline, with its last-known container pills, inflating the worker count.

Both rows carry the **same display name**, and the page rendered **no id at all**. So the operator picks one to Remove by guesswork — and removing the live one takes that host out of the fleet.

## Why the automatic purge isn't the answer

It only deletes rows with no `api_key_enc`, and **the first heartbeat of every worker sets that** — so no row that ever heartbeated is eligible. `_check_stale_workers` records the reason: a host persists its key locally and re-presents it, so deleting an enrolled row leaves no match for that key.

Widening the purge would trade a cosmetic duplicate for an outage. A test now pins that it stays as it is, with the reasoning intact.

## The fix

What was missing is the information needed to choose correctly:

- every card shows the **`client_id`** (falling back to `#rowid` for pre-`client_id` workers)
- a **duplicated name is flagged**, with the cause and what to compare
- the **removal prompt names the id**

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.26% coverage**, 2963 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| remove the id element (the original state) | 4 |
| drop the duplicate flag | 3 |
| take the id out of the removal prompt | 1 |

The id tests were **rewritten after the first control caught them**. They matched `w.client_id ||` anywhere in the file — and that expression appears six times in the per-machine power inputs from #219, which are data attributes the user never reads. Deleting the *visible* id left them passing. They now pin the rendered element.

Closes CashPilot-3fr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Fleet worker cards now display each worker’s client ID, making similarly named workers easier to distinguish.
  - Duplicate worker names are clearly flagged with guidance for comparison and redeployment.
  - Worker removal confirmations now identify the specific worker being removed while retaining the existing re-enrollment warning.

- **Bug Fixes**
  - Improved worker removal safety by preventing ambiguity when multiple workers share the same display name.
  - Automatic purging behavior remains limited to unenrolled workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->