### PR TITLE
fix: a worker named "toString" was never flagged as a duplicate

### DIFF
--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -255,21 +255,36 @@ CASHPILOT_WORKER_NAME=server-name</code>
     body.innerHTML = rows + services;
   }
 
+  // How many workers share each display name.
+  //
+  // A worker redeployed with a new or empty /data registers under a fresh
+  // client_id, and the old row stays forever — offline, same display name,
+  // last-known container pills. The operator then picks one to Remove by
+  // guesswork, and removing the LIVE one takes that host out of the fleet.
+  // Naming the duplicates and showing the id is what makes that choice safe
+  // (CashPilot-3fr).
+  //
+  // Object.create(null), not {}. A worker name is user-controlled
+  // (CASHPILOT_WORKER_NAME), so it can be "__proto__" or "toString". On a plain
+  // object `counts["__proto__"] = ...` hits a setter and the count never
+  // sticks, and `counts["toString"] || 0` reads the inherited FUNCTION —
+  // producing the string "function toString() { [native code] }11" as a count.
+  // Either way two workers with that name are never flagged as duplicates,
+  // which is the one case this whole feature exists for. (CodeRabbit, PR #220.)
+  function countWorkerNames(workers) {
+    const counts = Object.create(null);
+    for (const w of workers || []) {
+      const key = String(w.name || '');
+      counts[key] = (counts[key] || 0) + 1;
+    }
+    return counts;
+  }
+
   function renderWorkers(workers) {
     const container = document.getElementById('fleet-workers');
     if (!container) return;
 
-    // A worker redeployed with a new or empty /data registers under a fresh
-    // client_id, and the old row stays forever — offline, same display name,
-    // last-known container pills. The operator then picks one to Remove by
-    // guesswork, and removing the LIVE one used to lock that host out
-    // permanently. Naming the duplicates and showing the id is what makes that
-    // choice safe (CashPilot-3fr).
-    const nameCounts = {};
-    for (const w of workers) {
-      const key = String(w.name || '');
-      nameCounts[key] = (nameCounts[key] || 0) + 1;
-    }
+    const nameCounts = countWorkerNames(workers);
 
     let html = '';
 

--- a/scripts/fleet_staleness_check.mjs
+++ b/scripts/fleet_staleness_check.mjs
@@ -33,9 +33,9 @@ function extract(name) {
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
 const fmtBytes = b => `${b}B`;
-const source = [extract('staleNote'), extract('renderContainers'), extract('renderApps')].join('\n');
-const build = new Function('esc', 'fmtBytes', `${source}; return {renderContainers, renderApps, staleNote};`);
-const {renderContainers, renderApps} = build(esc, fmtBytes);
+const source = [extract('staleNote'), extract('renderContainers'), extract('renderApps'), extract('countWorkerNames')].join('\n');
+const build = new Function('esc', 'fmtBytes', `${source}; return {renderContainers, renderApps, staleNote, countWorkerNames};`);
+const {renderContainers, renderApps, countWorkerNames} = build(esc, fmtBytes);
 
 const WORKER = {
   name: 'geiserback',
@@ -86,9 +86,31 @@ check('app traffic tooltip survives', appsOnline.includes('24h:'),
 check('offline apps keep both tooltips', appsOffline.includes('Last reported') && appsOffline.includes('24h:'),
   'the staleness note replaced the traffic figures instead of joining them');
 
+// 6. Duplicate display names, including names that collide with Object's own
+//    keys. A worker name is user-controlled (CASHPILOT_WORKER_NAME), and on a
+//    plain {} a name of "__proto__" or "toString" makes the count unusable —
+//    so two such workers are never flagged, which is the one case the feature
+//    exists for. This cannot be seen from the source; it has to be run.
+const named = names => names.map(n => ({name: n}));
+const ordinary = countWorkerNames(named(['watchtower', 'watchtower', 'geiserback']));
+check('an ordinary duplicate is counted', ordinary['watchtower'] === 2,
+  `expected 2, got ${JSON.stringify(ordinary['watchtower'])}`);
+check('a unique name is counted once', ordinary['geiserback'] === 1,
+  `expected 1, got ${JSON.stringify(ordinary['geiserback'])}`);
+
+for (const hostile of ['__proto__', 'toString', 'constructor', 'valueOf', 'hasOwnProperty']) {
+  const counts = countWorkerNames(named([hostile, hostile]));
+  check(`duplicate "${hostile}" is flagged`, counts[hostile] === 2,
+    `count was ${JSON.stringify(counts[hostile])} — a plain {} makes this unusable`);
+}
+check('a single hostile name is not flagged', countWorkerNames(named(['__proto__']))['__proto__'] === 1,
+  'a lone worker was reported as a duplicate');
+check('no workers is not a crash', Object.keys(countWorkerNames([])).length === 0, 'empty input misbehaved');
+check('undefined is not a crash', Object.keys(countWorkerNames(undefined)).length === 0, 'undefined misbehaved');
+
 if (failures.length) {
   console.error('fleet staleness check FAILED:');
   for (const f of failures) console.error(`  - ${f}`);
   process.exit(1);
 }
-console.log(`fleet staleness check passed (${11} assertions)`);
+console.log(`fleet staleness check passed (${20} assertions)`);


### PR DESCRIPTION
CodeRabbit on #220, and it is a real reachable bug rather than a theoretical one: a worker name is user-controlled via `CASHPILOT_WORKER_NAME`.

## Measured, not reasoned about

```js
counts["__proto__"] = (counts["__proto__"] || 0) + 1   // -> {}
counts["toString"]  = (counts["toString"]  || 0) + 1   // -> "function toString() { [native code] }11"
```

Assigning to `__proto__` hits a setter and never sticks. Reading `toString` picks up the **inherited function** and concatenates onto it. Either way the count isn't a number, `> 1` is false, and **two workers with that name are never flagged** — the one case the feature exists for.

Affects `__proto__`, `toString`, `constructor`, `valueOf`, `hasOwnProperty`.

## The fix

`Object.create(null)`.

The counting is now a **named function** so it can be *run* rather than read — the node harness exercises it directly with all five hostile names, and CI already runs that harness.

## Evidence

Negative control — restoring the plain `{}`:

```
- duplicate "__proto__" is flagged: count was {}
- duplicate "toString" is flagged: count was "function toString() { [native code] }11"
- duplicate "constructor" is flagged: count was "function Object() { [native code] }11"
- duplicate "valueOf" is flagged: count was "function valueOf() { [native code] }11"
- duplicate "hasOwnProperty" is flagged: count was "function hasOwnProperty() { [native code] }11"
- a single hostile name is not flagged: a lone worker was reported as a duplicate
```

`ruff check` + `ruff format --check` clean, 20 harness assertions, 2963 passed.

Process note: I merged #220 before reading this comment, which was out of order — the rule is to address findings first. This is the follow-up.