### PR TITLE
fix: the LAN-isolation warning named the wrong service, twice

### DIFF
--- a/app/lan_isolation.py
+++ b/app/lan_isolation.py
@@ -84,23 +84,39 @@ def exceptions_for(service: dict[str, Any] | None) -> list[dict[str, str]]:
                 "detail": f"Port {port} must accept inbound connections, or the node cannot do its job.",
             }
         )
-    # Keyed on HAVING a collector, not on being one particular service. The
-    # `or slug == "storj"` this replaces never changed an outcome — storj
-    # declares a collector, so the first clause already matched — while
-    # hardcoding a slug in app/ is exactly what the catalog exists to avoid.
-    if (service or {}).get("collector"):
-        api_url_env = [
-            e.get("key")
-            for e in (_docker(service).get("env") or [])
-            if isinstance(e, dict) and "URL" in str(e.get("key", ""))
-        ]
-        if api_url_env:
+    # Gated on CashPilot actually having a collector for this slug, and on that
+    # collector reading from an address the user configures.
+    #
+    # It used to be `if service.get("collector")` plus "any docker env whose key
+    # contains URL". Every one of the 50 YAMLs carries a collector: block
+    # whether or not a collector exists, so the first half was always true; and
+    # the second half matched proxybase-xyz's BACKEND_URL, which is the
+    # PROVIDER'S REMOTE endpoint (https://api.proxybase.xyz), not a local
+    # dashboard. So the page told users that a service with no collector at all
+    # — collector.type is manual, the slug is absent from COLLECTOR_MAP — needed
+    # a network exception for a remote URL, and said CashPilot read its earnings
+    # from a local dashboard. Both halves were false.
+    #
+    # Meanwhile storj, the one service that genuinely serves its earnings from a
+    # local dashboard on port 14002, got no exception at all — so a user
+    # isolating their containers lost Storj collection with no warning.
+    #
+    # Imported lazily: app.collectors pulls in every collector module, and this
+    # module is imported by anything that assesses a service.
+    from app.collectors import _COLLECTOR_ARGS, COLLECTOR_MAP
+
+    slug = str((service or {}).get("slug") or "")
+    if slug in COLLECTOR_MAP:
+        # The collector's own configured address, not an arbitrary env var. A
+        # leading "?" marks the argument optional in the registry.
+        url_args = [a.lstrip("?") for a in _COLLECTOR_ARGS.get(slug, []) if "url" in a.lower()]
+        if url_args:
             found.append(
                 {
                     "kind": "collector_reachability",
                     "detail": (
-                        "CashPilot reads this service's earnings from its own local dashboard, so that "
-                        f"address ({', '.join(str(k) for k in api_url_env)}) must stay reachable from the UI."
+                        "CashPilot reads this service's earnings from an address you configure "
+                        f"({', '.join(url_args)}), so that address must stay reachable from the UI."
                     ),
                 }
             )

--- a/tests/test_beads_batch_36.py
+++ b/tests/test_beads_batch_36.py
@@ -1,0 +1,114 @@
+"""CashPilot-wi7: the LAN-isolation warning named the wrong service, twice.
+
+``app/lan_isolation.py`` raised a ``collector_reachability`` exception when a
+service had a ``collector:`` block AND any docker env whose key contained
+"URL". Both halves were wrong:
+
+* every one of the 50 catalog YAMLs carries a ``collector:`` block whether or
+  not CashPilot has a collector for it, so the first half was always true;
+* the second matched proxybase-xyz's ``BACKEND_URL``, which is the PROVIDER'S
+  REMOTE endpoint (``https://api.proxybase.xyz`` per the service's own env
+  description), not a local dashboard.
+
+So the page told users that ProxyBase Markets — ``collector.type: manual``, slug
+absent from ``COLLECTOR_MAP``, no collector at all — needed a network exception,
+with the reason "CashPilot reads this service's earnings from its own local
+dashboard". Nothing in that sentence was true of it.
+
+And Storj, the one service that genuinely serves its earnings from a local
+dashboard on port 14002, got no exception — so a user isolating their containers
+lost Storj collection with no warning. The warning was on the service that did
+not need it and missing from the one that did.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _exceptions(slug):
+    from app import catalog, lan_isolation
+
+    return lan_isolation.assess(catalog.get_service(slug))["exceptions"]
+
+
+def _kinds(slug):
+    return [e["kind"] for e in _exceptions(slug)]
+
+
+class TestTheWarningGoesToTheServiceThatNeedsIt:
+    def test_storj_is_warned(self):
+        """It serves earnings from a local dashboard; isolation breaks that."""
+        assert "collector_reachability" in _kinds("storj")
+
+    def test_the_reason_names_the_setting_the_user_configures(self):
+        detail = next(e["detail"] for e in _exceptions("storj") if e["kind"] == "collector_reachability")
+        assert "api_url" in detail
+
+    def test_proxybase_is_not_warned(self):
+        """It has no collector, and its BACKEND_URL is the provider's own API."""
+        assert "collector_reachability" not in _kinds("proxybase-xyz")
+
+    def test_the_claim_about_a_local_dashboard_is_gone(self):
+        """It was said of a remote endpoint, which is what made it false."""
+        source = (ROOT / "app" / "lan_isolation.py").read_text(encoding="utf-8")
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+        assert "its own local dashboard" not in code
+
+
+class TestTheGateIsKeyedOnAnActualCollector:
+    def test_a_yaml_collector_block_is_not_enough(self):
+        """Every catalog entry has one, so it can never distinguish anything."""
+        from app import catalog
+
+        with_block = [s for s in catalog.get_services() if (s.get("collector") or {})]
+        assert len(with_block) > 40, "the premise changed: not every service declares a collector block"
+
+    def test_the_registry_is_what_decides(self):
+        from app.collectors import COLLECTOR_MAP
+
+        assert "storj" in COLLECTOR_MAP
+        assert "proxybase-xyz" not in COLLECTOR_MAP
+
+    @pytest.mark.parametrize("slug", ["honeygain", "earnapp", "grass"])
+    def test_a_collector_with_no_configurable_url_is_not_warned(self, slug):
+        """The exception is about an ADDRESS staying reachable.
+
+        A collector that talks to the provider's own cloud has no local address
+        to protect, so warning about it would be the proxybase mistake again.
+        """
+        assert "collector_reachability" not in _kinds(slug)
+
+    def test_no_service_slug_is_hardcoded_in_the_module(self):
+        """The catalog exists so app/ does not branch on individual services."""
+        source = (ROOT / "app" / "lan_isolation.py").read_text(encoding="utf-8")
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+        for slug in ('"storj"', '"proxybase-xyz"', '"honeygain"'):
+            assert slug not in code, f"{slug} is branched on in app/lan_isolation.py"
+
+
+class TestTheRestOfTheAssessmentIsUnchanged:
+    """The control: this must not have removed the exceptions that were right."""
+
+    def test_inbound_port_exceptions_survive(self):
+        assert "inbound_port" in _kinds("storj")
+
+    def test_a_service_needing_a_port_still_says_so(self):
+        details = [e["detail"] for e in _exceptions("storj") if e["kind"] == "inbound_port"]
+        assert details and any("inbound" in d for d in details)
+
+    def test_assess_still_returns_a_verdict(self):
+        from app import catalog, lan_isolation
+
+        out = lan_isolation.assess(catalog.get_service("storj"))
+        assert out["verdict"]
+        assert out["slug"] == "storj"
+
+    def test_an_unknown_service_is_still_handled(self):
+        from app import lan_isolation
+
+        assert lan_isolation.assess(None)["verdict"] == lan_isolation.NOT_ISOLATABLE


### PR DESCRIPTION
## The defect

`lan_isolation` raised a `collector_reachability` exception when a service had a `collector:` block **and** any docker env whose key contained `URL`. Both halves were wrong:

- **every one of the 50 catalog YAMLs carries a `collector:` block** whether or not CashPilot has a collector for it — so the first half was always true;
- the second matched proxybase-xyz's `BACKEND_URL`, which is the **provider's remote endpoint** (`https://api.proxybase.xyz`, per the service's own env description), not a local dashboard.

So the page told users that **ProxyBase Markets** — `collector.type: manual`, slug absent from `COLLECTOR_MAP`, no collector at all — needed a network exception because *"CashPilot reads this service's earnings from its own local dashboard"*. Nothing in that sentence was true of it.

And **Storj**, the one service that genuinely serves its earnings from a local dashboard on port 14002, got **no exception** — so a user isolating their containers lost Storj collection with no warning.

The warning was on the service that didn't need it, and missing from the one that did.

## The fix

The gate is `COLLECTOR_MAP` membership plus the collector's **own configured URL argument** — so it names the setting the user actually sets (`api_url`) rather than an arbitrary env var.

No slug is hardcoded: the registry decides, which is what the catalog exists for. A test asserts that, since the code this replaces had already been through one round of de-hardcoding. `app.collectors` is imported lazily because it pulls in every collector module.

After the fix:

| service | warned | correct |
|---|---|---|
| storj | ✅ | serves earnings locally on :14002 |
| proxybase-xyz | ❌ | no collector; `BACKEND_URL` is remote |
| honeygain / earnapp / grass | ❌ | collectors talk to the provider's cloud |

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.27% coverage**, 2977 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| the YAML-block-plus-any-URL-env gate (the original) | 4 |
| warn for every collector, not only those with a URL argument | 3 |

Controls also pin that the `inbound_port` exceptions and the overall verdict are unchanged — this must not have "fixed" the warning by removing the ones that were right.

Closes CashPilot-wi7