### PR TITLE
fix: the wizard's expected end state was a dashboard reading zero

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1211,6 +1211,9 @@ async def api_services_available(request: Request) -> list[dict[str, Any]]:
     services = catalog.get_services()
     deployments = await database.get_deployments()
     deployed_slugs = {d["slug"] for d in deployments}
+    # Imported here rather than at module scope: app.collectors pulls in every
+    # collector module.
+    from app.collectors import COLLECTOR_MAP as collector_map
 
     # Also check worker containers for deployed status (catches externally-deployed services)
     worker_containers = await _get_all_worker_containers()
@@ -1235,6 +1238,11 @@ async def api_services_available(request: Request) -> list[dict[str, Any]]:
         svc["deployed"] = slug in deployed_slugs or slug in worker_slugs
         svc["manual_only"] = not has_image
         svc["node_count"] = len(worker_node_counts.get(slug, set()))
+        # The setup wizard reads this endpoint, and it needs to know whether
+        # earnings tracking takes a SECOND set of credentials — the service
+        # detail view already says so, and the wizard is the screen a new user
+        # actually sees (CashPilot-p6s).
+        svc["has_collector"] = slug in collector_map
         available.append(svc)
     return available
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1886,6 +1886,26 @@ const CP = (() => {
     }
   }
 
+  // Earnings tracking takes a SECOND set of credentials.
+  //
+  // The container credentials only configure the container; the dashboard shows
+  // no balance until the same values are entered again under Settings →
+  // Collectors. The service-detail view said so; the setup wizard — the one
+  // screen a new user actually sees — did not, so the expected end state of
+  // onboarding was a dashboard reading zero (CashPilot-p6s).
+  //
+  // One function rather than two copies: a notice that exists twice drifts, and
+  // the wizard's version is the one that matters most.
+  function collectorCredentialsNotice(slug) {
+    return `
+        <div style="font-size:0.8rem; color:var(--text-muted); background:var(--bg-subtle, rgba(255,255,255,0.03)); border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin:10px 0;">
+          The credentials above run the service. To also see its <strong>balance</strong> on the dashboard,
+          add earnings-tracking credentials under
+          <a href="#" data-action="openCredentialModal" data-prevent="1" data-a1="${escapeHtml(slug)}" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
+          after deploying. This is optional — the service earns either way.
+        </div>`;
+  }
+
   function renderServiceSetupForm(svc, workers) {
     const isDeployed = svc.deployed || false;
     const dashboardUrl = (svc.cashout && svc.cashout.dashboard_url) || svc.website || '';
@@ -1953,6 +1973,8 @@ const CP = (() => {
       </div>
 
       ${envFields}
+
+      ${svc.has_collector ? collectorCredentialsNotice(svc.slug) : ''}
 
       ${(() => {
         const onlineWorkers = (workers || []).filter(w => w.status === 'online');
@@ -2343,13 +2365,7 @@ const CP = (() => {
       // The fields above only configure the container that earns; they don't
       // let CashPilot read your balance. Make that explicit at deploy time.
       if (svc.has_collector) {
-        html += `
-        <div style="font-size:0.8rem; color:var(--text-muted); background:var(--bg-subtle, rgba(255,255,255,0.03)); border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin:10px 0;">
-          The credentials above run the service. To also see its <strong>balance</strong> on the dashboard,
-          add earnings-tracking credentials under
-          <a href="#" data-action="openCredentialModal" data-prevent="1" data-a1="${escapeHtml(svc.slug)}" style="color:var(--accent, #3b82f6);">Settings → Collectors</a>
-          after deploying. This is optional — the service earns either way.
-        </div>`;
+        html += collectorCredentialsNotice(svc.slug);
       }
 
       if (allDeployed && onlineWorkers.length > 0) {

--- a/tests/test_beads_batch_37.py
+++ b/tests/test_beads_batch_37.py
@@ -1,0 +1,104 @@
+"""CashPilot-p6s: the wizard's expected end state was a dashboard reading zero.
+
+Step 3 of the setup wizard says "Already have an account? Enter your credentials
+below." A reasonable user concludes that entering them is what makes earnings
+appear. It is not: those values only configure the CONTAINER. The dashboard
+shows no balance until the same credentials are entered again under
+Settings → Collectors.
+
+The service-detail view says exactly that. The wizard — the one screen a new
+user actually sees — said nothing, so completing onboarding correctly still left
+the dashboard at zero with no explanation.
+
+``/api/services/available``, which is what the wizard reads, did not even report
+``has_collector``, so the wizard could not have known.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def js() -> str:
+    text = APP_JS.read_text(encoding="utf-8")
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestTheWizardSaysIt:
+    def test_the_setup_form_renders_the_notice(self):
+        source = js()
+        i = source.index("function renderServiceSetupForm")
+        j = source.index("function ", i + 10)
+        assert "collectorCredentialsNotice" in source[i:j], "the wizard still says nothing about collectors"
+
+    def test_it_is_gated_on_the_service_having_one(self):
+        """A service with no collector has no second step to warn about."""
+        source = js()
+        assert "svc.has_collector ? collectorCredentialsNotice" in source
+
+    def test_the_endpoint_the_wizard_reads_reports_it(self):
+        """The wizard could not have known: the field was not in the payload."""
+        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        i = source.index("async def api_services_available")
+        j = source.index("\n@app.", i)
+        assert 'svc["has_collector"]' in source[i:j]
+
+    def test_the_notice_names_where_to_go(self):
+        assert "Settings → Collectors" in js()
+
+    def test_it_says_the_service_still_earns(self):
+        """Without this it reads as "your deployment is broken", which it is not."""
+        assert "the service earns either way" in js()
+
+
+class TestThereIsOnlyOneWording:
+    """Two copies of a notice drift, and the wizard's is the one that matters."""
+
+    def test_the_helper_exists(self):
+        assert "function collectorCredentialsNotice(slug)" in js()
+
+    def test_both_screens_use_it(self):
+        source = js()
+        assert source.count("collectorCredentialsNotice(") >= 3, (
+            "expected the definition plus a call from the wizard and the detail view"
+        )
+
+    def test_the_detail_view_no_longer_inlines_its_own(self):
+        source = js()
+        i = source.index("function collectorCredentialsNotice")
+        after = source[source.index("}", source.index("return `", i)) :]
+        assert "The credentials above run the service" not in after, "a second copy of the notice is back"
+
+    def test_the_slug_is_escaped(self):
+        """It goes into a data attribute reached through innerHTML."""
+        source = js()
+        i = source.index("function collectorCredentialsNotice")
+        assert "escapeHtml(slug)" in source[i : i + 900]
+
+
+class TestTheDistinctionIsRealNotCosmetic:
+    """The premise: container credentials and collector credentials differ."""
+
+    def test_a_service_with_a_collector_is_flagged(self):
+        from app.collectors import COLLECTOR_MAP
+
+        assert "honeygain" in COLLECTOR_MAP
+
+    def test_a_service_without_one_is_not(self):
+        from app.collectors import COLLECTOR_MAP
+
+        assert "proxybase-xyz" not in COLLECTOR_MAP
+
+    @pytest.mark.parametrize("slug", ["honeygain", "iproyal"])
+    def test_the_collector_takes_its_own_arguments(self, slug):
+        """If they were the same values, re-entering them would be pointless."""
+        from app.collectors import _COLLECTOR_ARGS
+
+        assert _COLLECTOR_ARGS.get(slug), f"{slug} has a collector but declares no arguments"


### PR DESCRIPTION
## The defect

Step 3 of the setup wizard says:

> Already have an account? Enter your credentials below.

A reasonable user concludes that entering them is what makes earnings appear. **It is not.** Those values only configure the *container*. The dashboard shows no balance until the same credentials are entered again under **Settings → Collectors**.

The service-detail view says exactly that. The wizard — the one screen a new user actually sees — said nothing. So completing onboarding *correctly* still left the dashboard at zero, with no explanation.

`/api/services/available`, which is what the wizard reads, **didn't even report `has_collector`** — so the wizard could not have known.

## The fix

The endpoint reports it, and the wizard shows the notice under the credential fields.

The notice is now **one function used by both screens** rather than two copies. A notice that exists twice drifts, and the wizard's is the one that matters most.

The wording keeps *"the service earns either way"* — without it the notice reads as "your deployment is broken", which it isn't: the container is running and earning, only the in-dashboard balance is missing.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.27% coverage**, 2990 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| wizard stops showing the notice (the original state) | 3 |
| endpoint stops reporting `has_collector` | 1 |
| detail view goes back to its own copy | 2 |

Controls also pin that the distinction is real rather than cosmetic — `honeygain` has a collector with its own declared arguments, `proxybase-xyz` has none — so the notice isn't warning about a difference that doesn't exist.

Closes CashPilot-p6s