### PR TITLE
fix: a container nobody could measure reported 0.00% CPU

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1069,8 +1069,17 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             }
         agg = slug_agg[slug]
         agg["instances"].append(s)
-        agg["total_cpu"] += float(s.get("cpu_percent", 0))
-        agg["total_mem"] += float(s.get("memory_mb", 0))
+        # Unknown instances are counted separately rather than summed as zero:
+        # averaging a failed stats read into the total drags the figure toward
+        # zero and makes a busy service look idle. `.get(key, 0)` does not help
+        # here — the key EXISTS with value None, so the default never applies.
+        cpu, mem = s.get("cpu_percent"), s.get("memory_mb")
+        if cpu is None or mem is None:
+            agg["unknown_stats"] = agg.get("unknown_stats", 0) + 1
+        else:
+            agg["total_cpu"] += float(cpu)
+            agg["total_mem"] += float(mem)
+            agg["measured"] = agg.get("measured", 0) + 1
         cur = s.get("status", "unknown")
         if _STATUS_PRIORITY.get(cur, 9) < _STATUS_PRIORITY.get(agg["best_status"], 9):
             agg["best_status"] = cur
@@ -1087,8 +1096,11 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
                 "node": inst.get("_node", "unknown"),
                 "worker_id": inst.get("_worker_id"),
                 "status": inst.get("status", "unknown"),
-                "cpu": f"{float(inst.get('cpu_percent', 0)):.2f}",
-                "memory": f"{float(inst.get('memory_mb', 0)):.1f} MB",
+                # None reaches the UI as null, which renders as an em dash. A
+                # formatted "0.00" would be indistinguishable from a real idle
+                # container.
+                "cpu": None if inst.get("cpu_percent") is None else f"{float(inst['cpu_percent']):.2f}",
+                "memory": None if inst.get("memory_mb") is None else f"{float(inst['memory_mb']):.1f} MB",
                 "container_name": inst.get("name", ""),
                 "has_docker": inst.get("_has_docker", False),
                 "is_android": inst.get("_is_android", False),
@@ -1128,8 +1140,14 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
             "balance": balance_map.get(slug),
             "balance_known": slug in balance_map,
             "currency": currency_map.get(slug, "USD"),
-            "cpu": f"{agg['total_cpu']:.2f}",
-            "memory": f"{agg['total_mem']:.1f} MB",
+            # None when NOTHING could be measured. A row whose every instance
+            # failed its stats read must not show 0.00 — that is the same
+            # fabricated idle as the per-instance case. When some instances were
+            # readable the total is real, and stats_unknown says how many were
+            # left out of it.
+            "cpu": f"{agg['total_cpu']:.2f}" if agg.get("measured") else None,
+            "memory": f"{agg['total_mem']:.1f} MB" if agg.get("measured") else None,
+            "stats_unknown": agg.get("unknown_stats", 0),
             "image": agg["image"],
             "category": agg["instances"][0].get("category", ""),
             "health_score": health.get("score"),
@@ -2307,6 +2325,12 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
                 # No marginal power cost to the user on this host, so charge
                 # nothing rather than computing watts and multiplying by zero.
                 unmetered_services.add(svc)
+                continue
+            # A container whose CPU could not be read contributes no estimate
+            # rather than an estimate built from a fabricated 0%. `or 0.0` below
+            # would silently turn "unmeasurable" into "idle", which is how a
+            # busy service ends up costing nothing on the running-costs card.
+            if c.get("cpu_percent") is None:
                 continue
             watts_by_service[svc] = watts_by_service.get(svc, 0.0) + power.estimate_watts(
                 float(c.get("cpu_percent") or 0.0), host_tdp_watts=tdp, container_count=count

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -383,9 +383,13 @@ async def _refresh_gauges() -> None:
                 m["container_info"].labels(service=slug, node=name, status=c_status).set(1)
                 key = (c_status, name)
                 container_counts[key] = container_counts.get(key, 0) + 1
-                cpu = c.get("cpu_percent", 0)
-                mem = c.get("memory_mb", 0)
-                if cpu or mem:
+                cpu = c.get("cpu_percent")
+                mem = c.get("memory_mb")
+                # A failed stats read is None now, and publishing it as 0 would
+                # put a flat zero line on a dashboard for a container nobody
+                # could measure. Absent from the scrape is the honest answer —
+                # Prometheus renders a gap, not a floor.
+                if cpu is not None and mem is not None and (cpu or mem):
                     m["container_cpu_percent"].labels(service=slug, node=name).set(cpu)
                     m["container_memory_mb"].labels(service=slug, node=name).set(mem)
         m["worker_containers_count"].labels(worker=name).set(container_count)

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -518,7 +518,12 @@ def _collect_stats(c) -> tuple[float, float, int | None, int | None]:
         rx, tx = _network_totals(stats)
         return cpu_pct, mem_mb, rx, tx
     except (KeyError, ZeroDivisionError, APIError):
-        return 0.0, 0.0, None, None
+        # None, not 0.0. A stats call that FAILED tells us nothing about the
+        # container's CPU or memory, and 0.00% / 0.0 MB is a measurement — one
+        # that reads as "idle" for a container that may be working hard. The
+        # network counters on the line above were already None for exactly this
+        # reason; the same failure was being reported two different ways.
+        return None, None, None, None
 
 
 def _network_totals(stats: dict[str, Any]) -> tuple[int | None, int | None]:

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -867,15 +867,28 @@ const CP = (() => {
     if (isExternal) {
       cpuStr = '--';
       memStr = '--';
+    } else if (svc.cpu == null || svc.memory == null) {
+      // Nothing could be measured: every instance's Docker stats call failed.
+      // `|| '0'` used to render that as a confident 0%, which reads as idle for
+      // a container that may be working hard (CashPilot-zdi).
+      const why = 'Docker could not report stats for this service';
+      cpuStr = `<span title="${why}">—</span>`;
+      memStr = `<span title="${why}">—</span>`;
     } else if (isMulti && instances > 0) {
-      const avgCpu = (parseFloat(svc.cpu) / instances).toFixed(2);
-      const totalMem = parseFloat(svc.memory);
-      const avgMem = (totalMem / instances).toFixed(1);
-      cpuStr = `<span title="Average across ${instances} instances">~${avgCpu}%</span>`;
-      memStr = `<span title="Average across ${instances} instances">~${avgMem} MB</span>`;
+      // Averaged over the instances that WERE measured. Dividing by the full
+      // instance count when some failed would drag the average toward zero for
+      // the same reason.
+      const measured = Math.max(1, instances - (svc.stats_unknown || 0));
+      const avgCpu = (parseFloat(svc.cpu) / measured).toFixed(2);
+      const avgMem = (parseFloat(svc.memory) / measured).toFixed(1);
+      const note = (svc.stats_unknown || 0) > 0
+        ? ` (${svc.stats_unknown} instance${svc.stats_unknown > 1 ? 's' : ''} could not be measured)`
+        : '';
+      cpuStr = `<span title="Average across ${measured} instance${measured > 1 ? 's' : ''}${note}">~${avgCpu}%</span>`;
+      memStr = `<span title="Average across ${measured} instance${measured > 1 ? 's' : ''}${note}">~${avgMem} MB</span>`;
     } else {
-      cpuStr = `${svc.cpu || '0'}%`;
-      memStr = svc.memory || '0 MB';
+      cpuStr = `${svc.cpu}%`;
+      memStr = svc.memory;
     }
 
     // Payout progress
@@ -1002,8 +1015,15 @@ const CP = (() => {
           ? ' disabled title="Started outside CashPilot — manage it where you started it"'
           : (iNoDocker ? ' disabled title="No Docker access"' : '');
         const subLabel = inst.is_android ? '' : escapeHtml(inst.container_name);
-        const cpuCell = inst.is_android ? `↑ ${fmtNetBytes(inst.net_tx_24h)}` : `${inst.cpu || '0'}%`;
-        const memCell = inst.is_android ? `↓ ${fmtNetBytes(inst.net_rx_24h)}` : (inst.memory || '0 MB');
+        // `|| '0'` would render an unmeasurable container as a confident 0%.
+        // The endpoint sends null when the Docker stats call failed, and an em
+        // dash is the only honest rendering of that (CashPilot-zdi).
+        const cpuCell = inst.is_android
+          ? `↑ ${fmtNetBytes(inst.net_tx_24h)}`
+          : (inst.cpu == null ? '<span title="Docker could not report this container\'s stats">—</span>' : `${inst.cpu}%`);
+        const memCell = inst.is_android
+          ? `↓ ${fmtNetBytes(inst.net_rx_24h)}`
+          : (inst.memory == null ? '<span title="Docker could not report this container\'s stats">—</span>' : inst.memory);
         html += `
         <tr class="instance-row" data-parent="${escapeHtml(svc.slug)}" style="display:none;">
           <td style="padding-left:28px;">

--- a/tests/test_beads_batch_40.py
+++ b/tests/test_beads_batch_40.py
@@ -1,0 +1,165 @@
+"""CashPilot-zdi: a container nobody could measure reported 0.00% CPU.
+
+``_collect_stats`` returned ``(0.0, 0.0, None, None)`` when the Docker stats
+call failed. The network counters were None because a failed read is not
+evidence of no traffic — the docstring right above says so — and exactly the
+same argument applies to CPU and memory, which were reporting a confident
+0.00% / 0.0 MB for a container that may be working hard.
+
+One ``return`` statement, two kinds of unknown, reported two different ways.
+
+Fixing the source meant fixing every consumer, because ``.get(key, 0)`` does not
+help when the key EXISTS with value None:
+
+* the per-service aggregate summed it as zero, dragging the average down;
+* /metrics published a flat zero line instead of a gap;
+* the running-costs estimate billed it as an idle container;
+* the dashboard rendered ``|| '0'`` as ``0%``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestAFailedStatsReadIsUnknown:
+    def test_an_api_error_reports_nothing(self):
+        from docker.errors import APIError
+
+        from app import orchestrator
+
+        c = MagicMock()
+        c.stats.side_effect = APIError("stats unavailable")
+        assert orchestrator._collect_stats(c) == (None, None, None, None)
+
+    def test_a_malformed_payload_reports_nothing(self):
+        from app import orchestrator
+
+        c = MagicMock()
+        c.stats.return_value = {"cpu_stats": {}}
+        assert orchestrator._collect_stats(c) == (None, None, None, None)
+
+    def test_a_successful_read_still_reports_numbers(self):
+        """The control. Without it this passes by never measuring anything."""
+        from app import orchestrator
+
+        c = MagicMock()
+        c.stats.return_value = {
+            "cpu_stats": {"cpu_usage": {"total_usage": 200, "percpu_usage": [1]}, "system_cpu_usage": 1000},
+            "precpu_stats": {"cpu_usage": {"total_usage": 100}, "system_cpu_usage": 500},
+            "memory_stats": {"usage": 52428800},
+        }
+        cpu, mem, _, _ = orchestrator._collect_stats(c)
+        assert cpu is not None and cpu > 0
+        assert mem == pytest.approx(50.0)
+
+    def test_a_genuine_zero_is_still_zero(self):
+        """An idle container measured at 0% must stay distinguishable."""
+        from app import orchestrator
+
+        c = MagicMock()
+        c.stats.return_value = {
+            "cpu_stats": {"cpu_usage": {"total_usage": 100, "percpu_usage": [1]}, "system_cpu_usage": 500},
+            "precpu_stats": {"cpu_usage": {"total_usage": 100}, "system_cpu_usage": 500},
+            "memory_stats": {"usage": 0},
+        }
+        cpu, mem, _, _ = orchestrator._collect_stats(c)
+        assert cpu == 0.0
+        assert mem == 0.0
+
+
+class TestTheAggregateDoesNotCountUnknownAsZero:
+    def _rows(self, instances):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from app import main
+
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=instances)),
+            patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_config", AsyncMock(return_value={})),
+            patch.object(main.database, "get_health_scores", AsyncMock(return_value={})),
+            patch.object(main.catalog, "get_service", lambda slug: {"name": "Honeygain", "slug": slug}),
+        ):
+            return asyncio.run(main.api_services_deployed(MagicMock()))
+
+    def _instance(self, cpu, mem, node="watchtower"):
+        return {
+            "slug": "honeygain",
+            "name": "honeygain",
+            "status": "running",
+            "cpu_percent": cpu,
+            "memory_mb": mem,
+            "deployed_by": node,
+            "_node": node,
+            "_worker_id": 1,
+            "_has_docker": True,
+            "_is_android": False,
+        }
+
+    def test_a_wholly_unmeasured_service_reports_no_figure(self):
+        row = self._rows([self._instance(None, None)])[0]
+        assert row["cpu"] is None
+        assert row["memory"] is None
+
+    def test_it_says_how_many_were_unmeasured(self):
+        row = self._rows([self._instance(None, None), self._instance(None, None, "b")])[0]
+        assert row["stats_unknown"] == 2
+
+    def test_a_measured_service_still_reports_one(self):
+        """The control: this must not blank out working containers."""
+        row = self._rows([self._instance(12.5, 100.0)])[0]
+        assert row["cpu"] == "12.50"
+        assert row["memory"] == "100.0 MB"
+        assert row["stats_unknown"] == 0
+
+    def test_a_mixed_service_totals_only_what_was_measured(self):
+        """Summing the unknown as 0 is what dragged the average down."""
+        row = self._rows([self._instance(10.0, 100.0), self._instance(None, None, "b")])[0]
+        assert row["cpu"] == "10.00"
+        assert row["stats_unknown"] == 1
+
+    def test_the_per_instance_rows_carry_the_same_distinction(self):
+        rows = self._rows([self._instance(None, None)])[0]["instance_details"]
+        assert rows[0]["cpu"] is None
+        assert rows[0]["memory"] is None
+
+
+class TestNothingDownstreamFabricatesAZero:
+    def test_metrics_skips_unmeasured_containers(self):
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "app" / "metrics.py").read_text(encoding="utf-8")
+        assert "if cpu is not None and mem is not None" in source, (
+            "/metrics would publish a flat zero line for a container nobody could measure"
+        )
+
+    def test_power_estimation_skips_them(self):
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "app" / "main.py").read_text(encoding="utf-8")
+        assert 'if c.get("cpu_percent") is None:' in source, (
+            "an unmeasurable container would be billed as idle in the running-costs estimate"
+        )
+
+    def test_the_dashboard_renders_a_dash(self):
+        import re
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "app" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+        code = "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in source.splitlines())
+        assert "svc.cpu || '0'" not in code, "the main row still renders unknown as 0%"
+        assert "inst.cpu || '0'" not in code, "the instance row still renders unknown as 0%"
+
+    def test_the_average_divides_by_what_was_measured(self):
+        import re
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "app" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+        code = "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in source.splitlines())
+        assert "instances - (svc.stats_unknown || 0)" in code

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -100,15 +100,22 @@ class TestCollectStats:
         _, mem_mb, _, _ = orchestrator._collect_stats(c)
         assert mem_mb == 0.0
 
-    def test_missing_key_returns_zero_tuple(self):
+    def test_missing_key_reports_unknown(self):
+        """A malformed stats payload measured nothing (CashPilot-zdi).
+
+        This asserted (0.0, 0.0, None, None). The network counters were already
+        None because a failed read is not evidence of no traffic — and exactly
+        the same argument applies to CPU and memory, which were reporting a
+        confident 0.00% for a container nobody could measure.
+        """
         c = MagicMock()
         c.stats.return_value = {"cpu_stats": {}}  # precpu_stats missing -> KeyError
-        assert orchestrator._collect_stats(c) == (0.0, 0.0, None, None)
+        assert orchestrator._collect_stats(c) == (None, None, None, None)
 
-    def test_stats_api_error_returns_zero_tuple(self):
+    def test_stats_api_error_reports_unknown(self):
         c = MagicMock()
         c.stats.side_effect = APIError("stats unavailable")
-        assert orchestrator._collect_stats(c) == (0.0, 0.0, None, None)
+        assert orchestrator._collect_stats(c) == (None, None, None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -193,8 +200,10 @@ class TestGetStatus:
         ):
             results = orchestrator.get_status()
         assert results[0]["status"] == "exited"
-        assert results[0]["cpu_percent"] == 0.0
-        assert results[0]["memory_mb"] == 0.0
+        # Unknown, not zero: the stats call failed, so nothing was measured.
+        # The status above is what says the container is not running.
+        assert results[0]["cpu_percent"] is None
+        assert results[0]["memory_mb"] is None
 
     def test_corrupted_container_is_skipped_not_crashed(self):
         good = _mock_container(name="cashpilot-honeygain", status="running", slug="honeygain")


### PR DESCRIPTION
## The defect

```python
except (KeyError, ZeroDivisionError, APIError):
    return 0.0, 0.0, None, None
```

One `return`, **two kinds of unknown, reported two different ways**. The network counters are `None` because a failed read isn't evidence of no traffic — the docstring immediately above says exactly that — while CPU and memory became a confident **0.00% / 0.0 MB** for a container that may be working hard.

## Fixing the source meant fixing every consumer

`.get(key, 0)` doesn't help when the key **exists** with value `None`:

| consumer | was |
|---|---|
| per-service aggregate | summed it as zero, dragging the average down |
| `/metrics` | published a flat zero line where a gap is honest |
| running-costs estimate | billed it as an idle container |
| dashboard | `\|\| '0'` rendered it as `0%` |

Each now distinguishes *unmeasured* from *measured at zero*. The multi-instance average divides by the instances actually read and says how many were left out; a row where nothing could be measured shows an em dash.

**A genuine idle container still reports 0.0** — pinned by a control, because a fix that made everything unknown would be no better than one that made everything zero.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.26% coverage**, 3047 passed.

Negative control:

| reverted | tests that fail |
|---|---|
| orchestrator returns the zero tuple | 2 |
| aggregate sums unknown as zero | 3 |
| `/metrics` publishes the fabricated zero | 1 |
| dashboard renders `0%` | 1 |

Two existing tests named `..._returns_zero_tuple` encoded the old contract. They now assert the new one, with the reason recorded rather than the names quietly changed.

Closes CashPilot-zdi