### PR TITLE
fix: two affirmatives nobody had earned

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,12 @@ scheduler = AsyncIOScheduler()
 
 # In-memory store for the latest collector alerts (errors from last run)
 _collector_alerts: list[dict[str, str]] = []
+# Whether a collection has ever COMPLETED here. An empty alert list means
+# "nothing is wrong" only once something has looked; before that it means
+# "nothing has been checked", and the bell used to render both as "All
+# collectors healthy" (CashPilot-tb5). Restored on startup from durable state so
+# a restart does not reset the claim to "never ran" while data exists.
+_collection_has_run: bool = False
 _collection_lock = asyncio.Lock()
 _collection_semaphore = asyncio.Semaphore(8)
 
@@ -508,6 +514,16 @@ async def _warm_collector_alerts() -> None:
         seen.add(key)
         restored.append({"kind": alert["kind"], "platform": alert["subject"], "error": alert["message"]})
     _collector_alerts = restored
+    # A restart must not make the bell claim nothing has ever been checked. Any
+    # stored alert, or any earnings row, is proof that a collection ran.
+    global _collection_has_run
+    if restored:
+        _collection_has_run = True
+    else:
+        try:
+            _collection_has_run = bool(await database.get_earnings_summary())
+        except Exception as exc:  # noqa: BLE001 - a warm-up must not block startup
+            logger.warning("Could not tell whether a collection has run before: %s", exc)
 
 
 async def _run_collection() -> None:
@@ -633,6 +649,11 @@ async def _run_collection() -> None:
             ]
         finally:
             metrics.record_collection_end(start_time, success, platforms_ok)
+            # Set even on a failed run: the bell's question is "has anything
+            # looked", and a run that tried and failed HAS looked — its failure
+            # is in the alert list the bell is about to show.
+            global _collection_has_run
+            _collection_has_run = True
 
 
 # ---------------------------------------------------------------------------
@@ -1941,13 +1962,20 @@ async def api_earnings_summary(request: Request) -> dict[str, Any]:
             total_adjusted += adjusted
             total_bonus_usd += bonus
 
-    # Count active (running) services from worker data
-    active = 0
+    # Count active (running) services from worker data.
+    #
+    # None, not 0, when the count could not be taken. _get_all_worker_containers
+    # opens SQLite, so a locked or busy database — or a JSON-decode failure on a
+    # worker row — lands here while containers are in fact running, and "0"
+    # reads as "nothing is running". Logged at WARNING rather than DEBUG: DEBUG
+    # is off in production, so the only two places that could have said anything
+    # both said nothing (CashPilot-45k).
+    active: int | None = None
     try:
         worker_containers = await _get_all_worker_containers()
         active = sum(1 for s in worker_containers if s.get("status") == "running")
     except Exception as exc:
-        logger.debug("active-service count failed: %s", exc)
+        logger.warning("Could not count active services, reporting it as unknown: %s", exc)
     summary["active_services"] = active
     # A total that silently omits holdings is indistinguishable from a correct
     # one. The count was already being computed in database.py and only logged;
@@ -2870,8 +2898,20 @@ async def api_disclosure_coverage(request: Request) -> dict[str, Any]:
 
 
 @app.get("/api/collector-alerts")
-async def api_collector_alerts(request: Request) -> list[dict[str, str]]:
-    """Return collector errors from the last collection run (sanitized)."""
+async def api_collector_alerts(request: Request) -> dict[str, Any]:
+    """Collector errors from the last run, and whether a run has happened.
+
+    The bell rendered an empty list as "All collectors healthy". On a fresh
+    install — or after a restart, before the first hourly collection — nothing
+    has been checked, so that affirmative is unearned: it is the same
+    absent-equals-true shape this codebase rejects everywhere else. The bell's
+    own FAILURE path is written correctly ("Alerts unavailable" rather than
+    healthy), which makes the never-ran case the outlier (CashPilot-tb5).
+
+    Returning an object rather than a bare list so "no alerts" and "nothing has
+    run" can be told apart at all. The UI is the only consumer and ships with
+    this.
+    """
     _require_auth_api(request)
     sanitized: list[dict[str, str]] = []
     for alert in _collector_alerts:
@@ -2882,7 +2922,7 @@ async def api_collector_alerts(request: Request) -> list[dict[str, str]]:
         # `kind` is additive and defaults to "collector", so a frontend that
         # does not read it behaves exactly as before.
         sanitized.append({"kind": alert.get("kind", "collector"), "platform": alert["platform"], "error": clean})
-    return sanitized
+    return {"alerts": sanitized, "collected": _collection_has_run}
 
 
 @app.get("/api/exchange-rates")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -488,7 +488,10 @@ const CP = (() => {
       setTextContent('total-earnings', money(displayTotal));
       setTextContent('today-earnings', money(data.today || 0));
       setTextContent('month-earnings', money(data.month || 0));
-      setTextContent('active-services', data.active_services || 0);
+      // `|| 0` would render "could not be counted" as "nothing is running".
+      // The endpoint sends null when the count could not be taken
+      // (CashPilot-45k).
+      setTextContent('active-services', data.active_services == null ? '\u2014' : data.active_services);
 
       const nothingYet = document.getElementById('no-readings-note');
       if (nothingYet) nothingYet.style.display = data.has_readings === false ? '' : 'none';
@@ -2934,14 +2937,23 @@ const CP = (() => {
     if (!container || !badge || !list) return;
 
     try {
-      const alerts = await api('/api/collector-alerts');
+      const payload = await api('/api/collector-alerts');
+      const alerts = payload.alerts || [];
       // Clear any muted "alerts unavailable" styling left over from a prior
       // failed poll now that the fetch succeeded.
       badge.style.background = '';
       badge.title = '';
-      if (!alerts || alerts.length === 0) {
+      if (alerts.length === 0) {
         badge.style.display = 'none';
-        list.innerHTML = '<div class="notify-empty">All collectors healthy</div>';
+        // "Healthy" is a claim about something that was CHECKED. On a fresh
+        // install, or after a restart before the first collection, nothing has
+        // been — and saying so is the same absent-equals-true this codebase
+        // rejects everywhere else. The bell's failure path already gets this
+        // right ("Alerts unavailable"), which made the never-ran case the
+        // outlier (CashPilot-tb5).
+        list.innerHTML = payload.collected
+          ? '<div class="notify-empty">All collectors healthy</div>'
+          : '<div class="notify-empty">No collection has run yet — nothing has been checked.</div>';
         return;
       }
 

--- a/tests/test_audit_guards.py
+++ b/tests/test_audit_guards.py
@@ -451,7 +451,9 @@ class TestADetectedPayoutActuallyReachesTheUser:
             patch.object(main, "_require_auth_api", lambda r: None),
         ):
             out = asyncio.run(main.api_collector_alerts(MagicMock()))
-        assert out[0]["kind"] == "collector", "an untagged alert must default to collector, not vanish"
+        # The endpoint returns {alerts, collected} so "no alerts" and "nothing
+        # has run" can be told apart at all (CashPilot-tb5).
+        assert out["alerts"][0]["kind"] == "collector", "an untagged alert must default to collector, not vanish"
 
 
 class TestTheCredentialCooldownCannotBeRaced:

--- a/tests/test_beads_batch_41.py
+++ b/tests/test_beads_batch_41.py
@@ -1,0 +1,160 @@
+"""CashPilot-45k and -tb5: two affirmatives nobody had earned.
+
+**45k** — the Active Services card showed "0" when the count could not be taken.
+``_get_all_worker_containers`` opens SQLite, so a locked or busy database, or a
+JSON-decode failure on a worker row, lands in the ``except`` while containers
+are in fact running. The fallback was ``0``, which reads as "nothing is
+running", and the only other signal was a ``logger.debug`` — and DEBUG is off in
+production, so both places that could have said something said nothing.
+
+**tb5** — the bell rendered an empty alert list as "All collectors healthy". On
+a fresh install, or after a restart before the first hourly collection, nothing
+has been checked. The bell's own FAILURE path is written correctly ("Alerts
+unavailable" rather than healthy), which makes the never-ran case the outlier
+rather than a matter of style.
+
+Both are the same shape: absent presented as an affirmative.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def js() -> str:
+    text = APP_JS.read_text(encoding="utf-8")
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+async def _summary(*, worker_read_fails):
+    from app import main
+
+    containers = (
+        AsyncMock(side_effect=Exception("database is locked")) if worker_read_fails else AsyncMock(return_value=[])
+    )
+    with (
+        patch.object(main, "_require_auth_api", lambda r: None),
+        patch.object(main.database, "get_earnings_dashboard_summary", AsyncMock(return_value={"total": 0})),
+        patch.object(main.database, "get_config", AsyncMock(return_value={})),
+        patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),
+        patch.object(main, "_get_all_worker_containers", containers),
+    ):
+        return await main.api_earnings_summary(MagicMock())
+
+
+class TestAnUncountableFleetIsUnknown:
+    @pytest.mark.asyncio
+    async def test_a_failed_read_reports_none(self):
+        assert (await _summary(worker_read_fails=True))["active_services"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_successful_read_of_nothing_still_reports_zero(self):
+        """The control. A fleet with no running containers really is zero."""
+        assert (await _summary(worker_read_fails=False))["active_services"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_failure_is_logged_where_it_can_be_seen(self, caplog):
+        """DEBUG is off in production, so a debug log is the same as silence."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="app.main"):
+            caplog.clear()
+            await _summary(worker_read_fails=True)
+        assert any("Could not count active services" in r.getMessage() for r in caplog.records)
+
+    def test_the_card_renders_a_dash(self):
+        source = js()
+        assert "data.active_services || 0" not in source, "unknown still renders as 0"
+        assert "data.active_services == null" in source
+
+
+class TestTheBellDoesNotClaimUncheckedHealth:
+    async def _alerts(self, *, alerts, has_run):
+        from app import main
+
+        with (
+            patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_collector_alerts", alerts),
+            patch.object(main, "_collection_has_run", has_run),
+        ):
+            return await main.api_collector_alerts(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_install_reports_that_nothing_has_run(self):
+        out = await self._alerts(alerts=[], has_run=False)
+        assert out["collected"] is False
+        assert out["alerts"] == []
+
+    @pytest.mark.asyncio
+    async def test_after_a_run_with_no_problems_it_says_so(self):
+        """The control: a genuine all-clear must remain expressible."""
+        out = await self._alerts(alerts=[], has_run=True)
+        assert out["collected"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_alerts_still_come_through_tagged(self):
+        out = await self._alerts(alerts=[{"platform": "grass", "error": "boom"}], has_run=True)
+        assert out["alerts"][0]["kind"] == "collector"
+
+    def test_the_ui_distinguishes_the_two(self):
+        source = js()
+        assert "payload.collected" in source
+        assert "No collection has run yet" in source
+
+    def test_the_all_clear_is_still_possible(self):
+        """The control: the affirmative must survive for the case that earns it."""
+        assert "All collectors healthy" in js()
+
+    def test_the_ui_reads_the_new_shape(self):
+        source = js()
+        assert "payload.alerts" in source
+
+
+class TestTheFlagSurvivesARestart:
+    """A restart must not make the bell claim nothing has ever been checked."""
+
+    async def _warm(self, *, stored_alerts, earnings):
+        from app import main
+
+        with (
+            patch.object(main, "_collection_has_run", False),
+            patch.object(main.database, "list_alerts", AsyncMock(return_value=stored_alerts)),
+            patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=earnings)),
+        ):
+            await main._warm_collector_alerts()
+            return main._collection_has_run
+
+    @pytest.mark.asyncio
+    async def test_stored_alerts_prove_a_run_happened(self):
+        stored = [{"kind": "collector", "subject": "grass", "message": "boom"}]
+        assert await self._warm(stored_alerts=stored, earnings=[]) is True
+
+    @pytest.mark.asyncio
+    async def test_earnings_rows_prove_it_too(self):
+        rows = [{"platform": "honeygain", "balance": 1.0, "currency": "USD"}]
+        assert await self._warm(stored_alerts=[], earnings=rows) is True
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_fresh_install_stays_false(self):
+        """The control: without it this passes by always claiming a run."""
+        assert await self._warm(stored_alerts=[], earnings=[]) is False
+
+    @pytest.mark.asyncio
+    async def test_a_failed_lookup_does_not_claim_a_run(self):
+        from app import main
+
+        with (
+            patch.object(main, "_collection_has_run", False),
+            patch.object(main.database, "list_alerts", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_earnings_summary", AsyncMock(side_effect=Exception("locked"))),
+        ):
+            await main._warm_collector_alerts()
+            assert main._collection_has_run is False

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -820,7 +820,10 @@ class TestMainEarningsSummaryWithWorkerException:
         ):
             resp = client.get("/api/earnings/summary")
             assert resp.status_code == 200
-            assert resp.json()["active_services"] == 0
+            # None, not 0. The count could not be TAKEN — reporting zero here
+            # says "nothing is running" about a fleet nobody could read
+            # (CashPilot-45k).
+            assert resp.json()["active_services"] is None
 
 
 class TestMainServicesDeployedMultiStatus:


### PR DESCRIPTION
Two P3s, one shape: **absent presented as an affirmative.**

## `45k` — "Active Services: 0" when the count could not be taken

`_get_all_worker_containers` opens SQLite, so a locked or busy database — or a JSON-decode failure on a worker row — lands in the `except` **while containers are in fact running**. The fallback was `0`, which reads as *"nothing is running"*.

The only other signal was `logger.debug`, and **DEBUG is off in production** — so both places that could have said something said nothing.

Now `None`, rendered as an em dash, with the failure logged at WARNING.

## `tb5` — "All collectors healthy" before anything had run

The bell rendered an empty alert list as an affirmative. On a fresh install, or after a restart before the first hourly collection, **nothing has been checked**.

What makes this an outlier rather than a matter of style: the bell's own *failure* path is already written correctly — it says "Alerts unavailable", not "healthy".

`/api/collector-alerts` now returns `{alerts, collected}` rather than a bare list, so the two cases can be told apart at all. The UI is the only consumer and ships with this.

Two details that are deliberate:

- **`collected` is set even on a failed run.** The bell's question is *"has anything looked"* — a run that tried and failed has looked, and its failure is in the list the bell is about to show.
- **It's restored at startup** from stored alerts or any earnings row, so a restart doesn't reset the claim to "never ran" while data exists. A lookup that itself fails leaves it `False` rather than asserting a run happened.

## Evidence

`ruff check` + `ruff format --check` clean, `node --check` and both CI harnesses clean, **95.27% coverage**, 3061 passed.

| reverted | tests that fail |
|---|---|
| count falls back to 0 | 1 |
| failure logged at DEBUG | 1 |
| endpoint hardcodes `collected` | 1 |
| bell claims health unconditionally | 1 |
| restart restore dropped | 2 |

Controls also pin the genuine cases: a fleet really at zero still reports `0`, and a real all-clear still says "All collectors healthy" — a fix that made everything unknown would be no better than one that made everything affirmative.

Two existing tests asserted the old contracts; both now assert the new ones with the reason recorded.

Closes CashPilot-45k
Closes CashPilot-tb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collector alerts now indicate whether a collection has completed, distinguishing an all-clear result from no collection history.
  * Dashboard active-service counts show an em dash when data is unavailable instead of displaying zero.

* **Bug Fixes**
  * Improved collection status restoration after restarts.
  * Prevented failed worker-data reads from being reported as zero active services.
  * Added clearer handling for failed and successful collection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->