### PR TITLE
fix: the lockout alarm skipped the lockout it was most needed for

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -450,24 +450,47 @@ async def _send_heartbeat() -> None:
         status = exc.response.status_code
         _last_error = f"authentication rejected ({status})" if status in (401, 403) else "connection failed"
         logger.warning("Heartbeat failed: %s", exc)
-        if status == 401 and _worker_key:
+        if status == 401:
+            # Counted whether or not we hold our own key. The condition used to
+            # be `and _worker_key`, which skipped the alarm in exactly the case
+            # it is most needed: a worker that LOST /data/.worker_key — a partial
+            # restore, an appdata copy that skips dotfiles — holds no key, sends
+            # the shared one, and is refused because the UI's row for this
+            # client_id is enrolled and confirmed. That worker 401'd forever and
+            # logged nothing but a generic "Heartbeat failed" every 60 seconds,
+            # while its service containers kept earning (CashPilot-65s).
             _consecutive_auth_failures += 1
             if _consecutive_auth_failures == _AUTH_FAILURE_ALARM_AFTER:
-                # A per-worker key rejected repeatedly almost always means our
-                # client_id no longer matches the row the UI enrolled — usually
-                # because the id was derived from a container hostname that
-                # changed on recreate. Service containers keep earning through
-                # this, so nothing else surfaces the problem: say it plainly once.
-                logger.error(
-                    "Rejected %d times with this worker's own key. The UI does not "
-                    "recognise client_id %r. If the UI still lists this worker under a "
-                    "different id, stop this container, write that id into %s, and start "
-                    "it again to reclaim the existing row.",
-                    _consecutive_auth_failures,
-                    CLIENT_ID,
-                    _WORKER_ID_FILE,
-                )
-            elif _consecutive_auth_failures >= _AUTH_FAILURE_DISCARD_AFTER:
+                # Two different lockouts, two different fixes. Saying the wrong
+                # one is worse than saying nothing: the previous message told the
+                # operator to write a client_id into /data/.worker_id, which is
+                # the fix for neither of the lockouts that actually happen — in
+                # both the id is fine and it is the KEY that has to change — and
+                # it named an id the dashboard has never displayed.
+                if _worker_key:
+                    logger.error(
+                        "Rejected %d times with this worker's own key. Either it was removed "
+                        "in the fleet dashboard, or the UI's credential-encryption key changed "
+                        "so it can no longer read the copy it stored. Both are recovered the "
+                        "same way and this worker will do it itself after about %d more "
+                        "rejections: discard the key and re-enrol. To fix it now, delete %s "
+                        "on this host and restart the container.",
+                        _consecutive_auth_failures,
+                        _AUTH_FAILURE_DISCARD_AFTER - _consecutive_auth_failures,
+                        _WORKER_KEY_FILE,
+                    )
+                else:
+                    logger.error(
+                        "Rejected %d times using the shared CASHPILOT_API_KEY. The UI already "
+                        "has a confirmed enrolment for client_id %r, so it refuses the shared "
+                        "key for it — this worker has lost the per-worker key it was issued "
+                        "(%s is missing). Restore that file, or remove this worker in the fleet "
+                        "dashboard and it will enrol again on its next heartbeat.",
+                        _consecutive_auth_failures,
+                        CLIENT_ID,
+                        _WORKER_KEY_FILE,
+                    )
+            elif _worker_key and _consecutive_auth_failures >= _AUTH_FAILURE_DISCARD_AFTER:
                 # Sustained rejection of our own key is what a worker REMOVED in
                 # the dashboard looks like from here. Re-enrol rather than 401
                 # forever on a host that is still running containers.

--- a/tests/test_beads_batch_42.py
+++ b/tests/test_beads_batch_42.py
@@ -1,0 +1,125 @@
+"""CashPilot-65s: the lockout alarm skipped the lockout it was most needed for.
+
+The alarm was gated on ``if status == 401 and _worker_key:``. A worker that LOST
+``/data/.worker_key`` — a partial restore, an appdata copy that skips dotfiles —
+holds no key. It sends the shared ``CASHPILOT_API_KEY``, the UI refuses it
+because its row for that client_id is enrolled and confirmed, and the worker
+falls into the ``else`` branch that RESETS the counter. So it 401'd forever and
+logged nothing but a generic "Heartbeat failed" every 60 seconds, while its
+service containers kept earning and nothing else surfaced the problem.
+
+The alarm that did fire named the wrong fix. It told the operator to write a
+client_id into ``/data/.worker_id``, which is the fix for neither lockout that
+actually happens — the row was removed, or the stored key can no longer be
+decrypted, and in both the id is fine and it is the KEY that has to change. It
+also named an id the dashboard has never displayed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    import httpx
+
+    import app.worker_api as w
+except ImportError:  # pragma: no cover - CI always has these
+    pytest.skip("requires the app dependencies", allow_module_level=True)
+
+
+def _alarms(*, holds_key, count, caplog, tmp_path):
+    """Drive N consecutive 401 heartbeats and return the ERROR records."""
+    key_file = tmp_path / ".worker_key"
+    if holds_key:
+        key_file.write_text("own")
+    saved = w._worker_key
+    w._worker_key = "own" if holds_key else None
+    w._consecutive_auth_failures = 0
+    try:
+        with caplog.at_level(logging.ERROR, logger="app.worker_api"):
+            caplog.clear()
+            for _ in range(count):
+                request = httpx.Request("POST", "http://ui:8080/api/workers/heartbeat")
+                response = httpx.Response(401, request=request, json={})
+                client = MagicMock()
+                client.__aenter__ = AsyncMock(return_value=client)
+                client.__aexit__ = AsyncMock(return_value=False)
+                client.post = AsyncMock(return_value=response)
+                with (
+                    patch.object(w, "_WORKER_KEY_FILE", key_file),
+                    patch.object(w, "UI_URL", "http://ui:8080"),
+                    patch("app.worker_api.orchestrator.get_status", return_value=[]),
+                    patch("app.worker_api.orchestrator.docker_available", return_value=True),
+                    patch("app.worker_api.httpx.AsyncClient", return_value=client),
+                ):
+                    asyncio.run(w._send_heartbeat())
+        return [r.getMessage() for r in caplog.records]
+    finally:
+        w._worker_key = saved
+        w._consecutive_auth_failures = 0
+
+
+class TestAWorkerWithNoKeyIsAlsoTold:
+    def test_it_alarms(self, caplog, tmp_path):
+        messages = _alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path)
+        assert any("Rejected" in m for m in messages), (
+            "a worker that lost its key file still 401s in silence — the case the alarm exists for"
+        )
+
+    def test_it_names_the_missing_file(self, caplog, tmp_path):
+        messages = _alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path)
+        joined = " ".join(messages)
+        assert str(w._WORKER_KEY_FILE) in joined or ".worker_key" in joined
+
+    def test_it_gives_the_recovery(self, caplog, tmp_path):
+        """Restore the file, or remove the worker so it enrols again."""
+        joined = " ".join(_alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path))
+        assert "remove this worker in the fleet dashboard" in joined
+
+    def test_it_says_which_key_was_refused(self, caplog, tmp_path):
+        joined = " ".join(_alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path))
+        assert "CASHPILOT_API_KEY" in joined
+
+    def test_it_stays_quiet_below_the_threshold(self, caplog, tmp_path):
+        """The control: two 401s across a restart are ordinary."""
+        messages = _alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER - 1, caplog=caplog, tmp_path=tmp_path)
+        assert not [m for m in messages if "Rejected" in m]
+
+
+class TestTheAdviceMatchesTheLockout:
+    def test_a_worker_holding_a_key_is_told_to_discard_it(self, caplog, tmp_path):
+        joined = " ".join(_alarms(holds_key=True, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path))
+        assert "re-enrol" in joined
+        # The harness patches _WORKER_KEY_FILE to a tmp path, so the message
+        # carries THAT path — comparing against the module constant would be
+        # comparing against a value the code under test never saw.
+        assert ".worker_key" in joined
+
+    def test_neither_message_tells_anyone_to_edit_the_id_file(self, caplog, tmp_path):
+        """The id is fine in both real lockouts; editing it fixes neither."""
+        for holds in (True, False):
+            joined = " ".join(
+                _alarms(holds_key=holds, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path)
+            )
+            assert str(w._WORKER_ID_FILE) not in joined, f"the id file is still named (holds_key={holds})"
+
+    def test_the_two_messages_are_different(self, caplog, tmp_path):
+        """One fix for two different situations is how the old one went wrong."""
+        with_key = " ".join(
+            _alarms(holds_key=True, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path)
+        )
+        without = " ".join(
+            _alarms(holds_key=False, count=w._AUTH_FAILURE_ALARM_AFTER, caplog=caplog, tmp_path=tmp_path)
+        )
+        assert with_key != without
+
+    def test_the_self_heal_still_only_applies_when_there_is_a_key_to_discard(self):
+        """A keyless worker has nothing to discard; discarding must not fire."""
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "app" / "worker_api.py").read_text(encoding="utf-8")
+        assert "elif _worker_key and _consecutive_auth_failures >= _AUTH_FAILURE_DISCARD_AFTER:" in source

--- a/tests/test_worker_keys.py
+++ b/tests/test_worker_keys.py
@@ -399,15 +399,25 @@ class TestTheAlarmActuallyFires(TestAuthFailureAlarmCounter):
         with caplog.at_level(logging.ERROR, logger="app.worker_api"):
             caplog.clear()
             self._run(statuses)
-        return [r for r in caplog.records if "does not recognise client_id" in r.getMessage()]
+        # Matched on "Rejected N times", which both lockout messages share.
+        # It used to match "does not recognise client_id" — the wording of an
+        # alarm that told the operator to edit /data/.worker_id, which is the
+        # fix for neither lockout that actually happens (CashPilot-65s).
+        return [r for r in caplog.records if "Rejected" in r.getMessage()]
 
     def test_three_straight_401s_tell_the_operator(self, caplog):
         assert len(self._alarms([401, 401, 401], caplog)) == 1
 
-    def test_it_names_the_id_and_the_file_needed_to_fix_it(self, caplog):
+    def test_it_names_the_file_that_has_to_go(self, caplog):
+        """The key, not the id.
+
+        This worker holds a key that is being refused, so the recovery is to
+        discard it — either by waiting for the automatic re-enrolment or by
+        deleting the file. The id is fine in both real lockouts.
+        """
         message = self._alarms([401, 401, 401], caplog)[0].getMessage()
-        assert w.CLIENT_ID in message, "an alarm without the id cannot be acted on"
-        assert str(w._WORKER_ID_FILE) in message, "the operator needs to know where to write it"
+        assert str(w._WORKER_KEY_FILE) in message, "the operator is not told which file to remove"
+        assert "re-enrol" in message, "nothing says the worker will recover on its own"
 
     def test_it_stays_quiet_below_the_threshold(self, caplog):
         """Two 401s across a restart are ordinary, not an identity mismatch."""


### PR DESCRIPTION
## The defect

```python
if status == 401 and _worker_key:
```

A worker that **lost** `/data/.worker_key` — a partial restore, an appdata copy that skips dotfiles — holds no key. It sends the shared `CASHPILOT_API_KEY`, the UI refuses it because its row for that `client_id` is enrolled and confirmed, and the worker fell into the `else` branch that **resets the counter**.

So it 401'd forever and logged nothing but a generic `Heartbeat failed` every 60 seconds — while its service containers kept earning, so nothing else surfaced the problem.

## The alarm that *did* fire named the wrong fix

It told the operator to write a `client_id` into `/data/.worker_id`. That's the fix for **neither** lockout that actually happens:

| lockout | what's actually wrong | the fix |
|---|---|---|
| row removed in the dashboard | key no longer matches any row | discard the key |
| encryption key changed | UI can't read the key it stored | discard the key |

In both, the id is fine and it's the **key** that has to change. It also named an id the dashboard has never displayed.

## The fix

Both cases alarm, each with the recovery that applies:

- **holding a refused key** → it will re-enrol itself after N more rejections; delete the key file to force it now
- **no key at all** → the shared key is refused because an enrolment already exists; restore the file, or remove the worker in the dashboard so it enrols again

The automatic discard still only fires when there *is* a key to discard.

## Evidence

`ruff check` + `ruff format --check` clean, both CI harnesses clean, **95.27% coverage**, 3070 passed.

| reverted | tests that fail |
|---|---|
| re-gate the counter on holding a key (the original bug) | 4 |
| one message for both lockouts | 6 |
| let a keyless worker try to discard | 1 |

The existing alarm tests matched the phrase `"does not recognise client_id"` — the wording being removed. Their detector now matches `"Rejected"`, which both messages share, and the assertion about naming the **id** file became one about naming the **key** file: the thing that actually has to go.

Closes CashPilot-65s