### PR TITLE
fix: exchange-rate staleness was computed, published, and read by nobody

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -202,12 +202,41 @@ const CP = (() => {
     return map[locale] || map[locale.split('-')[0]] || 'USD';
   }
 
+  // Which sources are currently stale, and what that means for what is shown.
+  //
+  // exchange_rates.py keeps a separate clock per source, each advanced only on
+  // that source's own HTTP 200, and publishes crypto_stale / fiat_stale. No
+  // caller ever asked. So if CoinGecko stopped responding after one successful
+  // fetch, every token balance kept rendering at a price that could be hours or
+  // days old, and nothing on screen changed (CashPilot-dfw).
+  function staleRateNotice() {
+    const cryptoStale = _exchangeRates.crypto_stale === true;
+    // Fiat only matters when a conversion actually uses it — a viewer reading in
+    // USD is not affected by a stale USD->X table, and warning them would be the
+    // kind of noise that teaches people to ignore warnings.
+    const fiatStale = _exchangeRates.fiat_stale === true && _displayCurrency !== 'USD';
+    if (!cryptoStale && !fiatStale) return '';
+    const sources = [];
+    if (cryptoStale) sources.push('crypto prices');
+    if (fiatStale) sources.push(`${_displayCurrency} exchange rates`);
+    return `Using cached ${sources.join(' and ')} — the last refresh failed, so converted figures may be out of date.`;
+  }
+
+  function renderStaleRateNotice() {
+    const note = document.getElementById('rates-stale-note');
+    if (!note) return;
+    const message = staleRateNotice();
+    note.textContent = message;
+    note.style.display = message ? '' : 'none';
+  }
+
   async function loadExchangeRates() {
     try {
       _exchangeRates = await api('/api/exchange-rates');
     } catch (err) {
       console.warn('Could not refresh exchange rates, keeping previous values:', err);
     }
+    renderStaleRateNotice();
   }
 
   async function loadTopbarEarnings() {
@@ -3040,6 +3069,9 @@ const CP = (() => {
       _displayCurrency = select.value;
       localStorage.setItem('cp-display-currency', select.value);
       toast(`Display currency set to ${select.value}`, 'success');
+      // The fiat half of the staleness notice depends on which currency is being
+      // read, so it has to be recomputed when that changes.
+      renderStaleRateNotice();
       const topbarSelect = document.getElementById('topbar-currency');
       if (topbarSelect) topbarSelect.value = select.value;
     });
@@ -3131,6 +3163,7 @@ const CP = (() => {
     select.addEventListener('change', () => {
       _displayCurrency = select.value;
       localStorage.setItem('cp-display-currency', select.value);
+      renderStaleRateNotice();
       // Re-render dashboard if on that page
       if (document.body.dataset.page === 'dashboard') {
         loadDashboardStats();

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -12,6 +12,11 @@
     <div class="stat-value highlight" id="total-earnings">—</div>
     <div id="total-bonus-note" style="display:none; font-size:0.7rem; color:var(--text-muted); margin-top:2px;"></div>
     <div id="no-readings-note" style="display:none; font-size:0.7rem; color:var(--text-muted); margin-top:2px;">Nothing collected yet</div>
+    <!-- app/exchange_rates.py tracks per-source staleness and publishes it on
+         /api/exchange-rates, and nothing ever read it: a MYST balance kept
+         being converted at a price that could be hours or days old with no
+         indication on screen (CashPilot-dfw). -->
+    <div id="rates-stale-note" style="display:none; font-size:0.7rem; color:var(--warning); margin-top:2px;"></div>
   </div>
   <div class="stat-card">
     <div class="stat-label">Today</div>

--- a/scripts/currency_check.mjs
+++ b/scripts/currency_check.mjs
@@ -45,5 +45,37 @@ for (const [label, native, disp, fiat, crypto, expectApprox] of cases) {
   if (!ok) bad++;
   console.log(`${label} approx=${String(shows).padEnd(5)} expected=${String(expectApprox).padEnd(5)} ${ok?'ok':'MISMATCH'}   (${f.fmt(24.90, native)})`);
 }
+
+// Stale-rate reporting (CashPilot-dfw).
+//
+// exchange_rates.py keeps a separate staleness clock per source and publishes
+// crypto_stale / fiat_stale on /api/exchange-rates. Nothing read either, so a
+// token balance kept being converted at a price that could be hours or days old
+// with nothing on screen changing. This is conditional logic about which source
+// matters to which viewer, so it is RUN rather than read.
+const staleFn = grab('staleRateNotice');
+const staleCases = [
+  ['fresh rates, USD viewer            ', {crypto_stale:false, fiat_stale:false}, 'USD', false, null],
+  ['fresh rates, GBP viewer            ', {crypto_stale:false, fiat_stale:false}, 'GBP', false, null],
+  ['crypto stale, USD viewer           ', {crypto_stale:true,  fiat_stale:false}, 'USD', true,  'crypto prices'],
+  ['crypto stale, GBP viewer           ', {crypto_stale:true,  fiat_stale:false}, 'GBP', true,  'crypto prices'],
+  // A USD viewer is not affected by a stale USD->X table, and warning them
+  // would be the noise that teaches people to ignore warnings.
+  ['fiat stale, USD viewer             ', {crypto_stale:false, fiat_stale:true},  'USD', false, null],
+  ['fiat stale, GBP viewer             ', {crypto_stale:false, fiat_stale:true},  'GBP', true,  'GBP exchange rates'],
+  ['both stale, GBP viewer             ', {crypto_stale:true,  fiat_stale:true},  'GBP', true,  'and'],
+  // Absent is not stale: an older UI, or a payload that never carried the field.
+  ['field absent entirely              ', {}, 'GBP', false, null],
+];
+for (const [label, rates, disp, expectNotice, mustMention] of staleCases) {
+  const f = new Function('_displayCurrency','_exchangeRates',
+    `${staleFn}; return staleRateNotice;`)(disp, {fiat:{USD:1,GBP:0.79}, crypto_usd:{MYST:0.087}, ...rates});
+  const notice = f();
+  let ok = Boolean(notice) === expectNotice;
+  if (ok && mustMention) ok = notice.includes(mustMention);
+  if (!ok) bad++;
+  console.log(`${label} notice=${String(Boolean(notice)).padEnd(5)} expected=${String(expectNotice).padEnd(5)} ${ok?'ok':'MISMATCH'}   ${notice ? '"'+notice+'"' : ''}`);
+}
+
 console.log(bad ? '\nRESULT: FAIL' : '\nRESULT: PASS');
 process.exit(bad ? 1 : 0);

--- a/tests/test_beads_batch_45.py
+++ b/tests/test_beads_batch_45.py
@@ -1,0 +1,112 @@
+"""CashPilot-dfw: staleness was computed, published, and read by nobody.
+
+``app/exchange_rates.py`` keeps a SEPARATE clock per source, each advanced only
+on that source's own HTTP 200 — deliberately, so a failure on one never marks
+the other stale — and publishes ``stale``, ``crypto_stale`` and ``fiat_stale``
+on ``/api/exchange-rates``.
+
+No caller ever asked. So if CoinGecko stopped responding after one successful
+fetch, the cached rates never expired and nothing on screen changed: a MYST
+balance kept being converted and displayed at a price that could be hours or
+days old, with no indication at all.
+
+The behaviour itself is exercised by scripts/currency_check.mjs, which runs the
+real function against controlled state — this is conditional logic about which
+source matters to which viewer, and a string assertion cannot see it. These
+tests pin the wiring and the invariants that harness cannot reach.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+def js() -> str:
+    text = APP_JS.read_text(encoding="utf-8")
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return "\n".join(re.sub(r"(^|\s)//.*$", "", line) for line in text.splitlines())
+
+
+class TestThePublishedStalenessIsRead:
+    @pytest.mark.parametrize("field", ["crypto_stale", "fiat_stale"])
+    def test_the_ui_reads_it(self, field):
+        assert f"_exchangeRates.{field}" in js(), f"{field} is published and still ignored"
+
+    def test_the_backend_still_publishes_it(self):
+        """The premise. If get_all stops sending these, the UI reads nothing."""
+        from app import exchange_rates
+
+        published = exchange_rates.get_all()
+        assert "crypto_stale" in published
+        assert "fiat_stale" in published
+
+    def test_the_two_clocks_are_still_separate(self):
+        """A failure on one source must not mark the other stale.
+
+        That separation is the reason the UI can name which source is behind,
+        so it is worth pinning here rather than only in the module.
+        """
+        source = (ROOT / "app" / "exchange_rates.py").read_text(encoding="utf-8")
+        assert "def crypto_rates_stale" in source
+        assert "def fiat_rates_stale" in source
+
+    def test_the_notice_is_rendered_somewhere(self):
+        assert "rates-stale-note" in js()
+        assert "rates-stale-note" in (ROOT / "app" / "templates" / "dashboard.html").read_text(encoding="utf-8")
+
+    def test_it_is_refreshed_when_rates_are(self):
+        source = js()
+        i = source.index("async function loadExchangeRates")
+        assert "renderStaleRateNotice()" in source[i : i + 500]
+
+    def test_it_is_refreshed_when_the_display_currency_changes(self):
+        """The fiat half depends on which currency is being read."""
+        source = js()
+        changes = [m.start() for m in re.finditer(r"_displayCurrency = select\.value;", source)]
+        assert changes, "the display-currency handlers moved"
+        for i in changes:
+            assert "renderStaleRateNotice()" in source[i : i + 400], (
+                "a currency change leaves the staleness notice showing the previous answer"
+            )
+
+
+class TestTheHarnessCoversTheBehaviour:
+    """The conditional logic is run, not read — and CI runs it."""
+
+    def test_the_harness_exercises_the_function(self):
+        source = (ROOT / "scripts" / "currency_check.mjs").read_text(encoding="utf-8")
+        assert "staleRateNotice" in source
+
+    def test_ci_runs_that_harness(self):
+        workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+        assert "currency_check.mjs" in workflow
+
+    def test_the_harness_passes(self):
+        import shutil
+
+        node = shutil.which("node")
+        if node is None:
+            pytest.skip("node is not installed; CI runs this as its own step")
+        result = subprocess.run([node, "scripts/currency_check.mjs"], cwd=ROOT, capture_output=True, text=True)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_it_covers_the_case_that_must_stay_quiet(self):
+        """A USD viewer is unaffected by a stale USD->X table.
+
+        Warning them would be the noise that teaches people to ignore warnings,
+        so the harness has to assert the silence as well as the alarm.
+        """
+        source = (ROOT / "scripts" / "currency_check.mjs").read_text(encoding="utf-8")
+        assert "fiat stale, USD viewer" in source
+
+    def test_it_covers_an_absent_field(self):
+        """Absent is not stale: an older payload must not raise a false alarm."""
+        source = (ROOT / "scripts" / "currency_check.mjs").read_text(encoding="utf-8")
+        assert "field absent entirely" in source


### PR DESCRIPTION
## The defect

`app/exchange_rates.py` goes to real trouble here: a **separate clock per source**, each advanced only on that source's own HTTP 200 — deliberately, so a failure on one never marks the other stale — with `stale`, `crypto_stale` and `fiat_stale` all published on `/api/exchange-rates`.

**No caller ever asked.**

So if CoinGecko stopped responding after one successful fetch, the cached rates never expired and nothing on screen changed. A MYST balance kept being converted and displayed at a price that could be hours or days old, with no indication at all.

## The fix

The dashboard says so, naming which source is behind.

Two things it deliberately does **not** do:

- **A USD viewer isn't warned about a stale USD→X fiat table.** No conversion they see uses it, and warning people who are fine is how a safety notice gets ignored.
- **An absent field isn't treated as stale.** An older payload must not raise a false alarm.

The notice is recomputed when the display currency changes, since the fiat half of the question depends on which currency is being read.

## Evidence

The behaviour is exercised by `scripts/currency_check.mjs`, which **runs the real function** against controlled state — this is conditional logic about which source matters to which viewer, and a string assertion can't see it. CI already runs that harness.

```
fresh rates, USD viewer     notice=false expected=false ok
crypto stale, USD viewer    notice=true  expected=true  ok   "Using cached crypto prices — …"
fiat stale, USD viewer      notice=false expected=false ok
fiat stale, GBP viewer      notice=true  expected=true  ok   "Using cached GBP exchange rates — …"
both stale, GBP viewer      notice=true  expected=true  ok   "…crypto prices and GBP exchange rates…"
field absent entirely       notice=false expected=false ok
```

Negative control — each fails the harness:

| reverted | result |
|---|---|
| ignore staleness entirely (the original state) | FAIL |
| warn a USD viewer about stale fiat (the noise) | FAIL |
| treat an absent field as stale | FAIL |

`ruff check` + `ruff format --check` clean, **95.28% coverage**, 3100 passed.

Closes CashPilot-dfw