### PR TITLE
fix: collect credentials that were stored before saving them began tracking

### DIFF
--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -232,6 +232,32 @@ def make_collectors(
     return collectors
 
 
+def fully_configured_slugs(config: dict[str, str]) -> set[str]:
+    """Slugs whose every REQUIRED credential key has a value in ``config``.
+
+    The one predicate behind "this service's credentials are complete". It is
+    what Settings renders as the green "Configured" badge, what decides whether
+    saving credentials starts tracking a service, and what the startup backfill
+    uses to catch credentials stored before tracking existed. Three copies of it
+    would eventually disagree, and the failure when they do is silent: a badge
+    that says Configured for a service nothing collects.
+
+    REQUIRED only. Optional args (``?``-prefixed in ``_COLLECTOR_ARGS``) are
+    exactly the ones a collector works without, so demanding them would refuse
+    to track a service that would collect perfectly well.
+
+    A collector with no required args at all is NOT included. There is no
+    credential to be complete, so "the user configured this" would be asserting
+    something the user never did.
+    """
+    configured: set[str] = set()
+    for slug in COLLECTOR_MAP:
+        required = [f"{slug}_{arg}" for arg in _COLLECTOR_ARGS.get(slug, []) if not arg.startswith("?")]
+        if required and all(config.get(key) for key in required):
+            configured.add(slug)
+    return configured
+
+
 def build_one(slug: str, config: dict[str, str]) -> tuple[Any | None, list[str]]:
     """Build a single, UNCACHED collector for an on-demand credential test.
 

--- a/app/main.py
+++ b/app/main.py
@@ -526,6 +526,50 @@ async def _warm_collector_alerts() -> None:
             logger.warning("Could not tell whether a collection has run before: %s", exc)
 
 
+async def _track_fully_configured_services() -> int:
+    """Give every fully-credentialled service a deployment row, so it is collected.
+
+    Collection iterates DEPLOYMENT ROWS (``make_collectors``), so a service with
+    no row is never collected however complete its credentials are. Saving
+    credentials has created that row since the fix in #187 — but only at save
+    time, and nothing has ever repaired a database written before it.
+
+    That leaves the upgrade path in exactly the state the fix was meant to end:
+    credentials stored under an older version show the green "Configured" badge,
+    no collector is ever built for them, and no earnings arrive. Nothing prompts
+    the user to re-save, because as far as the UI is concerned everything is
+    already correct. So this runs once per start and is idempotent — a slug that
+    already has a row of any status is left exactly as it is, because that row
+    may carry a real container id and spec that must not be replaced with an
+    empty placeholder.
+
+    Returns the number of rows created, for the log line and the tests.
+    """
+    from app.collectors import fully_configured_slugs
+
+    try:
+        config = await database.get_config() or {}
+        if not isinstance(config, dict):
+            return 0
+        existing = {d.get("slug") for d in await database.get_deployments()}
+        tracked = 0
+        for slug in sorted(fully_configured_slugs(config)):
+            if slug in existing or not catalog.get_service(slug):
+                continue
+            await database.save_deployment(slug=slug, container_id="", status="external")
+            tracked += 1
+        if tracked:
+            logger.info(
+                "Started tracking %d service(s) whose credentials were stored before "
+                "saving them began tracking; their earnings will be collected from now on",
+                tracked,
+            )
+        return tracked
+    except Exception as exc:  # noqa: BLE001 - bookkeeping must never block startup
+        logger.warning("Could not backfill tracking for stored credentials: %s", exc)
+        return 0
+
+
 async def _run_collection() -> None:
     """Collect earnings from all deployed services that have collectors."""
     global _collector_alerts
@@ -764,6 +808,9 @@ async def lifespan(app: FastAPI):
     # silently clear the notification bell while the underlying collector is still
     # broken (previously these lived only in memory).
     await _warm_collector_alerts()
+    # Credentials saved before saving them began creating a tracking row are
+    # otherwise inert forever, while Settings shows them as "Configured".
+    await _track_fully_configured_services()
     # First-run setup token: while no users exist, require a one-time token
     # (printed below) for /register so a proxy-exposed instance cannot be seized
     # by the first public visitor. Persisted in config so it survives restarts;
@@ -3270,7 +3317,7 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
     # Auto-create "external" deployment records for manual-only services
     # whose collector credentials were just saved.  Without a deployment
     # row, _run_collection() will never instantiate the collector.
-    from app.collectors import _COLLECTOR_ARGS
+    from app.collectors import fully_configured_slugs
 
     # Completeness is judged against the MERGED config, not this request.
     #
@@ -3282,14 +3329,13 @@ async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]
     #
     # Still scoped to the slugs this request touched, so saving one service's
     # credentials does not sweep the whole catalog.
+    #
+    # The completeness rule itself lives in collectors.fully_configured_slugs,
+    # shared with the startup backfill so the two can never disagree about which
+    # services are ready to collect.
     stored = await database.get_config() or {}
-    for slug, arg_keys in _COLLECTOR_ARGS.items():
+    for slug in fully_configured_slugs(stored):
         if not any(k.startswith(f"{slug}_") for k in sanitized):
-            continue
-        required_keys = [f"{slug}_{a.lstrip('?')}" for a in arg_keys if not a.startswith("?")]
-        if not required_keys:
-            continue
-        if not all(stored.get(k) for k in required_keys):
             continue
         svc = catalog.get_service(slug)
         if not svc:

--- a/tests/test_beads_batch_46.py
+++ b/tests/test_beads_batch_46.py
@@ -147,6 +147,7 @@ class TestTheStartupBackfill:
         make_collectors reads `slug` off each deployment, so that is what has to
         be right — asserting the row merely exists proves nothing.
         """
+        from app import collectors as collectors_mod
         from app import main
         from app.collectors import make_collectors
 
@@ -161,6 +162,13 @@ class TestTheStartupBackfill:
                 "the backfilled row does not produce a collector, so nothing is collected"
             )
         finally:
+            # Evict BEFORE closing. make_collectors caches by slug and hands the
+            # cached instance back whenever the resolved kwargs match, so
+            # closing without evicting leaves a closed httpx client in the cache
+            # for the next caller with the same credentials to be given.
+            for slug in [d["slug"] for d in deployments]:
+                collectors_mod._cached_collectors.pop(slug, None)
+                collectors_mod._cached_kwargs.pop(slug, None)
             for collector in collectors:
                 await collector.close()
 

--- a/tests/test_beads_batch_46.py
+++ b/tests/test_beads_batch_46.py
@@ -1,0 +1,302 @@
+"""CashPilot-h3d: "Configured" for credentials that are never collected.
+
+The bead's premise was that saving credentials in Settings → Collectors turned
+the badge green while nothing ever collected them, because collection iterates
+DEPLOYMENT ROWS (`make_collectors`) and saving credentials created none.
+
+Half of that is now false: #187 made `POST /api/config` create an `external`
+deployment row for any service whose required credentials are complete. The
+badge and the tracking agree at save time.
+
+The other half survived, and only on the path nobody tests by hand: a database
+written BEFORE that fix. Those credentials are complete, so Settings shows
+"Configured"; no row exists, so no collector is ever built; and nothing ever
+re-runs the save path, because the user has no reason to re-save credentials the
+UI says are fine. The fix that was supposed to end this state left every
+existing install in it.
+
+So: one predicate (`collectors.fully_configured_slugs`) shared by the save path
+and a startup backfill, rather than a second inline copy that can drift from it.
+
+The backfill is deliberately narrow. It never touches a slug that already has a
+row — that row can carry a real container id and an encrypted spec, and
+replacing it with an empty placeholder would lose the spec a later redeploy
+needs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestTheCompletenessPredicate:
+    """One rule for "these credentials are complete", used by both callers."""
+
+    def _slugs(self, config):
+        from app.collectors import fully_configured_slugs
+
+        return fully_configured_slugs(config)
+
+    def _required_keys(self, slug):
+        from app.collectors import _COLLECTOR_ARGS
+
+        return [f"{slug}_{a}" for a in _COLLECTOR_ARGS.get(slug, []) if not a.startswith("?")]
+
+    def test_a_service_with_every_required_key_is_configured(self):
+        keys = self._required_keys("honeygain")
+        assert keys, "honeygain has no required credentials — this test would prove nothing"
+        assert "honeygain" in self._slugs({k: "value" for k in keys})
+
+    def test_one_missing_required_key_is_not_configured(self):
+        """The exact case the badge used to get wrong: email set, password not."""
+        keys = self._required_keys("honeygain")
+        assert len(keys) > 1, "needs a multi-field service to distinguish partial from complete"
+        assert "honeygain" not in self._slugs({k: "value" for k in keys[:-1]})
+
+    def test_an_empty_string_does_not_count_as_set(self):
+        """Cleared credentials are stored as "", not deleted."""
+        keys = self._required_keys("honeygain")
+        config = {k: "value" for k in keys}
+        config[keys[0]] = ""
+        assert "honeygain" not in self._slugs(config)
+
+    def test_optional_keys_are_not_demanded(self):
+        """A collector works without them, so requiring them would refuse to track."""
+        from app.collectors import _COLLECTOR_ARGS
+
+        # Needs BOTH: an optional arg to ignore, and a required one to satisfy.
+        # storj declares only `?api_url`, so it has no required credentials at
+        # all and is deliberately never claimed — picking it proved the opposite
+        # of what this test is about.
+        slug = next(
+            (
+                s
+                for s, args in _COLLECTOR_ARGS.items()
+                if s in self._all()
+                and any(a.startswith("?") for a in args)
+                and any(not a.startswith("?") for a in args)
+            ),
+            None,
+        )
+        if slug is None:
+            pytest.skip("no collector currently mixes required and optional arguments")
+        assert slug in self._slugs({k: "value" for k in self._required_keys(slug)})
+
+    def _all(self):
+        from app.collectors import COLLECTOR_MAP
+
+        return set(COLLECTOR_MAP)
+
+    def test_nothing_is_configured_by_an_empty_config(self):
+        assert self._slugs({}) == set()
+
+    def test_a_slug_with_no_required_args_is_never_claimed(self):
+        """There is no credential to be complete, so the user configured nothing."""
+        from app.collectors import _COLLECTOR_ARGS, COLLECTOR_MAP
+
+        bare = [s for s in COLLECTOR_MAP if not [a for a in _COLLECTOR_ARGS.get(s, []) if not a.startswith("?")]]
+        for slug in bare:
+            assert slug not in self._slugs({f"{slug}_anything": "value"})
+
+    def test_it_only_reports_slugs_that_have_a_collector(self):
+        """Tracking a slug with no collector class would create a row that collects nothing."""
+        from app.collectors import _COLLECTOR_ARGS, COLLECTOR_MAP
+
+        config = {f"{slug}_{a.lstrip('?')}": "value" for slug, args in _COLLECTOR_ARGS.items() for a in args}
+        assert self._slugs(config) <= set(COLLECTOR_MAP)
+
+
+class TestTheStartupBackfill:
+    """The upgrade path: credentials stored before saving them began tracking."""
+
+    @pytest.fixture
+    def db(self, tmp_path, monkeypatch):
+        import asyncio
+
+        from app import database
+
+        monkeypatch.setattr(database, "DB_DIR", tmp_path)
+        monkeypatch.setattr(database, "DB_PATH", tmp_path / "h3d.db")
+        monkeypatch.setattr(database, "_shared_db", None, raising=False)
+        asyncio.run(database.init_db())
+        return database
+
+    def _honeygain_config(self):
+        from app.collectors import _COLLECTOR_ARGS
+
+        return {f"honeygain_{a}": "value" for a in _COLLECTOR_ARGS["honeygain"] if not a.startswith("?")}
+
+    @pytest.mark.asyncio
+    async def test_it_creates_a_row_for_stranded_credentials(self, db):
+        """The whole bead: complete credentials, no row, nothing collecting."""
+        from app import main
+
+        await db.set_config_bulk(self._honeygain_config())
+        assert not await db.get_deployments(), "fixture is wrong — a row already exists"
+
+        created = await main._track_fully_configured_services()
+
+        assert created == 1
+        slugs = {d["slug"] for d in await db.get_deployments()}
+        assert "honeygain" in slugs, "credentials stored before the fix are still never collected"
+
+    @pytest.mark.asyncio
+    async def test_the_row_it_creates_is_one_collection_will_use(self, db):
+        """A row of the wrong shape would satisfy the test above and collect nothing.
+
+        make_collectors reads `slug` off each deployment, so that is what has to
+        be right — asserting the row merely exists proves nothing.
+        """
+        from app import main
+        from app.collectors import make_collectors
+
+        await db.set_config_bulk(self._honeygain_config())
+        await main._track_fully_configured_services()
+
+        deployments = await db.get_deployments()
+        config = await db.get_config()
+        collectors = make_collectors(deployments, config)
+        try:
+            assert any(type(c).__name__.lower().startswith("honeygain") for c in collectors), (
+                "the backfilled row does not produce a collector, so nothing is collected"
+            )
+        finally:
+            for collector in collectors:
+                await collector.close()
+
+    @pytest.mark.asyncio
+    async def test_incomplete_credentials_are_left_alone(self, db):
+        """Tracking a service that cannot collect would create a permanent failure."""
+        from app import main
+
+        partial = self._honeygain_config()
+        partial.pop(sorted(partial)[-1])
+        await db.set_config_bulk(partial)
+
+        assert await main._track_fully_configured_services() == 0
+        assert not await db.get_deployments()
+
+    @pytest.mark.asyncio
+    async def test_it_is_idempotent_across_restarts(self, db):
+        """It runs on every start; the second start must be a no-op."""
+        from app import main
+
+        await db.set_config_bulk(self._honeygain_config())
+        first = await main._track_fully_configured_services()
+        second = await main._track_fully_configured_services()
+
+        assert (first, second) == (1, 0)
+        assert len([d for d in await db.get_deployments() if d["slug"] == "honeygain"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_it_never_overwrites_a_real_deployment(self, db):
+        """That row holds the container id and the encrypted spec a redeploy needs.
+
+        Replacing it with an empty placeholder would lose the spec, and the next
+        redeploy would silently rebuild the container from the catalog instead.
+        """
+        from app import main
+
+        await db.set_config_bulk(self._honeygain_config())
+        await db.save_deployment(
+            slug="honeygain", container_id="abc123", spec={"image": "pinned:1.2.3"}, status="running"
+        )
+
+        assert await main._track_fully_configured_services() == 0
+
+        row = await db.get_deployment("honeygain")
+        assert row["container_id"] == "abc123"
+        assert row["status"] == "running"
+        assert (await db.get_deployment_spec("honeygain")) == {"image": "pinned:1.2.3"}
+
+    @pytest.mark.asyncio
+    async def test_a_stopped_deployment_is_also_left_alone(self, db):
+        """Status is not the question — presence of a row is."""
+        from app import main
+
+        await db.set_config_bulk(self._honeygain_config())
+        await db.save_deployment(slug="honeygain", container_id="dead", status="stopped")
+
+        assert await main._track_fully_configured_services() == 0
+        assert (await db.get_deployment("honeygain"))["status"] == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_a_database_failure_does_not_stop_startup(self, db, monkeypatch):
+        """It runs inside lifespan; raising there takes the whole app down."""
+        from app import main
+
+        async def _boom():
+            raise RuntimeError("database is unreadable")
+
+        monkeypatch.setattr(db, "get_config", _boom)
+        assert await main._track_fully_configured_services() == 0
+
+
+class TestItActuallyRunsOnStartup:
+    """A backfill nobody calls fixes nothing."""
+
+    def test_lifespan_calls_it(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from app import main
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(main.lifespan.__wrapped__)))
+        called = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "_track_fully_configured_services" in called, (
+            "the backfill is defined but never runs, so no existing install is repaired"
+        )
+
+    def test_it_runs_before_collection_is_scheduled(self):
+        """Otherwise the first collection after an upgrade still misses them."""
+        import inspect
+
+        from app import main
+
+        source = inspect.getsource(main.lifespan.__wrapped__)
+        assert source.index("_track_fully_configured_services") < source.index('id="collect"')
+
+
+class TestTheSavePathStillTracks:
+    """The half of the bead that #187 fixed must not regress while sharing code."""
+
+    def test_it_uses_the_shared_predicate(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from app import main
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(main.api_set_config)))
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)} | {
+            alias.name for n in ast.walk(tree) if isinstance(n, ast.ImportFrom) for alias in n.names
+        }
+        assert "fully_configured_slugs" in names, "the save path has its own copy of the completeness rule again"
+
+    def test_it_stays_scoped_to_the_slugs_the_request_touched(self):
+        """Saving one service's credentials must not sweep the whole catalog.
+
+        Without this the shared predicate — which looks at the merged config —
+        would track every already-configured service on any unrelated save.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from app import main
+
+        source = textwrap.dedent(inspect.getsource(main.api_set_config))
+        tree = ast.parse(source)
+        loops = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.For)
+            and isinstance(node.iter, ast.Call)
+            and getattr(node.iter.func, "id", "") == "fully_configured_slugs"
+        ]
+        assert len(loops) == 1, "expected exactly one loop over fully_configured_slugs"
+        guard = ast.dump(ast.Module(body=loops[0].body, type_ignores=[]))
+        assert "sanitized" in guard, "the loop no longer restricts itself to the slugs this request touched"


### PR DESCRIPTION
## The bead

`CashPilot-h3d` — Settings → Collectors reports "Configured" for credentials that can never be used.

Half of the premise is already false. #187 made `POST /api/config` create an `external` deployment row whenever a service's required credentials are complete, so at save time the badge and the tracking agree.

The other half survived, on the path nobody exercises by hand: **a database written before that fix.**

- credentials are complete → Settings shows the green **Configured** badge
- no deployment row exists → `make_collectors` never builds a collector
- no earnings ever arrive
- nothing re-runs the save path, because the user has no reason to re-save credentials the UI says are fine

The fix that was supposed to end this state left every existing install sitting in it.

## The change

- `collectors.fully_configured_slugs(config)` — one predicate for "these credentials are complete", now shared by the save path and the backfill instead of a second inline copy that can drift.
- `_track_fully_configured_services()` runs once per start, before the collection job is scheduled, and gives every fully-credentialled service its tracking row.

Deliberately narrow:

- **Idempotent.** A slug that already has a row of any status is left exactly as it is — that row can carry a real container id and an encrypted spec, and replacing it with an empty placeholder would lose the spec a later redeploy needs.
- **Required credentials only.** Optional args are the ones a collector works without; demanding them would refuse to track a service that would collect perfectly well.
- **A collector with no required args is never claimed.** There is no credential to be complete, so "the user configured this" would assert something the user never did. (`storj` is the live case.)
- **A database failure cannot block startup** — this runs inside `lifespan`.

## Evidence

18 new tests in `tests/test_beads_batch_46.py`. One of them drives `make_collectors` over the backfilled row and asserts a Honeygain collector comes out, because a row of the wrong shape would satisfy "a row exists" and still collect nothing.

Four negative controls, all caught:

| reverted | result |
|---|---|
| backfill defined but never called from `lifespan` | 2 failed |
| backfill overwrites an existing deployment row | 3 failed |
| predicate accepts partial credentials (`all` → `any`) | 3 failed |
| save path stops scoping to the slugs the request touched | 1 failed |

Sources verified byte-identical to the originals after every revert.

Gates: `ruff check` clean, `ruff format --check` clean, `currency_check.mjs` PASS, `fleet_staleness_check.mjs` PASS (20 assertions), **3118 passed, 95.29% coverage**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Services with complete required credentials are now automatically prepared at startup, even when deployment records are missing.
  * Existing deployment records are preserved, and repeated startup processing avoids creating duplicates.
  * Credential validation is now applied consistently when saving configuration.
* **Reliability**
  * Improved handling of incomplete, optional-only, unsupported, and failed service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->