### PR TITLE
ci: make five guards report what they actually checked

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
-      - run: pip install ruff
-      - run: ruff check app/ && ruff format --check app/
+          python-version: "3.14"
+      # The lockfile's ruff, not whatever released today. This job gates
+      # build-ui/build-worker/retag-*, so a floating ruff that adds a default
+      # rule turns the RELEASE red on a commit that changed nothing -- in the
+      # same run whose `ci` job just passed lint on the pinned version. Scope is
+      # `.` here too; `app/` alone let a scripts/ or tests/ violation pass one
+      # gate and fail another.
+      - run: pip install uv
+      - run: uv sync --frozen --extra dev
+      - run: uv run ruff check . && uv run ruff format --check .
 
   # Multi-arch build (amd64 + arm64) in a single QEMU-emulated job on the X64
   # runner. buildx pushes the multi-platform manifest under all tags directly,
@@ -191,6 +198,19 @@ jobs:
     if: ${{ always() && inputs.version != '' }}
     runs-on: ubuntu-latest
     steps:
+      # This job is the only one in this file that talks to Docker Hub without
+      # logging in first. Anonymous pulls share a per-IP quota with every other
+      # project on the same GitHub-hosted runner egress, so a rate limit here
+      # reports "MISSING" for images that published perfectly — and because
+      # verify-tags failing fails release.yml's `build`, which `publish` needs,
+      # the run then withholds the git tag and the GitHub Release for a release
+      # that is actually complete.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Every published tag must resolve
         env:
           UI_TAGS: ${{ needs.resolve-tags.outputs.ui_tags }}
@@ -204,14 +224,18 @@ jobs:
           missing=0
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
-            if docker manifest inspect "$tag" >/dev/null 2>&1; then
+            # Capture stderr instead of discarding it. `2>&1 >/dev/null` threw
+            # away the registry's actual answer, so a rate limit, a 5xx or a DNS
+            # failure all printed the single word MISSING and the ::error::
+            # below then asserted a cause that was not true.
+            if err=$(docker manifest inspect "$tag" 2>&1); then
               echo "ok      $tag"
             else
-              echo "MISSING $tag"
+              echo "MISSING $tag -- registry said: ${err}"
               missing=1
             fi
           done < /tmp/tags.txt
           if [ "$missing" -ne 0 ]; then
-            echo "::error::A release tag is missing. The compose files pin both images to the same tag, so a partial release breaks the documented quickstart."
+            echo "::error::A tag this release claims to have published did not resolve. Read the registry response printed above BEFORE assuming a partial build: an auth or rate-limit failure looks identical here. If the images really are missing, the compose files pin both to the same tag, so a partial release breaks the documented quickstart."
             exit 1
           fi

--- a/.github/workflows/collector-live-check.yml
+++ b/.github/workflows/collector-live-check.yml
@@ -51,7 +51,37 @@ jobs:
           # marker yet, so without this the job fails EVERY night and files a
           # false drift alert — which trains the maintainer to ignore the one
           # alert designed to catch a real provider change.
-          uv run pytest tests/ -m live -q 2>&1 | tee live.log || [ "${PIPESTATUS[0]}" = "5" ]
+          #
+          # PIPESTATUS is captured into `rc` immediately, because EVERY later
+          # command overwrites it -- including the `[ ... ]` test that used to be
+          # on the right of this `||`. Reading ${PIPESTATUS[0]} on any subsequent
+          # line yields that test's own status, not pytest's.
+          rc=0
+          uv run pytest tests/ -m live -q 2>&1 | tee live.log || rc=${PIPESTATUS[0]}
+          # ...but say so. Masking exit 5 keeps the job green, which is right —
+          # and it also makes "green" mean two different things: "every provider
+          # still matches its collector" and "nothing was checked at all". Today
+          # it is always the second (no test carries the marker yet), so the
+          # nightly run is a safety net that reports healthy while catching
+          # nothing. The summary makes which one it is visible without turning
+          # the job red and training alert-blindness.
+          #
+          # A REAL failure (exit 1) must still redden the job and reach the
+          # issue-filing step below. Masking only the empty case is the whole
+          # point; masking everything would turn this into a silencer.
+          if [ "$rc" != "0" ] && [ "$rc" != "5" ]; then
+            exit "$rc"
+          fi
+          if [ "$rc" = "5" ]; then
+            {
+              echo "### Provider-drift detection is NOT active"
+              echo
+              echo "0 tests carry the \`live\` marker, so **no collector was checked against a real API**."
+              echo "This job passed because there was nothing to run — not because the providers are unchanged."
+              echo
+              echo "To activate it, mark a collector test with \`@pytest.mark.live\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Open an issue when a provider's shape changed
         if: failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
-      - name: Install Ruff
-        run: pip install ruff
+      # The lockfile's ruff, so this gate and release.yml's cannot reach
+      # different verdicts about the same commit.
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync from the lockfile
+        run: uv sync --frozen --extra dev
 
       - name: Ruff check
-        run: ruff check .
+        run: uv run ruff check .
 
       - name: Ruff format check
-        run: ruff format --check .
+        run: uv run ruff format --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,13 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          # The interpreter the images ship (Dockerfile:2, Dockerfile.worker:2),
+          # and the one test.yml uses. This job is what the release is actually
+          # gated on -- test.yml gates nothing -- so on 3.12 a commit could be
+          # tagged and pushed to Docker Hub while its 3.14 suite was red.
+          # uv sync --frozen resolves markers per interpreter, so the two really
+          # did install different wheels. Same class as CashPilot-de1.
+          python-version: '3.14'
       - name: Install uv
         run: pip install uv --quiet
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ coverage.xml
 htmlcov/
 
 # Agent / tooling working dirs (not part of the project)
+#
+# .beads/ is NOT optional here and must not be "helpfully" committed later. The
+# usual beads convention is to commit the export so the tracker travels with the
+# repo; this repository is the exception, because the backlog contains real
+# wallet addresses and this repo is PUBLIC. It was previously protected only by
+# .git/info/exclude, which is local to one clone and travels with nothing.
+.beads/
 .omc/
 .claude/
 .sddw/

--- a/tests/test_ci_gates_report_what_they_checked.py
+++ b/tests/test_ci_gates_report_what_they_checked.py
@@ -1,0 +1,317 @@
+"""refine-loop segment 1: guards that did not guard what they claimed.
+
+Five independent places where a check looked like it was protecting something
+and was not. None of them changes what the application does; all of them change
+what the project can conclude from a green run.
+
+1. The nightly collector-live-check collects **zero** tests — no test carries the
+   ``live`` marker — masks pytest's exit 5, and is therefore green every morning.
+   "Green" meant both "every provider still matches its collector" and "nothing
+   was checked at all", and it was always the second. The masking stays (a job
+   that fails every night trains people to ignore it); the empty case now says so
+   in the step summary.
+
+2. ``verify-tags`` was the only job in build.yml that talked to Docker Hub
+   without logging in, and it discarded stderr. An anonymous rate limit — shared
+   per egress IP with every other project on GitHub-hosted runners — printed
+   ``MISSING`` for images that had published perfectly, and the ``::error::``
+   then asserted a partial release that had not happened. Because verify-tags
+   failing fails release.yml's ``build``, which ``publish`` needs, the run then
+   withheld the git tag and the GitHub Release for a complete release.
+
+3. release.yml's ``ci`` job — the one the release is actually gated on, since
+   test.yml gates nothing — ran the suite on Python 3.12 while both images ship
+   3.14. ``uv sync --frozen`` resolves markers per interpreter, so the two gates
+   really did install different wheels. This is the shape of CashPilot-de1,
+   where a different resolution silently covered 65 of 76 routes.
+
+4. build.yml and lint.yml installed ruff unpinned while release.yml used the
+   lockfile's. A ruff release that adds a default rule turned the **release** red
+   on a commit that changed nothing, in the same run whose ``ci`` job had just
+   passed lint on the pinned version. They also disagreed on scope (``app/`` vs
+   ``.``).
+
+5. ``.beads/`` was kept out of git only by ``.git/info/exclude``, which is local
+   to one clone and is not itself tracked. The backlog holds real wallet
+   addresses and this repository is public, so the protection had to travel with
+   the repo.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+SHIPPED_PYTHON = "3.14"
+"""The interpreter both Dockerfiles use. Derived below, never assumed."""
+
+
+def _wf(name):
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _steps(job):
+    return job.get("steps") or []
+
+
+class TestTheNightlyLiveCheckAdmitsWhenItCheckedNothing:
+    """It may stay green on an empty run; it may not stay silent about it."""
+
+    def _text(self):
+        return (WORKFLOWS / "collector-live-check.yml").read_text(encoding="utf-8")
+
+    def test_no_test_currently_carries_the_live_marker(self):
+        """The premise. If this ever fails, the job started doing real work."""
+        # Excludes THIS file, which necessarily names the marker in order to
+        # talk about it — the first version of this test matched its own prose
+        # and reported live tests that do not exist.
+        marked = [
+            p
+            for p in (ROOT / "tests").rglob("*.py")
+            if p != Path(__file__).resolve() and "@pytest.mark.live" in p.read_text(encoding="utf-8")
+        ]
+        assert not marked, (
+            f"live tests now exist ({[p.name for p in marked]}) — the 'nothing was checked' "
+            "summary is no longer the normal case and this file should be revisited"
+        )
+
+    def test_it_still_masks_the_empty_run(self):
+        """Failing every night is what trains people to ignore the alert.
+
+        Behaviour is proven by the executing test below; this only pins that the
+        exit status is CAPTURED rather than re-read later, which is the mistake
+        that made the summary unreachable.
+        """
+        text = self._text()
+        assert "rc=${PIPESTATUS[0]}" in text
+        assert '[ "$rc" = "5" ]' in text
+
+    def test_it_writes_the_empty_case_to_the_step_summary(self):
+        text = self._text()
+        assert "GITHUB_STEP_SUMMARY" in text, "an empty run is still indistinguishable from a clean one"
+
+    def test_the_summary_says_nothing_was_checked(self):
+        """A neutral note would be read as success. It has to be explicit."""
+        text = self._text()
+        assert "NOT active" in text
+        assert "no collector was checked against a real API" in text
+
+    @pytest.mark.parametrize(
+        ("pytest_exit", "expect_rc", "expect_summary"),
+        [(5, 0, True), (0, 0, False), (1, 1, False)],
+        ids=["empty-run-is-masked-and-announced", "clean-run-stays-quiet", "real-failure-still-reddens"],
+    )
+    def test_the_step_behaves_correctly_when_actually_run(self, pytest_exit, expect_rc, expect_summary):
+        """Executes the step's shell against a stubbed pytest, rather than reading it.
+
+        The first version of this class asserted only that one string appeared
+        before another in the file. That passed against a step which could never
+        emit the summary at all: ``PIPESTATUS`` is overwritten by every
+        subsequent command, including the ``[ ... ]`` test that was on the right
+        of the ``||``, so the later read always saw that test's own status
+        instead of pytest's. A string test cannot see a bug like that; only
+        running it can.
+        """
+        import os
+        import subprocess
+        import tempfile
+
+        script = next(
+            step["run"]
+            for job in _wf("collector-live-check.yml")["jobs"].values()
+            for step in _steps(job)
+            if "pytest" in str(step.get("run", ""))
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            stub = Path(tmp) / "uv"
+            stub.write_text(f"#!/bin/sh\nexit {pytest_exit}\n")
+            stub.chmod(0o755)
+            summary = Path(tmp) / "summary.md"
+            summary.write_text("")
+            env = {**os.environ, "PATH": f"{tmp}:{os.environ['PATH']}", "GITHUB_STEP_SUMMARY": str(summary)}
+            result = subprocess.run(["bash", "-e", "-c", script], cwd=tmp, env=env, capture_output=True, text=True)
+            # Read INSIDE the context manager: the directory is gone after it.
+            written = summary.read_text()
+
+        assert result.returncode == expect_rc, (
+            f"pytest exiting {pytest_exit} should leave the step at rc={expect_rc}; got {result.returncode}"
+        )
+        assert ("NOT active" in written) is expect_summary
+
+    def test_a_real_failure_can_still_reach_the_issue_filing_step(self):
+        """Masking everything would turn a masking bug into a silencing bug."""
+        doc = _wf("collector-live-check.yml")
+        job = next(j for j in doc["jobs"].values() if any("pytest" in str(s.get("run", "")) for s in _steps(j)))
+        assert any(str(s.get("if", "")).strip() == "failure()" for s in _steps(job)), (
+            "nothing reacts to a genuine live-test failure any more"
+        )
+
+
+class TestTheTagVerifierCanTellApartMissingAndUnreachable:
+    def _job(self):
+        return _wf("build.yml")["jobs"]["verify-tags"]
+
+    def test_it_authenticates_to_the_registry(self):
+        """It was the only Docker Hub caller here that did not."""
+        assert any("docker/login-action" in str(s.get("uses", "")) for s in _steps(self._job())), (
+            "anonymous manifest inspects share a per-IP rate limit and fail this gate for images that published fine"
+        )
+
+    def test_it_pins_the_same_action_version_as_its_siblings(self):
+        """A second pin for one action is drift, and a guessed SHA is worse."""
+        doc = _wf("build.yml")
+        pins = {
+            str(s.get("uses"))
+            for job in doc["jobs"].values()
+            for s in _steps(job)
+            if "docker/login-action" in str(s.get("uses", ""))
+        }
+        assert len(pins) == 1, f"docker/login-action is pinned to more than one version: {sorted(pins)}"
+
+    def test_it_keeps_the_registry_response(self):
+        runs = " ".join(str(s.get("run", "")) for s in _steps(self._job()))
+        assert "err=$(docker manifest inspect" in runs
+
+    def test_it_no_longer_discards_stderr(self):
+        runs = " ".join(str(s.get("run", "")) for s in _steps(self._job()))
+        assert 'inspect "$tag" >/dev/null 2>&1' not in runs, "the registry's actual answer is thrown away again"
+
+    def test_it_prints_that_response_on_failure(self):
+        """Captured but unprinted would be exactly as useless."""
+        runs = " ".join(str(s.get("run", "")) for s in _steps(self._job()))
+        assert "${err}" in runs
+
+    def test_the_error_no_longer_asserts_a_single_cause(self):
+        runs = " ".join(str(s.get("run", "")) for s in _steps(self._job()))
+        assert "::error::A release tag is missing." not in runs, (
+            "it states a partial release as fact when an auth or rate-limit failure looks identical"
+        )
+
+
+class TestTheReleaseGateRunsWhatShips:
+    def _dockerfile_python(self, name):
+        line = next(
+            line for line in (ROOT / name).read_text(encoding="utf-8").splitlines() if line.startswith("FROM python:")
+        )
+        return line.split("FROM python:")[1].split("-")[0]
+
+    @pytest.mark.parametrize("dockerfile", ["Dockerfile", "Dockerfile.worker"])
+    def test_the_images_ship_the_python_this_file_pins(self, dockerfile):
+        """Derives the expectation instead of hardcoding it twice."""
+        assert self._dockerfile_python(dockerfile) == SHIPPED_PYTHON
+
+    def _python_versions(self, workflow, job):
+        return {
+            str(s["with"]["python-version"])
+            for s in _steps(_wf(workflow)["jobs"][job])
+            if isinstance(s.get("with"), dict) and "python-version" in s["with"]
+        }
+
+    def test_the_release_gate_uses_it(self):
+        """release.yml's `ci` is what gates the release; test.yml gates nothing."""
+        assert self._python_versions("release.yml", "ci") == {SHIPPED_PYTHON}
+
+    def test_the_standalone_suite_uses_it_too(self):
+        assert self._python_versions("test.yml", "test") == {SHIPPED_PYTHON}
+
+    def test_the_release_job_really_does_depend_on_that_gate(self):
+        """If `release` stopped needing `ci`, none of the above would matter."""
+        assert "ci" in _wf("release.yml")["jobs"]["release"]["needs"]
+
+
+class TestEveryLintGateReachesTheSameVerdict:
+    """Three gates, one commit — they must not be able to disagree."""
+
+    LINT_JOBS = [("build.yml", "lint"), ("lint.yml", "ruff")]
+
+    @pytest.mark.parametrize(("workflow", "job"), LINT_JOBS)
+    def test_it_does_not_install_a_floating_ruff(self, workflow, job):
+        for step in _steps(_wf(workflow)["jobs"][job]):
+            run = str(step.get("run", "")).strip()
+            # Matched as a PATTERN: `run != "pip install ruff"` was satisfied by
+            # `pip install ruff -U`, `pip install ruff --quiet`, or any two-line
+            # run block.
+            assert not re.search(r"pip install\b[^\n]*\bruff\b", run), (
+                f"{workflow}:{job} lints with whatever ruff released today: {run}"
+            )
+
+    @pytest.mark.parametrize(("workflow", "job"), LINT_JOBS)
+    def test_it_resolves_ruff_from_the_lockfile(self, workflow, job):
+        runs = " ".join(str(s.get("run", "")) for s in _steps(_wf(workflow)["jobs"][job]))
+        assert "uv sync --frozen" in runs
+        assert "uv run ruff check ." in runs, f"{workflow}:{job} does not lint the whole tree with the pinned ruff"
+
+    @pytest.mark.parametrize(("workflow", "job"), LINT_JOBS)
+    def test_every_ruff_invocation_goes_through_uv(self, workflow, job):
+        """`uv sync` puts ruff in .venv, NOT on PATH.
+
+        Deleting `pip install ruff` while leaving a bare `ruff format --check .`
+        does not fall back to a pinned ruff -- it exits 127. The earlier version
+        of this class asserted only the *check* command and was blind to a format
+        step that could no longer run at all.
+        """
+        for step in _steps(_wf(workflow)["jobs"][job]):
+            run = str(step.get("run", "")).strip()
+            if not run or "ruff" not in run:
+                continue
+            assert run.startswith("uv run ruff"), f"{workflow}:{job} invokes ruff outside the synced environment: {run}"
+
+    def test_the_lint_job_still_gates_the_builds(self):
+        """The point of pinning it is that it can fail a release."""
+        doc = _wf("build.yml")
+        for job in ("build-ui", "build-worker"):
+            assert "lint" in doc["jobs"][job]["needs"]
+
+    def test_the_build_lint_checks_formatting_too(self):
+        runs = " ".join(str(s.get("run", "")) for s in _steps(_wf("build.yml")["jobs"]["lint"]))
+        assert "ruff format --check ." in runs
+
+
+class TestTheBacklogCannotBeCommitted:
+    """It holds real wallet addresses and this repository is public."""
+
+    def test_the_committed_gitignore_excludes_it(self):
+        """.git/info/exclude is local to one clone and is not tracked."""
+        entries = {
+            line.strip() for line in (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines() if line.strip()
+        }
+        assert ".beads/" in entries
+
+    def test_git_agrees_that_it_is_ignored_by_that_file(self):
+        """Proves the rule is effective, not merely present."""
+        import subprocess
+
+        if not (ROOT / ".git").exists():
+            pytest.skip("not a git checkout (sdist/export); the .gitignore assertion above still holds")
+        result = subprocess.run(
+            ["git", "check-ignore", "-v", ".beads"], cwd=ROOT, capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, ".beads is not ignored at all"
+        assert result.stdout.startswith(".gitignore:"), (
+            f"still relying on a non-portable exclude: {result.stdout.strip()}"
+        )
+
+    def test_the_reason_is_recorded_next_to_the_rule(self):
+        """Without it, a later 'fix' restores the usual commit-the-beads convention."""
+        # Anchored on the RULE line, not the first occurrence of the string:
+        # the explanation itself mentions .beads/, so `text.index` landed inside
+        # the comment it was meant to be reading.
+        lines = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        rule = next(i for i, line in enumerate(lines) if line.strip() == ".beads/")
+        preceding = "\n".join(lines[max(0, rule - 12) : rule])
+        assert "PUBLIC" in preceding and "wallet addresses" in preceding
+
+    def test_no_beads_file_is_tracked(self):
+        """The rule only prevents new adds; this catches one already in the index."""
+        import subprocess
+
+        tracked = subprocess.run(
+            ["git", "ls-files", ".beads"], cwd=ROOT, capture_output=True, text=True, check=False
+        ).stdout.strip()
+        assert not tracked, f"wallet addresses are committed to a public repo: {tracked}"

--- a/tests/test_ci_gates_report_what_they_checked.py
+++ b/tests/test_ci_gates_report_what_they_checked.py
@@ -289,10 +289,20 @@ class TestTheBacklogCannotBeCommitted:
 
         if not (ROOT / ".git").exists():
             pytest.skip("not a git checkout (sdist/export); the .gitignore assertion above still holds")
+        # Checks a path INSIDE the directory, not the directory itself.
+        # `.beads/` is a directory-only pattern, and git can only tell that a
+        # path is a directory if it exists on disk -- so `check-ignore .beads`
+        # answers "not ignored" on any fresh checkout where the tracker has not
+        # been initialised, which is every CI run. This test passed locally and
+        # failed on CI for exactly that reason.
         result = subprocess.run(
-            ["git", "check-ignore", "-v", ".beads"], cwd=ROOT, capture_output=True, text=True, check=False
+            ["git", "check-ignore", "-v", ".beads/config.yaml"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
         )
-        assert result.returncode == 0, ".beads is not ignored at all"
+        assert result.returncode == 0, ".beads contents are not ignored at all"
         assert result.stdout.startswith(".gitignore:"), (
             f"still relying on a non-portable exclude: {result.stdout.strip()}"
         )


### PR DESCRIPTION
Behaviour-preserving. Nothing under `app/`, `services/`, `Dockerfile*`, compose, or docs is touched, so the application is unchanged and `release.yml`'s path filter correctly triggers no release.

Five places where a check looked like it was protecting something and was not.

## 1. The nightly provider-drift check was inert and looked healthy

`collector-live-check.yml` runs nightly and is described in `pyproject.toml` as *"the one thing here that can notice a provider changed its API"*. It collects **zero** tests — `grep -rl "@pytest.mark.live" tests/` returns nothing — exits 5, and masks that exit. So it is green every morning, and green meant two different things: *"every provider still matches its collector"* and *"nothing was checked at all."* It was always the second.

The masking is **kept** — a job that fails every night is how you train someone to ignore the one alert designed to catch a real change. What changes is that the empty case now says so in the step summary.

## 2. `verify-tags` could withhold a release for images that published fine

It was the only job in `build.yml` that talked to Docker Hub without logging in, and it ran `docker manifest inspect "$tag" >/dev/null 2>&1`. Every failure mode — an anonymous rate limit (shared per egress IP across GitHub-hosted runners), a 5xx, DNS — collapsed to the word `MISSING`, and the `::error::` then asserted a specific cause that was false. Since `verify-tags` failing fails `release.yml`'s `build`, which `publish` needs, a rate limit meant **no git tag and no GitHub Release** for a complete release.

Now it logs in with the same pinned action its four siblings use, keeps the registry's response, and prints it.

## 3. The release gate ran a different interpreter from the one that ships

`release.yml`'s `ci` job is what the release is gated on — `test.yml` gates nothing. It ran on Python 3.12; both Dockerfiles ship `python:3.14-alpine`. `uv sync --frozen` resolves markers per interpreter, so the two gates genuinely installed different wheels. This is the shape of **CashPilot-de1**, where a different resolution silently covered 65 of 76 routes.

## 4. Three lint gates could reach different verdicts on one commit

`build.yml` and `lint.yml` ran `pip install ruff` (unpinned); `release.yml` ran the lockfile's. `build.yml`'s lint job gates `build-ui`/`build-worker`/`retag-*`, so a ruff release adding a default rule turns the **release** red on a commit that changed nothing — in the same run whose `ci` job just passed lint on the pinned version. They also disagreed on scope (`app/` vs `.`).

## 5. `.beads/` was protected by a file that travels with nothing

`git check-ignore -v .beads` resolved to `.git/info/exclude:12`, and `git ls-files .git/info/exclude` confirms that file is **not tracked**. The backlog holds real wallet addresses and this repository is public, so the protection had to be committed. The reason is recorded beside the rule, because the usual beads convention is the opposite and a later "fix" would otherwise undo it.

## Review found two blocking bugs in the first version of this change

Worth stating plainly, because one of them was the same sin the PR is about.

**My live-check summary could never fire.** `PIPESTATUS` is overwritten by every subsequent command — including the `[ ... ]` test that was on the right of the `||` — so reading `${PIPESTATUS[0]}` on a later line always saw that test's status, not pytest's. A fix for "a guard that doesn't guard" that itself did nothing. Now the status is captured into `rc` immediately, and a real failure (exit 1) still reddens the job rather than being swallowed.

**`lint.yml`'s format step lost its ruff.** `uv sync` installs into `.venv`, not onto `PATH`, so deleting `pip install ruff` while leaving a bare `ruff format --check .` exits 127 — red on every push.

My original tests were all string-presence and could not see either. That is why there is now a test that **executes** the extracted step against a stubbed pytest:

| pytest exits | step rc | summary written |
|---|---|---|
| 5 (empty run) | 0 | yes |
| 0 (clean run) | 0 | no |
| 1 (real failure) | 1 | no |

## Evidence

31 tests. Ten negative controls, all caught — including three that reproduce the exact bugs review found:

| reverted | result |
|---|---|
| `PIPESTATUS` re-read instead of captured | 1 failed |
| a real failure silenced | 1 failed |
| bare `ruff format` with no ruff on PATH | 1 failed |
| live-check summary removed | 1 failed |
| `verify-tags` login removed | 1 failed |
| stderr discarded again | 2 failed |
| release gate back to 3.12 | 1 failed |
| floating ruff in build.yml | 3 failed |
| floating ruff in lint.yml | 2 failed |
| `.beads/` unignored | 3 failed |

All sources verified byte-identical after every revert.

Gates: `ruff check` clean, `ruff format --check` clean, `currency_check.mjs` PASS, `fleet_staleness_check.mjs` PASS, **3175 passed, 95.32% coverage**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build and release validation with clearer registry errors and consistent Python-version checks.
  - Corrected live-check failure handling so genuine test failures are reported instead of being masked.
  - Clarified when live checks run without collecting tests.

- **Tests**
  - Added comprehensive verification for CI gates, release alignment, lint consistency, registry checks, and protected local data.

- **Chores**
  - Standardized dependency and lint validation across automated workflows.
  - Prevented sensitive wallet-related data from being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->