### PR TITLE
fix: unknown watts must suppress the net, not price it at zero

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2342,6 +2342,11 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
     except (TypeError, ValueError):
         host_tdp = power.DEFAULT_HOST_TDP_WATTS
 
+    # Whether the power side of this endpoint has any input at all. An empty
+    # `statuses` from a FAILURE is not the same fact as an empty one from a
+    # fleet with nothing running, and the difference decides whether a net
+    # figure exists (CashPilot-c6u).
+    watts_known = True
     try:
         statuses = await _get_all_worker_containers()
     except Exception as exc:
@@ -2349,6 +2354,7 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
         # come from the database and are still perfectly reportable.
         logger.warning("Worker status unavailable for the power estimate: %s", exc)
         statuses = []
+        watts_known = False
     # Only RUNNING containers. A stopped one draws nothing, and counting it
     # inflates a worker's container count, which shrinks every running service's
     # share of that host's idle floor and understates the fleet's real cost.
@@ -2462,7 +2468,24 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
     # earnings, so there is no honest net. Reporting gross alone is what this
     # module already does when no tariff is set at all: "a zero cost would
     # render gross as net and quietly overstate earnings."
-    result = power.summarise(rows, price_per_kwh=(price_usd if fx_ok else 0.0), currency="USD")
+    #
+    # Unknown WATTS suppress the net for the same reason unknown FX does, and
+    # through the same mechanism: a zero price makes summarise report cost and
+    # net as None instead of as numbers. Without this, a failed worker lookup
+    # charged every service 0 W, cost summed to 0.00, and the endpoint returned
+    # total_net == total_gross with cost_known TRUE -- gross presented as profit,
+    # which is the one thing this endpoint's docstring promises it never does.
+    # cost_known came from `price_per_kwh > 0` alone and never asked whether any
+    # watts had actually been measured (CashPilot-c6u).
+    result = power.summarise(rows, price_per_kwh=(price_usd if (fx_ok and watts_known) else 0.0), currency="USD")
+    if not watts_known:
+        result["cost_known"] = False
+        result["watts_unavailable"] = True
+        result["cost_unavailable_reason"] = (
+            "CashPilot could not reach its workers, so it does not know what any service "
+            "is drawing right now. Earnings below are real; the running cost and the net "
+            "figure are unknown for this window, not zero."
+        )
     if not fx_ok:
         result["cost_known"] = False
         result["fx_unavailable"] = True

--- a/tests/test_beads_batch_48.py
+++ b/tests/test_beads_batch_48.py
@@ -1,0 +1,190 @@
+"""CashPilot-c6u: a worker-status failure made net earnings report gross as profit.
+
+``/api/earnings/net`` exists to answer "what did I actually keep?". Its docstring
+promises it never presents gross as profit, and ``app/power.py`` says the same
+thing twice: *"a zero cost would render gross as net and quietly overstate
+earnings."*
+
+It did exactly that. ``_get_all_worker_containers`` reaches the workers over
+HTTP, so it fails for ordinary reasons — a host down, a proxy blip, a busy
+SQLite. The handler caught that and substituted ``statuses = []``, which is a
+different FACT from "nothing is running" but was indistinguishable downstream.
+Every service was then charged 0 W, ``total_cost`` summed to 0.00, and
+``total_net`` came out equal to ``total_gross``.
+
+The lie is ``cost_known``. ``app/power.py:137`` derives it from
+``price_per_kwh > 0`` — the tariff alone — and never asks whether any watts were
+measured. So with a tariff configured the endpoint reported a cost of zero and
+a net equal to gross, and labelled it *known*.
+
+The endpoint's own comment already described this outcome as a bug that had bitten
+the project twice, both times through the ``service`` vs ``slug`` key. The except
+branch recreates the same precondition by a different route.
+
+The fix reuses the mechanism already in this handler for unavailable FX: a zero
+price makes ``summarise`` report cost and net as ``None`` rather than as numbers.
+Unknown watts now suppress the net the same way, and say why.
+
+Gross is still reported. It comes from the database and is unaffected by whether
+a worker answered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def rows():
+    """One platform with real earnings, so a zero net is unmistakably wrong."""
+    return [{"platform": "honeygain", "usd": 10.0}]
+
+
+async def _call_net(monkeypatch, *, worker_lookup, config, days=7):
+    """Drive api_earnings_net with the worker lookup and config under test."""
+    from app import main
+
+    with (
+        patch.object(main, "_get_all_worker_containers", worker_lookup),
+        # list_workers supplies the per-machine power metadata; it is a real DB
+        # read that is irrelevant to this bead. Checked the actual names rather
+        # than guessing: main.py:2385 calls database.list_workers().
+        patch.object(main.database, "list_workers", AsyncMock(return_value=[])),
+        patch.object(main.database, "get_earned_by_platform", AsyncMock(return_value={"honeygain": 10.0})),
+        patch.object(main.database, "get_config", AsyncMock(return_value=config)),
+        patch.object(main, "_require_auth_api", lambda _r: None),
+    ):
+        return await main.api_earnings_net(request=None, days=days)
+
+
+TARIFF = {"power_price_per_kwh": "0.30", "power_currency": "USD"}
+
+
+class TestAFailedWorkerLookupSuppressesTheNet:
+    """The bead. A tariff IS configured, so the old code produced numbers."""
+
+    @pytest.mark.asyncio
+    async def test_cost_is_not_reported_as_known(self, monkeypatch):
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert result["cost_known"] is False, (
+            "the endpoint claims to know a cost it could not measure — this is the whole bead"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_net_is_not_reported_at_all(self, monkeypatch):
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert result["total_net"] is None, "a net figure was produced from watts nobody could read"
+
+    @pytest.mark.asyncio
+    async def test_the_cost_is_not_reported_as_zero(self, monkeypatch):
+        """Zero is a measurement. This was not one."""
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert result["total_cost"] is None
+
+    @pytest.mark.asyncio
+    async def test_net_does_not_silently_equal_gross(self, monkeypatch):
+        """The precise shape of the old bug, asserted directly."""
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert not (result["total_net"] == result["total_gross"] and result["cost_known"]), (
+            "gross is being presented as profit, which this endpoint promises never to do"
+        )
+
+    @pytest.mark.asyncio
+    async def test_gross_is_still_reported(self, monkeypatch):
+        """It comes from the database and a worker outage cannot affect it."""
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert result["total_gross"] == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_it_says_why(self, monkeypatch):
+        """A suppressed figure with no explanation reads as a broken page."""
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        reason = result["cost_unavailable_reason"]
+        assert "workers" in reason
+        assert "not zero" in reason, "the reason must rule out the reading the number would have suggested"
+
+    @pytest.mark.asyncio
+    async def test_the_cause_is_machine_readable(self, monkeypatch):
+        """Distinguishable from the FX cause, which sets its own flag."""
+        result = await _call_net(
+            monkeypatch,
+            worker_lookup=AsyncMock(side_effect=RuntimeError("worker unreachable")),
+            config=TARIFF,
+        )
+        assert result.get("watts_unavailable") is True
+        assert result.get("fx_unavailable") is not True
+
+
+class TestAWorkingLookupIsUnaffected:
+    """The suppression must be narrow, or it silences the normal case."""
+
+    @pytest.mark.asyncio
+    async def test_an_empty_but_successful_lookup_still_reports_a_cost(self, monkeypatch):
+        """A fleet with nothing running is a MEASUREMENT of zero draw.
+
+        This is the case that separates the fix from "always report unknown":
+        the same empty list, arrived at honestly, must still produce a net.
+        """
+        result = await _call_net(monkeypatch, worker_lookup=AsyncMock(return_value=[]), config=TARIFF)
+        assert result["cost_known"] is True
+        assert result["total_net"] is not None
+        assert result.get("watts_unavailable") is not True
+
+    @pytest.mark.asyncio
+    async def test_a_running_fleet_reports_a_cost(self, monkeypatch):
+        statuses = [{"slug": "honeygain", "status": "running", "worker_id": 1}]
+        result = await _call_net(monkeypatch, worker_lookup=AsyncMock(return_value=statuses), config=TARIFF)
+        assert result["cost_known"] is True
+        assert result["total_cost"] is not None
+
+    @pytest.mark.asyncio
+    async def test_no_tariff_still_reports_unknown_for_its_own_reason(self, monkeypatch):
+        """The pre-existing behaviour, which this must not disturb."""
+        result = await _call_net(monkeypatch, worker_lookup=AsyncMock(return_value=[]), config={})
+        assert result["cost_known"] is False
+        assert result["total_net"] is None
+        assert result.get("watts_unavailable") is not True
+
+
+class TestTheTwoUnknownCausesDoNotMaskEachOther:
+    @pytest.mark.asyncio
+    async def test_both_failing_reports_both(self, monkeypatch):
+        """A tariff in a currency with no rate AND unreachable workers."""
+        from app import main
+
+        with patch.object(main.exchange_rates, "to_usd", lambda *_a, **_k: None):
+            result = await _call_net(
+                monkeypatch,
+                worker_lookup=AsyncMock(side_effect=RuntimeError("down")),
+                config={"power_price_per_kwh": "0.30", "power_currency": "GBP"},
+            )
+        assert result["cost_known"] is False
+        assert result["total_net"] is None
+        assert result.get("watts_unavailable") is True
+        assert result.get("fx_unavailable") is True


### PR DESCRIPTION
Closes `CashPilot-c6u` (P1), found by the refine sweep and verified at the anchors before filing.

## What was wrong

`/api/earnings/net` answers "what did I actually keep?". Its docstring promises it never presents gross as profit, and `app/power.py` says the same thing twice: *"a zero cost would render gross as net and quietly overstate earnings."*

It did that. `_get_all_worker_containers` reaches the workers over HTTP, so it fails for ordinary reasons — a host down, a proxy blip, a busy SQLite. The handler caught that and substituted `statuses = []`:

```python
except Exception as exc:
    logger.warning("Worker status unavailable for the power estimate: %s", exc)
    statuses = []
```

Downstream, that is indistinguishable from a fleet with nothing running. Every service was charged 0 W, `total_cost` summed to `0.00`, and `total_net` came out **equal to `total_gross`**.

The lie is `cost_known`. `app/power.py:137` derives it from the tariff alone:

```python
configured = price_per_kwh > 0
```

It never asks whether any watts were measured. So with a tariff set, the endpoint reported a cost of zero and a net equal to gross, and labelled it **known**.

This endpoint's own comment already describes that outcome as a bug that bit the project twice, both times through the `service` vs `slug` key. The `except` branch recreates the same precondition by a different route.

## The fix

An empty list from a **failure** is not the same fact as an empty list from an idle fleet. The handler now tracks which one it has, and unknown watts suppress the net through the mechanism **already in this function** for unavailable FX — passing a zero price, which makes `summarise` return `None` for cost and net rather than numbers.

Gross is still reported: it comes from the database and no worker outage can affect it.

| condition | `cost_known` | `total_cost` | `total_net` | `total_gross` |
|---|---|---|---|---|
| worker lookup failed | `false` | `null` | `null` | reported |
| fleet genuinely idle | `true` | number | number | reported |
| no tariff configured | `false` | `null` | `null` | reported |
| FX rate unavailable | `false` | `null` | `null` | reported |

`watts_unavailable` and `fx_unavailable` are separate flags, so the two causes never mask each other, and the reason string rules out the zero reading in words: *"the running cost and the net figure are unknown for this window, not zero."*

## Evidence

11 tests. Four negative controls, all caught:

| reverted | result |
|---|---|
| the original bug — unknown watts priced at the tariff | 2 failed |
| `watts_known` never set false | 7 failed |
| suppressed but unexplained | 2 failed |
| **over-broad** — an idle fleet also reports unknown | 3 failed |

That last one matters as much as the first: it proves the suppression is narrow, and that a genuine measurement of zero draw still produces a net.

Gates: `ruff check` clean, `ruff format --check` clean, both Node harnesses PASS, **3186 passed, 95.34% coverage**.