### PR TITLE
fix: stop asserting a zero nobody measured, and say why Settings is empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Currency formatting behaviour
         run: node scripts/currency_check.mjs
 
+      # Also browser-free. A string test can prove the Settings catch is no
+      # longer empty; only running it proves BOTH panels get written and that
+      # what lands in them says why (CashPilot-cn3).
+      - name: Settings failure path
+        run: node scripts/settings_failure_check.mjs
+
       # Also behaviour pytest cannot reach, and for the same reason: these
       # renderers live in a <script> block inside a Jinja template, so a Python
       # assertion could only prove the source mentions a variable — never what

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2607,8 +2607,34 @@ const CP = (() => {
       renderCollectors(collectorsMeta, config);
       loadCredentialHealth();
     } catch (err) {
-      // Settings may not be available yet
+      // Say what happened. /api/env-info and /api/collectors/meta each carry
+      // their own .catch, so the only call that can reject is /api/config —
+      // and its rejection aborts the whole Promise.all before either render
+      // runs. Both panels then keep the template's "Loading..." forever, and
+      // this catch used to be empty, so nothing ever corrected it: an expired
+      // session or a restarting server looked like a page that simply never
+      // finished loading (CashPilot-cn3).
+      //
+      // Every other loader here writes a reason into its own container; this
+      // one was the outlier.
+      settingsPanelsFailed(err);
     }
+  }
+
+  // Exported for the harness: the message is the whole point of the fix, so it
+  // has to be reachable without a browser.
+  function settingsLoadFailureMessage(err) {
+    const detail = (err && err.message) ? String(err.message) : '';
+    return `Could not load settings${detail ? `: ${detail}` : ''}. Your session may have expired — `
+      + `reload the page, and sign in again if you are asked to.`;
+  }
+
+  function settingsPanelsFailed(err) {
+    const message = settingsLoadFailureMessage(err);
+    ['env-vars-container', 'collectors-container'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.innerHTML = `<p style="color:var(--error);font-size:0.85rem;">${escapeHtml(message)}</p>`;
+    });
   }
 
   function renderEnvVars(envInfo, config) {

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -30,7 +30,13 @@
   </div>
   <div class="stat-card">
     <div class="stat-label">Active Services</div>
-    <div class="stat-value" id="active-services">0</div>
+    {# Em-dash, like every sibling card. app.js already renders the em-dash when
+       the count comes back null, and its catch deliberately PRESERVES whatever
+       is displayed so a transient fetch failure cannot look like earnings
+       dropping to zero. On a FIRST load that fails, what it preserved was this
+       literal 0 — so the one card fixed for this in JS was the one where a
+       template character undid the fix (CashPilot-pmi). #}
+    <div class="stat-value" id="active-services">&mdash;</div>
   </div>
 </div>
 

--- a/scripts/settings_failure_check.mjs
+++ b/scripts/settings_failure_check.mjs
@@ -1,0 +1,80 @@
+// Run the real Settings failure path against a stub DOM.
+//
+// CashPilot-cn3: /api/env-info and /api/collectors/meta each carry their own
+// .catch, so the only call in loadSettings' Promise.all that can reject is
+// /api/config — and its rejection aborts the whole thing before either render
+// function runs. Both panels then keep the template's "Loading..." string, and
+// the catch body was empty, so nothing ever corrected it. An expired session or
+// a restarting server looked like a page that simply never finished loading.
+//
+// A string test can prove the catch is no longer empty. It cannot prove that
+// BOTH containers get written, or that what lands in them says anything useful.
+// So this executes the real functions.
+//
+//   node scripts/settings_failure_check.mjs
+//
+// Exits non-zero on any mismatch.
+import {readFileSync} from 'node:fs';
+
+const src = readFileSync('app/static/js/app.js', 'utf8');
+const grab = name => {
+  const i = src.indexOf(`function ${name}(`);
+  if (i < 0) {
+    console.error(`FAIL: ${name} is not defined in app/static/js/app.js`);
+    process.exit(1);
+  }
+  const rest = src.slice(i);
+  const end = rest.search(/\n  (?:async )?function [A-Za-z_]/);
+  return rest.slice(0, end > 0 ? end : 2000);
+};
+
+// A DOM small enough to be obviously correct: two containers holding exactly
+// what the template ships.
+const made = {};
+const document = {
+  getElementById(id) {
+    if (!['env-vars-container', 'collectors-container'].includes(id)) return null;
+    if (!made[id]) made[id] = {innerHTML: 'Loading...'};
+    return made[id];
+  },
+};
+
+const fns = grab('escapeHtml') + '\n' + grab('settingsLoadFailureMessage') + '\n' + grab('settingsPanelsFailed');
+const run = new Function('document', `${fns}; return {settingsLoadFailureMessage, settingsPanelsFailed};`)(document);
+
+let bad = 0;
+const check = (label, cond, detail) => {
+  console.log(`  ${cond ? 'ok  ' : 'FAIL'} ${label}${cond ? '' : `  <- ${detail}`}`);
+  if (!cond) bad++;
+};
+
+// --- the message itself -----------------------------------------------------
+const msg = run.settingsLoadFailureMessage(new Error('401 Unauthorized'));
+check('names a cause', /session|expired/i.test(msg), msg);
+check('names an action', /reload|sign in/i.test(msg), msg);
+check('carries the underlying detail', msg.includes('401 Unauthorized'), msg);
+
+const bare = run.settingsLoadFailureMessage(undefined);
+check('survives an error with no message', bare.length > 0 && !bare.includes('undefined'), bare);
+
+// --- what actually lands in the panels --------------------------------------
+run.settingsPanelsFailed(new Error('boom'));
+for (const id of ['env-vars-container', 'collectors-container']) {
+  const html = made[id].innerHTML;
+  check(`${id} no longer says Loading`, !html.includes('Loading...'), html);
+  check(`${id} explains itself`, /session|expired/i.test(html), html);
+}
+
+// --- the message is escaped before it reaches innerHTML ---------------------
+// The detail comes from a server response, so it is untrusted.
+made['env-vars-container'] = {innerHTML: 'Loading...'};
+made['collectors-container'] = {innerHTML: 'Loading...'};
+run.settingsPanelsFailed(new Error('<img src=x onerror=alert(1)>'));
+check(
+  'the error detail is escaped, not injected',
+  !made['env-vars-container'].innerHTML.includes('<img'),
+  made['env-vars-container'].innerHTML,
+);
+
+console.log(bad ? `\nRESULT: FAIL (${bad})` : '\nRESULT: PASS');
+process.exit(bad ? 1 : 0);

--- a/tests/test_beads_batch_49.py
+++ b/tests/test_beads_batch_49.py
@@ -1,0 +1,138 @@
+"""CashPilot-pmi and CashPilot-cn3: two places the UI spoke without evidence.
+
+**pmi** — the dashboard's "Active Services" card was initialised to a literal
+``0`` in the template while its three siblings used an em-dash. ``app.js``
+already renders the em-dash when the count comes back null, commenting that
+``|| 0`` "would render 'could not be counted' as 'nothing is running'"; and its
+catch deliberately PRESERVES whatever is displayed, so a transient failure
+cannot look like earnings dropping to zero. Compose the three and a **first**
+load that fails preserves the hardcoded ``0``. The one card fixed for this in JS
+was the one where a template character undid the fix.
+
+**cn3** — the Settings panels showed "Loading..." forever. Two of the three calls
+in ``loadSettings``' ``Promise.all`` carry their own ``.catch``; ``/api/config``
+did not, so its rejection aborted the whole thing before either render function
+ran, and the outer catch body was empty. An expired session or a restarting
+server was indistinguishable from a page that never finished loading.
+
+The behaviour of the Settings fix is proven by ``scripts/settings_failure_check.mjs``,
+which runs the real functions against a stub DOM — a string assertion could show
+the catch is non-empty but never that both panels get written, nor that what
+lands in them is useful. What is pinned here is the wiring that harness cannot
+see: that the catch calls it, and that the harness runs in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "app" / "templates" / "dashboard.html"
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+class TestNoStatCardClaimsAMeasurementItDoesNotHave:
+    """The template's initial text is what a failed first load leaves on screen."""
+
+    def _cards(self):
+        html = DASHBOARD.read_text(encoding="utf-8")
+        # (id, initial text) for every stat-value element.
+        return re.findall(r'<div class="stat-value[^"]*" id="([^"]+)">([^<]*)</div>', html)
+
+    def test_the_dashboard_has_stat_cards_to_check(self):
+        """A regex that silently matches nothing would make every test below vacuous."""
+        assert len(self._cards()) >= 4, f"only found {self._cards()} — the sweep is not seeing the template"
+
+    def test_active_services_no_longer_starts_at_zero(self):
+        """The bead, stated directly."""
+        cards = dict(self._cards())
+        assert "active-services" in cards
+        assert cards["active-services"].strip() != "0", (
+            "a failed first load leaves this on screen, and it reads as a measured zero"
+        )
+
+    @pytest.mark.parametrize("card_id", ["total-earnings", "today-earnings", "month-earnings", "active-services"])
+    def test_it_initialises_to_the_unknown_marker(self, card_id):
+        cards = dict(self._cards())
+        assert cards[card_id].strip() in ("&mdash;", "—"), (
+            f"{card_id} starts as {cards[card_id]!r}, which asserts a value nothing measured"
+        )
+
+    def test_no_stat_card_anywhere_starts_as_a_number(self):
+        """Catches the next card added, not just the four that exist today."""
+        numeric = [
+            (cid, text)
+            for cid, text in self._cards()
+            if re.fullmatch(r"[\s$€£]*-?[\d.,]+%?\s*", text or "") and text.strip()
+        ]
+        assert not numeric, f"these assert a measurement before one is taken: {numeric}"
+
+    def test_the_js_still_renders_the_marker_for_a_null_count(self):
+        """The template fix is worthless if the render path regresses."""
+        js = APP_JS.read_text(encoding="utf-8")
+        assert "data.active_services == null ? '\\u2014' : data.active_services" in js
+
+
+class TestTheSettingsPanelsSayWhyTheyAreEmpty:
+    def _load_settings_body(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("async function loadSettings(")
+        rest = js[start:]
+        end = re.search(r"\n  (?:async )?function [A-Za-z_]", rest)
+        return rest[: end.start()] if end else rest[:3000]
+
+    def test_the_catch_is_no_longer_empty(self):
+        body = self._load_settings_body()
+        catch = body[body.index("} catch (err) {") :]
+        assert "settingsPanelsFailed(err)" in catch, (
+            "the failure is swallowed again, so both panels keep saying Loading forever"
+        )
+
+    def test_the_handler_exists(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        assert "function settingsPanelsFailed(" in js
+        assert "function settingsLoadFailureMessage(" in js
+
+    def test_both_containers_are_targeted(self):
+        """One panel fixed and one still spinning would be worse than neither."""
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("function settingsPanelsFailed(")
+        body = js[start : start + 700]
+        assert "env-vars-container" in body
+        assert "collectors-container" in body
+
+    def test_the_message_is_escaped_before_it_reaches_innerhtml(self):
+        """The detail comes from a server response, so it is untrusted."""
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("function settingsPanelsFailed(")
+        body = js[start : start + 700]
+        assert "escapeHtml(message)" in body
+
+    def test_the_templates_still_ship_a_loading_placeholder(self):
+        """The premise: without it there would be nothing to get stuck on."""
+        settings = (ROOT / "app" / "templates" / "settings.html").read_text(encoding="utf-8")
+        assert settings.count("Loading...") >= 2
+
+
+class TestTheHarnessActuallyRunsInCI:
+    """A behavioural harness nobody runs proves nothing."""
+
+    def test_the_script_exists(self):
+        assert (ROOT / "scripts" / "settings_failure_check.mjs").is_file()
+
+    def test_the_workflow_runs_it(self):
+        doc = yaml.safe_load((ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8"))
+        commands = " ".join(
+            str(step.get("run", "")) for job in doc["jobs"].values() for step in (job.get("steps") or [])
+        )
+        assert "node scripts/settings_failure_check.mjs" in commands
+
+    def test_it_is_browser_free_like_its_siblings(self):
+        """The Chrome-dependent harnesses cannot run in CI; this one must not need one."""
+        text = (ROOT / "scripts" / "settings_failure_check.mjs").read_text(encoding="utf-8")
+        assert "9222" not in text
+        assert "puppeteer" not in text.lower()


### PR DESCRIPTION
Closes `CashPilot-pmi` and `CashPilot-cn3` (both P2). Found by the refine sweep, each verified at its anchors before filing.

## pmi — a measured-looking zero

Three of the dashboard's four stat cards initialise to an em-dash. `#active-services` initialised to a literal `0`.

That card is the one that was **specifically fixed for this in JS**:

```js
// `|| 0` would render "could not be counted" as "nothing is running".
setTextContent('active-services', data.active_services == null ? '—' : data.active_services);
```

and the fetch's catch deliberately preserves whatever is on screen:

```js
} catch (err) {
  // Keep whatever was already displayed — a transient fetch failure
  // must not look like the dashboard's earnings dropped to zero.
```

Compose the three and the bug appears only on a **first** load that fails: "whatever was already displayed" is the template's hardcoded `0`. The user is told, in the same typeface as a real measurement, that nothing is running — at the moment nothing was measured.

One character in a template undid a fix that had already been made in JS.

The test that pins it is not "this card says em-dash" — it is **no stat card anywhere may initialise to a numeric literal**, so the next card added is covered too.

## cn3 — panels that spin forever

```js
const [config, envInfo, collectorsMeta] = await Promise.all([
  api('/api/config'),                       // no .catch
  api('/api/env-info').catch(() => []),
  api('/api/collectors/meta').catch(() => []),
]);
...
} catch (err) {
  // Settings may not be available yet
}
```

Two of the three calls defend themselves; `/api/config` does not. Its rejection aborts the whole `Promise.all` before either render function runs, both containers keep the template's `Loading...`, and the empty catch guarantees nothing will ever say otherwise. An expired session, a restarting server, or a network blip is indistinguishable from a page that just never finished loading.

Every other loader in this file writes a reason into its container. This one was the outlier.

Now both panels get a cause and an action, and the server's detail is escaped before it reaches `innerHTML` — it is untrusted input.

## Evidence

`scripts/settings_failure_check.mjs` runs the **real** functions against a stub DOM, and is wired into `test.yml` beside the existing browser-free harnesses. A string assertion can prove the catch is non-empty; only running it proves both panels get written, that the text is useful, and that the detail is escaped.

16 pytest tests plus 9 harness assertions. Six negative controls, all caught:

| reverted | caught by | result |
|---|---|---|
| the hardcoded `0` restored | pytest | 3 failed |
| catch emptied again | pytest | 1 failed |
| only one panel written | harness | FAIL |
| message no longer escaped | harness + pytest | FAIL / 1 failed |
| message reduced to "please try again" | harness | FAIL |
| harness removed from CI | pytest | 1 failed |

One control initially reported NOT CAUGHT and was **my error, not a gap**: the anchor `${escapeHtml(message)}` also occurs in `toast()`, so the patch landed on the wrong function. Re-run with a unique anchor, both the harness and pytest catch it.

Gates: `ruff check` clean, `ruff format --check` clean, `node --check` clean, all three browser-free harnesses PASS, **3191 passed, 95.32% coverage**.