### PR TITLE
fix: three ways the fleet page misled the person reading it

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3799,11 +3799,21 @@ async def api_fleet_summary(request: Request) -> dict[str, Any]:
     total_running = 0
     online_workers = 0
 
+    # Containers on workers that are NOT online. They are still running and
+    # still earning -- an unreachable worker is a reporting gap, not a stopped
+    # one -- so the fleet page can say how much of the estate these cards leave
+    # out instead of letting a reboot read as containers lost (CashPilot-wij).
+    unreachable_containers = 0
+    unreachable_workers = 0
+
     for w in workers:
+        _parse_worker_json(w)
         if w["status"] != "online":
+            if w["container_count"]:
+                unreachable_workers += 1
+                unreachable_containers += w["container_count"]
             continue
         online_workers += 1
-        _parse_worker_json(w)
         total_services += w["container_count"]
         total_running += w["running_count"]
 
@@ -3812,6 +3822,8 @@ async def api_fleet_summary(request: Request) -> dict[str, Any]:
         "online_workers": online_workers,
         "total_containers": total_services,
         "running_containers": total_running,
+        "unreachable_containers": unreachable_containers,
+        "unreachable_workers": unreachable_workers,
     }
 
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3238,6 +3238,26 @@ const CP = (() => {
   // -----------------------------------------------------------
   // Public API
   // -----------------------------------------------------------
+  // The frontend had NO date formatting of any kind — grep for toLocaleString,
+  // toLocaleDateString or `new Date(` across app.js and fleet.html returned zero
+  // hits — so every timestamp reached the user as whatever the server
+  // serialised. The DB writes datetime('now'), which SQLite produces in UTC, and
+  // it was rendered raw and unlabelled: a viewer in CEST read a worker that
+  // heartbeated five minutes ago as two hours stale, right next to the words
+  // "This host is not reachable" and one click from Remove (CashPilot-2dh).
+  function fmtTimestamp(value) {
+    if (!value) return { text: 'never', title: '' };
+    // SQLite's "YYYY-MM-DD HH:MM:SS" carries no zone designator, so Date.parse
+    // treats it as LOCAL time and silently shifts it. Say UTC explicitly.
+    const iso = String(value).trim().replace(' ', 'T');
+    const parsed = new Date(/[Zz]|[+-]\d{2}:?\d{2}$/.test(iso) ? iso : `${iso}Z`);
+    if (Number.isNaN(parsed.getTime())) {
+      // Unparseable is not a licence to invent a time. Show what we were given.
+      return { text: String(value), title: 'CashPilot could not read this timestamp' };
+    }
+    return { text: parsed.toLocaleString(), title: `${value} UTC` };
+  }
+
   return {
     api,
     toast,
@@ -3285,5 +3305,7 @@ const CP = (() => {
     // with a tariff in the user's own currency. The API is canonical USD now,
     // and this is the one place that knows the viewer's display currency.
     formatCurrency,
+    // Shared, so the next timestamp added does not repeat CashPilot-2dh.
+    fmtTimestamp,
   };
 })();

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -15,15 +15,22 @@
     <div class="stat-label">Online</div>
     <div class="stat-value" id="fleet-online-workers">-</div>
   </div>
+  {# "Workers" and "Online" are fleet-wide; these two count ONLY online workers
+     (api_fleet_summary skips offline ones before accumulating). Nothing said so,
+     so a host rebooting made "Services" drop and read as containers lost --
+     contradicting the dashboard note that routes the user to this very page:
+     "Containers keep running and earning while a worker is offline."
+     (CashPilot-wij) #}
   <div class="stat-card">
-    <div class="stat-label">Services</div>
+    <div class="stat-label" title="Counted across workers that are currently online. Containers on an offline worker keep running and earning; they are not included here.">Services <span style="opacity:0.6;">(online)</span></div>
     <div class="stat-value" id="fleet-total-containers">-</div>
   </div>
   <div class="stat-card">
-    <div class="stat-label">Running</div>
+    <div class="stat-label" title="Counted across workers that are currently online. Containers on an offline worker keep running and earning; they are not included here.">Running <span style="opacity:0.6;">(online)</span></div>
     <div class="stat-value" id="fleet-running-containers">-</div>
   </div>
 </div>
+<div id="fleet-unreachable-note" style="display:none; margin:-8px 0 16px; font-size:0.82rem; color:var(--warning);"></div>
 
 <!-- Add Worker Info -->
 <div class="card" style="margin-bottom: 24px;">
@@ -46,6 +53,12 @@ CASHPILOT_WORKER_NAME=server-name</code>
         <button class="btn btn-ghost btn-sm" data-action="toggleApiKey" id="reveal-btn">Reveal API Key</button>
         <button class="btn btn-ghost btn-sm" data-action="copyWorkerEnv">Copy</button>
         {% endif %}
+      </div>
+      {# Shown only when the clipboard API is unreachable — which is the normal
+         case on the plain-http LAN origin docs/fleet.md documents, because
+         navigator.clipboard is gated on a secure context. #}
+      <div id="worker-env-fallback" style="display:none; margin-top:8px;">
+        <textarea readonly rows="3" class="form-input" style="width:100%; font-family:monospace; font-size:0.78rem;"></textarea>
       </div>
     </div>
     <p style="color: var(--text-muted); margin-top: 8px; font-size: 0.82rem;">
@@ -155,6 +168,22 @@ CASHPILOT_WORKER_NAME=server-name</code>
       document.getElementById('fleet-online-workers').textContent = summary.online_workers || 0;
       document.getElementById('fleet-total-containers').textContent = summary.total_containers || 0;
       document.getElementById('fleet-running-containers').textContent = summary.running_containers || 0;
+
+      // Name what the two online-only cards leave out, rather than letting the
+      // drop read as containers lost.
+      const note = document.getElementById('fleet-unreachable-note');
+      const hidden = summary.unreachable_containers || 0;
+      if (note) {
+        if (hidden > 0) {
+          const w = summary.unreachable_workers || 0;
+          note.textContent = `${hidden} container${hidden === 1 ? '' : 's'} on `
+            + `${w} unreachable worker${w === 1 ? '' : 's'} ${hidden === 1 ? 'is' : 'are'} not counted above. `
+            + `They keep running and earning while their worker is offline — CashPilot just cannot see them right now.`;
+          note.style.display = '';
+        } else {
+          note.style.display = 'none';
+        }
+      }
 
       renderWorkers(workers);
       loadFleetEconomics();
@@ -323,7 +352,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
               <span>${esc(w.url || '-')}</span>
               <span>${esc(sysInfo.os || '-')}${sysInfo.os_version ? ' ' + esc(sysInfo.os_version) : ''}</span>
               <span>${esc(sysInfo.arch || '-')}</span>
-              <span>Last seen: ${w.last_heartbeat || 'never'}</span>
+              <span title="${esc(CP.fmtTimestamp(w.last_heartbeat).title)}">Last seen: ${esc(CP.fmtTimestamp(w.last_heartbeat).text)}</span>
               <span>
                 <label for="watts-${esc(w.client_id || w.id)}" style="color:var(--text-muted);">Draw</label>
                 <input id="watts-${esc(w.client_id || w.id)}" class="power-watts form-input" type="number" min="0" step="1"
@@ -389,7 +418,7 @@ CASHPILOT_WORKER_NAME=server-name</code>
   // signal. The state is still shown, because "what was running when we last
   // heard" is useful, but it is shown as a memory rather than a measurement.
   function staleNote(lastSeen) {
-    return `Last reported ${lastSeen || 'never'}. This host is not reachable, so this is the last known state, not the current one.`;
+    return `Last reported ${CP.fmtTimestamp(lastSeen).text}. This host is not reachable, so this is the last known state, not the current one.`;
   }
 
   function renderContainers(worker, isOnline) {
@@ -546,9 +575,44 @@ CASHPILOT_WORKER_NAME=server-name</code>
     // Lazily fetch the plaintext key (owner-only reveal endpoint) before copying.
     await fetchApiKey();
     const uiUrl = document.getElementById('env-ui-url').textContent;
+    // The key is only worth copying if we actually got one. On a failed reveal
+    // _apiKey is the literal string "(error)" or "(not configured)", and the
+    // old code toasted success regardless -- so the user pasted
+    // CASHPILOT_API_KEY=(error) into their compose file and then debugged a
+    // worker that could never enrol (CashPilot-0p4).
+    if (!_apiKey || _apiKey.startsWith('(')) {
+      CP.toast(`Nothing to copy — the API key reads ${_apiKey || 'as unset'}. Reveal it first.`, 'error');
+      return;
+    }
     const text = `CASHPILOT_UI_URL=${uiUrl}\nCASHPILOT_API_KEY=${_apiKey}\nCASHPILOT_WORKER_NAME=server-name`;
-    navigator.clipboard.writeText(text).then(() => CP.toast('Copied', 'success'));
+    // navigator.clipboard is gated on a SECURE CONTEXT, and docs/fleet.md
+    // documents the normal setup as plain http:// on the LAN. There the object
+    // is undefined, the property access throws inside this async function, and
+    // delegate.js calls it without awaiting -- so the button was simply dead,
+    // with no toast and no explanation, for exactly the multi-server users who
+    // need it most.
+    try {
+      if (!navigator.clipboard) throw new Error('clipboard unavailable');
+      await navigator.clipboard.writeText(text);
+      CP.toast('Copied', 'success');
+    } catch (err) {
+      showWorkerEnvFallback(text);
+    }
   };
+
+  // Selecting the text is the honest fallback: it cannot fail, and it puts the
+  // user one keystroke from the same result.
+  function showWorkerEnvFallback(text) {
+    const box = document.getElementById('worker-env-fallback');
+    if (!box) {
+      CP.toast('Copying needs a secure (https) page. Select the text above and copy it manually.', 'warning');
+      return;
+    }
+    box.style.display = '';
+    box.querySelector('textarea').value = text;
+    box.querySelector('textarea').select();
+    CP.toast('This page is not on https, so CashPilot cannot reach the clipboard. The text is selected — press Ctrl/Cmd+C.', 'warning');
+  }
 
   loadApiKeyStatus();
   loadFleet();

--- a/scripts/fleet_staleness_check.mjs
+++ b/scripts/fleet_staleness_check.mjs
@@ -33,9 +33,22 @@ function extract(name) {
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
 const fmtBytes = b => `${b}B`;
+// The REAL fmtTimestamp from app.js, not a stub. fleet.html reaches it through
+// the CP namespace, and a stub here would let the formatter break while this
+// harness stayed green — which is the whole failure mode these scripts exist to
+// catch (CashPilot-2dh).
+const appSrc = readFileSync('app/static/js/app.js', 'utf8');
+const fnStart = appSrc.indexOf('function fmtTimestamp(');
+if (fnStart < 0) throw new Error('fmtTimestamp is gone from app/static/js/app.js');
+const fnRest = appSrc.slice(fnStart);
+const fmtTimestamp = new Function(
+  `${fnRest.slice(0, fnRest.indexOf('\n  }\n') + 4)}; return fmtTimestamp;`,
+)();
+const CP = {fmtTimestamp};
+
 const source = [extract('staleNote'), extract('renderContainers'), extract('renderApps'), extract('countWorkerNames')].join('\n');
-const build = new Function('esc', 'fmtBytes', `${source}; return {renderContainers, renderApps, staleNote, countWorkerNames};`);
-const {renderContainers, renderApps, countWorkerNames} = build(esc, fmtBytes);
+const build = new Function('esc', 'fmtBytes', 'CP', `${source}; return {renderContainers, renderApps, staleNote, countWorkerNames};`);
+const {renderContainers, renderApps, staleNote, countWorkerNames} = build(esc, fmtBytes, CP);
 
 const WORKER = {
   name: 'geiserback',
@@ -45,7 +58,31 @@ const WORKER = {
 const APPS = [{slug: 'honeygain', running: true, net_tx_24h: 10, net_rx_24h: 20}];
 
 const failures = [];
-const check = (name, ok, detail) => { if (!ok) failures.push(`${name}: ${detail}`); };
+// Counted, not asserted. The summary line used to interpolate a hardcoded
+// `${20}`, so it reported twenty assertions whether twenty ran or two did --
+// a number that looked measured and was not, in a script whose whole job is
+// catching exactly that.
+let checksRun = 0;
+const check = (name, ok, detail) => { checksRun++; if (!ok) failures.push(`${name}: ${detail}`); };
+
+// 0. CashPilot-2dh. The DB stores UTC with no zone designator; rendering it raw
+//    made a worker that heartbeated minutes ago look hours stale, right beside
+//    "This host is not reachable" and one click from Remove.
+const utc = '2026-08-05 04:00:00';
+const shown = CP.fmtTimestamp(utc);
+check('a UTC stamp is not shown verbatim', shown.text !== utc,
+  `rendered "${shown.text}" unchanged, so the viewer reads UTC as local time`);
+check('the original UTC is still recoverable', shown.title.includes('UTC'),
+  `title was "${shown.title}"`);
+check('it is parsed as UTC, not as local time',
+  new Date(`${utc.replace(' ', 'T')}Z`).toLocaleString() === shown.text,
+  `got "${shown.text}"`);
+check('a missing stamp says never', CP.fmtTimestamp(null).text === 'never',
+  JSON.stringify(CP.fmtTimestamp(null)));
+check('an unreadable stamp is not invented', CP.fmtTimestamp('nonsense').text === 'nonsense',
+  JSON.stringify(CP.fmtTimestamp('nonsense')));
+check('the stale note uses the formatter', !staleNote(utc).includes(utc),
+  staleNote(utc));
 
 // 1. The defect itself. An unreachable host must not paint anything success-green.
 const offline = renderContainers(WORKER, false);
@@ -63,8 +100,14 @@ check('offline still lists the containers', offline.includes('honeygain'),
   'the container list vanished instead of being marked stale');
 check('offline says so in words', offline.includes('Last known state'),
   'nothing on the card says the state is not current');
-check('offline names when it was last seen', offline.includes('2026-08-04 09:12'),
+// The intent is unchanged -- the card must say WHEN this was last true -- but
+// the representation is now the viewer's local time rather than raw UTC
+// (CashPilot-2dh), so the assertion tracks the formatter instead of a literal.
+check('offline names when it was last seen',
+  offline.includes(CP.fmtTimestamp(WORKER.last_heartbeat).text),
   'the chip tooltip does not say when this was last true');
+check('and it is no longer the raw UTC string', !offline.includes('2026-08-04 09:12'),
+  'the raw stored value is still being shown to the viewer');
 
 // 4. A stopped container on a LIVE host must still read as stopped, not stale.
 const stoppedLive = renderContainers({...WORKER, containers: [{slug: 'grass', status: 'exited'}]}, true);
@@ -113,4 +156,4 @@ if (failures.length) {
   for (const f of failures) console.error(`  - ${f}`);
   process.exit(1);
 }
-console.log(`fleet staleness check passed (${20} assertions)`);
+console.log(`fleet staleness check passed (${checksRun} assertions)`);

--- a/tests/test_beads_batch_50.py
+++ b/tests/test_beads_batch_50.py
@@ -1,0 +1,201 @@
+"""CashPilot-2dh, -0p4, -wij: three ways the fleet page misled its reader.
+
+**2dh** — worker timestamps were rendered raw. The database writes
+``datetime('now')``, which SQLite produces in **UTC** with no zone designator,
+and the frontend had no date formatting of any kind: ``toLocaleString``,
+``toLocaleDateString`` and ``new Date(`` each returned zero hits across
+``app.js`` and ``fleet.html``. A viewer in CEST read a worker that heartbeated
+five minutes ago as two hours stale — directly beside the words "This host is
+not reachable", and one click from Remove.
+
+**0p4** — the Copy button claimed success in two situations where it had none.
+``navigator.clipboard`` is gated on a secure context, and ``docs/fleet.md``
+documents the normal setup as plain ``http://`` on the LAN, where the object is
+``undefined``; the property access threw inside an async function that
+``delegate.js`` calls without awaiting, so the button was silently dead. And when
+the key reveal failed, ``_apiKey`` was the literal ``(error)`` — copied, with a
+success toast, into a compose file that could never enrol a worker.
+
+**wij** — of four stat cards in one row, "Workers" and "Online" were fleet-wide
+while "Services" and "Running" counted only online workers, with nothing saying
+so. A rebooting host made "Services" drop, and it read as containers lost. The
+dashboard already ships the correct explanation and a button that sends the user
+to this very page to be misled by it.
+
+Behaviour lives in ``scripts/fleet_staleness_check.mjs``, which now runs the real
+``fmtTimestamp`` extracted from ``app.js`` rather than a stub — a stub would let
+the formatter break while the harness stayed green, which is the failure mode
+these scripts exist to catch.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+FLEET = ROOT / "app" / "templates" / "fleet.html"
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+HARNESS = ROOT / "scripts" / "fleet_staleness_check.mjs"
+
+
+class TestThereIsOneSharedTimestampFormatter:
+    def test_it_exists(self):
+        assert "function fmtTimestamp(" in APP_JS.read_text(encoding="utf-8")
+
+    def test_it_is_exported_for_the_templates(self):
+        """fleet.html reaches it through the CP namespace."""
+        js = APP_JS.read_text(encoding="utf-8")
+        export = js[js.rindex("  return {") :]
+        assert "fmtTimestamp," in export
+
+    def test_it_is_defined_outside_the_export_object(self):
+        """A function declaration inside the returned literal is a syntax error.
+
+        The first attempt at this landed there; `node --check` caught it.
+        """
+        js = APP_JS.read_text(encoding="utf-8")
+        assert js.index("function fmtTimestamp(") < js.rindex("  return {")
+
+    def test_no_raw_heartbeat_reaches_the_page(self):
+        html = FLEET.read_text(encoding="utf-8")
+        assert "${w.last_heartbeat || 'never'}" not in html, "the stored UTC value is rendered verbatim again"
+        assert "${lastSeen || 'never'}" not in html
+
+    def test_both_render_sites_use_the_formatter(self):
+        html = FLEET.read_text(encoding="utf-8")
+        assert html.count("CP.fmtTimestamp(") >= 3, "a timestamp site was left on the raw value"
+
+    def test_the_original_utc_is_still_recoverable(self):
+        """Converting without keeping the source would lose the audit trail."""
+        js = APP_JS.read_text(encoding="utf-8")
+        body = js[js.index("function fmtTimestamp(") :][:1200]
+        assert "UTC" in body
+
+
+class TestTheCopyButtonCannotClaimAnUnearnedSuccess:
+    def _body(self):
+        html = FLEET.read_text(encoding="utf-8")
+        start = html.index("window.copyWorkerEnv")
+        return html[start : start + 1800]
+
+    def test_it_refuses_the_sentinel_values(self):
+        """`(error)` and `(not configured)` are not keys."""
+        assert "_apiKey.startsWith('(')" in self._body()
+
+    def test_the_success_toast_is_no_longer_unconditional(self):
+        body = self._body()
+        assert "navigator.clipboard.writeText(text).then(() => CP.toast('Copied', 'success'));" not in body
+
+    def test_the_clipboard_write_is_awaited_and_caught(self):
+        """Unawaited, the rejection is invisible: delegate.js does not catch it."""
+        body = self._body()
+        assert "await navigator.clipboard.writeText(text)" in body
+        assert "catch" in body
+
+    def test_a_missing_clipboard_api_is_handled(self):
+        """It is undefined on the plain-http LAN origin the docs recommend."""
+        assert "!navigator.clipboard" in self._body()
+
+    def test_there_is_something_to_fall_back_to(self):
+        html = FLEET.read_text(encoding="utf-8")
+        assert 'id="worker-env-fallback"' in html, "the handler targets an element that does not exist"
+        assert "<textarea" in html[html.index('id="worker-env-fallback"') :][:400]
+
+
+class TestTheFleetCardsSayWhatTheyCount:
+    def test_the_online_only_cards_are_labelled(self):
+        html = FLEET.read_text(encoding="utf-8")
+        for card in ("fleet-total-containers", "fleet-running-containers"):
+            block = html[max(0, html.index(card) - 600) : html.index(card)]
+            assert "(online)" in block, f"{card} still reads as a fleet-wide total"
+
+    def test_the_fleet_wide_cards_are_not_mislabelled(self):
+        """Over-labelling would be its own inaccuracy.
+
+        Scoped to each fleet-wide card's own <div>, not to "everything before
+        the first online-only card" -- that slice necessarily contains the
+        Services label, so the first version of this test failed on correct
+        markup.
+        """
+        html = FLEET.read_text(encoding="utf-8")
+        for card in ("fleet-total-workers", "fleet-online-workers"):
+            start = html.rindex('<div class="stat-card">', 0, html.index(card))
+            block = html[start : html.index(card)]
+            assert "(online)" not in block, f"{card} is fleet-wide but labelled as online-only"
+
+    def test_the_endpoint_reports_what_the_cards_leave_out(self):
+        main = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        start = main.index("async def api_fleet_summary")
+        body = main[start : start + 2200]
+        assert '"unreachable_containers"' in body
+        assert '"unreachable_workers"' in body
+
+    def test_offline_workers_are_still_excluded_from_the_online_totals(self):
+        """The counts themselves must not change — only what is said about them."""
+        main = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        start = main.index("async def api_fleet_summary")
+        body = main[start : start + 2200]
+        assert 'if w["status"] != "online":' in body
+        assert 'total_services += w["container_count"]' in body
+
+    def test_the_page_renders_the_note(self):
+        html = FLEET.read_text(encoding="utf-8")
+        assert 'id="fleet-unreachable-note"' in html
+        assert "summary.unreachable_containers" in html
+
+    def test_the_note_denies_the_wrong_conclusion_explicitly(self):
+        """ "N not counted" alone still reads as "N lost"."""
+        html = FLEET.read_text(encoding="utf-8")
+        idx = html.index("summary.unreachable_containers")
+        block = html[idx : idx + 900]
+        assert "keep running and earning" in block
+
+
+class TestTheHarnessRunsTheRealFormatter:
+    def test_it_extracts_fmttimestamp_from_app_js(self):
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "app/static/js/app.js" in text
+        assert "fmtTimestamp" in text
+
+    def test_it_does_not_stub_it(self):
+        """A stub would let the formatter break while this stayed green."""
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "const fmtTimestamp = new Function(" in text
+
+    def test_it_fails_loudly_if_the_function_is_renamed(self):
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "throw new Error('fmtTimestamp is gone" in text
+
+    def test_the_assertion_count_is_counted_not_hardcoded(self):
+        """The summary line used to interpolate a literal and always say twenty.
+
+        Checks the console.log LINE, not the whole file: the comment recording
+        why necessarily quotes the old literal, and the first version of this
+        test matched its own explanation.
+        """
+        line = next(
+            line
+            for line in HARNESS.read_text(encoding="utf-8").splitlines()
+            if "assertions)" in line and "console" in line
+        )
+        assert not re.search(r"\$\{\d+\}", line), f"still interpolating a constant: {line.strip()}"
+        assert "checksRun" in line
+
+    @pytest.mark.parametrize("script", ["fleet_staleness_check.mjs", "settings_failure_check.mjs"])
+    def test_the_browser_free_harnesses_stay_browser_free(self, script):
+        text = (ROOT / "scripts" / script).read_text(encoding="utf-8")
+        assert "9222" not in text
+
+    def test_the_harness_reports_more_assertions_than_before(self):
+        """Guards against the count silently shrinking as checks are removed."""
+        import subprocess
+
+        result = subprocess.run(
+            ["node", "scripts/fleet_staleness_check.mjs"], cwd=ROOT, capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        count = int(re.search(r"\((\d+) assertions\)", result.stdout).group(1))
+        assert count >= 26, f"the harness now runs only {count} assertions"


### PR DESCRIPTION
Closes `CashPilot-2dh`, `CashPilot-0p4` and `CashPilot-wij` (all P3). All three are in `fleet.html`, which had not had the pass `app.js` received.

## 2dh — a live worker that looks two hours stale

The database stores UTC (`datetime('now')`, SQLite), and the frontend had **no date formatting of any kind**: `toLocaleString`, `toLocaleDateString` and `new Date(` each return **zero** hits across `app.js` and `fleet.html`. So the raw string went straight to the page.

A viewer in CEST reads `Last seen: 2026-08-05 04:00:00` at 06:05 local and concludes the worker has been silent for two hours. It heartbeated five minutes ago. That string is the evidence for *"This host is not reachable"*, and it also appears in the Remove-worker confirmation — acting on a misjudged staleness takes a live host out of the fleet.

One shared `fmtTimestamp` now:

| input | text | title |
|---|---|---|
| `2026-08-05 04:00:00` | local time | `2026-08-05 04:00:00 UTC` |
| `null` | `never` | — |
| unparseable | echoed back verbatim | "could not read this timestamp" |

The `Z` suffix matters: `Date.parse` treats a zone-less string as **local**, so parsing without it would have silently shifted the value in the other direction.

## 0p4 — a Copy button that reported success it never had

```js
navigator.clipboard.writeText(text).then(() => CP.toast('Copied', 'success'));
```

Two failures in one line. `navigator.clipboard` is gated on a **secure context**, and `docs/fleet.md` documents the normal setup as `http://192.168.10.100:8080` — there the object is `undefined`, the property access throws inside an `async` function, and `delegate.js` calls it without awaiting, so the rejection is unhandled. The button was simply dead, silently, for exactly the multi-server users who need it.

And when the owner-only reveal fails, `_apiKey` is the literal `(error)`. The toast said success anyway, so the user pasted `CASHPILOT_API_KEY=(error)` into their compose file and then debugged a worker that could never enrol.

Now: sentinels are refused by name, the write is awaited and caught, and a non-secure origin gets the text selected in a textarea with an explanation — a fallback that cannot itself fail.

## wij — a reboot that reads as lost containers

`api_fleet_summary` skips offline workers **before** accumulating, so of four cards in one row, `Workers`/`Online` are fleet-wide and `Services`/`Running` are online-only. Nothing said so.

The dashboard already ships the right explanation and a **"Check the fleet"** button beneath it:

> Services running on … are not shown here — this does not mean they stopped. Containers keep running and earning while a worker is offline.

The user was routed from a correct explanation to a page that restated the error it was written to prevent. The cards now say `(online)`, and the summary reports `unreachable_containers` / `unreachable_workers` so the page can name what it leaves out — and say explicitly that those containers keep running and earning.

**The counts themselves are unchanged.** A test pins that, so this stays a labelling fix.

## A bonus, found while testing

`fleet_staleness_check.mjs` ended with:

```js
console.log(`fleet staleness check passed (${20} assertions)`);
```

A hardcoded literal. It reported twenty assertions whether twenty ran or two did — a number that looked measured and was not, in the script whose whole job is catching that. It now counts: **28**.

The harness also now extracts the **real** `fmtTimestamp` from `app.js` instead of stubbing it. A stub would let the formatter break while the harness stayed green.

## Evidence

24 pytest tests, 28 harness assertions. Ten negative controls, all caught:

| reverted | caught by |
|---|---|
| raw UTC rendered again | pytest |
| timestamp parsed as local, not UTC | harness |
| a time invented for an unparseable value | harness |
| `(error)` sentinel copied | pytest |
| unawaited write with an unconditional toast | pytest |
| cards unlabelled | pytest |
| endpoint stops reporting what it omits | pytest |
| note never rendered | pytest |
| harness stubs the formatter | harness |
| assertion count hardcoded again | pytest |

All four sources verified byte-identical after every revert. Two of my own tests initially failed by matching their own explanatory text; both were replaced with structural checks.

Gates: `ruff check` clean, `ruff format --check` clean, `node --check` clean, all three browser-free harnesses PASS, **3226 passed, 95.34% coverage**.