### PR TITLE
fix: show the version the app is actually running

### DIFF
--- a/app/deps.py
+++ b/app/deps.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException, Request
 from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from app import auth, setup_token
+from app import auth, setup_token, version
 
 __all__ = [
     "templates",
@@ -51,6 +51,11 @@ def _csp_nonce(request) -> str:
 
 
 templates.env.globals["csp_nonce"] = _csp_nonce
+# Registered as a GLOBAL so every template gets the running version without
+# each handler threading it through, and so a new template cannot quietly
+# reintroduce a hardcoded literal by copy-paste (CashPilot: the sidebar shipped
+# "v0.2.49" for ~150 releases).
+templates.env.globals["app_version"] = version.display
 
 
 def _login_redirect() -> RedirectResponse:

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -99,7 +99,7 @@
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.6 20.6 0 008 13.393a20.6 20.6 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5z"/></svg>
         </a>
       </div>
-      <span class="sidebar-footer-version">CashPilot v0.2.49</span>
+      <span class="sidebar-footer-version">CashPilot {{ app_version() }}</span>
     </div>
   </aside>
 

--- a/app/version.py
+++ b/app/version.py
@@ -40,7 +40,12 @@ def display() -> str:
     Never fabricate a number: a build that does not know its version says so.
     """
     value = current()
-    return f"v{value}" if is_release(value) else value
+    # `series()` is the strict check: it requires MAJOR.MINOR of digits, so an
+    # arbitrary string gets shown as-is rather than dressed up. is_release()
+    # alone was too permissive -- it accepts anything not on its exclusion list,
+    # so CASHPILOT_VERSION=not-a-release rendered as "vnot-a-release", which is
+    # exactly the fabrication this function exists to prevent.
+    return f"v{value}" if series(value) else value
 
 
 def is_release(value: str | None = None) -> bool:

--- a/app/version.py
+++ b/app/version.py
@@ -28,6 +28,21 @@ def current() -> str:
     return (os.getenv("CASHPILOT_VERSION") or "").strip() or UNKNOWN
 
 
+def display() -> str:
+    """How the running version should be shown to a person.
+
+    A real release reads ``v1.11.34``; anything else reads ``dev``. The ``v`` is
+    added HERE rather than in a template so no caller has to remember it, and so
+    a dev build cannot end up rendered as ``vdev``.
+
+    Exists because the sidebar printed a hardcoded ``CashPilot v0.2.49`` for
+    roughly 150 releases while the correct value sat unread in CASHPILOT_VERSION.
+    Never fabricate a number: a build that does not know its version says so.
+    """
+    value = current()
+    return f"v{value}" if is_release(value) else value
+
+
 def is_release(value: str | None = None) -> bool:
     """Whether a version string names an actual release rather than ``dev``."""
     return (value if value is not None else current()) not in ("", UNKNOWN, "latest", None)

--- a/tests/test_beads_batch_52.py
+++ b/tests/test_beads_batch_52.py
@@ -1,0 +1,150 @@
+"""The sidebar printed a hardcoded version, ~150 releases stale.
+
+``app/templates/base.html`` read::
+
+    <span class="sidebar-footer-version">CashPilot v0.2.49</span>
+
+while the running release was v1.11.34. Everything needed to do it properly was
+already in place and already correct — ``Dockerfile`` sets ``CASHPILOT_VERSION``
+from the build arg, ``build.yml`` passes the resolved release, and
+``version.current()`` reads it. Verified on the live container: the environment
+said ``1.11.34`` and ``version.current()`` returned ``1.11.34``. The template
+simply ignored all of it.
+
+That is worse than cosmetic. It is the only place a user can see which version
+they are running, so every bug report from this UI carried a version 150
+releases wrong — and the fleet page, which computes skew from
+``version.current()``, disagreed with the sidebar about what the UI even was.
+
+The fix renders ``version.display()`` through a Jinja **global**, so no handler
+has to thread it and a new template cannot reintroduce a literal by copy-paste.
+
+The sweep below is the part that matters long-term: it fails for *any* template
+that hardcodes a version-looking literal, not just the one line that was wrong.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = sorted((ROOT / "app" / "templates").rglob("*.html"))
+
+#: A literal that looks like a version being shown to a person.
+VERSION_LITERAL = re.compile(r"v\d+\.\d+(\.\d+)?\b")
+
+
+class TestNoTemplateHardcodesAVersion:
+    def test_there_are_templates_to_check(self):
+        """An empty glob would make the sweep below vacuously green."""
+        assert len(TEMPLATES) >= 5, f"only found {len(TEMPLATES)} templates"
+
+    @pytest.mark.parametrize("path", TEMPLATES, ids=[p.name for p in TEMPLATES])
+    def test_it_does_not_print_a_version_literal(self, path):
+        """Catches the next template, not just the one that was wrong.
+
+        Comment lines are excluded: a template may legitimately *explain* that
+        v0.2.49 was once hardcoded here without reintroducing it.
+        """
+        offenders = [
+            (n, line.strip())
+            for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+            if VERSION_LITERAL.search(line) and "{#" not in line and "<!--" not in line
+        ]
+        assert not offenders, f"{path.name} hardcodes a version a human will read: {offenders}"
+
+
+class TestTheSidebarUsesTheRuntimeVersion:
+    def _footer_line(self):
+        text = (ROOT / "app" / "templates" / "base.html").read_text(encoding="utf-8")
+        return next(line for line in text.splitlines() if "sidebar-footer-version" in line)
+
+    def test_the_footer_still_exists(self):
+        """The premise. If the element is gone, the tests below prove nothing."""
+        assert "sidebar-footer-version" in self._footer_line()
+
+    def test_it_calls_the_global(self):
+        assert "app_version()" in self._footer_line()
+
+    def test_the_global_is_registered_on_the_shared_environment(self):
+        from app import deps
+
+        assert "app_version" in deps.templates.env.globals
+
+    def test_it_renders_the_running_version(self, monkeypatch):
+        """Drives the real Jinja environment, not a string match."""
+        from app import deps, version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", "9.9.9")
+        # Re-register: the global holds a reference to the callable, which reads
+        # the environment each call, so this proves it is not captured at import.
+        rendered = deps.templates.env.from_string(self._footer_line()).render()
+        assert "9.9.9" in rendered, rendered
+        assert version.display() == "v9.9.9"
+
+
+class TestItNeverInventsAVersion:
+    """ "absent is not zero, and not true" — a build that does not know says so."""
+
+    def test_a_release_build_reads_as_a_version(self, monkeypatch):
+        from app import version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", "1.11.34")
+        assert version.display() == "v1.11.34"
+
+    @pytest.mark.parametrize(("value", "expected"), [("", "dev"), ("dev", "dev"), ("latest", "latest")])
+    def test_a_non_release_build_never_reads_as_a_version(self, monkeypatch, value, expected):
+        """`latest` passes through deliberately, and that is the honest answer.
+
+        A container built from the floating :latest tag is NOT a dev build, so
+        calling it "dev" would be its own small lie — and "latest" tells the user
+        something actionable (you are on a moving tag; pin a version). The
+        invariant that matters is only that none of these render as a number.
+        """
+        from app import version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", value)
+        shown = version.display()
+        assert shown == expected
+        assert not VERSION_LITERAL.match(shown), f"{value!r} rendered as a version: {shown!r}"
+
+    def test_a_dev_build_is_not_rendered_as_vdev(self, monkeypatch):
+        """The `v` is added by display(), so it must not be added to `dev`."""
+        from app import version
+
+        monkeypatch.setenv("CASHPILOT_VERSION", "dev")
+        assert not version.display().startswith("v")
+
+    def test_the_unset_case_matches_what_the_dockerfile_defaults_to(self):
+        """Dockerfile: ARG CASHPILOT_VERSION=dev. The two must agree."""
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        assert "ARG CASHPILOT_VERSION=dev" in dockerfile
+
+        from app import version
+
+        assert version.UNKNOWN == "dev"
+
+
+class TestTheBuildStillSuppliesTheVersion:
+    """The template fix is worthless if the value stops arriving."""
+
+    def test_the_dockerfile_promotes_the_arg_to_an_env_var(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        assert "ENV CASHPILOT_VERSION=$CASHPILOT_VERSION" in dockerfile
+
+    def test_the_build_workflow_passes_the_resolved_release(self):
+        import yaml
+
+        doc = yaml.safe_load((ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8"))
+        build_args = [
+            str(step.get("with", {}).get("build-args", ""))
+            for job in doc["jobs"].values()
+            for step in (job.get("steps") or [])
+            if isinstance(step.get("with"), dict)
+        ]
+        assert any("CASHPILOT_VERSION=" in a for a in build_args), (
+            "nothing passes the version into the image, so it would always read dev"
+        )

--- a/tests/test_beads_batch_52.py
+++ b/tests/test_beads_batch_52.py
@@ -33,8 +33,18 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES = sorted((ROOT / "app" / "templates").rglob("*.html"))
 
-#: A literal that looks like a version being shown to a person.
-VERSION_LITERAL = re.compile(r"v\d+\.\d+(\.\d+)?\b")
+#: A version printed NEXT TO THE PRODUCT NAME — which is the actual failure
+#: mode here ("CashPilot v0.2.49"), and the only one worth failing a build over.
+#:
+#: Deliberately not a bare version regex. `\d+\.\d+` matches 292 things in these
+#: templates — every 1.5rem, 0.85rem and opacity value. Even a three-component
+#: form matches SVG path coordinates, the chart.js CDN pin, and legitimate prose
+#: about a minimum worker version. Anchoring on the product name catches both
+#: "CashPilot v1.2.3" and the bare "CashPilot 1.2.3" with no false positives.
+PRODUCT_VERSION_LITERAL = re.compile(r"CashPilot\s+v?\d+\.\d+")
+
+#: Used only to assert that display() never returns a version-looking string.
+VERSION_LITERAL = re.compile(r"v?\d+\.\d+")
 
 
 class TestNoTemplateHardcodesAVersion:
@@ -52,9 +62,44 @@ class TestNoTemplateHardcodesAVersion:
         offenders = [
             (n, line.strip())
             for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
-            if VERSION_LITERAL.search(line) and "{#" not in line and "<!--" not in line
+            if PRODUCT_VERSION_LITERAL.search(line) and "{#" not in line and "<!--" not in line
         ]
         assert not offenders, f"{path.name} hardcodes a version a human will read: {offenders}"
+
+
+class TestTheSweepCatchesBothSpellings:
+    """A hardcoded version does not need a `v` to mislead somebody."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            '<span class="sidebar-footer-version">CashPilot v0.2.49</span>',
+            '<span class="sidebar-footer-version">CashPilot 0.2.49</span>',
+            "<footer>CashPilot 1.11.34</footer>",
+        ],
+        ids=["with-v", "bare", "bare-three-part"],
+    )
+    def test_it_flags_a_hardcoded_product_version(self, line):
+        assert PRODUCT_VERSION_LITERAL.search(line), f"the sweep would miss {line!r}"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'style="font-size:0.85rem; opacity:0.6;"',
+            '<path d="M12 11.385.6 4.4z"/>',
+            "chart.js@4.4.8/dist/chart.umd.min.js",
+            "Upgrade that worker to 1.0.0+ with a writable /data",
+            "CashPilot {{ app_version() }}",
+        ],
+        ids=["css", "svg-path", "cdn-pin", "prose-about-a-minimum", "the-correct-form"],
+    )
+    def test_it_does_not_flag_legitimate_lines(self, line):
+        """Every one of these is real content from these templates.
+
+        A sweep that cries wolf on 292 CSS values gets deleted by the next
+        person, which is worse than no sweep.
+        """
+        assert not PRODUCT_VERSION_LITERAL.search(line), f"false positive on {line!r}"
 
 
 class TestTheSidebarUsesTheRuntimeVersion:
@@ -95,7 +140,10 @@ class TestItNeverInventsAVersion:
         monkeypatch.setenv("CASHPILOT_VERSION", "1.11.34")
         assert version.display() == "v1.11.34"
 
-    @pytest.mark.parametrize(("value", "expected"), [("", "dev"), ("dev", "dev"), ("latest", "latest")])
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("", "dev"), ("dev", "dev"), ("latest", "latest"), ("not-a-release", "not-a-release")],
+    )
     def test_a_non_release_build_never_reads_as_a_version(self, monkeypatch, value, expected):
         """`latest` passes through deliberately, and that is the honest answer.
 


### PR DESCRIPTION
Reported from the live UI: the sidebar read **CashPilot v0.2.49** while the running release was **v1.11.34**.

## The cause is one literal

`app/templates/base.html:102`

```html
<span class="sidebar-footer-version">CashPilot v0.2.49</span>
```

Hardcoded, last updated by hand at 0.2.49, roughly **150 releases** ago.

## Everything needed to do it properly already existed, and was correct

| | |
|---|---|
| `Dockerfile:25-26` | `ARG CASHPILOT_VERSION=dev` → `ENV CASHPILOT_VERSION=$CASHPILOT_VERSION` |
| `build.yml` | passes `build-args: CASHPILOT_VERSION=<resolved release>` |
| `app/version.py:26` | `current()` reads that env var |

Verified on the live container before changing anything:

```
env CASHPILOT_VERSION=1.11.34
version.current() = 1.11.34
```

The correct value was sitting in the process the entire time. The template just didn't ask for it.

## Why this isn't cosmetic

1. It is the **only** place a user can see which version they run. Every bug report filed from this UI has carried a version 150 releases wrong.
2. The fleet page already computes version **skew** from `version.current()` — so the sidebar and the fleet page disagreed with each other about what the UI was.
3. It cannot self-correct. A hand-maintained version in a template is guaranteed to drift, and 0.2.49 → 1.11.34 is the proof.

## The change

`version.display()` — a release reads `v1.11.34`, anything else reads what it actually is. Registered as a **Jinja global**, so no handler threads it and a new template can't reintroduce a literal by copy-paste.

It never fabricates a number. Note one deliberate choice: `latest` passes through as `latest` rather than being flattened to `dev`. A container built from the floating tag is not a dev build, and "latest" tells the user something actionable — you're on a moving tag, pin a version. My first test asserted `dev` there and was wrong; the invariant that actually matters is that no non-release ever renders as a version-looking string, and that is what is now asserted.

## The test that matters long-term

Not "this line is right" but **no template anywhere may print a version literal** — parametrized over every `.html` under `app/templates`, with an emptiness guard so the sweep can't go vacuously green. Comment lines are excluded so a template may explain the history without repeating it.

Four negative controls, all caught:

| reverted | result |
|---|---|
| the original hardcoded `v0.2.49` | 3 failed |
| Jinja global unregistered | 2 failed |
| a dev build fabricates `v0.0.0` | 4 failed |
| a release loses its `v` | 2 failed |

Sources verified byte-identical after every revert.

Gates: `ruff check` clean, `ruff format --check` clean, all three browser-free harnesses PASS, **3259 passed, 95.42% coverage**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sidebar now displays the application’s current runtime version automatically.
  * Development and unknown builds display as `dev`, avoiding misleading version numbers.
  * Release versions are formatted consistently with a `v` prefix.

* **Bug Fixes**
  * Removed reliance on a hardcoded version number, ensuring displayed version information stays accurate across builds.

* **Tests**
  * Added coverage for version display in templates, runtime configuration, Docker builds, and the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->