### PR TITLE
fix: the claim modal said "Service not found" about services that exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Settings failure path
         run: node scripts/settings_failure_check.mjs
 
+      # Also browser-free. The claim modal has to give THREE different answers
+      # for what looks like one empty result; only running it proves which.
+      - name: Claim modal honesty
+        run: node scripts/claim_modal_check.mjs
+
       # Also behaviour pytest cannot reach, and for the same reason: these
       # renderers live in a <script> block inside a Jinja template, so a Python
       # assertion could only prove the source mentions a variable — never what

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1456,6 +1456,42 @@ const CP = (() => {
   // -----------------------------------------------------------
   // Claim Modal
   // -----------------------------------------------------------
+  // Why this service has no earnings row, said accurately. Three different
+  // facts hide behind one empty result and they need three different answers.
+  async function renderNoEarningsYet(platform, title, body) {
+    let service = null;
+    try {
+      const available = await api('/api/services/available');
+      service = (available || []).find(s => s.slug === platform) || null;
+    } catch (err) {
+      // Could not check. Say that, rather than guessing at either answer.
+      if (title) title.textContent = 'Cashout';
+      if (body) {
+        body.innerHTML = `<p>Could not check this service right now: ${escapeHtml(err.message || 'request failed')}.</p>`;
+      }
+      return;
+    }
+
+    const name = service ? (service.name || platform) : platform;
+    if (title) title.textContent = `Cashout \u2014 ${name}`;
+    if (!body) return;
+
+    if (!service) {
+      // The only case that genuinely deserves the old wording.
+      body.innerHTML = `<p>${escapeHtml(name)} is not in the service catalog, so CashPilot knows nothing about its cashout.</p>`;
+      return;
+    }
+
+    // Deployed and running, but nothing has been read yet. Name the likely
+    // cause, because "no data" without a reason reads as a broken page.
+    const reason = service.has_collector
+      ? 'No earnings have been read for this service yet. Add its credentials in '
+        + 'Settings \u2192 Collectors, or wait for the next hourly collection if you already have.'
+      : 'CashPilot has no earnings collector for this service yet, so it cannot read a balance. '
+        + 'It may still be running and earning \u2014 check the provider\'s own dashboard.';
+    body.innerHTML = `<p>${escapeHtml(reason)}</p>`;
+  }
+
   async function openClaimModal(platform) {
     openModal('claim-modal');
     const title = document.getElementById('claim-modal-title');
@@ -1468,7 +1504,13 @@ const CP = (() => {
       const data = await api('/api/earnings/breakdown');
       const svc = data.find(s => s.platform === platform);
       if (!svc) {
-        if (body) body.innerHTML = '<p>Service not found.</p>';
+        // /api/earnings/breakdown is built from the EARNINGS table, so a service
+        // that has never produced a reading is simply absent from it. Reporting
+        // that absence as "Service not found" told the user the software had
+        // lost track of a service they were looking straight at -- it is in the
+        // catalog, on the dashboard, deployed and running. On this fleet that
+        // was 5 of 18 tracked services (CashPilot: claim-modal bead).
+        await renderNoEarningsYet(platform, title, body);
         return;
       }
 

--- a/scripts/claim_modal_check.mjs
+++ b/scripts/claim_modal_check.mjs
@@ -1,0 +1,120 @@
+// Run the real claim-modal fallback against stubbed API responses.
+//
+// The bug: openClaimModal looks the service up in /api/earnings/breakdown, which
+// is built from the EARNINGS table. A service that has never produced a reading
+// is simply absent from it, and the modal rendered that absence as
+//
+//     Service not found.
+//
+// which is false. The service is in the catalog, on the dashboard, deployed and
+// running. On the reference fleet that wording appeared for 5 of 18 tracked
+// services: anyone-protocol, proxybase, proxylite, titan, uprock.
+//
+// Three different facts hide behind one empty result and they need three
+// different answers. Only running the function can prove which one it gives, so
+// this drives it rather than grepping for a string.
+//
+//   node scripts/claim_modal_check.mjs
+//
+// Exits non-zero on any mismatch.
+import {readFileSync} from 'node:fs';
+
+const src = readFileSync('app/static/js/app.js', 'utf8');
+
+function grab(name) {
+  let i = src.indexOf(`function ${name}(`);
+  if (i < 0) {
+    console.error(`FAIL: ${name} is not defined in app/static/js/app.js`);
+    process.exit(1);
+  }
+  // Keep the `async` keyword. Slicing from `function` alone produced a
+  // non-async body containing `await`, which is a SyntaxError -- the extraction
+  // silently changed what it was testing.
+  const asyncPrefix = 'async ';
+  if (src.slice(i - asyncPrefix.length, i) === asyncPrefix) i -= asyncPrefix.length;
+  const rest = src.slice(i);
+  const end = rest.indexOf('\n  }\n');
+  return rest.slice(0, end + 4);
+}
+
+// The catalog the stub server will answer with.
+const CATALOG = [
+  {slug: 'anyone-protocol', name: 'Anyone Protocol', has_collector: true},
+  {slug: 'titan', name: 'Titan Network', has_collector: false},
+];
+
+let apiBehaviour = 'ok';
+const api = async path => {
+  if (apiBehaviour === 'throw') throw new Error('502 Bad Gateway');
+  if (path === '/api/services/available') return CATALOG;
+  throw new Error(`unexpected call: ${path}`);
+};
+const escapeHtml = s =>
+  String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[c]);
+
+const build = new Function(
+  'api',
+  'escapeHtml',
+  `${grab('renderNoEarningsYet')}; return renderNoEarningsYet;`,
+);
+const renderNoEarningsYet = build(api, escapeHtml);
+
+let bad = 0;
+const check = (label, cond, detail) => {
+  console.log(`  ${cond ? 'ok  ' : 'FAIL'} ${label}${cond ? '' : `  <- ${detail}`}`);
+  if (!cond) bad++;
+};
+
+async function run(platform) {
+  const title = {textContent: ''};
+  const body = {innerHTML: ''};
+  await renderNoEarningsYet(platform, title, body);
+  return {title: title.textContent, body: body.innerHTML};
+}
+
+// 1. THE BUG. A tracked service with a collector but no readings yet.
+const withCollector = await run('anyone-protocol');
+check('tracked service is no longer called "not found"', !withCollector.body.includes('not found'), withCollector.body);
+check('it names the service', withCollector.title.includes('Anyone Protocol'), withCollector.title);
+check(
+  'it says no earnings have been READ yet',
+  /no earnings have been read/i.test(withCollector.body),
+  withCollector.body,
+);
+check(
+  'it points at the actual next step',
+  /Settings/.test(withCollector.body) && /Collectors/.test(withCollector.body),
+  withCollector.body,
+);
+
+// 2. A tracked service with NO collector. Different cause, different answer:
+//    no credential will ever help, so telling them to add one would be wrong.
+const noCollector = await run('titan');
+check('a collector-less service says so', /no earnings collector/i.test(noCollector.body), noCollector.body);
+check(
+  'and does NOT send the user to add credentials',
+  !/Settings/.test(noCollector.body),
+  noCollector.body,
+);
+check(
+  'and admits it may still be earning',
+  /still be running and earning/i.test(noCollector.body),
+  noCollector.body,
+);
+
+// 3. Genuinely absent from the catalog -- the ONLY case that earns the old wording.
+const unknown = await run('does-not-exist');
+check('an uncatalogued slug is reported as not in the catalog', /not in the service catalog/i.test(unknown.body), unknown.body);
+
+// 4. The lookup itself failing must not be reported as either of the above.
+apiBehaviour = 'throw';
+const broken = await run('anyone-protocol');
+apiBehaviour = 'ok';
+check('a failed lookup says it could not check', /could not check/i.test(broken.body), broken.body);
+check('and does not claim the service is missing', !/not in the service catalog/i.test(broken.body), broken.body);
+
+// 5. The message is escaped before it reaches innerHTML.
+check('the error detail is escaped', !broken.body.includes('<script'), broken.body);
+
+console.log(bad ? `\nRESULT: FAIL (${bad})` : '\nRESULT: PASS');
+process.exit(bad ? 1 : 0);

--- a/tests/test_beads_batch_53.py
+++ b/tests/test_beads_batch_53.py
@@ -1,0 +1,94 @@
+"""The claim modal reported "Service not found" for services that plainly exist.
+
+``openClaimModal`` looks the service up in ``/api/earnings/breakdown``, which is
+built from the **earnings table**. A service that has never produced a reading is
+simply absent from it, and the modal rendered that absence as *Service not
+found* — which is false. It is in the catalog, on the dashboard, deployed and
+running.
+
+Measured on the reference fleet: **5 of 18 tracked services** hit this —
+``anyone-protocol``, ``proxybase``, ``proxylite``, ``titan``, ``uprock``.
+
+Three different facts hide behind one empty result:
+
+* not in the catalog at all — the only case that earns the old wording;
+* tracked, has a collector, no readings yet — add credentials, or wait;
+* tracked, no collector exists — no credential will ever help, and it may still
+  be earning on the provider's own dashboard.
+
+The behaviour lives in ``scripts/claim_modal_check.mjs``, which runs the real
+function against stubbed responses. What is pinned here is the wiring that a
+harness cannot see: that the failure path calls the helper at all, and that the
+harness runs in CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+HARNESS = ROOT / "scripts" / "claim_modal_check.mjs"
+
+
+class TestTheModalNoLongerLies:
+    def _open_claim_body(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("async function openClaimModal(")
+        return js[start : start + 1400]
+
+    def test_the_old_wording_is_gone_from_the_failure_path(self):
+        assert "Service not found." not in self._open_claim_body()
+
+    def test_it_delegates_to_the_explaining_helper(self):
+        assert "renderNoEarningsYet(platform, title, body)" in self._open_claim_body()
+
+    def test_the_helper_exists_and_is_async(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        assert "async function renderNoEarningsYet(" in js
+
+    def test_it_consults_the_catalog_rather_than_guessing(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("async function renderNoEarningsYet(")
+        body = js[start : start + 1800]
+        assert "/api/services/available" in body
+        assert "has_collector" in body
+
+    def test_a_failed_lookup_is_not_reported_as_a_missing_service(self):
+        """Three answers, plus "I could not check" — which is a fourth."""
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("async function renderNoEarningsYet(")
+        body = js[start : start + 1800]
+        assert "Could not check this service" in body
+
+    def test_the_error_detail_is_escaped(self):
+        js = APP_JS.read_text(encoding="utf-8")
+        start = js.index("async function renderNoEarningsYet(")
+        body = js[start : start + 1800]
+        assert "escapeHtml(err.message" in body
+
+
+class TestTheHarnessRunsInCI:
+    def test_the_script_exists(self):
+        assert HARNESS.is_file()
+
+    def test_the_workflow_runs_it(self):
+        doc = yaml.safe_load((ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8"))
+        commands = " ".join(
+            str(step.get("run", "")) for job in doc["jobs"].values() for step in (job.get("steps") or [])
+        )
+        assert "node scripts/claim_modal_check.mjs" in commands
+
+    def test_it_is_browser_free(self):
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "9222" not in text and "puppeteer" not in text.lower()
+
+    def test_it_keeps_the_async_keyword_when_extracting(self):
+        """Slicing from `function` alone yields a body with a bare `await`.
+
+        That is a SyntaxError, and it means the extraction silently changed what
+        was under test — which happened while writing this.
+        """
+        assert "asyncPrefix" in HARNESS.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes the claim-modal bead (P1). Reported live: clicking the cashout button on Anyone Protocol showed

> Checking eligibility...
> **Service not found.**

## It is not one service

`openClaimModal` looks the service up in `/api/earnings/breakdown`:

```js
const svc = data.find(s => s.platform === platform);
if (!svc) { body.innerHTML = '<p>Service not found.</p>'; return; }
```

That endpoint is built from the **earnings table**, so a tracked service that has never produced a reading is simply absent from it — and absence was reported as nonexistence.

Measured on the reference fleet:

```
tracked services (deployments):            18
platforms with ≥1 earnings row:            13
tracked but with NO earnings row:           5
  anyone-protocol, proxybase, proxylite, titan, uprock
```

**28% of what this user tracks.** The instinct that it was happening everywhere was right.

## Why the wording was the defect, not just unhelpful

The service demonstrably exists — catalog, dashboard, deployed, container running. "Service not found" says the software lost track of something the user is looking straight at. The true statement is "no earnings have been recorded yet", which points at a completely different next step.

## Four answers, not one

| situation | what it now says |
|---|---|
| not in the catalog | *not in the service catalog* — the only case that earns the old wording |
| tracked, has a collector, no readings | *no earnings read yet* → Settings → Collectors, or wait for the hourly run |
| tracked, **no** collector exists | *no collector for this service* — and it may still be earning; check the provider |
| the lookup itself failed | *could not check right now* + the reason |

That third row matters: telling someone with no collector to go add credentials would send them after something that can never work.

## Evidence

`scripts/claim_modal_check.mjs` runs the **real** function against stubbed responses — 11 assertions — and is wired into `test.yml` beside the other browser-free harnesses. A string test can prove the wording changed; only running it proves which answer each case gets.

Four negative controls, all caught:

| reverted | caught by |
|---|---|
| the original `Service not found.` | pytest (2 failed) |
| collapses the two tracked cases into one answer | harness (FAIL ×3) |
| a failed lookup reported as a missing service | harness (FAIL ×2) |
| harness dropped from CI | pytest (1 failed) |

Sources verified byte-identical after every revert.

One self-inflicted bug worth recording: the harness's function extractor sliced from `function`, dropping the `async` keyword, which produced a body with a bare `await` — a SyntaxError that meant the extraction had silently changed what was under test. Fixed, and a test now pins that the extractor keeps `async`.

Gates: `ruff` clean, `node --check` clean, all four harnesses PASS, **3278 passed, 95.44% coverage**.

## Still open

`anyone-protocol` **has** a registered collector and still has zero readings — so it either errors every run or has never succeeded. That is a separate question the modal was hiding, and is worth its own bead once this lands.