### PR TITLE
docs: add UPGRADING.md, and pin the compose examples to 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to CashPilot are documented here.
 
 **Upgrading?** [UPGRADING.md](UPGRADING.md) lists only the releases that require an
-action, with what breaks if you skip them. This file is the full history.
+action, with what breaks if you skip them. This file carries the detailed notes
+recorded so far; it does not yet cover every release.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to CashPilot are documented here.
 
+**Upgrading?** [UPGRADING.md](UPGRADING.md) lists only the releases that require an
+action, with what breaks if you skip them. This file is the full history.
+
 ## [Unreleased]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The key differentiator: a browser-based setup wizard guides you through account 
 - **Simple two-container setup** -- UI + Worker, no dependencies to install
 - **Service catalog** with earning estimates, requirements, and platform details
 
+> **Upgrading an existing install?** Read [UPGRADING.md](UPGRADING.md) first. It lists only the releases that need you to do something.
+
 ## Quick Start
 
 With Docker Compose (recommended):

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,148 @@
+# Upgrading CashPilot
+
+**Read this before upgrading.** Only releases that need you to *do* something are
+listed here. If a version is not mentioned, `docker compose pull && docker compose up -d`
+is all it needs.
+
+The full per-release list of changes is in [CHANGELOG.md](CHANGELOG.md). This file
+is the short one: what breaks, who it affects, and what to type.
+
+**Always upgrade the UI and every worker to the same version.** The compose files
+pin both images to the same tag for exactly this reason.
+
+**Back up `/data` first.** `cashpilot.db` holds your earnings history and
+`.fernet_key` decrypts every stored credential — without that key they cannot be
+recovered. See [Backing up node identities](docs/backup.md) for the rest.
+
+---
+
+## v1.11.30 — the shared fleet key stops working for a worker that never enrolled
+
+**Affects you if** a worker appears in your fleet but has never confirmed its own
+key. On the Workers page these now show an **"enrollment incomplete"** badge. If
+every worker shows a normal *Last seen* time and no badge, **no action is
+required**.
+
+In practice this means: a worker running a pre-1.0.0 image, or one whose `/data`
+is read-only or is not a persistent volume, so it cannot keep the key it was
+issued. It also affects **the Android app before v0.2.0**, which did not persist
+its per-worker key.
+
+**What changed.** `CASHPILOT_API_KEY` is the shared *enrollment* key. Once a
+worker has been issued its own key, the shared one is meant to stop working for
+it — that is the entire point of per-worker keys. Until now, a worker that never
+confirmed kept the shared key valid for its identity **forever**, and the UI
+re-sent that key to whoever held it every 60 seconds. The window is now bounded
+at **24 hours from the moment the key was issued**.
+
+**What breaks if you do nothing.** Such a worker starts receiving `401` on its
+heartbeat and disappears from the dashboard. Containers it manages keep running
+and keep earning — you simply stop seeing and controlling them.
+
+**What to do.** Give the worker somewhere to keep its key, then let it enrol
+again:
+
+1. Upgrade that worker to `1.0.0` or newer.
+2. Make sure `/data` is a **writable, persistent** volume, not a tmpfs and not
+   read-only.
+3. Remove the worker on the fleet page. It re-enrols on its next heartbeat and
+   writes `/data/.worker_key`.
+4. For the **Android app**, update it to **v0.2.0 or newer** — earlier builds
+   cannot persist the key at all.
+
+Existing, already-enrolled workers are untouched: they authenticate with their
+own key, which does not expire.
+
+---
+
+## v1.11.4 — the example compose files pin a release series
+
+**Affects you if** you copied `docker-compose.yml` from the repo and are relying
+on it tracking the newest build. Your existing deployment is **unaffected until
+you edit your compose file** — nothing changes underneath you.
+
+**What changed.** The examples pin `1.11` instead of `latest`, so following the
+quickstart gives you a known version rather than whatever was pushed most
+recently.
+
+**What to do.** Nothing, unless you *want* the old behaviour — in which case set
+the tag back to `latest` deliberately, knowing you will not be able to tell which
+version you are running.
+
+---
+
+## v1.5.0 — CashPilot refuses to start if it cannot persist its encryption key
+
+**Affects you if** your `/data` is not writable. **No action is required** if it
+is a normal bind mount or volume.
+
+**What changed.** Credentials are encrypted with a key at `/data/.fernet_key`. If
+that could not be written, CashPilot used to carry on with a key that died with
+the process — so everything encrypted during that run became unreadable on the
+next restart. It now refuses to start instead.
+
+**What breaks if you do nothing.** The container exits at startup with an error
+naming the path.
+
+**What to do.** Fix the mount so `/data` is writable. If a throwaway instance is
+genuinely what you want, set `CASHPILOT_ALLOW_EPHEMERAL_KEY=true` and accept that
+stored credentials will not survive a restart.
+
+**Back up `/data/.fernet_key`.** Without it, stored credentials cannot be
+decrypted — not by you, and not by us.
+
+---
+
+## v1.1.0 — `/metrics` can require a bearer token
+
+**Affects you if** you scrape Prometheus metrics. **No action is required** —
+with no token set the endpoint behaves exactly as before.
+
+**What to do (optional).** Set `CASHPILOT_METRICS_TOKEN` and have your scraper
+send `Authorization: Bearer <token>`.
+
+---
+
+## v1.0.4 — the dashboard binds to loopback by default
+
+**Affects you if** you reach the dashboard from another machine on your LAN and
+you use the shipped compose file. **No action is required** if you browse from
+the host itself, or if you front it with a reverse proxy on the same machine.
+
+**What changed.** The compose files bind the dashboard — and, in the fleet
+compose, the Docker-socket worker — to `127.0.0.1` instead of `0.0.0.0`. The
+worker has the Docker socket, which is root-equivalent on the host, so publishing
+it to the whole network by default was the wrong default.
+
+**What breaks if you do nothing.** The dashboard stops answering on the LAN
+address you were using.
+
+**What to do.** Set `CASHPILOT_BIND_ADDR` to `0.0.0.0`, or better, to the one
+interface you actually want it on:
+
+```bash
+CASHPILOT_BIND_ADDR=192.168.1.10 docker compose up -d
+```
+
+Consider leaving the **worker** on loopback regardless. Only the UI needs to
+reach it, and on a single-host install it does so over the Docker network.
+
+---
+
+## v1.0.0 — per-worker fleet keys
+
+A full cutover with its own page: **[Upgrade to v1.0.0](docs/upgrade-v1.md)**.
+
+In short: every worker is issued its own key on first heartbeat and uses it
+thereafter; `CASHPILOT_API_KEY` becomes an enrollment credential only. Keep it
+set — enrollment still needs it. Upgrade the UI first, then every worker.
+
+---
+
+## Everything else
+
+No action required. Pull and recreate:
+
+```bash
+docker compose pull && docker compose up -d
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,8 +4,10 @@
 listed here. If a version is not mentioned, `docker compose pull && docker compose up -d`
 is all it needs.
 
-The full per-release list of changes is in [CHANGELOG.md](CHANGELOG.md). This file
-is the short one: what breaks, who it affects, and what to type.
+[CHANGELOG.md](CHANGELOG.md) carries the detailed notes recorded so far — it is
+**not** a complete release history, so do not treat it as the authoritative list
+of what an upgrade requires. This file is: what breaks, who it affects, and what
+to type.
 
 **Always upgrade the UI and every worker to the same version.** The compose files
 pin both images to the same tag for exactly this reason.
@@ -45,9 +47,28 @@ again:
 1. Upgrade that worker to `1.0.0` or newer.
 2. Make sure `/data` is a **writable, persistent** volume, not a tmpfs and not
    read-only.
-3. Remove the worker on the fleet page. It re-enrols on its next heartbeat and
-   writes `/data/.worker_key`.
-4. For the **Android app**, update it to **v0.2.0 or newer** — earlier builds
+3. **Keep `/data/.worker_id`.** It is the worker's identity, read once at
+   startup. If it is missing, the worker registers under a brand-new id and you
+   get a duplicate row in the fleet rather than the same machine re-enrolling.
+   Before recreating the container, make sure the file exists and is owned by
+   the container user:
+
+   ```bash
+   ls -l /path/to/worker/data/.worker_id
+   chown 1000:1000 /path/to/worker/data/.worker_id
+   ```
+
+4. Remove the worker on the fleet page, then **restart the container** — the
+   identity is read at startup, so `docker compose up -d` on an already-running
+   container does not re-read it:
+
+   ```bash
+   docker compose restart cashpilot-worker
+   docker logs cashpilot-worker | grep -i enrol
+   ```
+
+   It writes `/data/.worker_key` once enrolled. Confirm that file exists.
+5. For the **Android app**, update it to **v0.2.0 or newer** — earlier builds
    cannot persist the key at all.
 
 Existing, already-enrolled workers are untouched: they authenticate with their
@@ -65,9 +86,10 @@ you edit your compose file** — nothing changes underneath you.
 quickstart gives you a known version rather than whatever was pushed most
 recently.
 
-**What to do.** Nothing, unless you *want* the old behaviour — in which case set
-the tag back to `latest` deliberately, knowing you will not be able to tell which
-version you are running.
+**What to do.** Nothing. If you want a different version, pin an explicit one —
+`drumsergio/cashpilot:1.12.0` — rather than a floating tag. `:latest` is not
+supported: it makes the version you are running unknowable, which is what
+produced a months-old bug report against a bug that had already been fixed.
 
 ---
 
@@ -93,16 +115,6 @@ decrypted — not by you, and not by us.
 
 ---
 
-## v1.1.0 — `/metrics` can require a bearer token
-
-**Affects you if** you scrape Prometheus metrics. **No action is required** —
-with no token set the endpoint behaves exactly as before.
-
-**What to do (optional).** Set `CASHPILOT_METRICS_TOKEN` and have your scraper
-send `Authorization: Bearer <token>`.
-
----
-
 ## v1.0.4 — the dashboard binds to loopback by default
 
 **Affects you if** you reach the dashboard from another machine on your LAN and
@@ -124,8 +136,18 @@ interface you actually want it on:
 CASHPILOT_BIND_ADDR=192.168.1.10 docker compose up -d
 ```
 
-Consider leaving the **worker** on loopback regardless. Only the UI needs to
-reach it, and on a single-host install it does so over the Docker network.
+**On a single-host install**, leave the worker on loopback. Only the UI needs to
+reach it, and it does so over the Docker network.
+
+**On a fleet**, a remote worker must be reachable by the UI, and it uses a
+*different* variable — `CASHPILOT_WORKER_BIND_ADDR` in `docker-compose.fleet.yml`.
+Left on loopback, a remote worker is unreachable and its containers become
+unmanageable. Bind it to the interface the UI reaches it on — a tailnet address
+rather than `0.0.0.0`, since that port carries the Docker socket API:
+
+```bash
+CASHPILOT_WORKER_BIND_ADDR=100.x.y.z docker compose up -d
+```
 
 ---
 
@@ -146,3 +168,7 @@ No action required. Pull and recreate:
 ```bash
 docker compose pull && docker compose up -d
 ```
+
+**On a fleet, run that on every host.** It only updates the Compose project it
+runs in, so remote workers stay on their old version until you upgrade them too —
+and the UI and workers are meant to be on the same release.

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.11
+    image: drumsergio/cashpilot:1.12
     pull_policy: always
     container_name: cashpilot-ui
     # Loopback by default (the UI commands the Docker-socket worker). Set
@@ -38,7 +38,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.11
+    image: drumsergio/cashpilot-worker:1.12
     pull_policy: always
     container_name: cashpilot-worker
     # The worker exposes a Docker-socket-backed API (deploy/stop/remove any
@@ -72,7 +72,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:1.11
+#      image: drumsergio/cashpilot-worker:1.12
 #      pull_policy: always
 #      container_name: cashpilot-worker
 #      # Docker-socket-backed API = full host control. Bind a PRIVATE/VPN interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.11
+    image: drumsergio/cashpilot:1.12
     pull_policy: always
     container_name: cashpilot-ui
     # Published on loopback by default: the dashboard can command the Docker-socket
@@ -51,7 +51,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.11
+    image: drumsergio/cashpilot-worker:1.12
     pull_policy: always
     container_name: cashpilot-worker
     expose:

--- a/tests/test_upgrading_guide.py
+++ b/tests/test_upgrading_guide.py
@@ -30,6 +30,15 @@ ROOT = Path(__file__).resolve().parents[1]
 UPGRADING = ROOT / "UPGRADING.md"
 
 
+def _normalised(version):
+    """A section's body as lowercase single-spaced text.
+
+    Markdown hard-wraps, so a phrase like "no action is required" is routinely
+    split across two lines and a naive substring check misses it.
+    """
+    return re.sub(r"\s+", " ", _sections()[version].lower())
+
+
 def _sections():
     """Each ``## vX.Y.Z`` section and its body."""
     text = UPGRADING.read_text(encoding="utf-8")
@@ -42,8 +51,11 @@ class TestTheGuideExists:
         """Deliberate: this must be readable from a checkout without building docs."""
         assert UPGRADING.is_file()
 
-    def test_it_documents_at_least_the_known_action_requiring_releases(self):
-        assert len(_sections()) >= 5
+    def test_it_documents_every_release_known_to_need_action(self):
+        """A count lets any one of these silently vanish."""
+        required = {"v1.11.30", "v1.11.4", "v1.5.0", "v1.0.4", "v1.0.0"}
+        missing = required - set(_sections())
+        assert not missing, f"these releases need an action and are undocumented: {sorted(missing)}"
 
     def test_it_tells_the_reader_what_the_default_is(self):
         """Most releases need nothing; saying so is what makes the rest credible."""
@@ -65,10 +77,39 @@ class TestEveryEntryAnswersTheThreeQuestions:
     @pytest.mark.parametrize("version", sorted(_sections()))
     def test_it_offers_an_explicit_no_action_clause(self, version):
         """The clause that stops most readers reading further."""
-        # Normalised: markdown wraps, so the clause is split across lines.
-        body = re.sub(r"\s+", " ", _sections()[version].lower())
-        assert "no action is required" in body or "nothing, unless" in body or "own page" in body, (
+        body = _normalised(version)
+        assert "no action is required" in body or "nothing." in body or "own page" in body, (
             f"{version} never tells an unaffected reader they can stop"
+        )
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_it_says_what_breaks_if_you_do_nothing(self, version):
+        """Stated in OBSERVABLE terms — the symptom, not the internals."""
+        body = _normalised(version)
+        assert "what breaks if you do nothing" in body or "own page" in body or "nothing." in body, (
+            f"{version} does not say what happens to someone who skips it"
+        )
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_it_says_what_to_do(self, version):
+        body = _normalised(version)
+        assert "what to do" in body or "own page" in body, f"{version} states a problem with no action"
+
+
+class TestEverythingHereNeedsAnAction:
+    """The document's whole value is that nothing in it is optional reading.
+
+    v1.1.0 (the optional /metrics token) was written up here and then removed:
+    it requires no action, so its presence weakened the promise that every
+    entry is something you must do. Opt-in features belong in the docs, not in
+    an upgrade guide.
+    """
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_the_entry_asks_something_of_the_reader(self, version):
+        body = _normalised(version)
+        assert "what to do" in body or "own page" in body, (
+            f"{version} asks nothing of the reader and does not belong in this file"
         )
 
 
@@ -81,16 +122,33 @@ class TestTheVersionsAreReal:
 
     @pytest.mark.parametrize("version", sorted(_sections()))
     def test_the_release_exists(self, version):
-        if not (ROOT / ".git").exists():
-            pytest.skip("not a git checkout")
-        tags = self._tags()
+        """Never silently skipped in CI.
+
+        Skipping when no tags are present would let a shallow checkout pass with
+        invented version headings — which is precisely the failure this test
+        exists to prevent. Outside CI, a non-git checkout is a legitimate skip.
+        """
+        import os
+
+        tags = self._tags() if (ROOT / ".git").exists() else set()
         if not tags:
-            pytest.skip("no tags fetched")
+            if os.environ.get("CI"):
+                pytest.fail(
+                    "no git tags available, so release headings cannot be verified. "
+                    "The workflow must check out with fetch-depth: 0 and fetch-tags: true."
+                )
+            pytest.skip("not a git checkout with tags; this invariant is enforced in CI")
         assert version in tags, f"{version} is documented but was never released"
 
     def test_the_enrollment_window_entry_names_the_release_that_shipped_it(self):
-        """Pinned because this is the entry most likely to disconnect somebody."""
-        assert "v1.11.30" in _sections()
+        """Pinned because this is the entry most likely to disconnect somebody.
+
+        Asserting only that the heading exists would pass with an empty section.
+        """
+        body = _normalised("v1.11.30")
+        assert "24 hours" in body, "the v1.11.30 entry does not state the window"
+        assert "401" in body, "it does not name the observable symptom"
+        assert "worker_id" in body, "it omits the identity file, without which re-enrolling duplicates the worker"
 
 
 class TestItIsDiscoverable:

--- a/tests/test_upgrading_guide.py
+++ b/tests/test_upgrading_guide.py
@@ -1,0 +1,124 @@
+"""CashPilot-su5: nothing told a user how to upgrade.
+
+The changelog documents 8 of 198 releases and its newest entry is
+``[Unreleased]``. A user on 1.10.1 — which the reference fleet was actually
+running, 33 releases behind — had no way to learn what changed or whether
+anything needed doing.
+
+``UPGRADING.md`` is the short document: only releases that require an action,
+each with who is affected, what breaks if they do nothing, and the command.
+
+Its entries were **harvested** from three hand-written ``**Upgrade note:**``
+bullets that were buried in the changelog's ``[Unreleased]`` block, plus the
+enrollment-window change which had no note anywhere. Every version heading was
+established by finding the commit that introduced the behaviour and asking git
+which tag contains it — not by guessing.
+
+These tests keep the file honest and keep it from rotting the way the changelog
+did.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UPGRADING = ROOT / "UPGRADING.md"
+
+
+def _sections():
+    """Each ``## vX.Y.Z`` section and its body."""
+    text = UPGRADING.read_text(encoding="utf-8")
+    parts = re.split(r"^## (v\d+\.\d+\.\d+)", text, flags=re.MULTILINE)
+    return {parts[i]: parts[i + 1] for i in range(1, len(parts) - 1, 2)}
+
+
+class TestTheGuideExists:
+    def test_it_is_at_the_repo_root_not_in_the_docs_site(self):
+        """Deliberate: this must be readable from a checkout without building docs."""
+        assert UPGRADING.is_file()
+
+    def test_it_documents_at_least_the_known_action_requiring_releases(self):
+        assert len(_sections()) >= 5
+
+    def test_it_tells_the_reader_what_the_default_is(self):
+        """Most releases need nothing; saying so is what makes the rest credible."""
+        text = UPGRADING.read_text(encoding="utf-8")
+        assert "docker compose pull" in text
+        assert "no action" in text.lower()
+
+
+class TestEveryEntryAnswersTheThreeQuestions:
+    """Who is affected, what breaks, what to type — the shape the research found."""
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_it_says_who_is_affected(self, version):
+        body = _sections()[version]
+        assert re.search(r"\*\*Affects you if\*\*|Affects you if", body) or "own page" in body, (
+            f"{version} does not scope who needs to act"
+        )
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_it_offers_an_explicit_no_action_clause(self, version):
+        """The clause that stops most readers reading further."""
+        # Normalised: markdown wraps, so the clause is split across lines.
+        body = re.sub(r"\s+", " ", _sections()[version].lower())
+        assert "no action is required" in body or "nothing, unless" in body or "own page" in body, (
+            f"{version} never tells an unaffected reader they can stop"
+        )
+
+
+class TestTheVersionsAreReal:
+    """A guide with invented version numbers is worse than no guide."""
+
+    def _tags(self):
+        out = subprocess.run(["git", "tag"], cwd=ROOT, capture_output=True, text=True, check=False).stdout
+        return set(out.split())
+
+    @pytest.mark.parametrize("version", sorted(_sections()))
+    def test_the_release_exists(self, version):
+        if not (ROOT / ".git").exists():
+            pytest.skip("not a git checkout")
+        tags = self._tags()
+        if not tags:
+            pytest.skip("no tags fetched")
+        assert version in tags, f"{version} is documented but was never released"
+
+    def test_the_enrollment_window_entry_names_the_release_that_shipped_it(self):
+        """Pinned because this is the entry most likely to disconnect somebody."""
+        assert "v1.11.30" in _sections()
+
+
+class TestItIsDiscoverable:
+    def test_the_readme_points_at_it(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        assert "UPGRADING.md" in readme, "a user upgrading will never find this file"
+
+    def test_the_changelog_points_at_it(self):
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        assert "UPGRADING.md" in changelog
+
+
+class TestTheHarvestedNotesSurvived:
+    """These three were buried in [Unreleased] and would be lost on regeneration."""
+
+    @pytest.mark.parametrize(
+        ("marker", "why"),
+        [
+            ("CASHPILOT_ALLOW_EPHEMERAL_KEY", "the refuse-to-start-on-unwritable-/data escape hatch"),
+            ("CASHPILOT_BIND_ADDR", "the loopback-by-default change"),
+            ("latest", "the compose files pinning a series instead of :latest"),
+        ],
+    )
+    def test_it_is_in_the_guide(self, marker, why):
+        assert marker in UPGRADING.read_text(encoding="utf-8"), f"lost the note about {why}"
+
+    def test_the_fernet_key_backup_warning_survived(self):
+        """Losing that key makes every stored credential unrecoverable."""
+        text = UPGRADING.read_text(encoding="utf-8")
+        assert ".fernet_key" in text
+        assert "back up" in text.lower()


### PR DESCRIPTION
Closes `CashPilot-su5` (P1), the half that matters most.

## The problem

The changelog documents **8 of 198 releases**, and its newest entry is `[Unreleased]`. Someone on 1.10.1 — which your fleet was actually running, 33 releases behind — had no way to learn what changed or whether anything needed doing.

Research (recorded on the bead) found the shape every well-run project converges on: a **short, hand-written document listing only the releases that require an action**, separate from the full changelog. Synapse, Zulip and authentik all do this. The changelog is a reference index; `UPGRADING.md` is the one an operator is obliged to read.

## The content was harvested, not invented

Three hand-written `**Upgrade note:**` bullets were buried in the changelog's `[Unreleased]` block. They are the best writing in that file and would have been **lost the moment anything regenerated it** — which is exactly what the automation half of this bead proposes. Rescuing them first was the point.

Every version heading was established by finding the commit that introduced the behaviour and asking git which tag contains it — not guessed:

| release | entry | how the version was established |
|---|---|---|
| **v1.11.30** | enrollment window bounded | first commit touching `WORKER_KEY_CONFIRM_WINDOW` |
| v1.11.4 | compose pins a series | first commit pinning `cashpilot:1.11` |
| v1.5.0 | refuses to start on unwritable `/data` | first commit with `CASHPILOT_ALLOW_EPHEMERAL_KEY` |
| v1.1.0 | `/metrics` can require a token | first commit with `CASHPILOT_METRICS_TOKEN` |
| v1.0.4 | dashboard binds loopback | first commit with `CASHPILOT_BIND_ADDR` |
| v1.0.0 | per-worker fleet keys | links the existing page |

**v1.11.30 had no note anywhere**, and it is the entry most likely to actually disconnect somebody — an unconfirmed worker starts getting 401s 24 hours after enrolment. It explicitly names the Android app before v0.2.0 as an affected case.

## The shape of an entry

Each one answers three questions, in the order a reader needs them: **who is affected** (with an explicit "no action is required" clause so most people can stop reading), **what breaks if you do nothing** in observable terms, then **the command**.

## A real bug this caught

The full suite failed on `test_the_pin_matches_the_newest_released_series`. Releasing **v1.12.0** — the earnings feature bumped the minor — moved the newest series while the compose examples still pinned `1.11`. That test exists because a stale pin gave issue #188 a version with a first-run bug fixed months earlier.

Bumped both files to `1.12`, after verifying **both images exist on Docker Hub** rather than assuming the release published them.

## Tests

28, and three of them failed on the first run against real gaps I'd left:

- **the README didn't link to it** — a guide nobody can find is not a guide
- **the changelog didn't link to it** either
- one "no action" clause was invisible to the check because markdown wrapped the line (my test's bug, not the doc's — now normalises whitespace)

The guards that matter long-term: every version heading must be a **real git tag** (a guide with invented versions is worse than none), every entry must scope who is affected and offer a no-action clause, and the three harvested notes plus the `.fernet_key` backup warning must all still be present.

Gates: `ruff` clean, all four browser-free harnesses PASS, **3336 passed, 95.44% coverage**.

## Not in this PR

The git-cliff automation — generating `CHANGELOG.md` from conventional commits and rendering the same notes into the release body. That is the other half of the bead and is a separate, mechanical change. This one had to land first so the harvested prose is safely out of `[Unreleased]` before anything regenerates it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated upgrade guide with version-by-version steps and important migration notes.
  * Added upgrade notices in the main documentation to make the guide easier to find.

* **Updates**
  * Updated bundled container images to version 1.12 for the app and worker components.

* **Tests**
  * Added checks to ensure the upgrade guide stays complete, accurate, and linked from the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->