### PR TITLE
fix: a container ID never overwrites a worker's real name

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1576,7 +1576,30 @@ async def upsert_worker(
             INSERT INTO workers (client_id, name, url, containers, apps, system_info, status, last_heartbeat)
             VALUES (?, ?, ?, ?, ?, ?, 'online', datetime('now'))
             ON CONFLICT(client_id) DO UPDATE SET
-                name = excluded.name,
+                -- Never replace a name we already have with a Docker container ID.
+                --
+                -- Inside a container, socket.gethostname() returns the first 12
+                -- hex characters of the container ID, and Docker regenerates that
+                -- on every recreate -- which is what an image bump does. So a
+                -- worker with no CASHPILOT_WORKER_NAME set reported a brand-new
+                -- meaningless name after every upgrade, and the fleet page's
+                -- labels churned while the machines had not changed at all.
+                -- Observed live: three workers renamed themselves during a
+                -- routine 1.10.1 -> 1.11.34 roll.
+                --
+                -- The worker's IDENTITY is already protected from this
+                -- (worker_api._name_is_ephemeral guards client_id); this is the
+                -- display name, which was not.
+                --
+                -- GLOB matches the whole string, so 12 character classes means
+                -- exactly 12 hex characters -- the container-ID shape and
+                -- nothing else. A real hostname, or anything the user set, is
+                -- kept and wins.
+                name = CASE
+                    WHEN excluded.name GLOB '[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]' AND COALESCE(workers.name, '') != ''
+                        THEN workers.name
+                    ELSE excluded.name
+                END,
                 url = excluded.url,
                 containers = excluded.containers,
                 apps = excluded.apps,

--- a/tests/test_beads_batch_55.py
+++ b/tests/test_beads_batch_55.py
@@ -1,0 +1,131 @@
+"""CashPilot-416: worker names churned on every container recreate.
+
+Inside a container, ``socket.gethostname()`` returns the first 12 hex characters
+of the container ID, and Docker regenerates that on every recreate — which is
+what an image bump does. ``worker_api.py:59`` defaults ``WORKER_NAME`` to it, and
+``upsert_worker`` wrote ``name = excluded.name`` unconditionally.
+
+So a worker with no ``CASHPILOT_WORKER_NAME`` set reported a brand-new
+meaningless name after every upgrade. Observed live: three workers renamed
+themselves during a routine 1.10.1 → 1.11.34 roll, from ``489bd13891b2`` and
+friends to ``35c04a0f43f5`` and friends. The machines had not changed at all.
+
+A name that changes when nothing about the machine changed is worse than no
+name: a user who learns which row is which loses that knowledge on the next
+upgrade.
+
+The worker's **identity** was already protected from exactly this —
+``worker_api._name_is_ephemeral`` guards ``client_id``, which is why the roll did
+not also create duplicate rows. The display name was not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+CONTAINER_ID = "35c04a0f43f5"
+ANOTHER_CONTAINER_ID = "b69b686b7a2b"
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    from app import database
+
+    monkeypatch.setattr(database, "DB_DIR", tmp_path)
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "names.db")
+    asyncio.run(database.init_db())
+    return database
+
+
+async def _name_after(db, first: str, second: str) -> str:
+    """Upsert twice under one client_id and return the stored name."""
+    await db.upsert_worker(client_id="c1", name=first)
+    await db.upsert_worker(client_id="c1", name=second)
+    row = await db.get_worker_by_client_id("c1") if hasattr(db, "get_worker_by_client_id") else None
+    if row is None:
+        workers = await db.list_workers()
+        row = next(w for w in workers if w["client_id"] == "c1")
+    return row["name"]
+
+
+class TestAContainerIdNeverOverwritesARealName:
+    @pytest.mark.asyncio
+    async def test_a_recreate_does_not_rename_a_named_worker(self, db):
+        """The bead: a user-set name must survive an image bump."""
+        assert await _name_after(db, "watchtower", CONTAINER_ID) == "watchtower"
+
+    @pytest.mark.asyncio
+    async def test_it_survives_repeated_recreates(self, db):
+        await db.upsert_worker(client_id="c1", name="geiserback")
+        for cid in (CONTAINER_ID, ANOTHER_CONTAINER_ID, "0111c4f0efd6"):
+            await db.upsert_worker(client_id="c1", name=cid)
+        workers = await db.list_workers()
+        assert next(w for w in workers if w["client_id"] == "c1")["name"] == "geiserback"
+
+    @pytest.mark.asyncio
+    async def test_one_container_id_does_not_replace_another(self, db):
+        """Churn between two meaningless names is still churn."""
+        assert await _name_after(db, CONTAINER_ID, ANOTHER_CONTAINER_ID) == CONTAINER_ID
+
+
+class TestRealNamesStillWin:
+    """The guard must be narrow, or it freezes names nobody can change."""
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_rename_a_worker(self, db):
+        assert await _name_after(db, CONTAINER_ID, "watchtower") == "watchtower"
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_rename_one_real_name_to_another(self, db):
+        assert await _name_after(db, "old-name", "new-name") == "new-name"
+
+    @pytest.mark.asyncio
+    async def test_a_first_registration_keeps_whatever_it_reports(self, db):
+        """With nothing stored, even a container ID is better than blank."""
+        await db.upsert_worker(client_id="c1", name=CONTAINER_ID)
+        workers = await db.list_workers()
+        assert next(w for w in workers if w["client_id"] == "c1")["name"] == CONTAINER_ID
+
+    @pytest.mark.parametrize(
+        "name",
+        ["35c04a0f43f", "35c04a0f43f5a", "ABCDEF012345", "my-host-12ab", "raspberrypi", "watchtower"],
+        ids=["11-hex", "13-hex", "uppercase", "hyphenated", "hostname", "word"],
+    )
+    @pytest.mark.asyncio
+    async def test_only_the_exact_container_id_shape_is_rejected(self, db, name):
+        """Guards against a sloppy pattern eating legitimate hostnames."""
+        assert await _name_after(db, "watchtower", name) == name
+
+
+class TestTheOtherFieldsStillUpdate:
+    """Freezing the name must not freeze the heartbeat's actual payload."""
+
+    @pytest.mark.asyncio
+    async def test_containers_and_url_still_change(self, db):
+        await db.upsert_worker(client_id="c1", name="watchtower", url="http://a:8081", containers="[]")
+        await db.upsert_worker(client_id="c1", name=CONTAINER_ID, url="http://b:8081", containers='[{"slug": "grass"}]')
+        workers = await db.list_workers()
+        row = next(w for w in workers if w["client_id"] == "c1")
+        assert row["name"] == "watchtower"
+        assert row["url"] == "http://b:8081"
+        assert "grass" in row["containers"]
+
+
+class TestTheIdentityGuardIsStillThere:
+    """This fix is about the DISPLAY name; identity was already protected."""
+
+    def test_the_worker_still_refuses_an_ephemeral_client_id(self):
+        from app import worker_api
+
+        assert hasattr(worker_api, "_name_is_ephemeral")
+
+    def test_it_recognises_the_container_id_shape(self, monkeypatch):
+        from pathlib import Path
+
+        from app import worker_api
+
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        assert worker_api._name_is_ephemeral(CONTAINER_ID) is True
+        assert worker_api._name_is_ephemeral("watchtower") is False


### PR DESCRIPTION
Closes `CashPilot-416` (P2).

## What happens

Inside a container, `socket.gethostname()` returns the first 12 hex characters of the container ID. Docker regenerates that on **every recreate** — which is exactly what an image bump does. `worker_api.py:59` defaults `WORKER_NAME` to it, and `upsert_worker` wrote:

```sql
name = excluded.name,
```

unconditionally.

**Observed live.** During a routine 1.10.1 → 1.11.34 roll, three workers renamed themselves — `489bd13891b2` → `35c04a0f43f5` and friends — while the machines had not changed at all.

A name that changes when nothing about the machine changed is worse than no name: a user who learns which row is which loses that knowledge on the next upgrade.

## What was already right

The worker's **identity** is already protected from precisely this. `worker_api._name_is_ephemeral` guards `client_id`, with a comment recording that treating a container ID as durable identity caused silent 401 outages upgrading 1.0.0 → 1.4.1. That guard is why the roll did **not** also create duplicate worker rows.

Only the *display name* was unprotected. This extends the same reasoning one field further.

## Why GLOB with twelve character classes

`GLOB` matches the whole string, so twelve classes means **exactly** twelve hex characters — the container-ID shape and nothing else. Verified against the cases that matter:

| name | outcome |
|---|---|
| `35c04a0f43f5` | recognised as a container ID |
| `watchtower`, `geiserback`, `raspberrypi` | kept |
| `35c04a0f43f` (11), `35c04a0f43f5a` (13) | kept |
| `ABCDEF012345` (uppercase) | kept |
| `my-host-12ab` | kept |

The guard is narrow on purpose. Too broad and it freezes the name forever, so nobody could ever rename a worker — that's one of the negative controls below.

## A correction to my own bead

I had written that the shipped compose files don't surface `CASHPILOT_WORKER_NAME`. **That was wrong** — `docker-compose.yml` sets `local` and `docker-compose.fleet.yml` sets `server-a`/`server-b`. The examples were already right; the gap is in hand-written deployments that predate them. No compose change is needed here.

## Evidence

15 tests. Three negative controls, all caught:

| reverted | result |
|---|---|
| the original unconditional overwrite | 4 failed |
| over-broad guard — freezes *any* rename | 7 failed |
| pattern too short — swallows real hostnames | 2 failed |

That middle one matters as much as the first: a fix that stops churn by making names immutable would be its own bug. Tests pin both directions — a user can still rename a worker, including one currently showing a container ID, and the other heartbeat fields (url, containers, apps) keep updating normally.

Source verified byte-identical after every revert.

Gates: `ruff` clean, **3363 passed, 95.44% coverage**.