### PR TITLE
docs: one configuration reference, and it states which source wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The key differentiator: a browser-based setup wizard guides you through account 
 - **Simple two-container setup** -- UI + Worker, no dependencies to install
 - **Service catalog** with earning estimates, requirements, and platform details
 
+> **Every setting, and which source wins:** [Configuration reference](docs/configuration.md)
+
 > **Upgrading an existing install?** Read [UPGRADING.md](UPGRADING.md) first. It lists only the releases that need you to do something.
 
 ## Quick Start

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,84 @@
+# Configuration reference
+
+Every `CASHPILOT_*` setting, what reads it, and — where a file can also supply
+the value — **which one wins**.
+
+That last column is the reason this page exists. Three settings look identical
+from the outside (a secret, supplied by an environment variable or by a file
+under `/data`) and resolve in three *different* directions. Each behaviour is
+defensible on its own; together they are impossible to guess.
+
+!!! warning "The precedence is not uniform, and the differences are deliberate"
+
+    - **Credential-encryption key** — the **file wins**. Switching keys would make
+      every stored credential unreadable, so an existing `/data/.fernet_key` beats
+      `CASHPILOT_ENCRYPTION_KEY`, and CashPilot logs loudly when they differ.
+    - **Session-signing key** — the **environment wins**. Sessions are cheap to
+      invalidate, so `CASHPILOT_SECRET_KEY` takes precedence and the file is only
+      a fallback.
+
+    If you set an environment variable and nothing changed, this is why.
+
+## UI
+
+| Variable | Default | What it does | Precedence |
+|---|---|---|---|
+| `CASHPILOT_SECRET_KEY` | generated | Signs session cookies. | **Env wins**, then `/data/.secret_key`, then a generated key that is persisted. A known-placeholder value is ignored. |
+| `CASHPILOT_ENCRYPTION_KEY` | generated | Fernet key for credentials at rest. | **File wins.** An existing `/data/.fernet_key` beats this; the env key is adopted only when no file exists. |
+| `CASHPILOT_ALLOW_EPHEMERAL_KEY` | `false` | Allow starting when the encryption key cannot be persisted. | — |
+| `CASHPILOT_API_KEY` | from `/fleet` | Shared **enrolment** key. Not an ongoing credential — see [Fleet](fleet.md). | Env, else `/fleet/.fleet_key`, else generated there. |
+| `CASHPILOT_ADMIN_API_KEY` | unset | Bearer token for API access without a session. | — |
+| `CASHPILOT_DATA_DIR` | `/data` | Where the database and keys live. | — |
+| `CASHPILOT_FLEET_DIR` | `/fleet` | Where the shared enrolment key lives. | — |
+| `CASHPILOT_BASE_URL` | unset | Absolute base URL, for links in notifications. | — |
+| `CASHPILOT_SECURE_COOKIE` | auto | Force the `Secure` cookie flag. | — |
+| `CASHPILOT_SESSION_EPOCH` | unset | Bumping this invalidates every existing session. | — |
+| `CASHPILOT_TRUSTED_PROXY` | unset | Trust `X-Forwarded-For` from these addresses. | — |
+| `CASHPILOT_COLLECT_INTERVAL` | `60` | Minutes between earnings collections. | — |
+| `CASHPILOT_HOSTNAME_PREFIX` | `cashpilot` | Prefix for managed container names. | — |
+| `CASHPILOT_VERSION` | `dev` | Set by the image build. Shown in the sidebar. | — |
+| `CASHPILOT_METRICS_ENABLED` | `false` | Serve `/metrics`. | — |
+| `CASHPILOT_METRICS_TOKEN` | unset | Require `Authorization: Bearer` on `/metrics`. | — |
+| `CASHPILOT_NTFY_URL` | unset | ntfy endpoint for alerts. | — |
+| `CASHPILOT_WEBHOOK_URL` | unset | Generic webhook for alerts. | — |
+| `CASHPILOT_TELEGRAM_BOT_TOKEN` | unset | Telegram alerts. | — |
+| `CASHPILOT_TELEGRAM_CHAT_ID` | unset | Telegram alerts. | — |
+| `CASHPILOT_WORKER_ALLOWED_HOSTS` | unset | Restrict which hosts the UI will proxy to. | — |
+| `CASHPILOT_WORKER_ALLOW_METADATA` | `false` | Allow proxying to cloud metadata IPs. Leave off. | — |
+| `CASHPILOT_WORKER_URL_POLICY` | strict | How worker URLs are validated. | — |
+
+## Worker
+
+| Variable | Default | What it does | Precedence |
+|---|---|---|---|
+| `CASHPILOT_UI_URL` | — | **Required.** Where to send heartbeats. | — |
+| `CASHPILOT_API_KEY` | — | **Required for enrolment only.** After enrolling, the worker uses its own key from `/data/.worker_key`. | — |
+| `CASHPILOT_WORKER_NAME` | hostname | Display name. **Set it.** Inside a container the default is the container ID, which Docker regenerates on every recreate. | — |
+| `CASHPILOT_WORKER_URL` | detected | The URL this worker **advertises**. | — |
+| `CASHPILOT_PORT` | `8081` | The port this worker **advertises** — see the note below. | — |
+| `CASHPILOT_WORKER_NETWORK` | detected | `residential` or `hosting`. | — |
+| `CASHPILOT_EGRESS_DETECT` | on | Hourly public-IP lookup. `off` disables it. | — |
+| `CASHPILOT_EGRESS_IP` | unset | State the public IP directly. A LAN or tailnet address is rejected. | — |
+| `CASHPILOT_EGRESS_IP_URL` | unset | Custom IP-echo endpoint. | — |
+| `CASHPILOT_ALLOWED_VOLUME_ROOTS` | unset | Host paths a deploy may bind-mount. | — |
+| `CASHPILOT_PIDS_LIMIT` | unset | `pids` limit applied to managed containers. | — |
+| `CASHPILOT_DATA_DIR` | `/data` | Where `.worker_id` and `.worker_key` live. | — |
+
+!!! danger "`CASHPILOT_PORT` does not change the port the worker listens on"
+
+    The listen port is fixed at `8081` by the image's `CMD`. `CASHPILOT_PORT`
+    only changes the port the worker **advertises** to the UI. Setting it alone
+    makes the worker advertise a port nothing is listening on, and the UI's
+    container commands then fail with nothing in the logs connecting the two.
+
+    To actually move the port, override the container's `command:` **and** set
+    `CASHPILOT_PORT` to match.
+
+## Compose-level
+
+These are read by the compose files, not by CashPilot itself.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `CASHPILOT_BIND_ADDR` | `127.0.0.1` | Which host interface publishes the **UI** port. |
+| `CASHPILOT_WORKER_BIND_ADDR` | `127.0.0.1` | Which host interface publishes the **worker** port, in the fleet compose. The worker holds the Docker socket — root-equivalent on the host — so publish it only on an interface the UI needs, never `0.0.0.0`. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Architecture: architecture.md
+  - Configuration: configuration.md
   - Direction and Roadmap: roadmap.md
   - Security Defaults: security-defaults.md
   - Network Isolation: isolation.md

--- a/tests/test_configuration_reference.py
+++ b/tests/test_configuration_reference.py
@@ -1,0 +1,124 @@
+"""CashPilot-5fy: no table of config options, and the precedence is not uniform.
+
+Three settings look identical from the outside — a secret supplied either by an
+environment variable or by a file under ``/data`` — and resolve in **different
+directions**:
+
+* the credential-encryption key: the **file** wins, because switching keys would
+  make every stored credential unreadable;
+* the session-signing key: the **environment** wins, because sessions are cheap
+  to invalidate.
+
+Both are defensible individually. Together they are impossible to guess, and
+nothing documented either — so "I set the env var and nothing changed" had no
+answer anywhere in the project.
+
+``docs/configuration.md`` is that answer. This test is what stops it rotting the
+way the changelog did: **every ``CASHPILOT_*`` the code actually reads must
+appear in the reference**, and the two documented precedence directions must
+still match the code.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+REFERENCE = ROOT / "docs" / "configuration.md"
+
+#: How every env-var read in this codebase looks.
+_READ = re.compile(r'(?:getenv|environ\.get|environ\[)\(?\s*["\'](CASHPILOT_[A-Z0-9_]+)["\']')
+
+
+def _read_in_code() -> set[str]:
+    names: set[str] = set()
+    for path in (ROOT / "app").rglob("*.py"):
+        names |= set(_READ.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def _documented() -> set[str]:
+    return set(re.findall(r"CASHPILOT_[A-Z0-9_]+", REFERENCE.read_text(encoding="utf-8")))
+
+
+class TestTheReferenceCoversWhatTheCodeReads:
+    def test_the_reference_exists(self):
+        assert REFERENCE.is_file()
+
+    def test_the_scan_finds_something(self):
+        """An empty scan would make the sweep below vacuously green."""
+        assert len(_read_in_code()) >= 20, "the env-var scan is not seeing the codebase"
+
+    def test_every_variable_the_code_reads_is_documented(self):
+        missing = sorted(_read_in_code() - _documented())
+        assert not missing, (
+            f"these are read by the code and absent from docs/configuration.md, so nobody can discover them: {missing}"
+        )
+
+    def test_it_does_not_document_variables_nothing_reads(self):
+        """A reference that lists dead knobs sends people after nothing.
+
+        The compose-level ones are exempt: they are read by the compose files,
+        not by Python, and the reference says so in its own section.
+        """
+        compose_only = {"CASHPILOT_BIND_ADDR", "CASHPILOT_WORKER_BIND_ADDR"}
+        ghosts = sorted(_documented() - _read_in_code() - compose_only)
+        assert not ghosts, f"documented but read by nothing: {ghosts}"
+
+    @pytest.mark.parametrize(
+        "name", sorted(compose for compose in ("CASHPILOT_BIND_ADDR", "CASHPILOT_WORKER_BIND_ADDR"))
+    )
+    def test_the_compose_only_variables_really_are_used_by_compose(self, name):
+        """Their exemption above is only honest if compose actually uses them."""
+        text = "".join(
+            (ROOT / f).read_text(encoding="utf-8") for f in ("docker-compose.yml", "docker-compose.fleet.yml")
+        )
+        assert name in text
+
+
+class TestThePrecedenceMatchesTheCode:
+    """The whole point of the page. If the code flips, this must fail."""
+
+    def test_the_encryption_key_file_still_wins(self):
+        source = (ROOT / "app" / "database.py").read_text(encoding="utf-8")
+        assert "An existing key file always wins" in source, (
+            "the credential-encryption precedence changed; docs/configuration.md says the FILE wins"
+        )
+
+    def test_the_session_key_env_still_wins(self):
+        """auth.py resolves the env var before the persisted file."""
+        source = (ROOT / "app" / "auth.py").read_text(encoding="utf-8")
+        body = source[source.index("def _resolve_secret_key") :][:900]
+        env_at = body.index("CASHPILOT_SECRET_KEY")
+        file_at = body.index(".secret_key")
+        assert env_at < file_at, (
+            "the session key no longer prefers the environment; docs/configuration.md says ENV wins"
+        )
+
+    def test_the_reference_states_both_directions(self):
+        text = REFERENCE.read_text(encoding="utf-8")
+        assert "File wins" in text and "Env wins" in text
+        assert "not uniform" in text, "the page does not warn that the directions differ"
+
+
+class TestTheAdvertiseOnlyPortIsCalledOut:
+    """The documented behaviour and the real behaviour disagreed for a long time."""
+
+    def test_the_reference_says_it_does_not_change_the_listen_port(self):
+        text = REFERENCE.read_text(encoding="utf-8")
+        assert "does not change the port the worker listens on" in text
+
+    def test_the_listen_port_really_is_fixed_in_the_image(self):
+        dockerfile = (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")
+        assert '"--port", "8081"' in dockerfile, "the worker's port is no longer hardcoded; the warning may be stale"
+
+    def test_the_variable_really_is_only_advertised(self):
+        source = (ROOT / "app" / "worker_api.py").read_text(encoding="utf-8")
+        uses = [ln for ln in source.splitlines() if "WORKER_PORT" in ln and "getenv" not in ln]
+        assert uses, "WORKER_PORT is no longer used at all"
+        assert all("url" in ln.lower() or 'f"http' in ln for ln in uses), (
+            f"WORKER_PORT is now used for something other than the advertised URL: {uses}"
+        )


### PR DESCRIPTION
Closes `CashPilot-5fy` (P2).

## The real problem was worse than a missing table

Three settings look identical from the outside — a secret supplied either by an environment variable or by a file under `/data` — and they resolve in **different directions**:

| setting | which wins | why |
|---|---|---|
| credential-encryption key | **the file** | switching keys would make every stored credential unreadable |
| session-signing key | **the environment** | sessions are cheap to invalidate |

Both are defensible on their own. Together they are impossible to guess, and **nothing documented either** — so *"I set the env var and nothing changed"* had no answer anywhere in the project.

The page leads with that, in a warning box, because it is the question the page exists to answer.

## Measured before writing

- **33** `CASHPILOT_*` variables are read in `app/`
- **8** appeared in no documentation at all: `BASE_URL`, `DATA_DIR`, `FLEET_DIR`, `HOSTNAME_PREFIX`, `SECURE_COOKIE`, `SESSION_EPOCH`, `TRUSTED_PROXY`, `VERSION`
- 2 that looked like ghosts — `CASHPILOT_BIND_ADDR`, `CASHPILOT_WORKER_BIND_ADDR` — turned out to be **compose-level**, read by the compose files rather than Python. They get their own section, and a test asserts that exemption is honest by checking compose really does use them.

## `CASHPILOT_PORT` gets a danger box

It does **not** change the port the worker listens on. That is fixed at `8081` by the image's `CMD`; the variable only changes what the worker **advertises** to the UI. Setting it alone makes a worker advertise a port nothing is listening on, and the UI's container commands then fail with nothing in the logs connecting the two.

## The guard is the point

A reference that rots is worse than none, and this project has a recent example — the changelog. So the test **enumerates every `CASHPILOT_*` the code actually reads** and fails when one is missing from the page. A new variable cannot be added without documenting it.

It also asserts the two precedence directions still match the code: if the encryption key stops preferring the file, or the session key stops preferring the environment, the test fails rather than the docs quietly lying. Same for the advertise-only port — it checks the Dockerfile still hardcodes `--port 8081` and that `WORKER_PORT` is still only used to build the advertised URL.

Three negative controls, all caught:

| reverted | result |
|---|---|
| a variable removed from the reference | 1 failed |
| the "not uniform" precedence warning removed | 1 failed |
| the advertise-only port warning removed | 1 failed |

Source verified byte-identical after every revert.

Linked from the README and added to the docs nav, so it is not another orphan.

Gates: `ruff` clean, **3375 passed, 95.44% coverage**.