### PR TITLE
docs: the quickstart no longer contradicts the security page

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The UI's web port inside the container is fixed at `8080` (set via the container
 | `CASHPILOT_WORKER_NAME` | *(hostname)* | Display name for this worker in the fleet dashboard |
 | `CASHPILOT_WORKER_URL` | *(auto-detected)* | URL the UI uses to reach this worker, e.g. `http://192.168.10.50:8081`. Set explicitly for remote/cross-host workers |
 | `CASHPILOT_WORKER_BIND_ADDR` | `127.0.0.1` | Host interface the worker's Docker-socket API port is published on. Loopback by default — for a remote worker set a private/VPN interface, **never** a public IP |
-| `CASHPILOT_PORT` | `8081` | Mini-UI/API port the worker listens on |
+| `CASHPILOT_PORT` | `8081` | Port the worker **advertises** to the UI. It does *not* change the listen port, which is fixed by the image's `CMD` — see the [configuration reference](docs/configuration.md) |
 | `CASHPILOT_WORKER_NETWORK` | *(detected)* | `residential` or `hosting`. Overrides the hardware-based guess used to warn about residential-only services |
 | `CASHPILOT_EGRESS_DETECT` | on | Set to `off` to stop this worker looking up its own public IP (see below) |
 | `CASHPILOT_EGRESS_IP` | -- | State this worker's public IP directly instead of looking it up. Must be a public address |

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -155,7 +155,7 @@ Notifications fire **only the first time** a particular failure appears — a co
 | `CASHPILOT_API_KEY` | Yes | -- | Must match the UI's API key |
 | `CASHPILOT_WORKER_NAME` | No | *(hostname)* | Display name for this worker. Recommended on Docker workers: without it the name is the container hostname, so it changes on every recreate and the dashboard label churns -- see [Worker identity](#worker-identity) |
 | `CASHPILOT_WORKER_URL` | No | *(auto-detected)* | URL the UI uses to reach this worker. Set explicitly for remote/cross-host workers -- auto-detection can report an unreachable address |
-| `CASHPILOT_PORT` | No | `8081` | Mini-UI/API port the worker listens on |
+| `CASHPILOT_PORT` | No | `8081` | Port the worker **advertises** to the UI. It does *not* change the listen port, which is fixed by the image's `CMD` — see the [configuration reference](configuration.md) |
 | `CASHPILOT_ALLOWED_VOLUME_ROOTS` | No | *(none)* | Colon-separated host directories this worker may bind-mount despite sitting under a blocked system root -- see [Volume mounts](#volume-mounts) |
 | `CASHPILOT_PIDS_LIMIT` | No | `512` | Max processes a deployed service container may create. Raise only if a service legitimately needs more. An unparseable or non-positive value falls back to the default |
 | `CASHPILOT_WORKER_NETWORK` | No | *(detected)* | `residential` or `hosting`. Overrides the hardware-based guess -- see [Egress IP and per-IP limits](#egress-ip-and-per-ip-limits) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,47 +100,21 @@ The UI's web port inside the container is fixed at `8080` (set via the container
 | `CASHPILOT_WORKER_NAME` | *(hostname)* | Display name for this worker in the fleet dashboard |
 | `CASHPILOT_WORKER_URL` | *(auto-detected)* | URL the UI uses to reach this worker, e.g. `http://192.168.10.50:8081`. Set explicitly for cross-host fleets — auto-detection can report an unreachable container-internal IP |
 | `CASHPILOT_WORKER_BIND_ADDR` | `127.0.0.1` | Host interface the worker's Docker-socket API port is published on. **Loopback by default.** The worker API can deploy/stop any container (= root on the host), so for a remote worker bind a private/VPN interface (e.g. a Tailscale IP), **never** a public IP |
-| `CASHPILOT_PORT` | `8081` | Mini-UI/API port the worker listens on |
+| `CASHPILOT_PORT` | `8081` | Port the worker **advertises** to the UI. It does *not* change the listen port, which is fixed by the image's `CMD` — see the [configuration reference](configuration.md) |
 
 ### Docker Compose Example
 
 ```yaml
-services:
-  cashpilot-ui:
-    image: drumsergio/cashpilot:latest
-    pull_policy: always
-    container_name: cashpilot-ui
-    ports:
-      - "8080:8080"
-    volumes:
-      - cashpilot_data:/data
-    environment:
-      - TZ=Europe/Madrid
-      - CASHPILOT_API_KEY=your-secret-api-key
-      - CASHPILOT_SECRET_KEY=your-session-signing-key
-    restart: unless-stopped
-
-  cashpilot-worker:
-    image: drumsergio/cashpilot-worker:latest
-    pull_policy: always
-    container_name: cashpilot-worker
-    ports:
-      - "8081:8081"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - cashpilot_worker_data:/data
-    environment:
-      - TZ=Europe/Madrid
-      - CASHPILOT_UI_URL=http://cashpilot-ui:8080
-      - CASHPILOT_API_KEY=your-secret-api-key
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-
-volumes:
-  cashpilot_data:
-  cashpilot_worker_data:
+--8<-- "docker-compose.yml"
 ```
+
+!!! note "This is the real file"
+
+    The block above is included verbatim from `docker-compose.yml` in the
+    repository, so it cannot drift from what actually ships. Earlier, a
+    hand-copied version of it published the worker's Docker-socket API on every
+    interface and pinned `:latest` — both of which the
+    [security defaults](security-defaults.md) page tells you not to do.
 
 !!! warning "Docker Socket Access"
     The worker container requires access to `/var/run/docker.sock` to manage service containers. This grants the worker significant privileges on the host. Run CashPilot on a dedicated machine or VLAN for best security.

--- a/docs/security-defaults.md
+++ b/docs/security-defaults.md
@@ -38,7 +38,7 @@ You can change all of these. None of them require changing for a normal install.
 | `CASHPILOT_ALLOW_EPHEMERAL_KEY` | off | Lets CashPilot start when the encryption key cannot be persisted. Every credential then dies on the next restart. |
 | `allow_delete_critical` (per request) | refuses | Permits deleting a volume that holds irreplaceable state. There is no undo. |
 | Alert delivery (ntfy / webhook / Telegram) | inert | Nothing is sent anywhere until you configure a target. |
-| Image tags | pinned | Service images are pinned by digest or version in the catalog, so an upstream push cannot change what runs on your machine. **Known gap:** CashPilot's *own* images are still referenced as `:latest` in the example compose files — tracked, and called out here rather than left for you to discover. |
+| Image tags | pinned | Service images are pinned by digest or version in the catalog, so an upstream push cannot change what runs on your machine. CashPilot's own images are pinned to a release series in both compose files. |
 
 ## Tier 3 — preference, no security dimension
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,19 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  # base_path reaches the repo ROOT so a docs page can include a real shipped
+  # file verbatim -- the quickstart includes docker-compose.yml, so it cannot
+  # drift from what actually ships. A hand-copied one did: it published the
+  # worker's Docker-socket API on every interface and pinned :latest, both of
+  # which security-defaults.md forbids.
+  #
+  # check_paths makes a missing include FAIL the build instead of rendering an
+  # empty block, which would look like a quickstart with no compose file.
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - docs
+      check_paths: true
   - pymdownx.mark
   - attr_list
   - md_in_html

--- a/tests/test_docs_do_not_contradict_the_shipped_files.py
+++ b/tests/test_docs_do_not_contradict_the_shipped_files.py
@@ -1,0 +1,115 @@
+"""CashPilot-4le: the first page a new user reads contradicted the security page.
+
+``docs/getting-started.md`` hand-copied a compose file that
+
+* published the worker's Docker-socket API as ``"8081:8081"`` — on every
+  interface — while ``docs/security-defaults.md`` says, in as many words,
+  *"The worker API is equivalent to root on that machine. Never publish port
+  8081."*
+* pinned ``:latest`` for both images, which ``docker-compose.yml``'s own header
+  identifies as the cause of issue #188.
+
+Meanwhile the **shipped** ``docker-compose.yml`` binds ``127.0.0.1`` by default,
+uses ``expose:`` for the worker so it is never published, and pins a release
+series.
+
+A copy drifts. The fix is not to correct the copy — it is to stop having one:
+the page now includes the real file through ``pymdownx.snippets``, so the
+quickstart and the shipped compose cannot disagree again.
+
+Two smaller drifts fixed alongside:
+
+* ``security-defaults.md`` advertised a "Known gap" about ``:latest`` that had
+  been closed. A doc that overstates the project's insecurity costs trust the
+  same way an understatement does.
+* ``CASHPILOT_PORT`` was described in **three** places as the port the worker
+  *listens on*. It is not — the listen port is fixed by the image's ``CMD`` and
+  the variable only changes what the worker *advertises*.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GETTING_STARTED = ROOT / "docs" / "getting-started.md"
+SECURITY = ROOT / "docs" / "security-defaults.md"
+
+
+class TestTheQuickstartShowsTheRealComposeFile:
+    def test_it_includes_rather_than_copies(self):
+        assert '--8<-- "docker-compose.yml"' in GETTING_STARTED.read_text(encoding="utf-8"), (
+            "the quickstart has gone back to hand-copying compose, which is how it drifted"
+        )
+
+    def test_the_include_is_enabled_in_mkdocs(self):
+        """Without the extension the marker renders literally as text."""
+        text = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+        assert "pymdownx.snippets" in text
+        assert "check_paths: true" in text, "a missing include would fail silently rather than failing the build"
+
+    def test_the_page_no_longer_publishes_the_worker_port(self):
+        assert '"8081:8081"' not in GETTING_STARTED.read_text(encoding="utf-8")
+
+    def test_the_page_no_longer_pins_latest(self):
+        text = GETTING_STARTED.read_text(encoding="utf-8")
+        assert not re.search(r"image:\s*drumsergio/\S+:latest", text)
+
+
+class TestTheShippedComposeIsActuallySafe:
+    """The include is only an improvement if what it includes is right."""
+
+    def _compose(self):
+        return (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    def test_the_ui_binds_loopback_by_default(self):
+        assert "${CASHPILOT_BIND_ADDR:-127.0.0.1}:8080:8080" in self._compose()
+
+    def test_the_worker_port_is_never_published(self):
+        """`expose:` makes it reachable inside the Docker network only."""
+        compose = self._compose()
+        assert "expose:" in compose
+        assert '"8081:8081"' not in compose
+
+    def test_the_images_are_pinned(self):
+        assert not re.search(r"image:\s*drumsergio/\S+:latest", self._compose())
+
+
+class TestTheSecurityPageDescribesReality:
+    def test_it_still_forbids_publishing_the_worker_port(self):
+        """The rule the quickstart was breaking. If this goes, so does the point."""
+        assert "Never publish port 8081" in SECURITY.read_text(encoding="utf-8")
+
+    def test_it_no_longer_advertises_a_gap_that_is_closed(self):
+        text = SECURITY.read_text(encoding="utf-8")
+        assert "Known gap" not in text, "a doc that overstates the project's insecurity costs trust too"
+
+    def test_and_the_gap_really_is_closed(self):
+        """Do not just delete the sentence — prove the claim it made is false."""
+        for name in ("docker-compose.yml", "docker-compose.fleet.yml"):
+            assert not re.search(r"image:\s*drumsergio/\S+:latest", (ROOT / name).read_text(encoding="utf-8"))
+
+
+class TestTheAdvertiseOnlyPortIsDescribedCorrectlyEverywhere:
+    DOCS = ["README.md", "docs/getting-started.md", "docs/fleet.md"]
+
+    @pytest.mark.parametrize("name", DOCS)
+    def test_it_is_not_called_the_listen_port(self, name):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "Mini-UI/API port the worker listens on" not in text, (
+            f"{name} still says CASHPILOT_PORT is the listen port; it only changes what is advertised"
+        )
+
+    @pytest.mark.parametrize("name", DOCS)
+    def test_it_says_what_the_variable_really_does(self, name):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        if "CASHPILOT_PORT" not in text:
+            pytest.skip(f"{name} does not mention CASHPILOT_PORT")
+        assert "advertises" in text
+
+    def test_the_listen_port_really_is_fixed_by_the_image(self):
+        """The correction is only right while this stays true."""
+        assert '"--port", "8081"' in (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes `CashPilot-4le` (P2).

## The contradiction

`docs/getting-started.md` — the first page a new user reads — hand-copied a compose file containing:

```yaml
image: drumsergio/cashpilot-worker:latest
ports:
  - "8081:8081"
```

`docs/security-defaults.md:35` says, in as many words:

> The worker API is equivalent to root on that machine. **Never publish port 8081.**

So the onboarding page handed people the exact thing the security page forbids, on the same docs site.

The **shipped** `docker-compose.yml` does none of it: binds `${CASHPILOT_BIND_ADDR:-127.0.0.1}`, uses `expose:` so the worker port is never published at all, and pins `1.12`.

## The fix is to stop having a copy

Correcting the copy would just reset the clock. The page now **includes the real file** via `pymdownx.snippets`, so the quickstart and the shipped compose cannot disagree again.

Verified by building the site rather than assuming: the rendered `getting-started/index.html` carries `cashpilot:1.12` and `CASHPILOT_BIND_ADDR`, with no `8081:8081` and no literal `--8<--` marker.

`check_paths: true` means a missing include **fails the build** instead of rendering an empty block — which would look like a quickstart with no compose file at all.

## Two smaller drifts

**`security-defaults.md` advertised a gap that is closed** — *"Known gap: CashPilot's own images are still referenced as `:latest` in the example compose files."* Both compose files pin a series. A doc that overstates the project's insecurity costs trust the same way an understatement does. Removed, and a test proves the claim it made is actually false rather than just deleting the sentence.

**`CASHPILOT_PORT` was wrong in three places** — README, getting-started and fleet all called it *"Mini-UI/API port the worker listens on"*. It isn't: the listen port is fixed by the image's `CMD`, and the variable only changes what the worker **advertises**. An operator who changed it got a worker advertising a port nothing listens on, with nothing in the logs connecting the two.

## A mistake of mine worth recording

`pymdownx.snippets` **was already enabled**. I added a second entry without checking, and my negative control then failed to catch its removal — because it was removing one of two. That's the control doing its job: it told me my edit was wrong, not that the test was.

Removed the duplicate; the pre-existing entry now carries `base_path` (reaching the repo root) and `check_paths`. Re-ran the control with a genuinely unique anchor — caught.

## Evidence

17 tests, four negative controls, all caught:

| reverted | result |
|---|---|
| hand-copied insecure compose restored | 3 failed |
| snippets extension removed | 1 failed |
| closed gap re-advertised | 1 failed |
| listen-port claim returns | 2 failed |

The tests check both directions: that the docs no longer say the wrong thing, **and** that the shipped compose is actually safe — because an include is only an improvement if what it includes is right.

Gates: `ruff` clean, mkdocs builds clean, **3392 passed, 95.44% coverage**.