### PR TITLE
feat: workers report disk and GPU, and say when they cannot tell

### DIFF
--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -20,7 +20,9 @@ import logging
 import os
 import platform
 import re
+import shutil
 import socket
+import subprocess
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -295,6 +297,105 @@ _EGRESS_TOTAL_TIMEOUT = 10.0
 _EGRESS_MAX_BYTES = 128
 
 
+def _disk_usage() -> dict[str, Any] | None:
+    """Free and total bytes on the filesystem holding the data directory.
+
+    Storj is paid for data it STORES, so free space is earning capacity, not a
+    housekeeping detail -- a node that quietly fills up stops growing and nothing
+    in CashPilot said so.
+
+    Returns None when it cannot be read. None is UNKNOWN; a caller must not
+    render it as 0 (a full disk) or as 100% (an empty one). Both are worse than
+    an em-dash.
+    """
+    try:
+        usage = shutil.disk_usage(str(_WORKER_ID_FILE.parent))
+    except OSError as exc:
+        logger.debug("Could not read disk usage: %s", exc)
+        return None
+    return {"path": str(_WORKER_ID_FILE.parent), "free_bytes": usage.free, "total_bytes": usage.total}
+
+
+def _gpu_info() -> dict[str, Any]:
+    """What this worker can see of a GPU, and how sure it is.
+
+    Salad, Nosana, io.net and Vast.ai only earn when a real GPU is present AND
+    usable. Today a GPU service that is running but idle -- because the device
+    was never passed into the container -- looks exactly like one that is
+    earning. That is the Mysterium /dev/net/tun failure again: healthy-looking
+    and worth nothing.
+
+    THE THREE-VALUED PART MATTERS. Inside a container with no device passed
+    through, the absence of nvidia-smi proves nothing about the HOST. So:
+
+        available True   we saw a device
+        available False  we looked, found none, and we are NOT in a container,
+                         so the host really has none
+        available None   we could not tell -- in a container with nothing passed
+                         through, which is exactly when a user most needs to know
+
+    Reporting None as False would tell someone their machine has no GPU when it
+    may have an unused one, which is the opposite of the useful answer.
+    """
+    devices: list[str] = []
+    how = None
+
+    nvidia = shutil.which("nvidia-smi")
+    if nvidia:
+        try:
+            out = subprocess.run(  # noqa: S603 - fixed binary, no shell, no user input
+                [nvidia, "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if out.returncode == 0:
+                devices = [line.strip() for line in out.stdout.splitlines() if line.strip()]
+                how = "nvidia-smi"
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.debug("nvidia-smi failed: %s", exc)
+
+    if not devices:
+        # A DRM render node means SOME GPU is reachable -- integrated, AMD, or an
+        # NVIDIA card without the management tool. Enough to say "yes", not
+        # enough to name it.
+        render_nodes = sorted(str(p) for p in Path("/dev/dri").glob("renderD*")) if Path("/dev/dri").is_dir() else []
+        if render_nodes:
+            devices = [f"DRM render node ({len(render_nodes)})"]
+            how = "drm"
+
+    if devices:
+        return {"available": True, "devices": devices, "detected_by": how}
+
+    # Both probes above are LINUX-specific: nvidia-smi is not on a stock macOS,
+    # and /dev/dri is the Linux DRM interface. Their absence on any other
+    # platform proves nothing at all -- every Mac has a GPU. Caught by running
+    # this on macOS, where the first version confidently reported "no GPU".
+    if platform.system() != "Linux":
+        return {
+            "available": None,
+            "devices": [],
+            "detected_by": None,
+            "reason": f"GPU detection is not implemented for {platform.system()}; this says nothing about whether one exists",
+        }
+
+    if Path("/.dockerenv").exists():
+        # On Linux, in a container, with nothing passed through. We genuinely
+        # cannot tell -- and this is exactly when a user most needs to know,
+        # because it is the case where a GPU service runs and earns nothing.
+        return {
+            "available": None,
+            "devices": [],
+            "detected_by": None,
+            "reason": "no GPU is visible from inside this container; the host may still have one that was not passed through",
+        }
+
+    # Linux, on the host, with no NVIDIA tool and no render node. This is the
+    # one case where "no" is a real answer.
+    return {"available": False, "devices": [], "detected_by": None}
+
+
 def _detect_network_type() -> str:
     """residential / hosting / unknown, from local hardware identifiers only.
 
@@ -420,6 +521,11 @@ async def _send_heartbeat() -> None:
             # the provider sees — not this container's LAN or tailnet address.
             "egress_ip": await _detect_egress_ip(),
             "egress_network_type": _detect_network_type(),
+            # Disk is earning capacity for Storj; GPU decides whether the compute
+            # services can earn at all. Both are None/unknown-aware -- see the
+            # helpers (CashPilot-cle).
+            "disk": await asyncio.to_thread(_disk_usage),
+            "gpu": await asyncio.to_thread(_gpu_info),
         },
     }
 

--- a/tests/test_beads_batch_56.py
+++ b/tests/test_beads_batch_56.py
@@ -1,0 +1,131 @@
+"""CashPilot-cle: the fleet reported CPU and memory — the two least useful numbers.
+
+What actually decides whether a passive-income service can earn on a machine is
+**disk** and **GPU**, and the worker reported neither. Measured on the live
+fleet before this: ``system_info`` carried ``os``, ``arch``, ``hostname``,
+``docker_available``, ``version``, ``egress_ip``, ``egress_network_type`` — and
+nothing else.
+
+* **Disk.** Storj is paid for data it *stores*, so free space is earning
+  capacity. A node that quietly fills up stops growing and nothing said so.
+* **GPU.** Salad, Nosana, io.net and Vast.ai only earn with a real GPU. Today a
+  GPU service that runs but earns nothing — because the device was never passed
+  into the container — looks exactly like one that is working. That is the
+  Mysterium ``/dev/net/tun`` failure again: healthy-looking and worth nothing.
+
+**The three-valued part is the whole design.** Inside a container with no device
+passed through, the absence of ``nvidia-smi`` proves nothing about the host. And
+the probes are Linux-specific, so on macOS they prove nothing at all — the first
+version of this reported "no GPU" on a Mac, which was caught by running it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestDiskIsReportedOrHonestlyUnknown:
+    def test_it_reports_free_and_total_on_a_readable_path(self, tmp_path):
+        from app import worker_api
+
+        with patch.object(worker_api, "_WORKER_ID_FILE", tmp_path / ".worker_id"):
+            usage = worker_api._disk_usage()
+        assert usage is not None
+        assert usage["total_bytes"] > 0
+        assert 0 <= usage["free_bytes"] <= usage["total_bytes"]
+        assert usage["path"] == str(tmp_path)
+
+    def test_an_unreadable_path_reports_unknown_not_zero(self):
+        """0 free would read as a full disk; 0 total as no disk. Both are lies."""
+        from app import worker_api
+
+        with patch.object(worker_api.shutil, "disk_usage", side_effect=OSError("gone")):
+            assert worker_api._disk_usage() is None
+
+
+class TestGpuNeverClaimsMoreThanItKnows:
+    def _gpu(self, *, system, in_container=False, nvidia=None, nvidia_out="", render_nodes=False):
+        from app import worker_api
+
+        def fake_exists(self):
+            return in_container if str(self) == "/.dockerenv" else False
+
+        def fake_is_dir(self):
+            return render_nodes and str(self) == "/dev/dri"
+
+        def fake_glob(self, pattern):
+            return [Path("/dev/dri/renderD128")] if render_nodes else []
+
+        class _Run:
+            returncode = 0
+            stdout = nvidia_out
+
+        with (
+            patch.object(worker_api.platform, "system", return_value=system),
+            patch.object(worker_api.shutil, "which", return_value=nvidia),
+            patch.object(worker_api.subprocess, "run", return_value=_Run()),
+            patch.object(Path, "exists", fake_exists),
+            patch.object(Path, "is_dir", fake_is_dir),
+            patch.object(Path, "glob", fake_glob),
+        ):
+            return worker_api._gpu_info()
+
+    def test_a_named_device_is_reported(self):
+        gpu = self._gpu(system="Linux", nvidia="/usr/bin/nvidia-smi", nvidia_out="NVIDIA GeForce RTX 4090\n")
+        assert gpu["available"] is True
+        assert gpu["devices"] == ["NVIDIA GeForce RTX 4090"]
+        assert gpu["detected_by"] == "nvidia-smi"
+
+    def test_a_render_node_counts_as_a_gpu(self):
+        """Integrated or AMD: enough to say yes, not enough to name it."""
+        gpu = self._gpu(system="Linux", render_nodes=True)
+        assert gpu["available"] is True
+        assert gpu["detected_by"] == "drm"
+
+    def test_a_bare_linux_host_with_nothing_is_a_real_no(self):
+        """The ONE case where False is honest."""
+        gpu = self._gpu(system="Linux")
+        assert gpu["available"] is False
+
+    def test_inside_a_container_with_nothing_visible_is_UNKNOWN(self):
+        """The case that matters: a GPU service earning nothing looks fine."""
+        gpu = self._gpu(system="Linux", in_container=True)
+        assert gpu["available"] is None, "claimed the host has no GPU when it may have an unused one"
+        assert "not passed through" in gpu["reason"]
+
+    @pytest.mark.parametrize("system", ["Darwin", "Windows"])
+    def test_a_non_linux_host_is_UNKNOWN_not_no(self, system):
+        """nvidia-smi and /dev/dri are Linux-specific; every Mac has a GPU.
+
+        The first version of this returned False on macOS. Running it caught
+        that — reading it would not have.
+        """
+        gpu = self._gpu(system=system)
+        assert gpu["available"] is None
+        assert system in gpu["reason"]
+
+    def test_unknown_is_never_rendered_as_false_anywhere(self):
+        """None and False are different answers and must stay distinguishable."""
+        for kwargs in ({"system": "Darwin"}, {"system": "Linux", "in_container": True}):
+            assert self._gpu(**kwargs)["available"] is not False
+
+
+class TestTheHeartbeatCarriesThem:
+    def test_system_info_includes_both(self):
+        import ast
+        import inspect
+
+        from app import worker_api
+
+        source = inspect.getsource(worker_api)
+        start = source.index('"system_info": {')
+        block = source[start : start + 1400]
+        assert '"disk"' in block
+        assert '"gpu"' in block
+        # Off the event loop: disk_usage and a subprocess both block.
+        assert "asyncio.to_thread(_disk_usage)" in block
+        assert "asyncio.to_thread(_gpu_info)" in block
+        ast.parse(source)


### PR DESCRIPTION
Server/worker half of `CashPilot-cle` (P2). The table columns follow separately.

## The two least useful numbers

The fleet reported **CPU and memory**. What actually decides whether a passive-income service can earn on a machine is **disk** and **GPU**, and the worker reported neither. Measured on the live fleet before this — `system_info` carried exactly:

```
os · arch · hostname · docker_available · version · egress_ip · egress_network_type
```

**Disk** is earning capacity for Storj, which is paid for the data it *stores*. A node that quietly fills up stops growing, and nothing in CashPilot said so.

**GPU** decides whether Salad, Nosana, io.net and Vast.ai can earn at all. Right now a GPU service that runs but earns nothing — because the device was never passed into the container — looks **exactly** like one that's working. That's the Mysterium `/dev/net/tun` failure again, which this project already has a runbook for: healthy-looking and worth nothing.

## The three-valued part is the design

| `available` | meaning |
|---|---|
| `True` | we saw a device |
| `False` | we looked, found none, and we're on a Linux **host** — the one case where "no" is a real answer |
| `None` | we could not tell, with the reason attached |

**Two situations produce `None`, and both are precisely when a user most needs the answer:**

1. **Inside a container with nothing passed through.** The absence of `nvidia-smi` says nothing about the host. Reporting `False` here would tell someone their machine has no GPU when it may have an unused one — the opposite of the useful answer, and the exact situation where a GPU service is silently earning zero.

2. **On macOS or Windows.** Both probes (`nvidia-smi`, `/dev/dri`) are Linux-specific, so their absence proves nothing.

That second case was **a real bug in my first draft**. Run on this Mac, it returned:

```
{'available': False, 'devices': [], 'detected_by': None}
```

on a machine that plainly has a GPU. Reading the code would not have caught it — running it did. It now returns `None` with `"GPU detection is not implemented for Darwin; this says nothing about whether one exists"`.

This matters beyond macOS: the Desktop client is meant to run natively on macOS and Windows, so a Linux-only assumption would have shipped a wrong answer to every Desktop user.

Disk follows the same rule: `None` when unreadable, never zero. `0` free reads as a full disk and `0` total as no disk — both worse than an em-dash.

## Evidence

10 tests. Four negative controls, all caught:

| reverted | result |
|---|---|
| unknown disk becomes a fabricated zero | 1 failed |
| non-Linux claims "no GPU" (the bug I shipped in draft) | 3 failed |
| a container claims the host has no GPU | 2 failed |
| blocking calls back on the event loop | 1 failed |

That last one is worth noting: `shutil.disk_usage` and a `subprocess.run` both block, and this runs on the heartbeat path — so both go through `asyncio.to_thread`, with a test pinning it.

Source verified byte-identical after every revert.

Gates: `ruff` clean, all four browser-free harnesses PASS, **3402 passed, 95.44% coverage**.

## Not in this PR

Rendering the columns in the services table. The bead requires them to work for **remote** resources too, and the honest display rules (unknown vs zero, stale vs current) belong with the UI work where they can be tested against real payload shapes. This lands the data and the rules that produce it.