### PR TITLE
docs: explain GPU passthrough, and pin that it stays optional

### DIFF
--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.12
+    image: drumsergio/cashpilot:1.13
     pull_policy: always
     container_name: cashpilot-ui
     # Loopback by default (the UI commands the Docker-socket worker). Set
@@ -38,7 +38,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.12
+    image: drumsergio/cashpilot-worker:1.13
     pull_policy: always
     container_name: cashpilot-worker
     # The worker exposes a Docker-socket-backed API (deploy/stop/remove any
@@ -50,6 +50,21 @@ services:
     # CASHPILOT_API_KEY secret.
     ports:
       - "${CASHPILOT_WORKER_BIND_ADDR:-127.0.0.1}:8081:8081"
+      # GPU passthrough. COMMENTED OUT ON PURPOSE: Docker refuses to start a
+      # container when a listed device does not exist, so uncommenting this on a
+      # host with no GPU breaks the worker outright (verified: `docker run
+      # --device /dev/does-not-exist` fails).
+      #
+      # Uncomment on a Linux host that HAS a GPU. Without it the worker cannot
+      # see the hardware, so CashPilot reports the GPU as *unknown* and cannot
+      # tell you whether Salad, Nosana, io.net or Vast.ai would earn here. Worse,
+      # a GPU service deployed without the device starts, looks healthy, and
+      # earns nothing -- the same shape as the Mysterium /dev/net/tun failure.
+      #
+      # NVIDIA cards use the NVIDIA Container Toolkit instead of /dev/dri; see
+      # the GPU section of the docs.
+      # devices:
+      #   - /dev/dri:/dev/dri
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - cashpilot_worker_data:/data
@@ -72,7 +87,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:1.12
+#      image: drumsergio/cashpilot-worker:1.13
 #      pull_policy: always
 #      container_name: cashpilot-worker
 #      # Docker-socket-backed API = full host control. Bind a PRIVATE/VPN interface

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -61,10 +61,28 @@ services:
       # a GPU service deployed without the device starts, looks healthy, and
       # earns nothing -- the same shape as the Mysterium /dev/net/tun failure.
       #
-      # NVIDIA cards use the NVIDIA Container Toolkit instead of /dev/dri; see
-      # the GPU section of the docs.
+      # Intel / AMD -- the kernel exposes the GPU as a DRM render node:
       # devices:
       #   - /dev/dri:/dev/dri
+      #
+      # NVIDIA is a DIFFERENT mechanism. /dev/dri does nothing for it, and
+      # installing the NVIDIA Container Toolkit is only the prerequisite -- the
+      # toolkit alone does NOT hand the GPU to a Compose service. You must also
+      # ask for it, with EITHER of these (both are Compose-spec attributes):
+      #
+      # gpus: all
+      #
+      # deploy:
+      #   resources:
+      #     reservations:
+      #       devices:
+      #         - driver: nvidia
+      #           count: all
+      #           capabilities: [gpu]
+      #
+      # Both of these also fail on a host with no NVIDIA GPU (verified: exit 1,
+      # "could not select device driver"), which is why they are commented out
+      # too. Pick ONE; do not set both.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - cashpilot_worker_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.12
+    image: drumsergio/cashpilot:1.13
     pull_policy: always
     container_name: cashpilot-ui
     # Published on loopback by default: the dashboard can command the Docker-socket
@@ -51,11 +51,26 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.12
+    image: drumsergio/cashpilot-worker:1.13
     pull_policy: always
     container_name: cashpilot-worker
     expose:
       - "8081"
+      # GPU passthrough. COMMENTED OUT ON PURPOSE: Docker refuses to start a
+      # container when a listed device does not exist, so uncommenting this on a
+      # host with no GPU breaks the worker outright (verified: `docker run
+      # --device /dev/does-not-exist` fails).
+      #
+      # Uncomment on a Linux host that HAS a GPU. Without it the worker cannot
+      # see the hardware, so CashPilot reports the GPU as *unknown* and cannot
+      # tell you whether Salad, Nosana, io.net or Vast.ai would earn here. Worse,
+      # a GPU service deployed without the device starts, looks healthy, and
+      # earns nothing -- the same shape as the Mysterium /dev/net/tun failure.
+      #
+      # NVIDIA cards use the NVIDIA Container Toolkit instead of /dev/dri; see
+      # the GPU section of the docs.
+      # devices:
+      #   - /dev/dri:/dev/dri
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - cashpilot_worker_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,10 +67,28 @@ services:
       # a GPU service deployed without the device starts, looks healthy, and
       # earns nothing -- the same shape as the Mysterium /dev/net/tun failure.
       #
-      # NVIDIA cards use the NVIDIA Container Toolkit instead of /dev/dri; see
-      # the GPU section of the docs.
+      # Intel / AMD -- the kernel exposes the GPU as a DRM render node:
       # devices:
       #   - /dev/dri:/dev/dri
+      #
+      # NVIDIA is a DIFFERENT mechanism. /dev/dri does nothing for it, and
+      # installing the NVIDIA Container Toolkit is only the prerequisite -- the
+      # toolkit alone does NOT hand the GPU to a Compose service. You must also
+      # ask for it, with EITHER of these (both are Compose-spec attributes):
+      #
+      # gpus: all
+      #
+      # deploy:
+      #   resources:
+      #     reservations:
+      #       devices:
+      #         - driver: nvidia
+      #           count: all
+      #           capabilities: [gpu]
+      #
+      # Both of these also fail on a host with no NVIDIA GPU (verified: exit 1,
+      # "could not select device driver"), which is why they are commented out
+      # too. Pick ONE; do not set both.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - cashpilot_worker_data:/data

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,9 +99,43 @@ devices:
     so this is shipped commented out. Uncommenting it on a GPU-less host breaks
     the worker outright.
 
-For **NVIDIA**, `/dev/dri` is not the mechanism — install the NVIDIA Container
-Toolkit and the worker will find `nvidia-smi`, which reports the real model name
-rather than just a device count.
+### NVIDIA is a different mechanism
+
+`/dev/dri` does nothing for an NVIDIA card, and installing the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+is only the **prerequisite** — the toolkit on its own does *not* hand the GPU to
+a Compose service. You have to ask for it as well, with **either** of these:
+
+=== "Shorthand"
+
+    ```yaml
+    gpus: all
+    ```
+
+=== "Explicit reservation"
+
+    ```yaml
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ```
+
+Both are Compose-spec attributes and both were validated against Compose
+v2.40.3. Pick one; do not set both. Use the explicit reservation when you need
+to pin particular cards, which it can do via `device_ids` and `capabilities`.
+
+!!! warning "These fail on a GPU-less host too"
+
+    Verified: on a machine with no NVIDIA card, *both* forms exit 1, the
+    reservation form reporting `could not select device driver`. So like
+    `/dev/dri`, they ship commented out rather than enabled by default.
+
+Once the GPU is actually allocated, the worker finds `nvidia-smi` and reports
+the real model name rather than just a device count.
 
 Passing a device into the worker only lets the **worker** see it. A deployed GPU
 **service** needs the device too — declare it in that service's catalog entry.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,38 @@ defensible on its own; together they are impossible to guess.
     To actually move the port, override the container's `command:` **and** set
     `CASHPILOT_PORT` to match.
 
+## GPU passthrough
+
+CashPilot reports a worker's GPU as one of three answers — **yes**, **no**, or
+**unknown** — and inside a container the honest answer is almost always
+*unknown*: the absence of a GPU there says nothing about the host.
+
+That matters because four services only earn with a real GPU (Salad, Nosana,
+io.net, Vast.ai), and a GPU service deployed **without** the device starts,
+reports healthy, and earns nothing. It is the same shape as the Mysterium
+`/dev/net/tun` failure.
+
+To let the worker see an Intel or AMD GPU, uncomment the block in the compose
+file:
+
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+```
+
+!!! warning "Only on a host that actually has one"
+
+    Docker **refuses to start a container** when a listed device does not exist,
+    so this is shipped commented out. Uncommenting it on a GPU-less host breaks
+    the worker outright.
+
+For **NVIDIA**, `/dev/dri` is not the mechanism — install the NVIDIA Container
+Toolkit and the worker will find `nvidia-smi`, which reports the real model name
+rather than just a device count.
+
+Passing a device into the worker only lets the **worker** see it. A deployed GPU
+**service** needs the device too — declare it in that service's catalog entry.
+
 ## Compose-level
 
 These are read by the compose files, not by CashPilot itself.

--- a/tests/test_beads_batch_56.py
+++ b/tests/test_beads_batch_56.py
@@ -166,9 +166,133 @@ class TestTheShippedComposeDoesNotBreakGpuLessHosts:
         """Whitespace-normalised: markdown hard-wraps, and "NVIDIA Container
         Toolkit" was split across two lines, so a contiguous substring check
         missed it. Third time this trap has bitten in this session."""
+        assert "NVIDIA Container Toolkit" in self._docs()
+        assert "GPU passthrough" in self._docs()
+
+    def _docs(self):
         import re
 
         raw = (self.ROOT / "docs" / "configuration.md").read_text(encoding="utf-8")
-        text = re.sub(r"\s+", " ", raw)
-        assert "NVIDIA Container Toolkit" in text
-        assert "GPU passthrough" in text
+        return re.sub(r"\s+", " ", raw)
+
+
+class TestTheNvidiaPathDoesNotStopAtTheToolkit:
+    """CodeRabbit caught a real gap: the toolkit is the prerequisite, not the
+    allocation.
+
+    Installing the NVIDIA Container Toolkit does **not** hand the GPU to a
+    Compose service — the service has to request it. Saying only "install the
+    toolkit" therefore left a reader with a card the worker still cannot see,
+    which is exactly the silent-earns-nothing failure this whole feature exists
+    to surface.
+
+    Both request forms were validated against Compose v2.40.3 on a real host,
+    and both were run on a machine with **no** NVIDIA card, where both exit 1
+    (``could not select device driver``). That is why they are commented out
+    alongside ``/dev/dri`` rather than enabled — the same reasoning, established
+    by running it rather than assuming it.
+    """
+
+    import pathlib
+
+    ROOT = pathlib.Path(__file__).resolve().parents[1]
+    COMPOSE = ["docker-compose.yml", "docker-compose.fleet.yml"]
+
+    def _docs(self):
+        import re
+
+        return re.sub(r"\s+", " ", (self.ROOT / "docs" / "configuration.md").read_text(encoding="utf-8"))
+
+    def test_the_docs_say_the_toolkit_alone_is_not_enough(self):
+        """The precise misconception, denied in words."""
+        text = self._docs()
+        assert "does not" in text.lower() or "not enough" in text.lower()
+        assert "prerequisite" in text.lower(), "nothing tells the reader the toolkit is only step one"
+
+    def test_the_docs_give_a_working_request(self):
+        text = self._docs()
+        assert "gpus: all" in text, "the shorthand form is missing"
+        assert "driver: nvidia" in text, "the explicit reservation form is missing"
+        assert "capabilities: [gpu]" in text
+
+    def test_the_docs_warn_it_also_breaks_a_gpu_less_host(self):
+        """Verified by running it; without this a reader enables it blindly."""
+        assert "could not select device driver" in self._docs()
+
+    @pytest.mark.parametrize("name", COMPOSE)
+    def test_the_compose_files_carry_the_same_hint(self, name):
+        text = (self.ROOT / name).read_text(encoding="utf-8")
+        assert "gpus: all" in text, f"{name} documents /dev/dri but not the NVIDIA request"
+        assert "driver: nvidia" in text
+
+    @pytest.mark.parametrize("name", COMPOSE)
+    def test_the_nvidia_request_is_not_actually_enabled(self, name):
+        """It fails on a GPU-less host, so it must stay commented like /dev/dri.
+
+        Parsed as YAML rather than grepped: a commented block is invisible to
+        the parser, so if either key became live this fails.
+        """
+        import yaml
+
+        worker = yaml.safe_load((self.ROOT / name).read_text(encoding="utf-8"))["services"]["cashpilot-worker"]
+        assert "gpus" not in worker, f"{name} requests a GPU unconditionally; GPU-less hosts fail to start"
+        reservations = (worker.get("deploy") or {}).get("resources", {}).get("reservations", {})
+        assert "devices" not in reservations, f"{name} reserves a GPU device unconditionally"
+
+    @pytest.mark.parametrize("name", COMPOSE)
+    def test_it_tells_the_reader_not_to_set_both(self, name):
+        """Two ways to ask for the same thing invites setting both."""
+        assert "do not set both" in (self.ROOT / name).read_text(encoding="utf-8").lower()
+
+
+class TestTheCommentedYamlIsActuallyValidYaml:
+    """A commented example nobody can uncomment is worse than none.
+
+    Uncommenting is the whole point of shipping it inert, so the block has to
+    parse *and* land at the right indentation once the ``# `` prefixes come off.
+    Nothing else in CI would ever catch a typo inside a comment.
+    """
+
+    import pathlib
+
+    ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+    @pytest.mark.parametrize("name", ["docker-compose.yml", "docker-compose.fleet.yml"])
+    @pytest.mark.parametrize("marker", ["gpus: all", "devices:\n      #   - /dev/dri:/dev/dri"])
+    def test_uncommenting_a_block_yields_parseable_yaml(self, name, marker):
+        import textwrap
+
+        import yaml
+
+        text = (self.ROOT / name).read_text(encoding="utf-8")
+        first = marker.splitlines()[0]
+        line = next(ln for ln in text.splitlines() if first in ln and ln.lstrip().startswith("#"))
+        block = []
+        for ln in text.splitlines()[text.splitlines().index(line) :]:
+            stripped = ln.strip()
+            if not stripped.startswith("#") or stripped == "#":
+                break
+            block.append(ln.replace("# ", "", 1))
+        uncommented = textwrap.dedent("\n".join(block))
+        parsed = yaml.safe_load(uncommented)
+        assert isinstance(parsed, dict) and parsed, f"{name}: {first!r} does not uncomment to valid YAML"
+
+    @pytest.mark.parametrize("name", ["docker-compose.yml", "docker-compose.fleet.yml"])
+    def test_the_reservation_block_uncomments_to_the_documented_shape(self, name):
+        import textwrap
+
+        import yaml
+
+        text = (self.ROOT / name).read_text(encoding="utf-8")
+        lines = text.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.strip().startswith("#") and "deploy:" in ln)
+        block = []
+        for ln in lines[start:]:
+            stripped = ln.strip()
+            if not stripped.startswith("#") or stripped == "#":
+                break
+            block.append(ln.replace("# ", "", 1))
+        parsed = yaml.safe_load(textwrap.dedent("\n".join(block)))
+        device = parsed["deploy"]["resources"]["reservations"]["devices"][0]
+        assert device["driver"] == "nvidia"
+        assert device["capabilities"] == ["gpu"]

--- a/tests/test_beads_batch_56.py
+++ b/tests/test_beads_batch_56.py
@@ -129,3 +129,46 @@ class TestTheHeartbeatCarriesThem:
         assert "asyncio.to_thread(_disk_usage)" in block
         assert "asyncio.to_thread(_gpu_info)" in block
         ast.parse(source)
+
+
+class TestTheShippedComposeDoesNotBreakGpuLessHosts:
+    """Docker refuses to start when a listed device is missing.
+
+    Verified on a real host: ``docker run --device /dev/does-not-exist`` fails,
+    while ``--device /dev/dri`` on a machine that has one works. So a hard
+    ``devices:`` entry in the shipped compose would break every user without a
+    GPU — it is documented and commented out instead.
+    """
+
+    import pathlib
+
+    ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+    @pytest.mark.parametrize("name", ["docker-compose.yml", "docker-compose.fleet.yml"])
+    def test_the_device_is_not_hard_required(self, name):
+        import yaml
+
+        doc = yaml.safe_load((self.ROOT / name).read_text(encoding="utf-8"))
+        worker = doc["services"]["cashpilot-worker"]
+        assert "devices" not in worker, (
+            f"{name} hard-requires a device; Docker refuses to start when it is missing, "
+            "so this breaks every host without a GPU"
+        )
+
+    @pytest.mark.parametrize("name", ["docker-compose.yml", "docker-compose.fleet.yml"])
+    def test_but_it_is_documented_in_place(self, name):
+        """Commented out is only helpful if it says why and when to enable it."""
+        text = (self.ROOT / name).read_text(encoding="utf-8")
+        assert "/dev/dri:/dev/dri" in text, f"{name} gives no hint that GPU passthrough is possible"
+        assert "does not exist" in text or "no GPU" in text
+
+    def test_the_docs_explain_the_nvidia_path_too(self):
+        """Whitespace-normalised: markdown hard-wraps, and "NVIDIA Container
+        Toolkit" was split across two lines, so a contiguous substring check
+        missed it. Third time this trap has bitten in this session."""
+        import re
+
+        raw = (self.ROOT / "docs" / "configuration.md").read_text(encoding="utf-8")
+        text = re.sub(r"\s+", " ", raw)
+        assert "NVIDIA Container Toolkit" in text
+        assert "GPU passthrough" in text


### PR DESCRIPTION
Follows `CashPilot#247`, and closes the finding that deploying it produced.

## The telemetry earned its keep on the first run

After deploying the disk/GPU reporting, every worker on the reference fleet answered:

```
gpu.available = None
reason = "no GPU is visible from inside this container;
          the host may still have one that was not passed through"
```

Then I checked the hosts:

```
watchtower   /dev/dri/renderD128  renderD129  renderD130
worker       (sees nothing)
```

Same on geiserback. **The GPUs are there; the workers cannot see them.**

That means CashPilot cannot tell you whether Salad, Nosana, io.net or Vast.ai would earn on those machines — and cannot catch the failure that actually costs money: a GPU service deployed *without* the device starts, reports healthy, and earns **nothing**. Same shape as the Mysterium `/dev/net/tun` failure this project already has a runbook for.

Worth noting: had my first draft shipped — the one that confidently returned `false` — this would have been reported as "no GPU" and the three idle render nodes would have stayed invisible. The three-valued answer is what prompted the check.

## Why the fix ships commented out

Verified on a real host rather than assumed:

```
docker run --device /dev/does-not-exist ...  -> fails
docker run --device /dev/dri ...             -> card0 card1 card2 card3 renderD128-130
```

Docker **refuses to start** a container when a listed device is missing. So a hard `devices:` entry in the shipped compose would break every user without a GPU — the opposite of helpful.

It is therefore documented in place, commented, with the reason and the exact condition for enabling it. A test asserts the shipped compose **never** hard-requires the device, and a second asserts the comment still explains when to turn it on — because a bare commented line teaches nobody anything.

The docs also cover two things that are easy to get wrong:

- **NVIDIA is a different mechanism** — the Container Toolkit, not `/dev/dri`. With it, `nvidia-smi` reports the real model name rather than a device count.
- **Passing the device to the worker only lets the *worker* see it.** A deployed GPU *service* needs the device declared in its own catalog entry — the capability added for the Mysterium TUN fix.

## Also in this PR

The compose pins move `1.12` → `1.13`. The project's own pin test caught that releasing v1.13.0 moved the newest series; both `1.13` images verified present on Docker Hub before bumping.

## Evidence

15 tests in the file, 4 negative controls from the parent PR still passing. Gates: `ruff` clean, **3407 passed, 95.44% coverage**.

One self-inflicted test bug worth recording: my docs assertion looked for the contiguous string `"NVIDIA Container Toolkit"`, which markdown had hard-wrapped across two lines. Third time that trap has bitten this session — the assertion now normalises whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for enabling GPU passthrough on Linux hosts, including Intel/AMD and NVIDIA configurations.
  * Clarified GPU detection states and setup requirements for GPU-dependent services.

* **Bug Fixes**
  * Docker Compose deployments no longer require GPU devices, allowing startup on hosts without GPUs.
  * Updated UI and worker images to version 1.13.

* **Documentation**
  * Expanded configuration guidance for GPU setup, device availability, and NVIDIA Container Toolkit requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->