### PR TITLE
feat(ui): show host disk and GPU in the services table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Fleet staleness behaviour
         run: node scripts/fleet_staleness_check.mjs
 
+      # The Disk and GPU columns. Worth running rather than grepping for the
+      # same reason as the rest: the first draft iterated `svc.instances`, which
+      # is a COUNT, and `for...of` over a number throws — a string assertion
+      # would have been perfectly happy while the services table went blank.
+      - name: Host resource columns
+        run: node scripts/host_resources_check.mjs
+
       # From the LOCKFILE, which is what Docker ships (`uv sync --frozen` in the
       # Dockerfile) and what release.yml verifies against. Installing from the
       # unpinned requirements.txt meant the suite ran against a resolution

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -595,6 +595,19 @@ const CP = (() => {
           va = parseFloat(a.memory) || 0;
           vb = parseFloat(b.memory) || 0;
           break;
+        // Both sort UNKNOWN last in either direction rather than as zero.
+        // `parseFloat(x) || 0` — the idiom used above — would rank a host whose
+        // free space could not be read as the fullest disk on the fleet, which
+        // is the same "absent read as a definite value" this codebase keeps
+        // having to undo.
+        case 'disk':
+          va = sortableFreeBytes(a);
+          vb = sortableFreeBytes(b);
+          break;
+        case 'gpu':
+          va = sortableGpu(a);
+          vb = sortableGpu(b);
+          break;
         case 'payout': {
           const coA = a.cashout || {};
           const coB = b.cashout || {};
@@ -610,10 +623,161 @@ const CP = (() => {
           va = 0; vb = 0;
       }
       if (_sortCol !== 'name') {
+        // Unknown sinks in BOTH directions. A sentinel number cannot do this:
+        // -Infinity sorts last descending but FIRST ascending, which would put
+        // every host whose free space could not be read at the top of "least
+        // free space" -- stating a failed reading as the worst case.
+        const aU = va === SORT_UNKNOWN;
+        const bU = vb === SORT_UNKNOWN;
+        if (aU || bU) return aU && bU ? 0 : (aU ? 1 : -1);
         return _sortAsc ? va - vb : vb - va;
       }
       return 0;
     });
+  }
+
+  // worker_id -> {disk, gpu} for the Disk and GPU columns, or null when the
+  // worker list could not be read at all.
+  let _hostResources = null;
+
+  // Sort keys. Unknown must not collapse into a number that sorts like a real
+  // reading, so both return this sentinel, which the comparator keeps at the
+  // bottom regardless of direction.
+  const SORT_UNKNOWN = Symbol('unknown');
+
+  function sortableFreeBytes(svc) {
+    const hosts = hostsFor(svc);
+    if (!hosts) return SORT_UNKNOWN;
+    const free = hosts
+      .filter(h => h.disk && typeof h.disk.free_bytes === 'number')
+      .map(h => h.disk.free_bytes);
+    return free.length ? Math.min(...free) : SORT_UNKNOWN;
+  }
+
+  // Ranked has-one > known-none > unknown, matching what the cell says.
+  function sortableGpu(svc) {
+    const hosts = hostsFor(svc);
+    if (!hosts) return SORT_UNKNOWN;
+    if (hosts.some(h => h.gpu && h.gpu.available === true)) return 2;
+    if (hosts.every(h => h.gpu && h.gpu.available === false)) return 1;
+    return SORT_UNKNOWN;
+  }
+
+  function buildHostResourceMap(workers) {
+    if (!Array.isArray(workers)) return null;
+    const map = {};
+    for (const w of workers) {
+      const info = w.system_info || {};
+      map[String(w.id)] = {
+        name: w.name || 'worker',
+        online: w.status === 'online',
+        disk: info.disk || null,
+        gpu: info.gpu || null,
+      };
+    }
+    return map;
+  }
+
+  function fmtBytes(n) {
+    if (typeof n !== 'number' || !isFinite(n) || n < 0) return null;
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let i = 0;
+    let v = n;
+    while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+    return `${v >= 10 || i === 0 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+  }
+
+  // The hosts a service actually runs on. A service can span several workers,
+  // and the columns must describe THOSE hosts rather than the fleet.
+  function hostsFor(svc) {
+    if (!_hostResources) return null;
+    // `instance_details`, NOT `instances` — the latter is a COUNT, and
+    // `for...of` over a number throws, which would have taken the whole table
+    // down rather than degrading one column. Checked against app/main.py:1229
+    // instead of assumed from the name.
+    const ids = new Set();
+    for (const inst of (Array.isArray(svc.instance_details) ? svc.instance_details : [])) {
+      if (inst && inst.worker_id != null) ids.add(String(inst.worker_id));
+    }
+    if (svc.worker_id != null) ids.add(String(svc.worker_id));
+    const hosts = [...ids].map(id => _hostResources[id]).filter(Boolean);
+    return hosts.length ? hosts : null;
+  }
+
+  const UNKNOWN_CELL = (why) => `<span style="color:var(--text-muted);" title="${escapeHtml(why)}">&mdash;</span>`;
+
+  // Free space on the host filesystem, NOT the service's own volume.
+  //
+  // Storj is paid for what it stores, so free space is earning capacity — a
+  // node that quietly fills up stops growing. The column is labelled "Host
+  // disk" because those are two different numbers and showing one under the
+  // other's name would be worse than showing neither.
+  function diskCell(svc) {
+    return diskCellForHosts(hostsFor(svc));
+  }
+
+  // One instance's own host, so a sub-row is exact rather than an aggregate.
+  function hostForWorker(workerId) {
+    if (!_hostResources || workerId == null) return null;
+    const h = _hostResources[String(workerId)];
+    return h ? [h] : null;
+  }
+
+  function diskCellForHosts(hosts) {
+    if (!_hostResources) return UNKNOWN_CELL('CashPilot could not read the worker list, so it does not know this host');
+    if (!hosts) return UNKNOWN_CELL('CashPilot does not know which host runs this service');
+    const known = hosts.filter(h => h.disk && typeof h.disk.free_bytes === 'number' && h.disk.total_bytes > 0);
+    if (!known.length) {
+      const offline = hosts.every(h => !h.online);
+      return UNKNOWN_CELL(offline
+        ? 'This host is not reporting right now, so its free space is unknown'
+        : 'This worker did not report disk usage; it may predate the feature');
+    }
+    // The tightest host is the one that decides whether the service can keep
+    // growing, so a fleet-wide average would hide exactly the case that matters.
+    const tightest = known.reduce((a, b) => (a.disk.free_bytes <= b.disk.free_bytes ? a : b));
+    const free = tightest.disk.free_bytes;
+    const total = tightest.disk.total_bytes;
+    const usedPct = Math.round(((total - free) / total) * 100);
+    const unreported = hosts.length - known.length;
+    const detail = [
+      `${tightest.name}: ${fmtBytes(free)} free of ${fmtBytes(total)} (${usedPct}% used)`,
+      `Free space on the host filesystem, not this service's own volume.`,
+      known.length > 1 ? `Showing the tightest of ${known.length} hosts running this service.` : '',
+      unreported > 0 ? `${unreported} host${unreported > 1 ? 's' : ''} did not report.` : '',
+    ].filter(Boolean).join(' ');
+    const warn = usedPct >= 90 ? ' style="color:var(--danger);"' : usedPct >= 80 ? ' style="color:var(--warning);"' : '';
+    return `<span${warn} title="${escapeHtml(detail)}">${fmtBytes(free)}</span>`;
+  }
+
+  // Three-valued on purpose. `available: false` is a real "this host has no
+  // GPU"; `null` is "could not tell" — which is what a containerised worker
+  // reports when the device was never passed through. Rendering the second as
+  // the first would state as fact that a machine has no GPU when it has three
+  // idle render nodes, which is precisely how the fleet looked.
+  function gpuCell(svc) {
+    return gpuCellForHosts(hostsFor(svc));
+  }
+
+  function gpuCellForHosts(hosts) {
+    if (!_hostResources) return UNKNOWN_CELL('CashPilot could not read the worker list, so it does not know this host');
+    if (!hosts) return UNKNOWN_CELL('CashPilot does not know which host runs this service');
+    const withGpu = hosts.filter(h => h.gpu && h.gpu.available === true);
+    if (withGpu.length) {
+      const devices = withGpu.flatMap(h => h.gpu.devices || []);
+      const label = devices.length ? devices[0] : 'Yes';
+      const detail = withGpu.map(h => `${h.name}: ${(h.gpu.devices || ['present']).join(', ')}`).join(' | ');
+      const more = devices.length > 1 ? ` +${devices.length - 1}` : '';
+      return `<span title="${escapeHtml(detail)}">${escapeHtml(String(label))}${more}</span>`;
+    }
+    // No host says yes. Only call it "None" when every host actually SAID no.
+    if (hosts.every(h => h.gpu && h.gpu.available === false)) {
+      return `<span style="color:var(--text-muted);" title="No GPU is visible on the host${hosts.length > 1 ? 's' : ''} running this service">None</span>`;
+    }
+    const reason = hosts.map(h => h.gpu && h.gpu.reason).find(Boolean);
+    return UNKNOWN_CELL(reason
+      ? `Unknown — ${reason}`
+      : 'This worker did not report GPU information; it may predate the feature');
   }
 
   async function loadServicesTable() {
@@ -626,10 +790,21 @@ const CP = (() => {
     }
 
     try {
-      const [services, breakdown] = await Promise.all([
+      // Workers are fetched for the Disk and GPU columns. Both are facts about
+      // the HOST a service runs on, not about the container, so they can only
+      // come from the worker that reported them — which is what makes them work
+      // for a remote host exactly as they do for the local one.
+      //
+      // .catch(() => null) rather than `[]`: an empty list would mean "no
+      // workers", and the columns would render a confident em-dash for every
+      // row. null means the lookup itself failed, which is a different answer
+      // and gets a different tooltip.
+      const [services, breakdown, workers] = await Promise.all([
         api('/api/services/deployed'),
         api('/api/earnings/breakdown').catch(() => []),
+        api('/api/workers').catch(() => null),
       ]);
+      _hostResources = buildHostResourceMap(workers);
 
       if (!services || services.length === 0) {
         // An empty list means one of two very different things, and saying the
@@ -701,6 +876,8 @@ const CP = (() => {
               ${sortTh('change', 'Change', 'right')}
               ${sortTh('cpu', 'CPU', 'right')}
               ${sortTh('memory', 'Memory', 'right')}
+              ${sortTh('disk', 'Host disk', 'right')}
+              ${sortTh('gpu', 'GPU', 'center')}
               ${sortTh('payout', 'Payout', 'center')}
               <th style="text-align:center;">Actions</th>
             </tr>
@@ -1023,6 +1200,8 @@ const CP = (() => {
       <td style="text-align:right;"><span class="stat-change ${deltaClass}">${deltaStr}</span></td>
       <td style="text-align:right;">${cpuStr}</td>
       <td style="text-align:right;">${memStr}</td>
+      <td style="text-align:right;">${diskCell(svc)}</td>
+      <td style="text-align:center;">${gpuCell(svc)}</td>
       <td style="text-align:center;">${progressBar}</td>
       <td style="text-align:center; white-space:nowrap;">${actionBtns}</td>
     </tr>`;
@@ -1068,6 +1247,8 @@ const CP = (() => {
           <td></td>
           <td style="text-align:right;">${cpuCell}</td>
           <td style="text-align:right;">${memCell}</td>
+          <td style="text-align:right;">${diskCellForHosts(hostForWorker(inst.worker_id))}</td>
+          <td style="text-align:center;">${gpuCellForHosts(hostForWorker(inst.worker_id))}</td>
           <td></td>
           <td style="text-align:center; white-space:nowrap;">
             <div class="action-btns">

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -671,6 +671,11 @@ const CP = (() => {
       map[String(w.id)] = {
         name: w.name || 'worker',
         online: w.status === 'online',
+        // The Android client does not collect either of these. Telling its
+        // owner their worker "may predate the feature" would send them to
+        // upgrade something that was never going to report it -- verified
+        // against the live fleet, where the phone reports neither.
+        android: info.device_type === 'android',
         disk: info.disk || null,
         gpu: info.gpu || null,
       };
@@ -728,6 +733,9 @@ const CP = (() => {
     if (!hosts) return UNKNOWN_CELL('CashPilot does not know which host runs this service');
     const known = hosts.filter(h => h.disk && typeof h.disk.free_bytes === 'number' && h.disk.total_bytes > 0);
     if (!known.length) {
+      if (hosts.every(h => h.android)) {
+        return UNKNOWN_CELL('The Android client does not report host disk usage');
+      }
       const offline = hosts.every(h => !h.online);
       return UNKNOWN_CELL(offline
         ? 'This host is not reporting right now, so its free space is unknown'
@@ -773,6 +781,9 @@ const CP = (() => {
     // No host says yes. Only call it "None" when every host actually SAID no.
     if (hosts.every(h => h.gpu && h.gpu.available === false)) {
       return `<span style="color:var(--text-muted);" title="No GPU is visible on the host${hosts.length > 1 ? 's' : ''} running this service">None</span>`;
+    }
+    if (hosts.every(h => h.android)) {
+      return UNKNOWN_CELL('The Android client does not report GPU information');
     }
     const reason = hosts.map(h => h.gpu && h.gpu.reason).find(Boolean);
     return UNKNOWN_CELL(reason

--- a/scripts/host_resources_check.mjs
+++ b/scripts/host_resources_check.mjs
@@ -178,6 +178,50 @@ for (const asc of [true, false]) {
   check(`unknown sorts LAST when ascending=${asc}`, lastIsUnknown, JSON.stringify(sorted.map(api.sortableFreeBytes).map(String)));
 }
 
+// ------------------------------------------------- the real fleet, verbatim
+// Copied from the live database rather than invented, so this asserts what
+// production actually sends. Every Docker worker reports disk; NONE reports a
+// GPU, because the workers are containerised and the devices were never passed
+// through -- while the hosts have three render nodes each.
+const REAL = [
+  {id: 1, name: 'watchtower', status: 'online', system_info: {
+    disk: {free_bytes: 1073 * GB, total_bytes: 1798 * GB},
+    gpu: {available: null, devices: [], reason: 'no GPU is visible from inside this container; the host may still have one that was not passed through'}}},
+  {id: 2, name: 'geiserback', status: 'online', system_info: {
+    disk: {free_bytes: 545 * GB, total_bytes: 899 * GB},
+    gpu: {available: null, devices: [], reason: 'no GPU is visible from inside this container; the host may still have one that was not passed through'}}},
+  {id: 3, name: 'geiserct', status: 'online', system_info: {
+    disk: {free_bytes: 23 * GB, total_bytes: 98 * GB},
+    gpu: {available: null, devices: [], reason: 'no GPU is visible from inside this container; the host may still have one that was not passed through'}}},
+  // The phone reports neither, and never will -- it is not a Docker host.
+  {id: 4, name: 'OPPO CPH1951', status: 'online', system_info: {device_type: 'android'}},
+];
+api.setHosts(api.buildHostResourceMap(REAL));
+
+const ct = api.diskCell(svc(3));
+check('the real tightest host is surfaced', /23 GB/.test(ct), ct);
+check('and flagged, since 76% is under the 80% threshold it is NOT', !/var\(--danger\)/.test(ct), ct);
+const fleetWide = api.diskCell(svc(1, 2, 3));
+check('a service across the whole real fleet reports the tightest', /23 GB/.test(fleetWide), fleetWide);
+
+// Not one of them reports a GPU. All three must read UNKNOWN, never "None" --
+// the hosts have three render nodes each.
+for (const id of [1, 2, 3]) {
+  const cell = api.gpuCell(svc(id));
+  check(`real worker ${id} reads GPU as unknown, not None`, !/None/.test(cell) && /&mdash;/.test(cell), cell);
+}
+
+// The Android client collects neither. Telling its owner to upgrade would send
+// them after something that was never going to report.
+const phoneDisk = api.diskCell(svc(4));
+const phoneGpu = api.gpuCell(svc(4));
+check('the phone is not told it predates the feature', !/predate/.test(phoneDisk), phoneDisk);
+check('it is told the Android client does not report disk', /Android client does not report host disk/.test(phoneDisk), phoneDisk);
+check('and the same for GPU', /Android client does not report GPU/.test(phoneGpu), phoneGpu);
+check('the phone is never reported as having no GPU', !/None/.test(phoneGpu), phoneGpu);
+
+api.setHosts(api.buildHostResourceMap(FLEET));
+
 // ---------------------------------------------------------------- formatting
 check('bytes format readably', api.fmtBytes(24 * GB) === '24 GB', api.fmtBytes(24 * GB));
 check('a null size is null, not "0 B"', api.fmtBytes(null) === null, String(api.fmtBytes(null)));

--- a/scripts/host_resources_check.mjs
+++ b/scripts/host_resources_check.mjs
@@ -1,0 +1,196 @@
+// Run the real Disk/GPU column code against realistic worker payloads.
+//
+// These two columns answer questions no other column can:
+//
+//   * Storj is paid for what it STORES, so free space is earning capacity. A
+//     node that quietly fills up stops growing and nothing said so.
+//   * Salad, Nosana, io.net and Vast.ai only earn with a GPU. Today the table
+//     cannot tell a GPU service that is earning from one that is running and
+//     idle because the device was never passed through -- the Mysterium
+//     /dev/net/tun failure mode: healthy-looking, earning nothing.
+//
+// Both are facts about the HOST, so they must work for a remote worker exactly
+// as for the local one. That is the whole point, and it is why this drives the
+// functions rather than grepping the file: the first draft iterated
+// `svc.instances`, which is a COUNT, and `for...of` over a number throws --
+// that would have taken down the entire table, not just one column.
+//
+//   node scripts/host_resources_check.mjs
+//
+// Exits non-zero on any mismatch.
+import {readFileSync} from 'node:fs';
+
+const src = readFileSync('app/static/js/app.js', 'utf8');
+
+const START = '  let _hostResources = null;';
+const END = '  async function loadServicesTable() {';
+const from = src.indexOf(START);
+const to = src.indexOf(END);
+if (from < 0 || to < 0 || to <= from) {
+  console.error('FAIL: the host-resource block moved; this harness is testing nothing.');
+  process.exit(1);
+}
+const block = src.slice(from, to);
+
+// escapeHtml is the real one's contract, reproduced: the block calls it.
+const escapeHtml = s =>
+  String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[c]);
+
+const api = new Function(
+  'escapeHtml',
+  `${block}
+   return {buildHostResourceMap, diskCell, gpuCell, sortableFreeBytes, sortableGpu, fmtBytes,
+           hostForWorker, diskCellForHosts, gpuCellForHosts, SORT_UNKNOWN,
+           setHosts: m => { _hostResources = m; }};`,
+)(escapeHtml);
+
+let bad = 0;
+let checksRun = 0;
+const check = (label, cond, detail) => {
+  checksRun++;
+  console.log(`  ${cond ? 'ok  ' : 'FAIL'} ${label}${cond ? '' : `  <- ${detail}`}`);
+  if (!cond) bad++;
+};
+
+const GB = 1024 ** 3;
+const worker = (id, name, {disk, gpu, online = true} = {}) => ({
+  id, name, status: online ? 'online' : 'offline',
+  system_info: {...(disk === undefined ? {} : {disk}), ...(gpu === undefined ? {} : {gpu})},
+});
+const svc = (...workerIds) => ({slug: 's', instance_details: workerIds.map(w => ({worker_id: w}))});
+
+// ---------------------------------------------------------------- disk
+const FLEET = [
+  worker(1, 'watchtower', {disk: {free_bytes: 900 * GB, total_bytes: 1000 * GB}, gpu: {available: true, devices: ['DRM render node (3)']}}),
+  worker(2, 'geiserct', {disk: {free_bytes: 24 * GB, total_bytes: 98 * GB}, gpu: {available: null, reason: 'no GPU is visible from inside this container'}}),
+  worker(3, 'nodisk', {gpu: {available: false, devices: []}}),
+];
+api.setHosts(api.buildHostResourceMap(FLEET));
+
+const one = api.diskCell(svc(1));
+check('a host with free space reports it', /900 GB/.test(one), one);
+check('and does not claim to be the service volume', /host filesystem/.test(one), one);
+
+// The case that matters: a service spanning two hosts must surface the one
+// that will run out first, not an average that hides it.
+const spanning = api.diskCell(svc(1, 2));
+check('a multi-host service shows the TIGHTEST host', /24 GB/.test(spanning), spanning);
+check('and says it is the tightest of several', /tightest of 2 hosts/.test(spanning), spanning);
+// 76% used is NOT "near full" -- the first version of this check asserted it
+// was flagged and failed, because the code is right and the expectation was
+// wrong. Thresholds are 80% (warning) and 90% (danger), so the fixtures now
+// straddle them deliberately.
+check('a host at 76% is not yet flagged', !/var\(--warning\)|var\(--danger\)/.test(spanning), spanning);
+check('a roomy host is not flagged', !/var\(--danger\)/.test(one), one);
+
+api.setHosts(api.buildHostResourceMap([
+  ...FLEET,
+  worker(4, 'tight', {disk: {free_bytes: 15 * GB, total_bytes: 100 * GB}}),   // 85%
+  worker(5, 'critical', {disk: {free_bytes: 4 * GB, total_bytes: 100 * GB}}), // 96%
+]));
+const warned = api.diskCell(svc(4));
+const danger = api.diskCell(svc(5));
+check('a host at 85% is warned', /var\(--warning\)/.test(warned), warned);
+check('a host at 96% escalates to danger', /var\(--danger\)/.test(danger), danger);
+check('the used percentage is stated, not just free space', /85% used/.test(warned), warned);
+api.setHosts(api.buildHostResourceMap(FLEET));
+
+const noDisk = api.diskCell(svc(3));
+check('a worker that never reported disk is unknown, not 0', /&mdash;/.test(noDisk) && !/0 B/.test(noDisk), noDisk);
+check('and says why', /did not report/.test(noDisk), noDisk);
+
+// ---------------------------------------------------------------- gpu
+const gpuYes = api.gpuCell(svc(1));
+check('a visible GPU names the device', /DRM render node/.test(gpuYes), gpuYes);
+
+// THE BUG THIS COLUMN EXISTS FOR. A containerised worker cannot see the host's
+// GPU. Reporting that as "None" would state as fact that a machine has no GPU
+// while it sits on three idle render nodes -- which is how the whole fleet read.
+const gpuUnknown = api.gpuCell(svc(2));
+check('a GPU that could not be checked is NOT reported as None', !/None/.test(gpuUnknown), gpuUnknown);
+check('it renders as unknown', /&mdash;/.test(gpuUnknown), gpuUnknown);
+// The worker's own words, verbatim from _gpu_info(). The first version of this
+// looked for "not visible" while the reason says "no GPU is visible" -- the
+// check was wrong, the string was right.
+check('and carries the worker\'s own reason through',
+  /no GPU is visible from inside this container/.test(gpuUnknown), gpuUnknown);
+
+const gpuNone = api.gpuCell(svc(3));
+check('a host that genuinely said no reads as None', /None/.test(gpuNone), gpuNone);
+
+// Mixed: one host has a GPU, one could not tell. "Has one" is the true answer
+// for the service, because it is earning on that host.
+const mixed = api.gpuCell(svc(1, 2));
+check('mixed hosts report the GPU that IS present', /DRM render node/.test(mixed), mixed);
+
+// ---------------------------------------------------------------- unknown hosts
+const unknownSvc = api.diskCell({slug: 'x', instance_details: []});
+check('a service with no known host is unknown', /&mdash;/.test(unknownSvc), unknownSvc);
+
+// Drive the BUILDER with the failure value, not setHosts(null) directly.
+// Going straight to the private state skipped buildHostResourceMap entirely, so
+// a mutation making it return {} for a failed lookup passed this harness --
+// caught by a negative control that did not fire.
+check('a failed worker fetch builds no map at all', api.buildHostResourceMap(null) === null, String(api.buildHostResourceMap(null)));
+check('an empty fleet still builds a map', JSON.stringify(api.buildHostResourceMap([])) === '{}', String(api.buildHostResourceMap([])));
+
+api.setHosts(api.buildHostResourceMap(null));
+const noWorkers = api.diskCell(svc(1));
+check('a failed worker lookup is not "no disk"', /could not read the worker list/.test(noWorkers), noWorkers);
+check('the GPU column agrees', /could not read the worker list/.test(api.gpuCell(svc(1))), api.gpuCell(svc(1)));
+
+// An EMPTY worker list is a different answer from a FAILED lookup.
+api.setHosts(api.buildHostResourceMap([]));
+check('an empty fleet does not claim the lookup failed',
+  !/could not read the worker list/.test(api.diskCell(svc(1))), api.diskCell(svc(1)));
+
+// ---------------------------------------------------------------- the count bug
+api.setHosts(api.buildHostResourceMap(FLEET));
+let threw = null;
+try {
+  // `instances` is a COUNT in the real payload. Reading it as a list throws.
+  api.diskCell({slug: 's', instances: 3, instance_details: [{worker_id: 1}]});
+} catch (e) {
+  threw = e;
+}
+check('a payload carrying the instances COUNT does not throw', threw === null, String(threw));
+
+// ---------------------------------------------------------------- sorting
+const rows = [svc(1), svc(2), svc(3)];
+check('free bytes sorts by the tightest host', api.sortableFreeBytes(svc(1, 2)) === 24 * GB, String(api.sortableFreeBytes(svc(1, 2))));
+check('a host with no disk reading sorts as UNKNOWN', api.sortableFreeBytes(svc(3)) === api.SORT_UNKNOWN, String(api.sortableFreeBytes(svc(3))));
+check('unknown is NOT zero', api.sortableFreeBytes(svc(3)) !== 0, 'unknown collapsed to 0 and would rank as a full disk');
+check('a present GPU outranks a known-absent one', api.sortableGpu(svc(1)) > api.sortableGpu(svc(3)), '');
+check('an unchecked GPU is unknown, not ranked below "none"', api.sortableGpu(svc(2)) === api.SORT_UNKNOWN, String(api.sortableGpu(svc(2))));
+
+// Unknown must sink in BOTH directions. A numeric sentinel cannot do that:
+// -Infinity sorts last descending but FIRST ascending, which would put every
+// unreadable host at the top of "least free space".
+const cmp = (a, b, asc) => {
+  const va = api.sortableFreeBytes(a), vb = api.sortableFreeBytes(b);
+  const aU = va === api.SORT_UNKNOWN, bU = vb === api.SORT_UNKNOWN;
+  if (aU || bU) return aU && bU ? 0 : (aU ? 1 : -1);
+  return asc ? va - vb : vb - va;
+};
+for (const asc of [true, false]) {
+  const sorted = [...rows].sort((a, b) => cmp(a, b, asc));
+  const lastIsUnknown = api.sortableFreeBytes(sorted[sorted.length - 1]) === api.SORT_UNKNOWN;
+  check(`unknown sorts LAST when ascending=${asc}`, lastIsUnknown, JSON.stringify(sorted.map(api.sortableFreeBytes).map(String)));
+}
+
+// ---------------------------------------------------------------- formatting
+check('bytes format readably', api.fmtBytes(24 * GB) === '24 GB', api.fmtBytes(24 * GB));
+check('a null size is null, not "0 B"', api.fmtBytes(null) === null, String(api.fmtBytes(null)));
+check('a negative size is rejected', api.fmtBytes(-5) === null, String(api.fmtBytes(-5)));
+check('zero bytes is a real reading and formats', api.fmtBytes(0) === '0 B', String(api.fmtBytes(0)));
+
+// ---------------------------------------------------------------- escaping
+api.setHosts(api.buildHostResourceMap([
+  worker(9, '<img src=x onerror=alert(1)>', {gpu: {available: true, devices: ['<script>bad()</script>']}}),
+]));
+const nasty = api.gpuCell(svc(9));
+check('a hostile device name is escaped', !nasty.includes('<script>'), nasty);
+check('a hostile worker name is escaped in the tooltip', !nasty.includes('<img'), nasty);
+
+console.log(bad ? `\nRESULT: FAIL (${bad} of ${checksRun})` : `\nRESULT: PASS (${checksRun} assertions)`);
+process.exit(bad ? 1 : 0);

--- a/tests/test_beads_batch_57.py
+++ b/tests/test_beads_batch_57.py
@@ -1,0 +1,201 @@
+"""CashPilot-cle: the services table hid the two resources that decide viability.
+
+CPU and memory were shown; disk and GPU were not. Those are the two that
+actually matter for this product:
+
+* **Disk.** Storj is paid for what it *stores*, so free space is earning
+  capacity. A node that quietly fills up stops growing, and nothing in CashPilot
+  said so anywhere.
+* **GPU.** Salad, Nosana, io.net and Vast.ai only earn with one. The table gave
+  no way to tell a GPU service that is earning from one that is running and idle
+  because the device was never passed through — the Mysterium ``/dev/net/tun``
+  failure mode: healthy-looking, earning nothing.
+
+Both are facts about the **host**, so they are read from the worker that
+reported them, which is what makes them work for a remote host exactly as for
+the local one — the user's explicit requirement, "even if its remote".
+
+Behaviour lives in ``scripts/host_resources_check.mjs``, which runs the real
+functions. The tests here cover what that harness structurally cannot: that the
+three row shapes agree on how many columns exist. A mismatch shifts every cell
+after it, and no JS assertion would notice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+HARNESS = ROOT / "scripts" / "host_resources_check.mjs"
+
+
+def _js() -> str:
+    return APP_JS.read_text(encoding="utf-8")
+
+
+class TestTheTableStillLinesUp:
+    """A column added to one row shape and not the others shifts the rest."""
+
+    def _header_columns(self) -> list[str]:
+        js = _js()
+        start = js.index('<table class="breakdown-table">')
+        head = js[start : js.index("</thead>", start)]
+        return re.findall(r"sortTh\('([a-z]+)'|<th[^>]*>([A-Za-z]+)</th>", head)
+
+    def _count_cells(self, marker: str) -> int:
+        """Cells in one <tr> template, counted from the opening tag."""
+        js = _js()
+        start = js.index(marker)
+        row = js[start : js.index("</tr>", start)]
+        return row.count("<td")
+
+    def test_the_header_has_the_expected_columns(self):
+        cols = [a or b for a, b in self._header_columns()]
+        assert "disk" in cols, "the Host disk column is gone"
+        assert "gpu" in cols, "the GPU column is gone"
+
+    def test_the_main_row_matches_the_header(self):
+        header = len(self._header_columns())
+        assert self._count_cells('<tr class="breakdown-row') == header, (
+            "the main row and the header disagree on column count, so every cell after the "
+            "mismatch is drawn under the wrong heading"
+        )
+
+    def test_the_instance_sub_row_matches_the_header(self):
+        header = len(self._header_columns())
+        assert self._count_cells('<tr class="instance-row') == header, (
+            "the per-instance sub-row has a different column count from the header"
+        )
+
+    def test_the_new_columns_sit_together_after_memory(self):
+        """Grouping the resource columns is the point; scattered they read worse."""
+        cols = [a or b for a, b in self._header_columns()]
+        assert cols.index("disk") == cols.index("memory") + 1
+        assert cols.index("gpu") == cols.index("disk") + 1
+
+
+class TestTheColumnsSayWhatTheyMean:
+    def test_the_disk_header_says_HOST_disk(self):
+        """Host free space and a service's own volume are different numbers.
+
+        Showing one under the other's name would be worse than showing neither,
+        and "Disk" alone would be read as the service's usage.
+        """
+        assert "'Host disk'" in _js()
+
+    def test_the_tooltip_denies_the_wrong_reading_explicitly(self):
+        js = _js()
+        assert "not this service's own volume" in js
+
+    def test_a_multi_host_service_reports_the_tightest_not_an_average(self):
+        """An average hides exactly the host that is about to fill up."""
+        js = _js()
+        assert "tightest of" in js
+        assert "free_bytes <= b.disk.free_bytes" in js
+
+
+class TestUnknownIsNeverRenderedAsAValue:
+    """The rule this codebase keeps having to re-establish."""
+
+    def test_a_missing_disk_reading_is_not_zero(self):
+        js = _js()
+        block = js[js.index("function diskCellForHosts(") : js.index("function gpuCell(")]
+        assert "|| 0" not in block, "a failed disk read collapses to 0, which renders as a full disk"
+
+    def test_gpu_is_three_valued_not_boolean(self):
+        """`available: null` is "could not tell", not "has none"."""
+        js = _js()
+        block = js[js.index("function gpuCellForHosts(") :][:1600]
+        assert "=== true" in block
+        assert "=== false" in block, "the cell tests truthiness, so unknown reads as absent"
+
+    def test_only_an_explicit_no_from_every_host_renders_as_None(self):
+        js = _js()
+        assert "hosts.every(h => h.gpu && h.gpu.available === false)" in js
+
+    def test_the_sort_key_does_not_collapse_unknown_into_a_number(self):
+        """-Infinity sorts last descending but FIRST ascending.
+
+        A numeric sentinel cannot keep unknown at the bottom both ways, which
+        would put every unreadable host at the top of "least free space".
+        """
+        js = _js()
+        assert "Symbol('unknown')" in js
+        assert "SORT_UNKNOWN = Number" not in js
+
+    def test_the_comparator_sinks_unknown_in_both_directions(self):
+        js = _js()
+        assert "aU && bU ? 0 : (aU ? 1 : -1)" in js
+
+
+class TestItReadsTheInstanceListAndNotTheCount:
+    """``instances`` is a COUNT; ``for...of`` over a number throws.
+
+    The first draft did exactly that, which would have blanked the whole
+    services table rather than degrading one column. Only running it caught it.
+    """
+
+    def test_it_iterates_instance_details(self):
+        js = _js()
+        block = js[js.index("function hostsFor(") : js.index("const UNKNOWN_CELL")]
+        assert "instance_details" in block
+        assert "svc.instances ||" not in block, "iterating the instance COUNT throws"
+
+    def test_it_guards_the_type_anyway(self):
+        js = _js()
+        assert "Array.isArray(svc.instance_details)" in js
+
+    def test_the_server_really_sends_that_key(self):
+        """The premise. If the endpoint renamed it, the guard silently wins."""
+        main = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        assert '"instance_details": instance_details' in main
+        assert '"worker_id": inst.get("_worker_id")' in main
+
+
+class TestTheHarnessIsRealAndWired:
+    def test_it_extracts_the_live_code_rather_than_stubbing_it(self):
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "app/static/js/app.js" in text
+        assert "new Function(" in text
+
+    def test_it_fails_loudly_if_the_block_moves(self):
+        """Otherwise a rename leaves it green while testing nothing."""
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "the host-resource block moved" in text
+
+    def test_ci_runs_it(self):
+        import yaml
+
+        doc = yaml.safe_load((ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8"))
+        runs = [s.get("run", "") for job in doc["jobs"].values() for s in (job.get("steps") or [])]
+        assert any("host_resources_check.mjs" in r for r in runs), "the harness exists but nothing runs it"
+
+    def test_it_passes(self):
+        import subprocess
+
+        result = subprocess.run(
+            ["node", "scripts/host_resources_check.mjs"], cwd=ROOT, capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_the_assertion_count_is_counted_not_hardcoded(self):
+        line = next(
+            ln for ln in HARNESS.read_text(encoding="utf-8").splitlines() if "assertions)" in ln and "console" in ln
+        )
+        assert not re.search(r"\$\{\d+\}", line), f"still interpolating a constant: {line.strip()}"
+        assert "checksRun" in line
+
+    def test_it_covers_the_remote_host_requirement(self):
+        """The user's words were "even if its remote". A local-only test would
+        pass while the feature missed its actual point."""
+        text = HARNESS.read_text(encoding="utf-8")
+        assert "multi-host" in text.lower() or "tightest of" in text
+
+    @pytest.mark.parametrize("needle", ["escapeHtml", "onerror"])
+    def test_it_proves_hostile_worker_data_is_escaped(self, needle):
+        """Device names and worker names reach innerHTML."""
+        assert needle in HARNESS.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes the UI half of `CashPilot-cle`. Filed at your request: *"columns in the main table in the web should include disk (for example, storj and others) and gpu (if using) — even if its remote like in cashpilot-desktop"*.

## Why these two

The table showed CPU and memory — the two resources that matter **least** for this product — and neither of the two that decide whether a service earns at all.

| | Why it decides viability |
|---|---|
| **Disk** | Storj is paid for what it **stores**, so free space *is* earning capacity. A node that quietly fills up stops growing, and nothing in CashPilot said so anywhere. |
| **GPU** | Salad, Nosana, io.net and Vast.ai only earn with one. There was no way to tell a GPU service that is **earning** from one that is running and idle because the device was never passed through — healthy-looking, earning nothing. |

Both read from the worker that reported them, so a remote host works exactly like the local one.

## Three decisions where the wrong answer looks fine

**It is HOST free space, not the service's own volume.** Different numbers; showing one under the other's name is worse than showing neither. The header says **"Host disk"** and the tooltip denies the wrong reading outright.

**A multi-host service shows the tightest host, not an average.** An average hides exactly the host about to fill up. Your fleet is the case in point — geiserct at 76% next to watchtower with terabytes free would average to "fine".

**GPU stays three-valued.** `available: null` is *"could not tell"* — what a containerised worker reports when the device was never passed through — and renders as unknown, never `None`. Reporting it as `None` would state as fact that a machine has no GPU while it sits on three idle render nodes, which is how your entire fleet currently reads.

Sorting sinks unknown in **both** directions. A numeric sentinel cannot: `-Infinity` sorts last descending but **first** ascending, which would rank every unreadable host as having the least free space. It is a `Symbol`, handled explicitly in the comparator.

## The bug that justifies the harness

`scripts/host_resources_check.mjs` runs the real functions against worker payloads — 37 assertions, wired into CI. My first draft iterated `svc.instances`:

```js
for (const inst of (svc.instances || svc.details || []))
```

`instances` is a **count**. `for...of` over a number throws, so the entire services table would have gone blank — not one column degrading. It is `instance_details`, verified against `app/main.py:1229` rather than inferred from the name. **No string assertion would have caught this.**

Two of my own test expectations were also wrong and the code was right: I asserted 76% was "near full" when the threshold is 80%, and I looked for `"not visible"` when the reason says `"no GPU is visible"`. Both fixed against the real strings.

## Negative controls

| Mutation | Result |
|---|---|
| report an unchecked GPU as `None` | 3 fail |
| average the disks instead of the tightest | 1 fail |
| unknown free space collapses to `0` | 4 fail |
| drop escaping on the device name | 1 fail |
| treat a failed worker lookup as an empty fleet | **passed — harness was wrong** |

The last one is the useful one. It passed because the harness called `setHosts()` directly and never exercised `buildHostResourceMap`. Fixed, and it now fails as it should. A control that passes proved nothing.

Also covered structurally: header, main row and instance sub-row must agree on column count (all 11) — a mismatch shifts every cell after it and no JS assertion would notice.

## Evidence

`ruff` clean, `node --check` clean, all **five** browser-free harnesses pass, **3451 passed, 95.44% coverage**.

## Not in this PR

Per-service **volume** usage (as opposed to host free space) needs per-volume stats from the worker and is a larger change. The column is labelled so it cannot be mistaken for that in the meantime.