### PR TITLE
fix: the fleet page turned "the phone could not tell" into "stopped"

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1135,7 +1135,23 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
     # service that is running on one worker and unknown on another reports
     # running -- a known fact beats a blind spot. It only wins when nothing else
     # is known, which is the honest answer at that point.
-    _STATUS_PRIORITY = {"running": 0, "restarting": 1, "exited": 2, "created": 3, "dead": 4, "unknown": 5}
+    # "stopped" is what _android_app_status emits; Docker's own word is "exited".
+    # It MUST be listed: an unlisted status falls through to .get(cur, 9), and
+    # with unknown ranked 5 a blind spot would have beaten a definite stopped --
+    # the exact inverse of the rule below. (CodeRabbit, PR #252.)
+    #
+    # "unknown" ranks LAST on purpose: best_status picks the lowest number, so a
+    # service running on one worker and unknown on another reports running -- a
+    # known fact beats a blind spot. It only wins when nothing else is known.
+    _STATUS_PRIORITY = {
+        "running": 0,
+        "restarting": 1,
+        "exited": 2,
+        "stopped": 2,
+        "created": 3,
+        "dead": 4,
+        "unknown": 5,
+    }
     slug_agg: dict[str, dict[str, Any]] = {}
     for s in statuses:
         slug = s["slug"]

--- a/app/main.py
+++ b/app/main.py
@@ -238,7 +238,15 @@ async def _get_all_worker_containers(workers: list[dict[str, Any]] | None = None
                         {
                             "slug": slug,
                             "name": a.get("slug", slug),
-                            "status": "running" if a.get("running") else "stopped",
+                            # Three-valued, matching what the Android client
+                            # now sends. `running` is None when the phone could
+                            # not determine it -- every detection signal degrades
+                            # to false when its permissions are denied -- and
+                            # `"running" if a.get("running") else "stopped"`
+                            # turned that into a confident "stopped", so the
+                            # fleet page stated the user's earning apps had died
+                            # when the device simply could not see them.
+                            "status": _android_app_status(a.get("running")),
                             "image": "",
                             "cpu_percent": 0,
                             "memory_mb": 0,
@@ -1123,7 +1131,11 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
         logger.warning("Could not load config for collector-setup check: %s", exc)
 
     # Aggregate by slug: one row per service
-    _STATUS_PRIORITY = {"running": 0, "restarting": 1, "exited": 2, "created": 3, "dead": 4}
+    # "unknown" ranks LAST on purpose: best_status picks the lowest number, so a
+    # service that is running on one worker and unknown on another reports
+    # running -- a known fact beats a blind spot. It only wins when nothing else
+    # is known, which is the honest answer at that point.
+    _STATUS_PRIORITY = {"running": 0, "restarting": 1, "exited": 2, "created": 3, "dead": 4, "unknown": 5}
     slug_agg: dict[str, dict[str, Any]] = {}
     for s in statuses:
         slug = s["slug"]
@@ -3596,6 +3608,19 @@ class WorkerHeartbeat(BaseModel):
     containers: list[dict[str, Any]] = []
     apps: list[dict[str, Any]] = []
     system_info: dict[str, Any] = {}
+
+
+def _android_app_status(running: object) -> str:
+    """How an Android app's three-valued ``running`` reads as a container status.
+
+    ``None`` is UNKNOWN and must not become ``"stopped"``. The phone reports it
+    when it cannot see -- notification-listener and usage access are what make
+    detection possible at all, and without them every signal reads false. A
+    worker on an older client that never sends null is unaffected.
+    """
+    if running is None:
+        return "unknown"
+    return "running" if running else "stopped"
 
 
 async def _earnings_for_worker(body: WorkerHeartbeat, days: int = 30) -> dict[str, Any] | None:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -780,6 +780,10 @@ img { max-width: 100%; }
   background: var(--error-soft);
   color: var(--error);
 }
+.badge-unknown {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
 .badge-error {
   background: var(--warning-soft);
   color: var(--warning);
@@ -821,6 +825,11 @@ img { max-width: 100%; }
   animation: pulse-glow 2s ease-in-out infinite;
 }
 .status-dot.stopped { background: var(--error); }
+/* "Unknown" is amber, deliberately NOT the stopped red. The two are different
+   claims: stopped means the service should be reporting and is not; unknown
+   means the worker could not see it. Colouring them alike is what made an
+   Android permission problem look like a fleet of dead apps. */
+.status-dot.unknown { background: var(--warning); }
 .status-dot.error   { background: var(--warning); }
 .status-dot.external { background: var(--accent-secondary); }
 .badge-external {

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.13
+    image: drumsergio/cashpilot:1.14
     pull_policy: always
     container_name: cashpilot-ui
     # Loopback by default (the UI commands the Docker-socket worker). Set
@@ -38,7 +38,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.13
+    image: drumsergio/cashpilot-worker:1.14
     pull_policy: always
     container_name: cashpilot-worker
     # The worker exposes a Docker-socket-backed API (deploy/stop/remove any
@@ -105,7 +105,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:1.13
+#      image: drumsergio/cashpilot-worker:1.14
 #      pull_policy: always
 #      container_name: cashpilot-worker
 #      # Docker-socket-backed API = full host control. Bind a PRIVATE/VPN interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.13
+    image: drumsergio/cashpilot:1.14
     pull_policy: always
     container_name: cashpilot-ui
     # Published on loopback by default: the dashboard can command the Docker-socket
@@ -51,7 +51,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.13
+    image: drumsergio/cashpilot-worker:1.14
     pull_policy: always
     container_name: cashpilot-worker
     expose:

--- a/tests/test_beads_batch_59.py
+++ b/tests/test_beads_batch_59.py
@@ -78,9 +78,15 @@ class TestAggregationPrefersAKnownFact:
     """``best_status`` picks the lowest priority number across instances."""
 
     def _priority(self) -> dict:
-        text = MAIN.read_text(encoding="utf-8")
-        line = next(ln for ln in text.splitlines() if "_STATUS_PRIORITY = {" in ln)
-        return ast.literal_eval(line.split("=", 1)[1].strip())
+        """Read the table out of the source, however it is formatted."""
+        tree = ast.parse(MAIN.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            targets = getattr(node, "targets", [])
+            if isinstance(node, ast.Assign) and any(
+                isinstance(x, ast.Name) and x.id == "_STATUS_PRIORITY" for x in targets
+            ):
+                return ast.literal_eval(node.value)
+        raise AssertionError("_STATUS_PRIORITY not found")
 
     def test_unknown_is_ranked_explicitly(self):
         """Relying on the `.get(cur, 9)` fallback leaves it undeclared."""
@@ -93,6 +99,28 @@ class TestAggregationPrefersAKnownFact:
         for status, rank in priority.items():
             if status != "unknown":
                 assert rank < unknown, f"{status!r} ranks worse than unknown, so a blind spot would win"
+
+    def test_every_status_this_module_emits_is_ranked(self):
+        """The flaw that let a real bug through.
+
+        The check above iterates the table's OWN keys, so it can only compare
+        statuses that are already in it — and ``"stopped"`` was not. Unlisted, it
+        fell through to ``.get(cur, 9)`` and LOST to ``"unknown"`` at 5, which is
+        the exact inverse of the rule. A table validated against itself proves
+        nothing; this validates it against what the code actually produces.
+        (CodeRabbit, PR #252.)
+        """
+        from app.main import _android_app_status
+
+        priority = self._priority()
+        emitted = {_android_app_status(v) for v in (None, True, False)}
+        missing = emitted - set(priority)
+        assert not missing, f"emitted but unranked, so it falls back to 9 and loses to unknown: {missing}"
+
+    def test_a_definite_stopped_beats_a_blind_spot(self):
+        """The specific inversion, stated as its own assertion."""
+        priority = self._priority()
+        assert priority["stopped"] < priority["unknown"]
 
     def test_running_is_still_the_best_answer(self):
         priority = self._priority()

--- a/tests/test_beads_batch_59.py
+++ b/tests/test_beads_batch_59.py
@@ -1,0 +1,121 @@
+"""The server turned "the phone could not tell" into "stopped".
+
+``app/main.py`` built each Android app's row with::
+
+    "status": "running" if a.get("running") else "stopped"
+
+The Android client now sends ``running: null`` when it cannot determine the
+answer — every one of its detection signals degrades to ``false`` when
+notification and usage access are denied, so it used to report *every* earning
+app as stopped. That was fixed on the phone (CashPilot-android-1oo); this is the
+other half, because a falsy ``None`` landed in the same ``else`` branch here and
+the fleet page inherited the identical false claim.
+
+The distinction is not cosmetic. **Stopped** means the service should be
+reporting and is not — restart it. **Unknown** means the worker could not see —
+grant the permission. Collapsing them sends a user to fix the wrong thing.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = ROOT / "app" / "main.py"
+CSS = ROOT / "app" / "static" / "css" / "style.css"
+APP_JS = ROOT / "app" / "static" / "js" / "app.js"
+
+
+class TestUnknownIsNotStopped:
+    @pytest.mark.parametrize(
+        ("running", "expected"),
+        [(None, "unknown"), (True, "running"), (False, "stopped")],
+        ids=["could-not-tell", "alive", "really-stopped"],
+    )
+    def test_the_three_answers_stay_three(self, running, expected):
+        from app.main import _android_app_status
+
+        assert _android_app_status(running) == expected
+
+    def test_a_real_stopped_is_still_reported(self):
+        """The fix is worthless if a genuine negative stops being surfaced."""
+        from app.main import _android_app_status
+
+        assert _android_app_status(False) == "stopped"
+
+    def test_no_two_answers_collapse(self):
+        from app.main import _android_app_status
+
+        answers = [_android_app_status(v) for v in (None, True, False)]
+        assert len(set(answers)) == 3, f"two states share a spelling: {answers}"
+
+    def test_the_old_truthiness_expression_is_gone(self):
+        """The old form put ``None`` in the ``else`` branch alongside ``False``.
+
+        Checked against EXECUTABLE lines only. The comment explaining the fix
+        necessarily quotes the expression it replaced, and the first version of
+        this test matched its own explanation — the fourth time that trap has
+        appeared in this project.
+        """
+        code = [ln for ln in MAIN.read_text(encoding="utf-8").splitlines() if not ln.lstrip().startswith("#")]
+        offenders = [ln.strip() for ln in code if 'if a.get("running") else' in ln]
+        assert not offenders, offenders
+
+    def test_the_heartbeat_path_uses_the_helper(self):
+        """Structural: the row builder must call it, not re-derive the status."""
+        tree = ast.parse(MAIN.read_text(encoding="utf-8"))
+        calls = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "_android_app_status" in calls
+
+
+class TestAggregationPrefersAKnownFact:
+    """``best_status`` picks the lowest priority number across instances."""
+
+    def _priority(self) -> dict:
+        text = MAIN.read_text(encoding="utf-8")
+        line = next(ln for ln in text.splitlines() if "_STATUS_PRIORITY = {" in ln)
+        return ast.literal_eval(line.split("=", 1)[1].strip())
+
+    def test_unknown_is_ranked_explicitly(self):
+        """Relying on the `.get(cur, 9)` fallback leaves it undeclared."""
+        assert "unknown" in self._priority()
+
+    def test_a_known_status_always_beats_unknown(self):
+        """Running on one worker and unknown on another must read as running."""
+        priority = self._priority()
+        unknown = priority["unknown"]
+        for status, rank in priority.items():
+            if status != "unknown":
+                assert rank < unknown, f"{status!r} ranks worse than unknown, so a blind spot would win"
+
+    def test_running_is_still_the_best_answer(self):
+        priority = self._priority()
+        assert priority["running"] == min(priority.values())
+
+
+class TestTheUIDistinguishesThem:
+    def test_unknown_has_its_own_badge(self):
+        assert ".badge-unknown" in CSS.read_text(encoding="utf-8")
+
+    def test_unknown_has_its_own_dot(self):
+        assert ".status-dot.unknown" in CSS.read_text(encoding="utf-8")
+
+    def test_unknown_is_not_coloured_like_stopped(self):
+        """Same colour is the same claim, whatever the label says."""
+        css = CSS.read_text(encoding="utf-8")
+        unknown = re.search(r"\.status-dot\.unknown\s*\{([^}]*)\}", css).group(1)
+        stopped = re.search(r"\.status-dot\.stopped\s*\{([^}]*)\}", css).group(1)
+        assert unknown.strip() != stopped.strip(), "unknown and stopped render identically"
+
+    def test_the_frontend_derives_the_class_from_the_status(self):
+        """It builds `badge-${status}`, so a new status needs no JS change —
+        only the CSS above. This pins that assumption."""
+        js = APP_JS.read_text(encoding="utf-8")
+        assert "badge-${statusClass}" in js
+        assert "svc.container_status" in js


### PR DESCRIPTION
The other half of `CashPilot-android-1oo`. The phone stopped lying in [CashPilot-android#49](https://github.com/GeiserX/CashPilot-android/pull/49); this stops the server translating the honest answer straight back into the lie.

## One falsy `None`

```python
"status": "running" if a.get("running") else "stopped"
```

The Android client now sends `running: null` when it cannot determine the answer — every one of its detection signals degrades to `false` when notification and usage access are denied, so it used to report *every* earning app as stopped.

`None` is falsy. It landed in the same `else` branch as a real `False`, and the fleet page reported the identical false claim, one hop later.

## Why this matters beyond wording

| | means | the fix is |
|---|---|---|
| **stopped** | the service should be reporting and is not | restart it |
| **unknown** | the worker could not see | grant the permission |

Collapsing them sends someone to fix the wrong thing, on a device where nothing was actually wrong.

## Aggregation prefers a known fact

`_STATUS_PRIORITY` now ranks `"unknown"` explicitly, and **last**. `best_status` picks the lowest number, so a service running on one worker and unknown on another still reports **running** — a known fact beats a blind spot, and unknown only wins when nothing else is known.

It previously fell through to the `.get(cur, 9)` fallback. That happened to give the same answer, but said nothing about intent — and a test asserting a fallback is a test that passes for the wrong reason.

## The UI

Its own amber badge and dot, not the stopped red. **Same colour is the same claim**, whatever the label says — there is a test that the two do not render identically.

The frontend builds `badge-${status}` from the string, so no JS change was needed; a test pins that assumption so the next status doesn't silently render unstyled.

## Also here

Compose pins `1.13` → `1.14`. The project's own pin test caught that releasing v1.14.0 moved the newest series; both 1.14 images verified present on Docker Hub before bumping.

## Evidence

`ruff` clean, `mkdocs build --strict` clean, all five browser-free harnesses pass, **3502 passed, 95.44% coverage**.

Five negative controls fire: collapsing `None` back to stopped, ranking unknown better than a known status, dropping it from the priority table, colouring it exactly like stopped, and re-deriving the status inline at the call site.

One test needed fixing before it was worth anything: my check that the old truthiness expression is gone **matched the comment explaining the fix**, which necessarily quotes it. It reads executable lines only now — the fourth time that trap has appeared in this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android services now preserve an **Unknown** status when their running state cannot be determined.
  * Known running services are no longer overridden by unknown status reports.

* **UI Improvements**
  * Unknown service states now use a warning-style indicator instead of the stopped/error styling.

* **Updates**
  * Updated application containers to version 1.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->