### PR TITLE
fix: three releases shipped one worker image, reporting the wrong version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,15 +214,25 @@ jobs:
           # The release input is "v1.2.3"; the image bakes the bare number.
           want="${VERSION#v}"
           echo "expecting CASHPILOT_VERSION=${want}"
-          printf '%s\n%s\n' "$UI_TAGS" "$WORKER_TAGS" > /tmp/vtags.txt
           bad=0
+          # A here-string, not a pipe and not a temp file: a `while` on the right
+          # of a pipe runs in a subshell, so `bad` set inside it would be lost --
+          # which is why the step above uses a file. This avoids both.
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
             # `docker buildx imagetools inspect --raw` returns the manifest, not
             # the config, so the env is not in it. Pulling is the reliable way to
             # read what the image actually declares.
-            if ! docker pull -q "$tag" >/dev/null 2>&1; then
-              echo "SKIP    $tag -- could not pull; the resolve check above owns that failure"
+            #
+            # A FAILED PULL IS A FAILURE, not something to skip. An earlier draft
+            # `continue`d here on the reasoning that the resolve check above owns
+            # it -- but that check uses `docker manifest inspect`, which can
+            # succeed while a pull fails, so skipping left the version unverified
+            # and `bad` at 0. That is a check that cannot fail, which is worse
+            # than no check: the release would publish looking verified.
+            if ! err=$(docker pull -q "$tag" 2>&1); then
+              echo "PULL FAILED  $tag -- ${err}"
+              bad=1
               continue
             fi
             got=$(docker image inspect "$tag" --format '{{range .Config.Env}}{{println .}}{{end}}' \
@@ -233,8 +243,8 @@ jobs:
               echo "WRONG   $tag reports '${got}', expected '${want}'"
               bad=1
             fi
-          done < /tmp/vtags.txt
+          done <<< "$(printf '%s\n%s\n' "$UI_TAGS" "$WORKER_TAGS")"
           if [ "$bad" -ne 0 ]; then
-            echo "::error::A published image reports a version other than the one it is tagged with. This is what a re-tagged or cache-stale image looks like: the tag resolves, so the check above passes, while every worker running it reports the WRONG version on the fleet page -- and a wrong version reads as a match, hiding the staleness version reporting exists to reveal. Do NOT fix this by re-tagging; rebuild the image."
+            echo "::error::A published image reports a version other than the one it is tagged with. This is what a re-tagged or cache-stale image looks like: the tag resolves, so the check above passes, while every worker running it reports the WRONG version on the fleet page -- and a wrong version reads as a match, hiding the staleness version reporting exists to reveal. Do NOT fix this by re-tagging; rebuild the image. A PULL FAILED line above means the version could not be read at all -- that is also a failure here, because an unverified image must not ship looking verified."
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,50 +122,6 @@ jobs:
   # This is a manifest re-point, not a rebuild: imagetools copies the existing
   # multi-arch descriptor to the new tags in seconds, so an unchanged image is
   # never rebuilt just to satisfy a naming convention.
-  retag-ui:
-    needs: [lint, resolve-tags]
-    if: ${{ !inputs.build_ui && inputs.version != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Re-point the unchanged UI image at this release's tags
-        # Tags derive from inputs.version, which workflow_dispatch lets a caller
-        # set freely. Interpolating that straight into `for tag in ...` would let
-        # a malformed value break Bash parsing in a step that runs AFTER the
-        # registry login, so it goes through the environment and is read as data.
-        env:
-          TAGS: ${{ needs.resolve-tags.outputs.ui_tags }}
-        run: |
-          printf '%s\n' "$TAGS" | while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            echo "retagging -> $tag"
-            docker buildx imagetools create -t "$tag" drumsergio/cashpilot:latest
-          done
-
-  retag-worker:
-    needs: [lint, resolve-tags]
-    if: ${{ !inputs.build_worker && inputs.version != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Re-point the unchanged worker image at this release's tags
-        env:
-          TAGS: ${{ needs.resolve-tags.outputs.worker_tags }}
-        run: |
-          printf '%s\n' "$TAGS" | while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            echo "retagging -> $tag"
-            docker buildx imagetools create -t "$tag" drumsergio/cashpilot-worker:latest
-          done
-
   build-worker:
     needs: [lint, resolve-tags]
     if: inputs.build_worker
@@ -194,7 +150,7 @@ jobs:
   # did not — the gap was only found by deploying. This closes that: if a tag
   # this release claims to have published does not resolve, the run fails.
   verify-tags:
-    needs: [resolve-tags, build-ui, build-worker, retag-ui, retag-worker]
+    needs: [resolve-tags, build-ui, build-worker]
     if: ${{ always() && inputs.version != '' }}
     runs-on: ubuntu-latest
     steps:
@@ -237,5 +193,48 @@ jobs:
           done < /tmp/tags.txt
           if [ "$missing" -ne 0 ]; then
             echo "::error::A tag this release claims to have published did not resolve. Read the registry response printed above BEFORE assuming a partial build: an auth or rate-limit failure looks identical here. If the images really are missing, the compose files pin both to the same tag, so a partial release breaks the documented quickstart."
+            exit 1
+          fi
+
+      # A tag RESOLVING says nothing about WHAT it resolves to. That gap shipped
+      # three releases of one worker image: 1.13.0, 1.14.0 and 1.14.1 all pointed
+      # at a single digest reporting CASHPILOT_VERSION=1.13.0, and the guard
+      # above passed every time because each tag existed.
+      #
+      # This checks the ARTIFACT instead of the label: pull the image config and
+      # require the version baked into it to equal the version being released. It
+      # catches a re-tag, a stale build cache and a skipped build alike -- all
+      # three produce a tag whose image disagrees with its name.
+      - name: Every published image must report the version it is tagged with
+        env:
+          UI_TAGS: ${{ needs.resolve-tags.outputs.ui_tags }}
+          WORKER_TAGS: ${{ needs.resolve-tags.outputs.worker_tags }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          # The release input is "v1.2.3"; the image bakes the bare number.
+          want="${VERSION#v}"
+          echo "expecting CASHPILOT_VERSION=${want}"
+          printf '%s\n%s\n' "$UI_TAGS" "$WORKER_TAGS" > /tmp/vtags.txt
+          bad=0
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            # `docker buildx imagetools inspect --raw` returns the manifest, not
+            # the config, so the env is not in it. Pulling is the reliable way to
+            # read what the image actually declares.
+            if ! docker pull -q "$tag" >/dev/null 2>&1; then
+              echo "SKIP    $tag -- could not pull; the resolve check above owns that failure"
+              continue
+            fi
+            got=$(docker image inspect "$tag" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+                  | sed -n 's/^CASHPILOT_VERSION=//p' | head -1)
+            if [ "$got" = "$want" ]; then
+              echo "ok      $tag reports ${got}"
+            else
+              echo "WRONG   $tag reports '${got}', expected '${want}'"
+              bad=1
+            fi
+          done < /tmp/vtags.txt
+          if [ "$bad" -ne 0 ]; then
+            echo "::error::A published image reports a version other than the one it is tagged with. This is what a re-tagged or cache-stale image looks like: the tag resolves, so the check above passes, while every worker running it reports the WRONG version on the fleet page -- and a wrong version reads as a match, hiding the staleness version reporting exists to reveal. Do NOT fix this by re-tagging; rebuild the image."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,24 @@ jobs:
     if: needs.release.outputs.new_tag
     uses: ./.github/workflows/build.yml
     with:
-      build_ui: ${{ needs.release.outputs.build_ui == 'true' }}
-      build_worker: ${{ needs.release.outputs.build_worker == 'true' }}
+      # BOTH images are built on every release, deliberately.
+      #
+      # The change detection above still decides whether to release AT ALL; it
+      # no longer decides whether to build. When it said "the worker did not
+      # change", build.yml re-tagged the previous image by copying its manifest
+      # -- and the version is BAKED INTO THAT IMAGE (Dockerfile ARG -> ENV). So
+      # the copy was not equivalent: cashpilot-worker:1.13.0, :1.14.0 and
+      # :1.14.1 all resolved to ONE digest that reported itself as 1.13.0, and
+      # every worker on the fleet page showed a version it was not running.
+      # A wrong version reads as a MATCH, which hides exactly the staleness
+      # version reporting exists to reveal.
+      #
+      # These are ~94MB Alpine images with a warm buildx cache, so the saving
+      # was small and the correctness cost was real. This file already records
+      # two incidents where skipping a build produced a green run that published
+      # nothing; this is the third of that family.
+      build_ui: true
+      build_worker: true
       version: ${{ needs.release.outputs.new_tag }}
     secrets: inherit
 

--- a/tests/test_beads_batch_61.py
+++ b/tests/test_beads_batch_61.py
@@ -151,6 +151,43 @@ class TestTheGuardChecksTheArtifactNotTheLabel:
         env = str(step.get("env", {}))
         assert "worker_tags" in env, env
 
+    def test_a_failed_pull_fails_the_run_rather_than_skipping(self):
+        """A check that can silently opt out is worse than no check.
+
+        My first version `continue`d on a pull failure, reasoning that the
+        resolve step above owned it. It does not: that step uses `docker
+        manifest inspect`, which can succeed while a pull fails, so a registry
+        hiccup left the version unverified with `bad` still 0 — and the release
+        published looking verified. (CodeRabbit, PR #254.)
+        """
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        run = step["run"]
+
+        # Scoped to the pull branch ALONE. Two earlier versions of this
+        # assertion passed against a deliberately broken workflow:
+        #   * `"PULL FAILED" in run` also matched the ::error:: text, which
+        #     mentions it -- the test matching its own prose;
+        #   * a `bad=1 in pull_block` slice that ran to `done <<<` swallowed the
+        #     legitimate `bad=1` in the version-mismatch branch below it.
+        start = run.index("if ! err=$(docker pull")
+        branch = run[start : run.index("fi", start)]
+        assert "bad=1" in branch, f"a failed pull does not mark the run failed:\n{branch}"
+        assert "owns that failure" not in run, "the silent-skip rationale is back"
+
+    def test_it_keeps_no_runtime_state_in_tmp(self):
+        """Replaced by a here-string, which also avoids the subshell that made
+        the neighbouring step use a file in the first place."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "/tmp" not in step["run"]
+
+    def test_the_loop_does_not_run_in_a_subshell(self):
+        """`while` on the right of a pipe loses `bad`, which is how this class of
+        check silently passes."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        run = step["run"]
+        assert "done <<<" in run, "the loop no longer reads from a here-string"
+        assert "| while" not in run and "|while" not in run
+
     def test_it_tells_the_reader_not_to_re_tag(self):
         """Re-tagging is the obvious 'fix' and it reproduces the defect."""
         step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())

--- a/tests/test_beads_batch_61.py
+++ b/tests/test_beads_batch_61.py
@@ -1,0 +1,183 @@
+"""CashPilot-ein: three releases shipped one worker image, reporting the wrong version.
+
+``cashpilot-worker:1.13.0``, ``:1.14.0`` and ``:1.14.1`` all resolved to a single
+digest whose baked ``CASHPILOT_VERSION`` was ``1.13.0``. Every worker on the
+fleet page therefore reported a version it was not running — and a *wrong*
+version reads as a **match**, hiding exactly the staleness that version
+reporting exists to reveal.
+
+The cause was an optimisation, not an accident. When change detection said the
+worker source had not changed, ``build.yml`` re-pointed the new release tags at
+the previous image with ``docker buildx imagetools create``, which copies a
+manifest. But the version is baked into the image (``ARG`` → ``ENV``), so the
+two releases' images are *not* equivalent and the copy asserted something false.
+
+Two things had to change:
+
+* build both images on every release — the saving was small, the correctness
+  cost was not;
+* verify the **artifact** rather than the label. The existing guard checks that a
+  published tag *resolves*, and a tag pointing at a stale image resolves
+  perfectly, which is why it passed three times.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD = ROOT / ".github" / "workflows" / "build.yml"
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def build_doc() -> dict:
+    return yaml.safe_load(BUILD.read_text(encoding="utf-8"))
+
+
+def release_doc() -> dict:
+    return yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+
+
+class TestNoImageIsEverRetagged:
+    """Copying a manifest asserts an equivalence the baked version breaks."""
+
+    def test_the_retag_jobs_are_gone(self):
+        jobs = set(build_doc()["jobs"])
+        assert "retag-ui" not in jobs, "retag-ui copies a manifest whose baked version is stale"
+        assert "retag-worker" not in jobs
+
+    def test_nothing_copies_a_manifest_any_more(self):
+        """`imagetools create` is the specific mechanism that did this."""
+        text = BUILD.read_text(encoding="utf-8")
+        offenders = [
+            line.strip()
+            for line in text.splitlines()
+            if "imagetools create" in line and not line.lstrip().startswith("#")
+        ]
+        assert not offenders, offenders
+
+    def test_no_job_depends_on_a_removed_one(self):
+        """A dangling `needs` makes the whole workflow invalid, not just skipped."""
+        doc = build_doc()
+        names = set(doc["jobs"])
+        for job, spec in doc["jobs"].items():
+            needs = spec.get("needs") or []
+            needs = [needs] if isinstance(needs, str) else needs
+            missing = set(needs) - names
+            assert not missing, f"{job} needs jobs that no longer exist: {missing}"
+
+    def test_nothing_READS_from_the_floating_latest_tag(self):
+        """The retag sourced its manifest from `:latest`.
+
+        Narrow on purpose. PUBLISHING `:latest` alongside the semver tags is
+        normal and still happens; my first version of this test forbade every
+        mention and failed on those publish targets — the test was wrong, not
+        the workflow. What must never happen is READING an image from a floating
+        tag to derive a release artifact, because whatever `latest` happens to
+        point at is then what the release inherits.
+
+        Executable lines only: the comment explaining the fix has to name
+        `:latest` to be understood.
+        """
+        code = [ln for ln in BUILD.read_text(encoding="utf-8").splitlines() if not ln.lstrip().startswith("#")]
+        reads = re.compile(r"(imagetools create|docker pull|^FROM)\b.*cashpilot(-worker)?:latest")
+        offenders = [ln.strip() for ln in code if reads.search(ln.strip())]
+        assert not offenders, offenders
+
+
+class TestBothImagesAreBuiltOnEveryRelease:
+    def test_the_release_forces_both_builds(self):
+        """Change detection still decides whether to RELEASE, not whether to BUILD."""
+        with_ = release_doc()["jobs"]["build"]["with"]
+        assert with_["build_ui"] is True, f"build_ui = {with_['build_ui']!r}"
+        assert with_["build_worker"] is True, f"build_worker = {with_['build_worker']!r}"
+
+    def test_both_build_jobs_still_exist(self):
+        jobs = set(build_doc()["jobs"])
+        assert {"build-ui", "build-worker"} <= jobs
+
+    def test_both_still_receive_the_version_as_a_build_arg(self):
+        """If the arg stops flowing, every image silently reports `dev`."""
+        doc = build_doc()
+        for job in ("build-ui", "build-worker"):
+            args = [
+                str(step.get("with", {}).get("build-args", ""))
+                for step in doc["jobs"][job]["steps"]
+                if isinstance(step.get("with"), dict)
+            ]
+            assert any("CASHPILOT_VERSION=" in a for a in args), f"{job} no longer passes the version"
+
+
+class TestTheGuardChecksTheArtifactNotTheLabel:
+    def _verify_steps(self) -> list[dict]:
+        return build_doc()["jobs"]["verify-tags"]["steps"]
+
+    def test_the_resolve_check_is_still_there(self):
+        """The new check complements it; it does not replace it."""
+        names = [s.get("name", "") for s in self._verify_steps()]
+        assert any("resolve" in n.lower() for n in names), names
+
+    def test_a_version_assertion_exists(self):
+        names = [s.get("name", "") for s in self._verify_steps()]
+        assert any("version" in n.lower() for n in names), names
+
+    def test_it_compares_against_the_release_input(self):
+        """Comparing against anything else could agree with itself."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "inputs.version" in str(step.get("env", {}))
+
+    def test_it_strips_the_tag_prefix(self):
+        """The input is `v1.2.3`; the image bakes the bare number."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "${VERSION#v}" in step["run"]
+
+    def test_it_reads_the_env_from_the_pulled_image(self):
+        """A manifest does not carry the config, so inspecting --raw would not see it."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "docker image inspect" in step["run"]
+        assert "CASHPILOT_VERSION=" in step["run"]
+
+    def test_it_fails_the_run_rather_than_warning(self):
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "exit 1" in step["run"]
+        assert "::error::" in step["run"]
+
+    def test_it_checks_the_worker_tags_too(self):
+        """The worker is the image that was actually wrong."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        env = str(step.get("env", {}))
+        assert "worker_tags" in env, env
+
+    def test_it_tells_the_reader_not_to_re_tag(self):
+        """Re-tagging is the obvious 'fix' and it reproduces the defect."""
+        step = next(s for s in self._verify_steps() if "version" in s.get("name", "").lower())
+        assert "rebuild" in step["run"].lower()
+
+
+class TestTheComparisonItselfIsCorrect:
+    """The shell logic, exercised directly against the real-world values.
+
+    Validated against the registry as it stood: the worker tagged 1.14.1 reports
+    1.13.0 (must fail), and the UI tagged 1.14.1 reports 1.14.1 (must pass). A
+    guard that flags everything is as useless as one that flags nothing.
+    """
+
+    @staticmethod
+    def _matches(reported: str, released: str) -> bool:
+        return reported == released.removeprefix("v")
+
+    def test_the_real_defect_is_caught(self):
+        assert not self._matches("1.13.0", "v1.14.1")
+
+    def test_a_correct_image_is_not_flagged(self):
+        assert self._matches("1.14.1", "v1.14.1")
+
+    def test_an_unstamped_image_is_caught(self):
+        """`dev` is the Dockerfile default when the arg never arrives."""
+        assert not self._matches("dev", "v1.14.1")
+
+    def test_an_empty_version_is_caught(self):
+        assert not self._matches("", "v1.14.1")


### PR DESCRIPTION
Closes `CashPilot-ein`. Found by deploying v1.14.1 to the fleet and checking what actually landed.

```
cashpilot-worker:1.13.0  sha256:a799de9a7eb9f0291...
cashpilot-worker:1.14.0  sha256:a799de9a7eb9f0291...
cashpilot-worker:1.14.1  sha256:a799de9a7eb9f0291...
```

**One digest, three releases** — and it bakes `CASHPILOT_VERSION=1.13.0`, confirmed both in the registry config and inside the running container. So every worker on the fleet page showed a version it was not running. **A wrong version reads as a match**, hiding exactly the staleness that version reporting exists to reveal.

The UI image *did* change between those releases, so this was not "nothing changed".

## The cause was an optimisation, not an accident

When change detection said the worker source was untouched, `build.yml` re-pointed the new release tags at the previous image with `docker buildx imagetools create` — which **copies a manifest**. But the version is baked into the image (`ARG` → `ENV`), so the two releases' images are *not* equivalent and the copy asserted something false. `retag-ui` had the identical latent defect.

Both retag jobs are gone; both images are now built on every release. Change detection still decides whether to **release** — it no longer decides whether to **build**. These are ~94 MB Alpine images with a warm cache, so the saving was small and the correctness cost real. This file already records **two** prior incidents where skipping a build produced a green run that published nothing; this is the third of that family.

## The existing guard could not catch it

`verify-tags` checks that a published tag **resolves** — and a tag pointing at a stale image resolves perfectly. It passed all three times.

The new step checks the **artifact** rather than the label: pull each published tag and require the baked version to equal the version being released. That catches a re-tag, a stale cache, and a skipped build alike.

**Validated against the registry as it actually stood**, so the guard is known to discriminate rather than merely to fire:

| | reports | verdict |
|---|---|---|
| `worker:1.14.1` | `1.13.0` | **WRONG** — the real defect, caught |
| `ui:1.14.1` | `1.14.1` | ok — no false positive |

## Evidence

`ruff` clean, `mkdocs --strict` clean, all five harnesses pass, **3541 passed, 95.44% coverage**.

Five negative controls fire: restoring the skip, deleting the assertion, comparing against a hardcoded version instead of the release input, warning instead of failing, and reintroducing a manifest copy.

One of my tests was wrong first — it forbade every mention of `:latest` and failed on the legitimate **publish** targets. Publishing `:latest` is normal; *reading* an image from a floating tag to derive a release artifact is the defect. Narrowed to that.

## What this does not fix

The already-published `1.14.x` worker tags still point at the 1.13.0 build. The next release rebuilds them correctly. **Re-tagging them by hand would reproduce the defect** — that's called out in the error message too.

Also worth flagging separately: I earlier claimed images were being pushed from outside CI. That was wrong — `build.yml` is a reusable workflow whose runs appear under "Auto Release", so querying it directly looks dormant. Nothing outside CI is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release builds now consistently publish both UI and worker images.
  - Published images are validated to ensure their embedded version matches the release version.
  - Prevented releases from relying on floating image tags or reusing unchanged image manifests.
  - Improved failure reporting when published images cannot be pulled or contain an incorrect version.

- **Tests**
  - Added coverage for image publication, version validation, tag handling, and workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->