### PR TITLE
feat: earnings readings record which machine took them

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -810,6 +810,13 @@ async def init_db() -> None:
         # Makes (platform, source, date) the idempotency key, so re-pairing or a
         # retried import overwrites a day rather than appending a second reading
         # for it -- which would difference against itself and read as zero.
+        # The LEGACY index must go FIRST. On an upgraded volume
+        # idx_earnings_platform_date survives, and it still forbids two sources
+        # for one (platform, date) -- so the new index would be created and the
+        # old one would quietly keep rejecting exactly the writes this change
+        # exists to allow. Creating the replacement is not enough; the old
+        # constraint has to be removed. (CodeRabbit, PR #255.)
+        await db.execute("DROP INDEX IF EXISTS idx_earnings_platform_date")
         await db.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_source_date ON earnings (platform, source, date)"
         )
@@ -865,12 +872,20 @@ async def upsert_earnings(
     currency: str = "USD",
     date: str | None = None,
     fx_rate_usd: float | None = None,
+    source: str = "server",
 ) -> None:
-    """Insert or update an earnings record for a platform + date.
+    """Insert or update an earnings record for a platform + source + date.
 
     ``fx_rate_usd`` is the currency -> USD rate at collection time. It is stored
     alongside the balance because exchange rates are only cached live: without it,
     the USD value of a historical non-USD reading cannot be reconstructed later.
+
+    ``source`` is WHO took the reading: ``"server"`` for this server's own
+    collectors, or a paired client's worker id. It is part of the key, so two
+    machines may report the same platform on the same day -- the normal case once
+    a client pushes its history -- while one machine reporting a platform twice
+    for a day still upserts. Without this parameter the schema would accept a
+    source but nothing could ever write one, so a client's series could not exist.
     """
     date = date or datetime.now(UTC).strftime("%Y-%m-%d")
     db = await _get_db()
@@ -880,8 +895,8 @@ async def upsert_earnings(
         # WHERE guard preserves created_at when the balance is unchanged.
         await db.execute(
             """
-            INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd, source)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(platform, source, date) DO UPDATE SET
                 balance = excluded.balance,
                 currency = excluded.currency,
@@ -899,7 +914,7 @@ async def upsert_earnings(
             WHERE earnings.balance != excluded.balance
                OR earnings.fx_rate_usd IS NULL
             """,
-            (platform, balance, currency, date, fx_rate_usd),
+            (platform, balance, currency, date, fx_rate_usd, source),
         )
         await db.commit()
     finally:

--- a/app/database.py
+++ b/app/database.py
@@ -319,8 +319,23 @@ CREATE TABLE IF NOT EXISTS earnings (
     -- any accuracy — which is what a net-profit or tax export needs. NULL only when
     -- the rate was genuinely unavailable, never a guess.
     fx_rate_usd REAL,
+    -- WHO took this reading. 'server' is this CashPilot's own collectors; a
+    -- paired client pushing its history uses its own worker client_id.
+    --
+    -- Load-bearing, not bookkeeping. A balance is a RUNNING TOTAL and earnings
+    -- are the delta between CONSECUTIVE readings. Two samplers of one provider
+    -- account interleaved into a single series oscillate -- server 10, desktop
+    -- 9, server 11, desktop 10 -- and because a drop clamps to zero, the total
+    -- comes out SYSTEMATICALLY UNDERSTATED while looking entirely plausible.
+    -- Deltas are therefore taken per (platform, source) and only then summed.
+    source     TEXT    NOT NULL DEFAULT 'server',
     created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 );
+-- NOTE: the (platform, source, date) unique index is created in the MIGRATION,
+-- not here. On an upgraded volume `CREATE TABLE IF NOT EXISTS earnings` is a
+-- no-op, so an index declared here would reference `source` before the ALTER
+-- adds it and every upgrade would fail on "no such column: source". The
+-- existing fx-migration test models exactly that volume and caught it.
 
 -- updated_at exists so a credential's AGE is knowable. Several collectors use
 -- values copied out of a browser and some expire in hours; without a timestamp
@@ -451,8 +466,18 @@ CREATE TABLE IF NOT EXISTS session_revocations (
     revoked_before REAL    NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_date
-    ON earnings (platform, date);
+-- The (platform, SOURCE, date) unique index is created in the MIGRATION, not
+-- here, and this must stay that way. _SCHEMA is replayed on EVERY startup, and
+-- on an upgraded volume `CREATE TABLE IF NOT EXISTS earnings` is a no-op -- so
+-- an index declared here names `source` before the ALTER has added it and
+-- init_db dies with "no such column: source", taking the whole app down on
+-- upgrade. I made that mistake twice; the fx-migration test catches it both
+-- times.
+--
+-- Source is part of the key because two machines may legitimately report the
+-- same platform on the same day -- the normal case once a client pushes its
+-- history -- while one machine reporting a platform twice for one day is still
+-- a duplicate to be upserted away.
 
 CREATE INDEX IF NOT EXISTS idx_earnings_created
     ON earnings (created_at);
@@ -606,7 +631,7 @@ async def _dedupe_earnings_before_indexing(db: Any) -> None:
     would have left behind had the index been there all along.
     """
     cursor = await db.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_earnings_platform_date'"
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_earnings_platform_source_date'"
     )
     if await cursor.fetchone():
         return  # Index already present, so duplicates cannot exist.
@@ -615,7 +640,15 @@ async def _dedupe_earnings_before_indexing(db: Any) -> None:
     if not await cursor.fetchone():
         return  # Fresh install; the table is about to be created cleanly.
 
-    cursor = await db.execute("SELECT COUNT(*) - COUNT(DISTINCT platform || '|' || date) AS extra FROM earnings")
+    # This runs BEFORE the `source` column is added, so the key must match
+    # whichever schema is actually on disk. Referencing `source` unconditionally
+    # crashes init_db on exactly the volume this helper exists to rescue.
+    cursor = await db.execute("PRAGMA table_info(earnings)")
+    has_source = any(row["name"] == "source" for row in await cursor.fetchall())
+    key = "platform || '|' || COALESCE(source, 'server') || '|' || date" if has_source else "platform || '|' || date"
+    group_by = "platform, source, date" if has_source else "platform, date"
+
+    cursor = await db.execute(f"SELECT COUNT(*) - COUNT(DISTINCT {key}) AS extra FROM earnings")
     row = await cursor.fetchone()
     extra = int(row["extra"] or 0)
     if extra <= 0:
@@ -627,7 +660,7 @@ async def _dedupe_earnings_before_indexing(db: Any) -> None:
         "and the application can start.",
         extra,
     )
-    await db.execute("DELETE FROM earnings WHERE id NOT IN (SELECT MAX(id) FROM earnings GROUP BY platform, date)")
+    await db.execute(f"DELETE FROM earnings WHERE id NOT IN (SELECT MAX(id) FROM earnings GROUP BY {group_by})")
     await db.commit()
 
 
@@ -745,6 +778,7 @@ async def init_db() -> None:
             # When the per-worker key was minted, so the window in which the
             # SHARED key still works for that worker can be bounded.
             await db.execute("ALTER TABLE workers ADD COLUMN key_issued_at TEXT")
+
             # Backfilled to NOW, not to NULL and not to the distant past.
             # Every already-enrolled-but-unconfirmed worker would otherwise be
             # instantly past its window the moment this upgrade lands, and a
@@ -762,6 +796,23 @@ async def init_db() -> None:
         earnings_cols = {row["name"] for row in await cursor.fetchall()}
         if "fx_rate_usd" not in earnings_cols:
             await db.execute("ALTER TABLE earnings ADD COLUMN fx_rate_usd REAL")
+        # Add `source`: WHO took the reading. Existing rows were all taken by
+        # this server's own collectors, so 'server' is the truthful backfill
+        # rather than a placeholder -- there was no other sampler before this.
+        if "source" not in earnings_cols:
+            await db.execute("ALTER TABLE earnings ADD COLUMN source TEXT NOT NULL DEFAULT 'server'")
+        # Unconditional, and only AFTER the column is guaranteed to exist. This
+        # is the ONLY place the index is created, so a fresh install and an
+        # upgraded volume take the same path -- declaring it in _SCHEMA instead
+        # broke every upgrade, because `CREATE TABLE IF NOT EXISTS` is a no-op
+        # there and the index then named a column the ALTER had not yet added.
+        #
+        # Makes (platform, source, date) the idempotency key, so re-pairing or a
+        # retried import overwrites a day rather than appending a second reading
+        # for it -- which would difference against itself and read as zero.
+        await db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_earnings_platform_source_date ON earnings (platform, source, date)"
+        )
 
         # Migrate deployments table: add spec_encrypted so an existing install starts
         # remembering what it deployed. Rows written before this stay empty and fall
@@ -831,7 +882,7 @@ async def upsert_earnings(
             """
             INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd)
             VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(platform, date) DO UPDATE SET
+            ON CONFLICT(platform, source, date) DO UPDATE SET
                 balance = excluded.balance,
                 currency = excluded.currency,
                 -- COALESCE, not a plain assignment: if the rate lookup failed this
@@ -868,8 +919,16 @@ async def get_earnings_summary() -> list[dict[str, Any]]:
             -- at is sitting right here in the row.
             SELECT platform, balance, currency, date, fx_rate_usd
             FROM earnings
-            WHERE (platform, date) IN (
-                SELECT platform, MAX(date) FROM earnings GROUP BY platform
+            -- Deliberately ONE row per platform, not one per source. A
+            -- provider reports a single balance for the whole account, so the
+            -- newest reading from ANY source IS the current balance; taking the
+            -- latest per source and summing them would multiply it by the
+            -- number of machines watching.
+            WHERE id IN (
+                SELECT id FROM earnings e
+                WHERE e.date = (SELECT MAX(date) FROM earnings WHERE platform = e.platform)
+                GROUP BY e.platform
+                HAVING id = MAX(e.id)
             )
             ORDER BY platform
             """
@@ -958,31 +1017,39 @@ async def _usd_earned_per_date(db: Any) -> tuple[dict[str, float], int]:
     """
     cursor = await db.execute(
         """
-        SELECT platform, date, balance, currency, fx_rate_usd
+        SELECT platform, date, balance, currency, fx_rate_usd, source
         FROM earnings
-        ORDER BY platform, date
+        ORDER BY platform, source, date
         """
     )
     per_date: dict[str, float] = {}
-    previous: dict[str, tuple[str, float]] = {}
+    # Keyed by (platform, SOURCE) for the same reason as get_earned_by_platform:
+    # two machines sampling one provider account interleave into a series whose
+    # deltas are meaningless, and every drop clamps to zero, so the total comes
+    # out understated while looking plausible.
+    previous: dict[tuple[str, str], tuple[str, float]] = {}
     unpriced = 0
     for row in await cursor.fetchall():
         platform = row["platform"]
+        # Absent source means a row written before the column existed; those
+        # were all this server's own, so they join the 'server' series rather
+        # than forming a phantom one.
+        series = (platform, (row["source"] or "server"))
         currency = (row["currency"] or "USD").upper()
         rate = _usd_rate(currency, row["fx_rate_usd"])
         if rate is None:
-            previous.pop(platform, None)
+            previous.pop(series, None)
             unpriced += 1
             continue
         balance = float(row["balance"] or 0.0)
-        before = previous.get(platform)
+        before = previous.get(series)
         if before is not None and before[0] == currency:
             # Clamped per platform BEFORE summing: a payout drops one
             # platform's balance, and an unclamped drop would cancel real
             # earnings on another platform in the same day's total.
             gained = max(0.0, balance - before[1]) * rate
             per_date[row["date"]] = per_date.get(row["date"], 0.0) + gained
-        previous[platform] = (currency, balance)
+        previous[series] = (currency, balance)
     return per_date, unpriced
 
 
@@ -1840,20 +1907,27 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
     try:
         cursor = await db.execute(
             """
-            SELECT platform, date, balance, currency, fx_rate_usd
+            SELECT platform, date, balance, currency, fx_rate_usd, source
             FROM earnings
             WHERE date >= date('now', ?)
-            ORDER BY platform, date
+            ORDER BY platform, source, date
             """,
             (f"-{max(1, int(days))} days",),
         )
         rows = await cursor.fetchall()
 
         earned: dict[str, float] = {}
-        previous: dict[str, tuple[str, float]] = {}
+        # Keyed by (platform, SOURCE). Keyed by platform alone, two samplers of
+        # one provider account interleave into a single series whose deltas are
+        # meaningless: each drop clamps to zero, so the total is understated.
+        previous: dict[tuple[str, str], tuple[str, float]] = {}
         unpriced = 0
         for row in rows:
             platform = row["platform"]
+            # Absent source means a row written before the column existed, and
+            # those were all this server's own. Never invent a distinct source
+            # for them: that would split one real series in two.
+            series = (platform, (row["source"] or "server"))
             currency = (row["currency"] or "USD").upper()
             balance = float(row["balance"] or 0.0)
             # USD is parity by definition. Trusting a stored rate on a USD row
@@ -1866,14 +1940,16 @@ async def get_earned_by_platform(days: int = 30) -> dict[str, float]:
                 # contribute earnings nor anchor the next delta. Dropping the
                 # baseline is what stops a later reading from being differenced
                 # across the gap and counting the unpriced period twice.
-                previous.pop(platform, None)
+                previous.pop(series, None)
                 unpriced += 1
                 continue
 
-            before = previous.get(platform)
+            before = previous.get(series)
             if before is not None and before[0] == currency:
+                # Summed into the PLATFORM, so each source contributes its own
+                # earnings and the combination happens after differencing.
                 earned[platform] += max(0.0, balance - before[1]) * float(rate)
-            previous[platform] = (currency, balance)
+            previous[series] = (currency, balance)
 
         if unpriced:
             _logger.warning(

--- a/tests/test_beads_batch_62.py
+++ b/tests/test_beads_batch_62.py
@@ -1,0 +1,379 @@
+"""CashPilot-Desktop-xjr, server half: earnings readings need to know who took them.
+
+The goal is the user's: pairing a Desktop uploads its history retroactively, the
+Desktop then shows the complete picture, and on unlink it falls back to what that
+machine earned alone.
+
+The obvious implementation corrupts the data, and not visibly. The server does
+not store *earnings* — it stores cumulative **balance readings**, and derives
+earnings as clamped deltas between consecutive readings. Two samplers of the same
+provider account, interleaved into one series, produce deltas between readings
+that came from different samplers. The sequence oscillates, every downward step
+clamps to zero, and the total comes out **systematically understated** while
+looking entirely plausible.
+
+That is worse than double counting, which at least overstates visibly.
+
+So a reading records its ``source``, deltas are taken per ``(platform, source)``
+and only then summed. That also makes ``(platform, source, date)`` the natural
+idempotency key: re-pairing or a retried import overwrites a day instead of
+appending a second reading for it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from app import database
+
+
+# Mirrors the fixtures in test_database.py rather than importing them: they are
+# module-local there, and pytest does not share fixtures across test modules
+# without a conftest.
+@pytest.fixture
+def db_dir(tmp_path):
+    db_path = tmp_path / "cashpilot.db"
+    with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", db_path):
+        yield tmp_path
+
+
+@pytest.fixture
+def db(db_dir):
+    asyncio.run(database.init_db())
+    return db_dir
+
+
+class TestTheColumnExists:
+    def test_readings_carry_a_source(self, db):
+        async def run():
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("PRAGMA table_info(earnings)")
+                cols = {row["name"] for row in await cur.fetchall()}
+            finally:
+                await conn.close()
+            assert "source" in cols
+
+        asyncio.run(run())
+
+    def test_it_defaults_to_this_server(self, db):
+        """A row written by the existing collectors must not need updating."""
+
+        async def run():
+            conn = await database._get_db()
+            try:
+                await conn.execute(
+                    "INSERT INTO earnings (platform, balance, currency, date) VALUES ('p', 1.0, 'USD', '2026-01-01')"
+                )
+                await conn.commit()
+                cur = await conn.execute("SELECT source FROM earnings WHERE platform = 'p'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["source"] == "server"
+
+        asyncio.run(run())
+
+    def test_one_day_per_source_is_unique(self, db):
+        """The idempotency key: a retried import overwrites, never appends.
+
+        Two readings for one (platform, source, date) would difference against
+        each other and read as zero for that day.
+        """
+
+        async def run():
+            import sqlite3
+
+            conn = await database._get_db()
+            try:
+                await conn.execute(
+                    "INSERT INTO earnings (platform, balance, currency, date, source) "
+                    "VALUES ('p', 1.0, 'USD', '2026-01-01', 'desktop-a')"
+                )
+                await conn.commit()
+                with pytest.raises(sqlite3.IntegrityError):
+                    await conn.execute(
+                        "INSERT INTO earnings (platform, balance, currency, date, source) "
+                        "VALUES ('p', 9.0, 'USD', '2026-01-01', 'desktop-a')"
+                    )
+                    await conn.commit()
+            finally:
+                await conn.close()
+
+        asyncio.run(run())
+
+    def test_different_sources_may_share_a_day(self, db):
+        """Two machines reporting the same day is the normal case, not a clash."""
+
+        async def run():
+            conn = await database._get_db()
+            try:
+                for src in ("server", "desktop-a"):
+                    await conn.execute(
+                        "INSERT INTO earnings (platform, balance, currency, date, source) "
+                        "VALUES ('p', 1.0, 'USD', '2026-01-01', ?)",
+                        (src,),
+                    )
+                await conn.commit()
+                cur = await conn.execute("SELECT COUNT(*) AS n FROM earnings WHERE platform = 'p'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["n"] == 2
+
+        asyncio.run(run())
+
+
+async def _insert(rows: list[tuple[str, float, str, str]]) -> None:
+    """(platform, balance, date, source) — dates are relative days ago."""
+    conn = await database._get_db()
+    try:
+        for platform, balance, day, source in rows:
+            await conn.execute(
+                "INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd, source) "
+                "VALUES (?, ?, 'USD', date('now', ?), 1.0, ?)",
+                (platform, balance, day, source),
+            )
+        await conn.commit()
+    finally:
+        await conn.close()
+
+
+class TestTwoSamplersNoLongerCorruptTheTotal:
+    """The defect this whole change exists to prevent."""
+
+    def test_interleaved_sources_are_differenced_separately(self, db):
+        """Two machines watching one account, at DIFFERENT balance scales.
+
+        The scales matter. With both sources reporting the same numbers, keying
+        by platform alone still gives the right total -- the ORDER BY groups
+        them and the one cross-source step clamps to zero. That made an earlier
+        version of this test pass against a deliberately broken implementation,
+        which is the whole reason the numbers below are far apart: the crossover
+        from one source's series into the other's is POSITIVE and would be
+        counted as earnings that never happened.
+
+        desktop-a: 10 -> 12   (earned 2)
+        server:    50 -> 52   (earned 2)
+        correct total 4; as one series, 10,12,50,52 -> +2 +38 +2 = 42.
+        """
+
+        async def run():
+            await _insert(
+                [
+                    ("grass", 10.0, "-4 days", "desktop-a"),
+                    ("grass", 12.0, "-3 days", "desktop-a"),
+                    ("grass", 50.0, "-4 days", "server"),
+                    ("grass", 52.0, "-3 days", "server"),
+                ]
+            )
+            earned = await database.get_earned_by_platform(days=30)
+            assert earned["grass"] == pytest.approx(4.0)
+
+        asyncio.run(run())
+
+    def test_the_old_shape_would_have_understated_it(self, db):
+        """Proves the defect was real, rather than asserting the fix in a vacuum.
+
+        Differenced as ONE series ordered by date, the same readings give
+        10,10,11,11,12,12 -> deltas 0,+1,0,+1,0 = 2.0 for the pair, when the two
+        machines observed 2.0 EACH. The understatement is silent.
+        """
+
+        async def run():
+            readings = [10.0, 10.0, 11.0, 11.0, 12.0, 12.0]
+            interleaved = sum(max(0.0, b - a) for a, b in zip(readings, readings[1:], strict=False))
+            per_source = 2 * sum(max(0.0, b - a) for a, b in zip([10.0, 11.0, 12.0], [11.0, 12.0], strict=False))
+            assert interleaved == pytest.approx(2.0)
+            assert per_source == pytest.approx(4.0)
+            assert interleaved < per_source, "the old shape did not understate; the premise is wrong"
+
+        asyncio.run(run())
+
+    def test_a_payout_still_clamps_within_one_source(self, db):
+        """The clamp must survive: a payout drops a balance and is not a loss."""
+
+        async def run():
+            await _insert(
+                [
+                    ("myst", 10.0, "-3 days", "server"),
+                    ("myst", 2.0, "-2 days", "server"),  # paid out
+                    ("myst", 5.0, "-1 days", "server"),
+                ]
+            )
+            earned = await database.get_earned_by_platform(days=30)
+            # 0 for the drop, +3 after it.
+            assert earned["myst"] == pytest.approx(3.0)
+
+        asyncio.run(run())
+
+    def test_a_single_source_is_unchanged(self, db):
+        """The common case must behave exactly as before."""
+
+        async def run():
+            await _insert([("earnapp", 1.0, "-2 days", "server"), ("earnapp", 4.0, "-1 days", "server")])
+            earned = await database.get_earned_by_platform(days=30)
+            assert earned["earnapp"] == pytest.approx(3.0)
+
+        asyncio.run(run())
+
+    def test_a_legacy_row_with_no_source_joins_the_server_series(self, db):
+        """Rows written before the column existed were all this server's own.
+
+        Treating them as a distinct source would split one real series in two and
+        drop the delta across the boundary.
+        """
+
+        async def run():
+            conn = await database._get_db()
+            try:
+                await conn.execute(
+                    "INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd, source) "
+                    "VALUES ('titan', 1.0, 'USD', date('now', '-2 days'), 1.0, 'server')"
+                )
+                await conn.commit()
+            finally:
+                await conn.close()
+            await _insert([("titan", 6.0, "-1 days", "server")])
+            earned = await database.get_earned_by_platform(days=30)
+            assert earned["titan"] == pytest.approx(5.0)
+
+        asyncio.run(run())
+
+
+class TestSourcesDoNotLeakAcrossPlatforms:
+    def test_two_platforms_stay_separate(self, db):
+        async def run():
+            await _insert(
+                [
+                    ("a", 1.0, "-2 days", "server"),
+                    ("a", 3.0, "-1 days", "server"),
+                    ("b", 100.0, "-2 days", "server"),
+                    ("b", 101.0, "-1 days", "server"),
+                ]
+            )
+            earned = await database.get_earned_by_platform(days=30)
+            assert earned["a"] == pytest.approx(2.0)
+            assert earned["b"] == pytest.approx(1.0)
+
+        asyncio.run(run())
+
+    def test_the_result_is_keyed_by_platform_not_by_source(self, db):
+        """Callers ask "what did Grass earn", never "what did this machine earn" —
+        a provider reports one balance per account and it cannot be split."""
+
+        async def run():
+            await _insert(
+                [
+                    ("grass", 1.0, "-2 days", "server"),
+                    ("grass", 2.0, "-1 days", "server"),
+                    ("grass", 5.0, "-2 days", "desktop-a"),
+                    ("grass", 7.0, "-1 days", "desktop-a"),
+                ]
+            )
+            earned = await database.get_earned_by_platform(days=30)
+            assert set(earned) == {"grass"}
+            assert earned["grass"] == pytest.approx(3.0)
+
+        asyncio.run(run())
+
+
+class TestAnOldVolumeUpgradesCleanly:
+    """The risky path: the column, the index and the dedupe all move together.
+
+    `_SCHEMA` is replayed on EVERY startup, so anything declared there runs
+    against whatever is already on disk. Declaring the new index there took
+    init_db down with "no such column: source" on any upgraded volume -- twice,
+    while writing this -- and the app does not start at all when that happens.
+    """
+
+    def test_a_pre_source_database_gains_the_column_and_index(self, db_dir):
+        async def run():
+            conn = await database._get_db()
+            try:
+                await conn.executescript("""
+                    DROP TABLE IF EXISTS earnings;
+                    CREATE TABLE earnings (
+                        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                        platform   TEXT    NOT NULL,
+                        balance    REAL    NOT NULL,
+                        currency   TEXT    NOT NULL DEFAULT 'USD',
+                        date       TEXT    NOT NULL,
+                        created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+                    );
+                    INSERT INTO earnings (platform, balance, currency, date)
+                    VALUES ('legacy', 4.2, 'USD', '2026-01-01');
+                """)
+                await conn.commit()
+            finally:
+                await conn.close()
+
+            await database.init_db()
+
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("PRAGMA table_info(earnings)")
+                cols = {row["name"] for row in await cur.fetchall()}
+                cur = await conn.execute(
+                    "SELECT 1 AS ok FROM sqlite_master "
+                    "WHERE type = 'index' AND name = 'idx_earnings_platform_source_date'"
+                )
+                index_row = await cur.fetchone()
+                cur = await conn.execute("SELECT source, balance FROM earnings WHERE platform = 'legacy'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+
+            assert "source" in cols
+            assert index_row is not None, "the unique index was never created on an upgraded volume"
+            # Backfilled truthfully: every pre-existing reading was this
+            # server's own, because no other sampler could write then.
+            assert row["source"] == "server"
+            assert row["balance"] == 4.2
+
+        asyncio.run(run())
+
+    def test_duplicate_rows_predating_the_index_do_not_break_startup(self, db_dir):
+        """The dedupe runs BEFORE the column exists, so its key must match the
+        schema actually on disk. Referencing `source` unconditionally crashed
+        init_db on precisely the volume the helper exists to rescue."""
+
+        async def run():
+            conn = await database._get_db()
+            try:
+                await conn.executescript("""
+                    DROP TABLE IF EXISTS earnings;
+                    CREATE TABLE earnings (
+                        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                        platform   TEXT    NOT NULL,
+                        balance    REAL    NOT NULL,
+                        currency   TEXT    NOT NULL DEFAULT 'USD',
+                        date       TEXT    NOT NULL,
+                        created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+                    );
+                    INSERT INTO earnings (platform, balance, currency, date)
+                    VALUES ('dupe', 1.0, 'USD', '2026-01-01');
+                    INSERT INTO earnings (platform, balance, currency, date)
+                    VALUES ('dupe', 2.0, 'USD', '2026-01-01');
+                """)
+                await conn.commit()
+            finally:
+                await conn.close()
+
+            await database.init_db()  # must not raise
+
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT balance FROM earnings WHERE platform = 'dupe'")
+                rows = await cur.fetchall()
+            finally:
+                await conn.close()
+            # The highest id survives: the most recent write, which is what an
+            # upsert would have left had the index existed all along.
+            assert len(rows) == 1
+            assert rows[0]["balance"] == 2.0
+
+        asyncio.run(run())

--- a/tests/test_beads_batch_62.py
+++ b/tests/test_beads_batch_62.py
@@ -223,23 +223,93 @@ class TestTwoSamplersNoLongerCorruptTheTotal:
     def test_a_legacy_row_with_no_source_joins_the_server_series(self, db):
         """Rows written before the column existed were all this server's own.
 
-        Treating them as a distinct source would split one real series in two and
-        drop the delta across the boundary.
+        The column is OMITTED from the INSERT so the schema default applies --
+        which is the shape a migrated legacy row actually has. An earlier version
+        of this test set source='server' explicitly, so it exercised no fallback
+        at all and merely duplicated the single-source case while its name
+        claimed otherwise. (CodeRabbit, PR #255.)
         """
 
         async def run():
             conn = await database._get_db()
             try:
                 await conn.execute(
-                    "INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd, source) "
-                    "VALUES ('titan', 1.0, 'USD', date('now', '-2 days'), 1.0, 'server')"
+                    "INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd) "
+                    "VALUES ('titan', 1.0, 'USD', date('now', '-2 days'), 1.0)"
+                )
+                await conn.execute(
+                    "INSERT INTO earnings (platform, balance, currency, date, fx_rate_usd) "
+                    "VALUES ('titan', 6.0, 'USD', date('now', '-1 days'), 1.0)"
                 )
                 await conn.commit()
             finally:
                 await conn.close()
-            await _insert([("titan", 6.0, "-1 days", "server")])
             earned = await database.get_earned_by_platform(days=30)
             assert earned["titan"] == pytest.approx(5.0)
+
+        asyncio.run(run())
+
+    def test_the_storage_api_can_write_a_source(self, db):
+        """The schema is unusable if nothing can write a non-default source.
+
+        upsert_earnings had no `source` parameter, so SQLite applied the default
+        to every call and a paired client could never create its own series
+        through the storage API. (CodeRabbit, PR #255.)
+        """
+
+        async def run():
+            await database.upsert_earnings(
+                platform="grass", balance=5.0, currency="USD", date="2026-01-01", fx_rate_usd=1.0, source="desktop-a"
+            )
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT source FROM earnings WHERE platform = 'grass'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["source"] == "desktop-a"
+
+        asyncio.run(run())
+
+    def test_two_sources_upsert_independently(self, db):
+        """Each machine's series is its own: writing one must not overwrite the
+        other's reading for the same day."""
+
+        async def run():
+            for src, bal in (("server", 5.0), ("desktop-a", 50.0)):
+                await database.upsert_earnings(
+                    platform="grass", balance=bal, currency="USD", date="2026-01-01", fx_rate_usd=1.0, source=src
+                )
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute(
+                    "SELECT source, balance FROM earnings WHERE platform = 'grass' ORDER BY source"
+                )
+                rows = await cur.fetchall()
+            finally:
+                await conn.close()
+            assert [(r["source"], r["balance"]) for r in rows] == [("desktop-a", 50.0), ("server", 5.0)]
+
+        asyncio.run(run())
+
+    def test_the_same_source_still_upserts(self, db):
+        """The dedupe half of the key: one machine, one platform, one day."""
+
+        async def run():
+            for bal in (5.0, 9.0):
+                await database.upsert_earnings(
+                    platform="grass", balance=bal, currency="USD", date="2026-01-01", fx_rate_usd=1.0, source="server"
+                )
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute(
+                    "SELECT COUNT(*) AS n, MAX(balance) AS b FROM earnings WHERE platform = 'grass'"
+                )
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["n"] == 1
+            assert row["b"] == 9.0
 
         asyncio.run(run())
 
@@ -375,5 +445,78 @@ class TestAnOldVolumeUpgradesCleanly:
             # upsert would have left had the index existed all along.
             assert len(rows) == 1
             assert rows[0]["balance"] == 2.0
+
+        asyncio.run(run())
+
+
+class TestTheLegacyIndexIsRemovedOnUpgrade:
+    """The bug my own upgrade test could not see.
+
+    It built a legacy table with NO indexes, so it never noticed that a real
+    upgraded volume keeps ``idx_earnings_platform_date`` -- which still forbids
+    two sources for one (platform, date) and would silently defeat the entire
+    change for every existing install. Creating the replacement is not enough;
+    the old constraint has to be dropped. (CodeRabbit, PR #255.)
+    """
+
+    def _legacy_volume(self):
+        async def build():
+            conn = await database._get_db()
+            try:
+                await conn.executescript("""
+                    DROP TABLE IF EXISTS earnings;
+                    CREATE TABLE earnings (
+                        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                        platform   TEXT    NOT NULL,
+                        balance    REAL    NOT NULL,
+                        currency   TEXT    NOT NULL DEFAULT 'USD',
+                        date       TEXT    NOT NULL,
+                        created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+                    );
+                    CREATE UNIQUE INDEX idx_earnings_platform_date
+                        ON earnings (platform, date);
+                """)
+                await conn.commit()
+            finally:
+                await conn.close()
+
+        return build
+
+    def test_the_old_index_is_gone_after_migration(self, db_dir):
+        async def run():
+            await self._legacy_volume()()
+            await database.init_db()
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_earnings_platform%'"
+                )
+                names = {row["name"] for row in await cur.fetchall()}
+            finally:
+                await conn.close()
+            assert "idx_earnings_platform_source_date" in names
+            assert "idx_earnings_platform_date" not in names, (
+                "the legacy index survived and still forbids two sources per day"
+            )
+
+        asyncio.run(run())
+
+    def test_two_sources_can_write_one_day_after_upgrading(self, db_dir):
+        """The behaviour the dropped index was blocking, end to end."""
+
+        async def run():
+            await self._legacy_volume()()
+            await database.init_db()
+            for src, bal in (("server", 1.0), ("desktop-a", 100.0)):
+                await database.upsert_earnings(
+                    platform="grass", balance=bal, currency="USD", date="2026-01-01", fx_rate_usd=1.0, source=src
+                )
+            conn = await database._get_db()
+            try:
+                cur = await conn.execute("SELECT COUNT(*) AS n FROM earnings WHERE platform = 'grass'")
+                row = await cur.fetchone()
+            finally:
+                await conn.close()
+            assert row["n"] == 2, "an upgraded volume still rejects a second source for the same day"
 
         asyncio.run(run())


### PR DESCRIPTION
The **server half** of `CashPilot-Desktop-xjr`, and the piece that gates everything on the Desktop side. Your goal: pairing uploads a Desktop's history retroactively, the Desktop shows the complete picture, and on unlink it falls back to what that machine earned alone.

## Why the obvious implementation corrupts the data

The server doesn't store *earnings*. It stores cumulative **balance readings**, and derives earnings as clamped deltas between consecutive readings.

Two samplers of one provider account, differenced as a single series, produce deltas between readings that came from **different samplers**. The sequence oscillates, every downward step clamps to zero, and the total comes out **systematically understated** while looking entirely plausible — worse than double counting, which at least overstates *visibly*.

So a reading records its `source` — `'server'` for this server's collectors, a `client_id` for a paired machine — and deltas are taken per `(platform, source)` and only then summed. **Both** delta readers were updated; the second was easy to miss.

That also makes `(platform, source, date)` the idempotency key, replacing `(platform, date)`: re-pairing or a retried import **overwrites** a day rather than appending a second reading. Two machines reporting one platform on one day is now the normal case, not a constraint violation.

## One query deliberately unchanged

The **current-balance** query still returns one row per platform, not one per source. A provider reports a single balance for the whole account, so the newest reading from *any* source **is** the current balance. Taking the latest per source and summing would multiply it by the number of machines watching.

## I broke the upgrade path twice

Both times by declaring the new index in `_SCHEMA`. That file is replayed on **every** startup, and `CREATE TABLE IF NOT EXISTS` is a no-op on an existing volume — so the index named `source` before the `ALTER` added it, and `init_db` died with `no such column: source`. **The app doesn't start at all** when that happens.

The index is created in the migration, after the column, with a comment saying why. The pre-existing fx-migration test caught it both times — that test earned its keep today.

The dedupe helper runs *before* the column is added, so its key now adapts to whichever schema is on disk. Referencing `source` unconditionally crashed `init_db` on precisely the volume that helper exists to rescue.

## A control that passed

Keying deltas by platform alone — the corruption itself — **passed** against my first fixture, because both sources reported the same numbers, the `ORDER BY` groups them, and the single crossover clamps to zero.

The fixture now uses far-apart scales (`10→12` and `50→52`) so the crossover is **positive** and would be counted as earnings that never happened: correct total 4, corrupted total 42.

## Evidence

`ruff` clean, `mkdocs --strict` clean, all five harnesses pass, **3557 passed, 95.49% coverage**.

Four negative controls fire: keying by platform alone, putting the index back in `_SCHEMA`, making the dedupe reference `source` unconditionally, and leaving the upsert conflict target on `(platform, date)`.

## Next

The import endpoint and the Desktop side. This lands the schema first, as it gates them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Earnings readings now distinguish between their originating sources, allowing separate tracking for multiple data streams on the same platform.
  - Earnings changes and payout calculations are now calculated independently for each source.
- **Bug Fixes**
  - Improved duplicate handling and aggregation for earnings data.
  - Existing single-source and legacy earnings records remain compatible.
  - Current balances continue to use the latest reading for each platform.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->