### PR TITLE
ci(release): bump the example compose pins, so the check guards the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,14 +262,35 @@ jobs:
           TAG="${{ needs.release.outputs.new_tag }}"
           SERIES="${TAG#v}"; SERIES="${SERIES%.*}"   # v1.16.2 -> 1.16
 
-          CURRENT=$(grep -oE 'drumsergio/cashpilot:[0-9]+\.[0-9]+' docker-compose.yml | head -1 | cut -d: -f2)
+          # Read the pins from BOTH files, and tolerate finding none.
+          #
+          # `|| true` is load-bearing twice over. Under `set -o pipefail` a grep
+          # that matches nothing fails the whole pipeline, so `set -e` would kill
+          # this step -- and this step runs AFTER the tag is pushed, so it would
+          # turn a successful release into a red one over a cosmetic edit. That
+          # is the exact failure this step's retry/warning logic exists to avoid,
+          # reappearing three lines earlier.
+          CURRENT=$(grep -ohE 'drumsergio/cashpilot(-worker)?:[0-9]+\.[0-9]+' \
+                      docker-compose.yml docker-compose.fleet.yml \
+                    | cut -d: -f2 | sort -u | tr '\n' ' ' || true)
+          CURRENT=$(echo "$CURRENT" | xargs || true)   # trim
+
+          if [ -z "$CURRENT" ]; then
+            echo "::warning::found no pinned cashpilot image in the compose files; leaving them alone"
+            exit 0
+          fi
           if [ "$CURRENT" = "$SERIES" ]; then
             # A patch release does not change the series. Committing an
             # unchanged file would push an empty commit on every patch.
+            #
+            # Both files are read, not just docker-compose.yml: if one had
+            # drifted and the other had not, reading only the first would report
+            # "already on $SERIES" and leave the other stale forever -- a silent
+            # no-op that looks exactly like success.
             echo "Pins already on $SERIES; nothing to do."
             exit 0
           fi
-          echo "Bumping the example pins $CURRENT -> $SERIES"
+          echo "Bumping the example pins [$CURRENT] -> $SERIES"
 
           sed -i -E "s|(drumsergio/cashpilot(-worker)?):[0-9]+\.[0-9]+|\1:$SERIES|g" \
             docker-compose.yml docker-compose.fleet.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,73 @@ jobs:
             git push origin "$TAG"
           fi
 
+      # The example compose files pin the major.minor series, and nothing moved
+      # them. So every minor release left docker-compose.yml and
+      # docker-compose.fleet.yml a series behind, and
+      # tests/test_compose_image_pins.py -- which is right to fail, a stale pin
+      # is what gave issue #188 a version with a first-run bug fixed months
+      # earlier -- went red on EVERY open branch until someone bumped them by
+      # hand. It blocked two unrelated PRs within hours of v1.15.0.
+      #
+      # The check was a tripwire on other people's work when it should have been
+      # a guard on the release. Now the release moves the pin itself, straight
+      # after the tag it is pinning to. (CashPilot-9fg.)
+      - name: Bump the example compose pins to this series
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.release.outputs.new_tag }}"
+          SERIES="${TAG#v}"; SERIES="${SERIES%.*}"   # v1.16.2 -> 1.16
+
+          CURRENT=$(grep -oE 'drumsergio/cashpilot:[0-9]+\.[0-9]+' docker-compose.yml | head -1 | cut -d: -f2)
+          if [ "$CURRENT" = "$SERIES" ]; then
+            # A patch release does not change the series. Committing an
+            # unchanged file would push an empty commit on every patch.
+            echo "Pins already on $SERIES; nothing to do."
+            exit 0
+          fi
+          echo "Bumping the example pins $CURRENT -> $SERIES"
+
+          sed -i -E "s|(drumsergio/cashpilot(-worker)?):[0-9]+\.[0-9]+|\1:$SERIES|g" \
+            docker-compose.yml docker-compose.fleet.yml
+
+          # Prove the edit did what it claims before committing it. A silently
+          # unmatched sed would otherwise commit nothing and report success,
+          # leaving the drift in place with no red build to reveal it.
+          #
+          # Plain ERE, no negative lookahead: that needs -P, and GNU grep
+          # REFUSES -E and -P together ("conflicting matchers specified"). The
+          # first version of this used both and appeared to work locally only
+          # because that shell's `grep` is a ugrep shim, which accepts it.
+          STRAY=$(grep -ohE 'drumsergio/cashpilot(-worker)?:[0-9]+\.[0-9]+' \
+                    docker-compose.yml docker-compose.fleet.yml \
+                  | cut -d: -f2 | sort -u | grep -vx "$SERIES" || true)
+          if [ -n "$STRAY" ]; then
+            echo "::error::a pin did not move to $SERIES (still on: $STRAY)"; exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docker-compose.yml docker-compose.fleet.yml
+          # [skip ci] because this must not start another release. The paths
+          # filter on this workflow does not list the compose files, so it would
+          # not fire anyway -- the marker is what keeps that true if the filter
+          # ever widens.
+          git commit -m "chore(compose): pin the examples to $SERIES [skip ci]"
+
+          # Push onto whatever main is NOW. The build job takes minutes, so
+          # something may well have merged since this run checked out -- and a
+          # release that fails at the last step because of an unrelated merge
+          # would leave the tag published and the pins stale, which is the
+          # position this whole step exists to avoid.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${GITHUB_REF_NAME}"; then exit 0; fi
+            echo "push rejected (attempt $attempt); rebasing onto the current branch"
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+          done
+          # Never fail the release for this: the tag and the images are already
+          # published and correct. Say so loudly instead.
+          echo "::warning::could not push the compose pin bump to $SERIES; bump it by hand"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:

--- a/tests/test_beads_batch_65.py
+++ b/tests/test_beads_batch_65.py
@@ -114,6 +114,32 @@ class TestTheReleaseMovesThePin:
         """Never a hardcoded 'main': the branch name is the runtime's to know."""
         assert "GITHUB_REF_NAME" in bump_step()["run"]
 
+    def test_the_series_is_read_from_both_files(self):
+        """Reading only docker-compose.yml made partial drift invisible.
+
+        If one file had drifted and the other had not, the "already on $SERIES"
+        check would fire on the first and leave the second stale forever — a
+        silent no-op that looks exactly like success. Verified on a Linux host:
+        with the two files on 1.14 and 1.16, the step now reports
+        `bump [1.14 1.16] -> 1.16` instead of `NOOP`.
+        """
+        run = bump_step()["run"]
+        read = run[run.index("CURRENT=") : run.index("if [ -z")]
+        assert "docker-compose.yml" in read and "docker-compose.fleet.yml" in read, read
+
+    def test_finding_no_pin_warns_instead_of_failing_the_release(self):
+        """`set -o pipefail` turns a grep that matches nothing into a failed
+        pipeline, and `set -e` then kills the step — which runs AFTER the tag is
+        pushed. So a compose file without a pin would turn a successful release
+        red over a cosmetic edit: the exact failure the retry logic below exists
+        to prevent, reappearing a few lines earlier.
+        """
+        run = bump_step()["run"]
+        read = run[run.index("CURRENT=") : run.index("if [ -z")]
+        assert "|| true" in read, "a grep miss still fails the step:\n" + read
+        guard = run[run.index("if [ -z") : run.index('if [ "$CURRENT" = "$SERIES" ]')]
+        assert "::warning::" in guard and "exit 0" in guard, guard
+
     def test_both_compose_files_are_covered(self):
         run = bump_step()["run"]
         assert "docker-compose.yml" in run

--- a/tests/test_beads_batch_65.py
+++ b/tests/test_beads_batch_65.py
@@ -1,0 +1,147 @@
+"""CashPilot-9fg: the compose-pin check was a tripwire, not a guard.
+
+``tests/test_compose_image_pins.py`` compares the example compose files' pinned
+``major.minor`` against the newest RELEASED series, and it is right to: a stale
+pin is what gave issue #188 a version with a first-run bug that had been fixed
+for months.
+
+But nothing moved the pin. So every minor release left both compose files a
+series behind and that test went red on **every open branch** until someone
+bumped them by hand — it blocked two unrelated PRs within hours of v1.15.0. The
+check was punishing whoever opened the next pull request for something the
+release had done.
+
+The release now moves the pin itself, straight after pushing the tag it is
+pinning to.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def publish_steps() -> list[dict]:
+    doc = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    return [s for s in doc["jobs"]["publish"]["steps"] if isinstance(s, dict)]
+
+
+def bump_step() -> dict:
+    for step in publish_steps():
+        if "compose pins" in (step.get("name") or ""):
+            return step
+    raise AssertionError(f"no compose-pin step: {[s.get('name') for s in publish_steps()]}")
+
+
+class TestTheReleaseMovesThePin:
+    def test_the_step_exists(self):
+        assert bump_step()["run"]
+
+    def test_it_runs_after_the_tag_is_pushed(self):
+        """Order matters and is not cosmetic. The pin test compares against the
+        newest RELEASED series, so bumping before the tag exists would leave the
+        files pinned to a version no release has published."""
+        names = [s.get("name") or s.get("uses") or "" for s in publish_steps()]
+        tag_at = next(i for i, n in enumerate(names) if "push tag" in n.lower())
+        bump_at = next(i for i, n in enumerate(names) if "compose pins" in n)
+        assert tag_at < bump_at, names
+
+    def test_it_derives_the_series_from_the_tag(self):
+        """Not from anything that could agree with itself."""
+        run = bump_step()["run"]
+        assert "needs.release.outputs.new_tag" in run
+        assert 'SERIES="${SERIES%.*}"' in run, "the patch component is not stripped"
+
+    def test_a_patch_release_changes_nothing(self):
+        """v1.16.2 is the same 1.16 series. Without this the release pushes an
+        empty commit to main on every patch."""
+        run = bump_step()["run"]
+        assert '[ "$CURRENT" = "$SERIES" ]' in run, run
+
+    def test_the_edit_is_verified_before_it_is_committed(self):
+        """A sed that matched nothing would commit nothing and report success,
+        leaving the drift in place with no red build to reveal it."""
+        run = bump_step()["run"]
+        assert "STRAY=" in run
+        assert "::error::" in run
+        assert "exit 1" in run
+
+    def test_the_guard_uses_no_perl_regex(self):
+        """GNU grep REFUSES -E and -P together ("conflicting matchers
+        specified", exit 2). The first version of this step used both and looked
+        fine locally only because that shell's `grep` is a ugrep shim, which
+        accepts it — so it would have failed on ubuntu-latest, in the release,
+        after the tag was already published.
+        """
+        run = bump_step()["run"]
+        offenders = [ln.strip() for ln in run.splitlines() if re.search(r"\bgrep\b.*-\w*P\b", ln)]
+        assert not offenders, offenders
+
+    def test_the_commit_cannot_start_another_release(self):
+        """release.yml triggers on pushes to main. Without the marker this would
+        be a release that releases.
+
+        Scoped to the `git commit` line. A plain `"[skip ci]" in run` passed with
+        the marker DELETED from the commit, because the comment above it explains
+        why the marker is there and therefore has to name it — the test matching
+        its own prose. Caught by a negative control.
+        """
+        commits = [ln for ln in bump_step()["run"].splitlines() if ln.strip().startswith("git commit")]
+        assert commits, "the step no longer commits anything"
+        assert all("[skip ci]" in ln for ln in commits), commits
+
+    def test_it_retries_rather_than_racing_a_merge(self):
+        """The build job takes minutes, so main may well have moved. A rejected
+        push must not be the end of it."""
+        run = bump_step()["run"]
+        assert "git pull --rebase" in run
+        assert "for attempt" in run
+
+    def test_a_failed_push_warns_rather_than_failing_the_release(self):
+        """The tag and the images are already published and correct by this
+        point. Failing here would turn a cosmetic miss into a red release."""
+        run = bump_step()["run"]
+        assert "::warning::" in run
+        tail = run[run.index("for attempt") :]
+        assert "::error::" not in tail, "a push failure is escalated to an error"
+
+    def test_it_pushes_to_the_branch_it_ran_on(self):
+        """Never a hardcoded 'main': the branch name is the runtime's to know."""
+        assert "GITHUB_REF_NAME" in bump_step()["run"]
+
+    def test_both_compose_files_are_covered(self):
+        run = bump_step()["run"]
+        assert "docker-compose.yml" in run
+        assert "docker-compose.fleet.yml" in run
+
+
+class TestTheSeriesArithmetic:
+    """The shell's series extraction, exercised directly.
+
+    Verified end to end against the real compose files on a Linux host with GNU
+    grep 3.12 before this was written; these pin the arithmetic so a later edit
+    cannot quietly change it.
+    """
+
+    @staticmethod
+    def _series(tag: str) -> str:
+        version = tag.removeprefix("v")
+        return version.rsplit(".", 1)[0]
+
+    def test_a_minor_release(self):
+        assert self._series("v1.16.0") == "1.16"
+
+    def test_a_patch_release_keeps_the_series(self):
+        assert self._series("v1.16.3") == "1.16"
+
+    def test_a_major_release(self):
+        assert self._series("v2.0.0") == "2.0"
+
+    def test_a_two_digit_minor(self):
+        """A naive cut on the first dot would give "1"."""
+        assert self._series("v1.100.2") == "1.100"


### PR DESCRIPTION
Closes `CashPilot-9fg`.

## The problem

`tests/test_compose_image_pins.py` compares the example compose files' pinned `major.minor` against the newest **released** series, and it is right to — a stale pin is what gave issue #188 a version with a first-run bug that had been fixed for months.

But **nothing moved the pin.** So every minor release left both compose files a series behind, and that test then went red on *every open branch* until someone bumped them by hand. It blocked two unrelated PRs within hours of v1.15.0.

The check was a tripwire on other people's work when it should have been a guard on the release.

## The fix

The release moves the pin itself, straight after pushing the tag it is pinning to. Order matters and is not cosmetic: the test compares against the newest **released** series, so bumping before the tag exists would pin to a version no release has published.

- **A patch release changes nothing.** `v1.16.2` is still the 1.16 series; without the guard the release pushes an empty commit on every patch.
- **The edit is verified before it is committed.** A `sed` that matched nothing would commit nothing and report success, leaving the drift in place with no red build to reveal it.
- **`[skip ci]` on the commit**, because `release.yml` triggers on pushes to main. The paths filter doesn't list the compose files so it wouldn't fire anyway — the marker keeps that true if the filter ever widens.
- **The push retries onto the current branch.** The build job takes minutes, so main may well have moved, and a release failing at the last step because of an unrelated merge would leave the tag published and the pins stale — exactly the position this exists to avoid. A push that still fails **warns** rather than failing the release: the tag and the images are already published and correct by then.

## Verification

Run end to end on a Linux host against the real compose files:

| Tag | Result |
|---|---|
| `v1.16.0` | `bump 1.15 -> 1.16`, both files, guard clean |
| `v1.16.3` | `NOOP (already 1.16)` |
| `v2.0.0` | `bump 1.16 -> 2.0` |

**The first version of the guard would have broken the release.** It used `grep -E -P`; GNU grep *refuses* that combination — `conflicting matchers specified`, exit 2 — and it looked fine locally only because this shell's `grep` is a `ugrep` shim, which accepts it. It would have failed in the release, after the tag was already pushed. Confirmed against GNU grep 3.12 on a real Linux host and rewritten as plain ERE. A test now forbids `-P` in that step.

Seven negative controls (step removed, bump before tag, no-op guard dropped, `-P` reintroduced, `[skip ci]` dropped, push failure escalated to an error, hardcoded `main`).

**One of them passed at first, which meant the test was wrong, not the code.** `"[skip ci]" in run` was satisfied by the *comment* above the commit — which has to name the marker in order to explain it. The test was matching its own prose. Now scoped to the `git commit` line, and it fails under the control.