### PR TITLE
fix(release): bump the compose pins through a PR, because main is protected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # For the compose-pin bump, which must go through a PR because main is
+      # protected. Nothing else in this job needs it.
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -257,6 +260,10 @@ jobs:
       # a guard on the release. Now the release moves the pin itself, straight
       # after the tag it is pinning to. (CashPilot-9fg.)
       - name: Bump the example compose pins to this series
+        env:
+          # gh needs a token; the job already holds contents: write, and
+          # pull-requests: write is added on the job below for the PR itself.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           TAG="${{ needs.release.outputs.new_tag }}"
@@ -319,19 +326,39 @@ jobs:
           # ever widens.
           git commit -m "chore(compose): pin the examples to $SERIES [skip ci]"
 
-          # Push onto whatever main is NOW. The build job takes minutes, so
-          # something may well have merged since this run checked out -- and a
-          # release that fails at the last step because of an unrelated merge
-          # would leave the tag published and the pins stale, which is the
-          # position this whole step exists to avoid.
-          for attempt in 1 2 3; do
-            if git push origin "HEAD:${GITHUB_REF_NAME}"; then exit 0; fi
-            echo "push rejected (attempt $attempt); rebasing onto the current branch"
-            git pull --rebase origin "${GITHUB_REF_NAME}"
-          done
-          # Never fail the release for this: the tag and the images are already
-          # published and correct. Say so loudly instead.
-          echo "::warning::could not push the compose pin bump to $SERIES; bump it by hand"
+          # THROUGH A PULL REQUEST, because main is protected.
+          #
+          # The first version pushed straight to main and was rejected three
+          # times with "Changes must be made through a pull request" (GH006) --
+          # observed in the v1.16.0 run, which shipped green only because the
+          # failure warns instead of failing. Branch protection is not going
+          # away, so the mechanism has to change rather than the retry count.
+          #
+          # A PR can be merged immediately here: main requires a PR but demands
+          # no approvals and no status checks (verified against the protection
+          # API). If that ever tightens, the merge below fails, the warning
+          # fires, and the release still ships -- which is the behaviour to keep.
+          BRANCH="chore/compose-pins-$SERIES"
+          git checkout -b "$BRANCH"
+          # --force-with-lease so a re-run reuses the branch instead of dying on
+          # it. Protection covers main, not this branch.
+          if ! git push --force-with-lease origin "$BRANCH"; then
+            echo "::warning::could not push $BRANCH; bump the compose pins to $SERIES by hand"
+            exit 0
+          fi
+
+          if ! gh pr create --base "${GITHUB_REF_NAME}" --head "$BRANCH" \
+                 --title "chore(compose): pin the examples to $SERIES" \
+                 --body "Automated by the $TAG release. The example compose files pin the major.minor series, and tests/test_compose_image_pins.py compares that pin against the newest released series -- so without this every open branch goes red until someone bumps them by hand."; then
+            echo "::warning::could not open the pin-bump PR for $SERIES; merge $BRANCH by hand"
+            exit 0
+          fi
+
+          if ! gh pr merge "$BRANCH" --squash --delete-branch; then
+            echo "::warning::opened the pin-bump PR for $SERIES but could not merge it; merge it by hand"
+            exit 0
+          fi
+          echo "Pins bumped to $SERIES via $BRANCH."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3

--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.15
+    image: drumsergio/cashpilot:1.16
     pull_policy: always
     container_name: cashpilot-ui
     # Loopback by default (the UI commands the Docker-socket worker). Set
@@ -38,7 +38,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.15
+    image: drumsergio/cashpilot-worker:1.16
     pull_policy: always
     container_name: cashpilot-worker
     # The worker exposes a Docker-socket-backed API (deploy/stop/remove any
@@ -105,7 +105,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:1.15
+#      image: drumsergio/cashpilot-worker:1.16
 #      pull_policy: always
 #      container_name: cashpilot-worker
 #      # Docker-socket-backed API = full host control. Bind a PRIVATE/VPN interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.15
+    image: drumsergio/cashpilot:1.16
     pull_policy: always
     container_name: cashpilot-ui
     # Published on loopback by default: the dashboard can command the Docker-socket
@@ -51,7 +51,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.15
+    image: drumsergio/cashpilot-worker:1.16
     pull_policy: always
     container_name: cashpilot-worker
     expose:

--- a/tests/test_beads_batch_65.py
+++ b/tests/test_beads_batch_65.py
@@ -107,16 +107,19 @@ class TestTheReleaseMovesThePin:
         assert "gh pr create" in run, run
         assert "gh pr merge" in run, run
 
-    def test_it_never_pushes_straight_to_the_release_branch(self):
+    def test_every_push_targets_the_delivery_branch(self):
         """The regression that matters: reintroducing a direct push would be
-        rejected on every release, silently, behind a warning."""
-        run = bump_step()["run"]
-        direct = [
-            ln.strip()
-            for ln in run.splitlines()
-            if "git push" in ln and "GITHUB_REF_NAME" in ln and "$BRANCH" not in ln
-        ]
-        assert not direct, direct
+        rejected on every release, silently, behind a warning.
+
+        Asserted POSITIVELY -- every `git push` must name "$BRANCH". The first
+        version filtered for lines mentioning GITHUB_REF_NAME, which meant a
+        hardcoded `git push origin main` -- the likeliest regression of all --
+        matched nothing and passed. (CodeRabbit, PR #260.)
+        """
+        pushes = [ln.strip() for ln in bump_step()["run"].splitlines() if "git push" in ln]
+        assert pushes, "the step no longer pushes anything"
+        offenders = [ln for ln in pushes if '"$BRANCH"' not in ln]
+        assert not offenders, f"a push does not target the delivery branch: {offenders}"
 
     def test_the_pr_targets_the_branch_the_release_ran_on(self):
         """Never a hardcoded 'main'."""
@@ -126,8 +129,15 @@ class TestTheReleaseMovesThePin:
 
     def test_the_step_has_a_token_to_talk_to_the_api(self):
         """`gh` without GH_TOKEN fails with an auth error that reads like a
-        permissions bug."""
-        assert "GH_TOKEN" in str(bump_step().get("env", {}))
+        permissions bug.
+
+        The EXACT mapping, not just the presence of the name: `GH_TOKEN: ""` and
+        `GH_TOKEN: ${{ secrets.SOMETHING_ELSE }}` both satisfied the first
+        version, and both would fail at run time in a way that looks like a
+        permissions problem rather than a typo. (CodeRabbit, PR #260.)
+        """
+        env = bump_step().get("env", {})
+        assert env.get("GH_TOKEN") == "${{ secrets.GITHUB_TOKEN }}", env
 
     def test_the_job_may_open_a_pull_request(self):
         """contents: write is not enough to open a PR; the API returns 403."""

--- a/tests/test_beads_batch_65.py
+++ b/tests/test_beads_batch_65.py
@@ -95,24 +95,63 @@ class TestTheReleaseMovesThePin:
         assert commits, "the step no longer commits anything"
         assert all("[skip ci]" in ln for ln in commits), commits
 
-    def test_it_retries_rather_than_racing_a_merge(self):
-        """The build job takes minutes, so main may well have moved. A rejected
-        push must not be the end of it."""
-        run = bump_step()["run"]
-        assert "git pull --rebase" in run
-        assert "for attempt" in run
+    def test_it_goes_through_a_pull_request(self):
+        """main is PROTECTED: "Changes must be made through a pull request".
 
-    def test_a_failed_push_warns_rather_than_failing_the_release(self):
+        The first version pushed straight to main and was rejected three times
+        with GH006 in the v1.16.0 run — which shipped green only because the
+        failure warns instead of failing. Branch protection is not going away,
+        so the mechanism had to change rather than the retry count.
+        """
+        run = bump_step()["run"]
+        assert "gh pr create" in run, run
+        assert "gh pr merge" in run, run
+
+    def test_it_never_pushes_straight_to_the_release_branch(self):
+        """The regression that matters: reintroducing a direct push would be
+        rejected on every release, silently, behind a warning."""
+        run = bump_step()["run"]
+        direct = [
+            ln.strip()
+            for ln in run.splitlines()
+            if "git push" in ln and "GITHUB_REF_NAME" in ln and "$BRANCH" not in ln
+        ]
+        assert not direct, direct
+
+    def test_the_pr_targets_the_branch_the_release_ran_on(self):
+        """Never a hardcoded 'main'."""
+        run = bump_step()["run"]
+        create = next(ln for ln in run.splitlines() if "gh pr create" in ln)
+        assert "GITHUB_REF_NAME" in create, create
+
+    def test_the_step_has_a_token_to_talk_to_the_api(self):
+        """`gh` without GH_TOKEN fails with an auth error that reads like a
+        permissions bug."""
+        assert "GH_TOKEN" in str(bump_step().get("env", {}))
+
+    def test_the_job_may_open_a_pull_request(self):
+        """contents: write is not enough to open a PR; the API returns 403."""
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+        perms = doc["jobs"]["publish"]["permissions"]
+        assert perms.get("pull-requests") == "write", perms
+
+    def test_every_delivery_failure_warns_rather_than_failing_the_release(self):
         """The tag and the images are already published and correct by this
-        point. Failing here would turn a cosmetic miss into a red release."""
-        run = bump_step()["run"]
-        assert "::warning::" in run
-        tail = run[run.index("for attempt") :]
-        assert "::error::" not in tail, "a push failure is escalated to an error"
+        point. Failing here would turn a cosmetic miss into a red release — and
+        that is not hypothetical: the v1.16.0 run hit exactly this path.
 
-    def test_it_pushes_to_the_branch_it_ran_on(self):
-        """Never a hardcoded 'main': the branch name is the runtime's to know."""
-        assert "GITHUB_REF_NAME" in bump_step()["run"]
+        Scoped to the DELIVERY half (push, PR, merge). The validation above it
+        still uses ::error:: for a sed that did not do what it claims, which is a
+        real defect rather than an environment refusal.
+        """
+        run = bump_step()["run"]
+        delivery = run[run.index('BRANCH="chore/compose-pins') :]
+        assert "::warning::" in delivery
+        assert "::error::" not in delivery, "a delivery failure is escalated to an error"
+        # Each of the three ways delivery can fail must exit 0, not fall through.
+        assert delivery.count("exit 0") >= 3, delivery
 
     def test_the_series_is_read_from_both_files(self):
         """Reading only docker-compose.yml made partial drift invisible.


### PR DESCRIPTION
The v1.16.0 release **proved the mechanism cannot work**, which is the useful outcome.

`main` is protected — *"Changes must be made through a pull request"* — so the bump was rejected three times with `GH006` and the step warned:

```
! [remote rejected] HEAD -> main (protected branch hook declined)
push rejected (attempt 3); rebasing onto the current branch
::warning::could not push the compose pin bump to 1.16
```

The retry-then-warn design is exactly what let **v1.16.0 ship green** instead of going red at the last step, and that half was right. But branch protection isn't going away, so the *mechanism* had to change rather than the retry count.

## What it does now

Creates a branch, opens a PR, merges it. That works here without weakening anything — `main` requires a PR but demands **no approvals and no status checks**, verified against the protection API rather than assumed. If that ever tightens, the merge fails, the warning fires, and the release still ships. That's the behaviour worth keeping.

Each of the three delivery steps — push, create, merge — warns and `exit 0`s on failure. The validation *above* them still uses `::error::`, because a `sed` that didn't do what it claims is a defect rather than an environment refusal.

Also bumps the pins to **1.16** by hand, which is what the failed run should have done, so `test_compose_image_pins.py` stops going red on every open branch.

## Verification

Five negative controls, all failing:

| Control | Test that fails |
|---|---|
| Back to a direct push to main | `test_it_goes_through_a_pull_request`, `test_it_never_pushes_straight_to_the_release_branch` |
| `pull-requests: write` removed | `test_the_job_may_open_a_pull_request` |
| `GH_TOKEN` removed | `test_the_step_has_a_token_to_talk_to_the_api` |
| A delivery failure escalated to `::error::` | `test_every_delivery_failure_warns_rather_than_failing_the_release` |
| PR base hardcoded to `main` | `test_the_pr_targets_the_branch_the_release_ran_on` |

3653 tests pass, coverage 95.55%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release updates now propose compose configuration changes through a pull request instead of directly modifying the release branch.
  * Release publication can complete successfully even when automated configuration delivery requires manual follow-up.

* **Updates**
  * Updated the CashPilot UI and worker container images to version 1.16 across standard and fleet deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->