### PR TITLE
feat(db): say what the schema is and what just migrated

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -387,7 +387,18 @@ CREATE TABLE IF NOT EXISTS users (
     username   TEXT    NOT NULL UNIQUE,
     password   TEXT    NOT NULL,
     role       TEXT    NOT NULL DEFAULT 'viewer',
-    created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+    created_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    -- Declared here as well as in the migration below, so a FRESH install does
+    -- not run an ALTER TABLE it never needed. Found by the startup log added in
+    -- CashPilot-sfbh: a brand-new database reported "Migrations applied this
+    -- boot: users.password_changed_at", which is exactly the noise that makes an
+    -- operator stop reading migration output.
+    --
+    -- Safe both ways: CREATE TABLE IF NOT EXISTS is a no-op on an existing
+    -- database, so it still gets the column from the migration. (Unlike adding
+    -- an INDEX here, which runs on existing tables and fails on a column they do
+    -- not have yet -- that mistake broke the upgrade path twice.)
+    password_changed_at REAL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS workers (
@@ -717,9 +728,24 @@ async def _encrypt_legacy_plaintext_credentials(db: Any) -> int:
     return len(stale)
 
 
+#: What this build's schema looks like. Bumped by hand when a migration is added.
+#:
+#: REPORTED, NEVER USED AS A GATE. Every migration below is guarded by its own
+#: ``PRAGMA table_info`` check, and that stays the source of truth. If this number
+#: decided whether migrations ran, a database whose user_version said 10 but was
+#: missing a column -- an interrupted upgrade, a restored backup, a hand-edited
+#: file -- could never be repaired, because the gate would say there was nothing
+#: to do. The guards are idempotent and cheap; the version is for the operator.
+SCHEMA_VERSION = 10
+
+
 async def init_db() -> None:
     """Create tables if they don't exist."""
     db = await _get_db()
+    # What actually changed on THIS boot, for the log line at the end. An
+    # operator watching `docker logs` during an upgrade could previously not
+    # tell a clean start from one that had just rewritten the earnings table.
+    applied: list[str] = []
     try:
         await _dedupe_earnings_before_indexing(db)
         await db.executescript(_SCHEMA)
@@ -727,6 +753,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(workers)")
         cols = {row["name"] for row in await cursor.fetchall()}
         if "client_id" not in cols:
+            applied.append("workers.client_id")
             # Rebuild table: UNIQUE moves from name → client_id, name becomes display-only.
             # Existing rows get client_id = name for backward compat.
             has_apps = "apps" in cols
@@ -767,16 +794,20 @@ async def init_db() -> None:
                 CREATE INDEX IF NOT EXISTS idx_workers_status ON workers (status);
             """)
         elif "apps" not in cols:
+            applied.append("workers.apps")
             await db.execute("ALTER TABLE workers ADD COLUMN apps TEXT NOT NULL DEFAULT '[]'")
 
         # Migrate workers table: add api_key_enc for per-worker fleet keys.
         # (cols is the pre-rebuild snapshot; on a fresh DB the column comes from
         # _SCHEMA so it is already present here and the ALTER is skipped.)
         if "api_key_enc" not in cols:
+            applied.append("workers.api_key_enc")
             await db.execute("ALTER TABLE workers ADD COLUMN api_key_enc TEXT")
         if "key_confirmed" not in cols:
+            applied.append("workers.key_confirmed")
             await db.execute("ALTER TABLE workers ADD COLUMN key_confirmed INTEGER NOT NULL DEFAULT 0")
         if "key_issued_at" not in cols:
+            applied.append("workers.key_issued_at")
             # When the per-worker key was minted, so the window in which the
             # SHARED key still works for that worker can be bounded.
             await db.execute("ALTER TABLE workers ADD COLUMN key_issued_at TEXT")
@@ -797,11 +828,13 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(earnings)")
         earnings_cols = {row["name"] for row in await cursor.fetchall()}
         if "fx_rate_usd" not in earnings_cols:
+            applied.append("earnings.fx_rate_usd")
             await db.execute("ALTER TABLE earnings ADD COLUMN fx_rate_usd REAL")
         # Add `source`: WHO took the reading. Existing rows were all taken by
         # this server's own collectors, so 'server' is the truthful backfill
         # rather than a placeholder -- there was no other sampler before this.
         if "source" not in earnings_cols:
+            applied.append("earnings.source")
             await db.execute("ALTER TABLE earnings ADD COLUMN source TEXT NOT NULL DEFAULT 'server'")
         # Unconditional, and only AFTER the column is guaranteed to exist. This
         # is the ONLY place the index is created, so a fresh install and an
@@ -829,6 +862,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(deployments)")
         deployment_cols = {row["name"] for row in await cursor.fetchall()}
         if "spec_encrypted" not in deployment_cols:
+            applied.append("deployments.spec_encrypted")
             await db.execute("ALTER TABLE deployments ADD COLUMN spec_encrypted TEXT NOT NULL DEFAULT ''")
         # Migrate config table: add updated_at so credential age is knowable.
         # Existing rows are left NULL — see the note on the back-fill below.
@@ -838,6 +872,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(config)")
         config_cols = {row["name"] for row in await cursor.fetchall()}
         if "updated_at" not in config_cols:
+            applied.append("config.updated_at")
             await db.execute("ALTER TABLE config ADD COLUMN updated_at TEXT")
             # Deliberately NOT back-filled with datetime('now').
             #
@@ -855,7 +890,30 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(users)")
         user_cols = {row["name"] for row in await cursor.fetchall()}
         if "password_changed_at" not in user_cols:
+            applied.append("users.password_changed_at")
             await db.execute("ALTER TABLE users ADD COLUMN password_changed_at REAL DEFAULT 0")
+
+        # The version the database CLAIMED before this boot. 0 on anything
+        # written before this was introduced, including a fully up-to-date one --
+        # so the first upgrade reports "was 0" and that is honest rather than
+        # alarming.
+        cursor = await db.execute("PRAGMA user_version")
+        row = await cursor.fetchone()
+        previous = int(row[0]) if row else 0
+        if previous != SCHEMA_VERSION:
+            # A literal: PRAGMA does not accept a bound parameter here. Safe
+            # because the value is this module's own int constant.
+            await db.execute(f"PRAGMA user_version = {int(SCHEMA_VERSION)}")
+
+        if applied:
+            _logger.info(
+                "Schema now at version %d (was %d). Migrations applied this boot: %s",
+                SCHEMA_VERSION,
+                previous,
+                ", ".join(applied),
+            )
+        else:
+            _logger.info("Schema at version %d; no migration needed this boot.", SCHEMA_VERSION)
 
         await db.commit()
 

--- a/tests/test_beads_batch_66.py
+++ b/tests/test_beads_batch_66.py
@@ -1,0 +1,164 @@
+"""CashPilot-sfbh: migrations ran and reported nothing.
+
+Every schema change in ``init_db`` is guarded by its own ``PRAGMA table_info``
+check, and they are careful. But **nothing said what happened.** An operator
+watching ``docker logs`` through an upgrade could not tell a clean start from one
+that had just rewritten the earnings table, and a bug report could not say either.
+
+Two things are now reported at startup: the schema version, and which migrations
+actually ran on this boot.
+
+THE DESIGN DECISION THAT MATTERS: the version is REPORTED, NEVER USED AS A GATE.
+If ``user_version`` decided whether migrations ran, a database whose version said
+10 but was missing a column -- an interrupted upgrade, a restored backup, a
+hand-edited file -- could never be repaired, because the gate would say there was
+nothing to do. The ``PRAGMA table_info`` guards stay the source of truth; they are
+idempotent and cheap. The version is for the human.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app import database
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", tmp_path / "cashpilot.db"):
+        yield tmp_path
+
+
+def _user_version() -> int:
+    async def run():
+        conn = await database._get_db()
+        cur = await conn.execute("PRAGMA user_version")
+        row = await cur.fetchone()
+        return int(row[0]) if row else 0
+
+    return asyncio.run(run())
+
+
+class TestTheVersionIsRecorded:
+    def test_a_fresh_database_ends_at_the_current_version(self, db_dir):
+        asyncio.run(database.init_db())
+        assert _user_version() == database.SCHEMA_VERSION
+
+    def test_the_constant_is_a_positive_int(self):
+        """A float or a string would be interpolated into the PRAGMA."""
+        assert isinstance(database.SCHEMA_VERSION, int)
+        assert database.SCHEMA_VERSION > 0
+
+    def test_a_second_boot_does_not_change_it(self, db_dir):
+        asyncio.run(database.init_db())
+        first = _user_version()
+        asyncio.run(database.init_db())
+        assert _user_version() == first
+
+
+class TestTheStartupLogSaysWhatHappened:
+    def test_a_fresh_database_reports_no_migration(self, db_dir, caplog):
+        """A brand-new file creates its tables from _SCHEMA; no guarded
+        migration fires, so saying one did would be false."""
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        assert any("no migration needed" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_it_always_says_something(self, db_dir, caplog):
+        """Silence is the defect being fixed. Whatever happened, one line."""
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        assert any("Schema" in (r.getMessage()) for r in caplog.records)
+
+    def test_an_upgraded_database_names_the_migrations_that_ran(self, db_dir, caplog):
+        """The case that matters. An OLD database -- one missing a column this
+        build adds -- must report exactly what was done to it."""
+
+        async def make_old():
+            conn = await database._get_db()
+            # A minimal pre-`source` earnings table, as a database written by an
+            # older build actually looks.
+            await conn.executescript(
+                """
+                CREATE TABLE earnings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    platform TEXT NOT NULL,
+                    balance REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    date TEXT NOT NULL,
+                    created_at TEXT
+                );
+                """
+            )
+            await conn.commit()
+
+        asyncio.run(make_old())
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+
+        messages = [r.getMessage() for r in caplog.records]
+        summary = next((m for m in messages if "Migrations applied this boot" in m), None)
+        assert summary, messages
+        assert "earnings.source" in summary, summary
+        assert "earnings.fx_rate_usd" in summary, summary
+
+    def test_the_upgrade_reports_the_version_it_came_from(self, db_dir, caplog):
+        """ "was 0" on anything written before this existed, including a database
+        that was otherwise fully up to date. Honest rather than alarming."""
+
+        async def make_old():
+            conn = await database._get_db()
+            await conn.executescript("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT NOT NULL);")
+            await conn.commit()
+
+        asyncio.run(make_old())
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("(was 0)" in m for m in messages), messages
+
+
+class TestTheVersionNeverGatesTheMigrations:
+    """The design decision, enforced.
+
+    A database claiming the current version but MISSING a column must still be
+    repaired. Gating on the version would make that database unfixable, and the
+    shapes that produce it -- an interrupted upgrade, a restored backup -- are
+    exactly when repair matters most.
+    """
+
+    def test_a_column_is_added_even_when_the_version_already_says_current(self, db_dir):
+        async def make_lying_db():
+            conn = await database._get_db()
+            await conn.executescript(
+                """
+                CREATE TABLE earnings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    platform TEXT NOT NULL,
+                    balance REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    date TEXT NOT NULL,
+                    created_at TEXT
+                );
+                """
+            )
+            await conn.execute(f"PRAGMA user_version = {database.SCHEMA_VERSION}")
+            await conn.commit()
+
+        asyncio.run(make_lying_db())
+        asyncio.run(database.init_db())
+
+        async def columns():
+            conn = await database._get_db()
+            cur = await conn.execute("PRAGMA table_info(earnings)")
+            return {row["name"] for row in await cur.fetchall()}
+
+        cols = asyncio.run(columns())
+        assert "source" in cols, "the version gated the migration; a damaged database is unrepairable"
+        assert "fx_rate_usd" in cols


### PR DESCRIPTION
Closes `CashPilot-sfbh`.

## The gap

Every schema change in `init_db` is guarded by its own `PRAGMA table_info` check, and they're careful. But **nothing said what happened.** An operator watching `docker logs` through an upgrade couldn't tell a clean start from one that had just rewritten the earnings table — and neither could a bug report.

Startup now says:

```
Schema now at version 10 (was 0). Migrations applied this boot: earnings.fx_rate_usd, earnings.source
Schema at version 10; no migration needed this boot.
```

## The design decision that matters

**The version is reported, never used as a gate.**

If `user_version` decided whether migrations ran, a database whose version said `10` but was *missing a column* — an interrupted upgrade, a restored backup, a hand-edited file — could never be repaired, because the gate would say there was nothing to do. Those are precisely the situations where repair matters most.

The `table_info` guards stay the source of truth; they're idempotent and cheap. A test enforces this by handing `init_db` a database that **claims the current version while missing two columns** and asserting both get added.

## It immediately found something

That's the point of the feature, and it paid for itself before merge. A brand-new database reported:

```
Migrations applied this boot: users.password_changed_at
```

`_SCHEMA` never declared that column, so **every fresh install ran an `ALTER TABLE` it never needed**. Declaring it in the `CREATE TABLE` fixes it, and is safe both ways: `CREATE TABLE IF NOT EXISTS` is a no-op on an existing database, which still gets the column from the migration.

Worth distinguishing from a mistake made twice earlier in this work: adding an **INDEX** to `_SCHEMA` is dangerous, because indexes *do* run against existing tables and fail on a column they don't have yet. A column in a `CREATE TABLE IF NOT EXISTS` has no such hazard.

## Verification

Four negative controls, all failing:

| Control | Test that fails |
|---|---|
| Gate the migrations on the version | `test_a_column_is_added_even_when_the_version_already_says_current` |
| Remove the log line | `test_it_always_says_something` + 2 others |
| Never write `user_version` | `test_a_fresh_database_ends_at_the_current_version` |
| Never populate `applied` | `test_an_upgraded_database_names_the_migrations_that_ran` |

3661 tests pass, coverage 95.51%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database schema version tracking and reporting.
  * Startup now records applied migrations and clearly indicates when no changes were needed.
  * Added support for tracking when user passwords were last changed.

* **Bug Fixes**
  * Database initialization now repairs missing migrations even when the recorded schema version is current.

* **Tests**
  * Added coverage for version persistence, migration logging, repeat initialization, and migration recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->