### PR TITLE
docs: a restore page, because losing .fernet_key is unrecoverable

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -387,7 +387,18 @@ CREATE TABLE IF NOT EXISTS users (
     username   TEXT    NOT NULL UNIQUE,
     password   TEXT    NOT NULL,
     role       TEXT    NOT NULL DEFAULT 'viewer',
-    created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+    created_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    -- Declared here as well as in the migration below, so a FRESH install does
+    -- not run an ALTER TABLE it never needed. Found by the startup log added in
+    -- CashPilot-sfbh: a brand-new database reported "Migrations applied this
+    -- boot: users.password_changed_at", which is exactly the noise that makes an
+    -- operator stop reading migration output.
+    --
+    -- Safe both ways: CREATE TABLE IF NOT EXISTS is a no-op on an existing
+    -- database, so it still gets the column from the migration. (Unlike adding
+    -- an INDEX here, which runs on existing tables and fails on a column they do
+    -- not have yet -- that mistake broke the upgrade path twice.)
+    password_changed_at REAL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS workers (
@@ -717,9 +728,24 @@ async def _encrypt_legacy_plaintext_credentials(db: Any) -> int:
     return len(stale)
 
 
+#: What this build's schema looks like. Bumped by hand when a migration is added.
+#:
+#: REPORTED, NEVER USED AS A GATE. Every migration below is guarded by its own
+#: ``PRAGMA table_info`` check, and that stays the source of truth. If this number
+#: decided whether migrations ran, a database whose user_version said 10 but was
+#: missing a column -- an interrupted upgrade, a restored backup, a hand-edited
+#: file -- could never be repaired, because the gate would say there was nothing
+#: to do. The guards are idempotent and cheap; the version is for the operator.
+SCHEMA_VERSION = 10
+
+
 async def init_db() -> None:
     """Create tables if they don't exist."""
     db = await _get_db()
+    # What actually changed on THIS boot, for the log line at the end. An
+    # operator watching `docker logs` during an upgrade could previously not
+    # tell a clean start from one that had just rewritten the earnings table.
+    applied: list[str] = []
     try:
         await _dedupe_earnings_before_indexing(db)
         await db.executescript(_SCHEMA)
@@ -727,6 +753,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(workers)")
         cols = {row["name"] for row in await cursor.fetchall()}
         if "client_id" not in cols:
+            applied.append("workers.client_id")
             # Rebuild table: UNIQUE moves from name → client_id, name becomes display-only.
             # Existing rows get client_id = name for backward compat.
             has_apps = "apps" in cols
@@ -767,16 +794,20 @@ async def init_db() -> None:
                 CREATE INDEX IF NOT EXISTS idx_workers_status ON workers (status);
             """)
         elif "apps" not in cols:
+            applied.append("workers.apps")
             await db.execute("ALTER TABLE workers ADD COLUMN apps TEXT NOT NULL DEFAULT '[]'")
 
         # Migrate workers table: add api_key_enc for per-worker fleet keys.
         # (cols is the pre-rebuild snapshot; on a fresh DB the column comes from
         # _SCHEMA so it is already present here and the ALTER is skipped.)
         if "api_key_enc" not in cols:
+            applied.append("workers.api_key_enc")
             await db.execute("ALTER TABLE workers ADD COLUMN api_key_enc TEXT")
         if "key_confirmed" not in cols:
+            applied.append("workers.key_confirmed")
             await db.execute("ALTER TABLE workers ADD COLUMN key_confirmed INTEGER NOT NULL DEFAULT 0")
         if "key_issued_at" not in cols:
+            applied.append("workers.key_issued_at")
             # When the per-worker key was minted, so the window in which the
             # SHARED key still works for that worker can be bounded.
             await db.execute("ALTER TABLE workers ADD COLUMN key_issued_at TEXT")
@@ -797,11 +828,13 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(earnings)")
         earnings_cols = {row["name"] for row in await cursor.fetchall()}
         if "fx_rate_usd" not in earnings_cols:
+            applied.append("earnings.fx_rate_usd")
             await db.execute("ALTER TABLE earnings ADD COLUMN fx_rate_usd REAL")
         # Add `source`: WHO took the reading. Existing rows were all taken by
         # this server's own collectors, so 'server' is the truthful backfill
         # rather than a placeholder -- there was no other sampler before this.
         if "source" not in earnings_cols:
+            applied.append("earnings.source")
             await db.execute("ALTER TABLE earnings ADD COLUMN source TEXT NOT NULL DEFAULT 'server'")
         # Unconditional, and only AFTER the column is guaranteed to exist. This
         # is the ONLY place the index is created, so a fresh install and an
@@ -829,6 +862,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(deployments)")
         deployment_cols = {row["name"] for row in await cursor.fetchall()}
         if "spec_encrypted" not in deployment_cols:
+            applied.append("deployments.spec_encrypted")
             await db.execute("ALTER TABLE deployments ADD COLUMN spec_encrypted TEXT NOT NULL DEFAULT ''")
         # Migrate config table: add updated_at so credential age is knowable.
         # Existing rows are left NULL — see the note on the back-fill below.
@@ -838,6 +872,7 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(config)")
         config_cols = {row["name"] for row in await cursor.fetchall()}
         if "updated_at" not in config_cols:
+            applied.append("config.updated_at")
             await db.execute("ALTER TABLE config ADD COLUMN updated_at TEXT")
             # Deliberately NOT back-filled with datetime('now').
             #
@@ -855,7 +890,30 @@ async def init_db() -> None:
         cursor = await db.execute("PRAGMA table_info(users)")
         user_cols = {row["name"] for row in await cursor.fetchall()}
         if "password_changed_at" not in user_cols:
+            applied.append("users.password_changed_at")
             await db.execute("ALTER TABLE users ADD COLUMN password_changed_at REAL DEFAULT 0")
+
+        # The version the database CLAIMED before this boot. 0 on anything
+        # written before this was introduced, including a fully up-to-date one --
+        # so the first upgrade reports "was 0" and that is honest rather than
+        # alarming.
+        cursor = await db.execute("PRAGMA user_version")
+        row = await cursor.fetchone()
+        previous = int(row[0]) if row else 0
+        if previous != SCHEMA_VERSION:
+            # A literal: PRAGMA does not accept a bound parameter here. Safe
+            # because the value is this module's own int constant.
+            await db.execute(f"PRAGMA user_version = {int(SCHEMA_VERSION)}")
+
+        if applied:
+            _logger.info(
+                "Schema now at version %d (was %d). Migrations applied this boot: %s",
+                SCHEMA_VERSION,
+                previous,
+                ", ".join(applied),
+            )
+        else:
+            _logger.info("Schema at version %d; no migration needed this boot.", SCHEMA_VERSION)
 
         await db.commit()
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,198 @@
+# Backing up and restoring CashPilot
+
+Two files decide whether a restore works. If you read nothing else on this page,
+read this box.
+
+!!! danger "`.fernet_key` is not recoverable"
+
+    Every credential you have entered — provider passwords, API keys, session
+    cookies — is encrypted in the database with the key in
+    `/data/.fernet_key`. **The database alone is not enough.** Restore
+    `cashpilot.db` without that key and every stored credential is permanently
+    undecryptable. There is no recovery, no reset, no support path: the
+    plaintext does not exist anywhere else.
+
+    Back up **both**, always, together.
+
+This page covers the CashPilot UI's own data. Backing up the *node identities*
+your services generate — the Mysterium keystore and friends — is a separate job
+and lives in [Backing Up Node Identities](backup.md).
+
+---
+
+## What is in `/data`
+
+The UI's `/data` volume (`cashpilot_data` in the shipped compose files):
+
+| Path | What it is | Lose it and… |
+|---|---|---|
+| `cashpilot.db` | SQLite: earnings history, deployments, workers, users, settings | you lose your history |
+| `.fernet_key` | Encrypts every stored credential, at rest | **every credential is permanently unreadable** |
+| `.secret_key` | Signs login sessions | everyone is logged out once; nothing else |
+
+`.secret_key` **may not exist**, and that is normal. It is only written when
+`CASHPILOT_SECRET_KEY` is unset — set the variable and the file is never
+created. Verified on a live install: `/data` held `.fernet_key` and nothing
+else.
+
+`.secret_key` and `.fernet_key` are **different keys with different jobs**, and
+they are easy to confuse because both are set by an environment variable with a
+similar name. `CASHPILOT_SECRET_KEY` signs sessions. `CASHPILOT_ENCRYPTION_KEY`
+is the credential key. Restoring the wrong one gets you a working login and
+unreadable credentials.
+
+There are two other volumes, and neither is precious:
+
+- `cashpilot_fleet` (`/fleet/.fleet_key`) — the shared enrollment key. Shared by
+  the UI and its co-located worker. If you lose it, set `CASHPILOT_API_KEY`
+  explicitly or let it regenerate and re-enroll the workers.
+- `cashpilot_worker_data` (`/data/.worker_key`) — that worker's own issued key.
+  Lose it and the worker re-enrolls on its next heartbeat. Nothing is destroyed.
+
+    The worker's `/data` is a **separate volume from the UI's, deliberately**.
+    The worker holds the Docker socket, which is root on the host; it has no
+    business being able to read the credential store. Do not consolidate them.
+
+---
+
+## Backup
+
+Stop nothing. SQLite is in WAL mode, but a plain file copy of a live database
+can still catch a torn write, so use SQLite's own backup command for the
+database and copy the keys alongside it.
+
+```bash
+# Everything that matters, into one dated directory.
+OUT="cashpilot-backup-$(date +%Y%m%d)"
+mkdir -p "$OUT"
+
+# The database, consistently, without stopping the container.
+docker exec cashpilot-ui sh -c \
+  'python -c "import sqlite3,sys; s=sqlite3.connect(\"/data/cashpilot.db\"); d=sqlite3.connect(\"/tmp/backup.db\"); s.backup(d); d.close(); s.close()"'
+docker cp cashpilot-ui:/tmp/backup.db "$OUT/cashpilot.db"
+docker exec cashpilot-ui rm -f /tmp/backup.db
+
+# THE key. Without it the database above is half a backup.
+docker cp cashpilot-ui:/data/.fernet_key "$OUT/.fernet_key"
+
+# Only present if CASHPILOT_SECRET_KEY is unset, so do not fail without it.
+docker cp cashpilot-ui:/data/.secret_key "$OUT/.secret_key" 2>/dev/null \
+  || echo "no .secret_key (CASHPILOT_SECRET_KEY is set in the environment) — fine"
+
+chmod 600 "$OUT"/.*key 2>/dev/null
+ls -la "$OUT"
+```
+
+!!! warning "The backup is now as sensitive as the server"
+
+    `.fernet_key` plus `cashpilot.db` is every provider credential you own, in a
+    directory. Treat that pair the way you would treat the passwords themselves:
+    encrypted storage, restricted permissions, and not in a git repository.
+
+### Verify it, or it is not a backup
+
+An untested backup is a hope. Check that the two files are non-empty and that
+the database opens:
+
+```bash
+test -s "$OUT/.fernet_key" && echo "key present"   # the one that cannot be regenerated
+sqlite3 "$OUT/cashpilot.db" "PRAGMA integrity_check;"   # expect: ok
+sqlite3 "$OUT/cashpilot.db" "SELECT count(*) FROM earnings;"
+```
+
+---
+
+## Restore
+
+Onto a fresh install, before it has generated its own keys:
+
+```bash
+docker compose down
+
+# Recreate the volume and put all three files back TOGETHER.
+docker volume create cashpilot_data
+docker run --rm -v cashpilot_data:/data -v "$PWD/$OUT":/backup alpine sh -c '
+  cp /backup/cashpilot.db /data/cashpilot.db &&
+  cp /backup/.fernet_key  /data/.fernet_key  &&
+  # Optional: absent whenever CASHPILOT_SECRET_KEY is set.
+  { [ -f /backup/.secret_key ] && cp /backup/.secret_key /data/.secret_key || true; } &&
+  chmod 600 /data/.fernet_key &&
+  chown -R 1000:1000 /data'
+
+docker compose up -d
+docker logs -f cashpilot-ui
+```
+
+### What the logs should say
+
+Two lines tell you the restore worked.
+
+The schema line reports the version and any migration that ran — expect a
+migration if the backup came from an older release, and none if it did not:
+
+```
+Schema at version 10; no migration needed this boot.
+Schema now at version 10 (was 0). Migrations applied this boot: earnings.source
+```
+
+And there should be **no** decryption error. If the key did not come across you
+will see this, once per affected credential:
+
+```
+Failed to decrypt a stored credential: the credential-encryption key
+(CASHPILOT_ENCRYPTION_KEY / /data/.fernet_key) does not match the key this
+value was encrypted with.
+```
+
+That message means exactly what it says: the database was restored and the key
+was not. Put the original `.fernet_key` back. **The credentials cannot be
+recovered any other way.**
+
+### Restoring the key by environment variable instead
+
+If you kept the key as a secret rather than a file, `CASHPILOT_ENCRYPTION_KEY`
+is adopted **only when no key file exists** — which covers both a fresh install
+and a restore onto an empty volume:
+
+```yaml
+environment:
+  - CASHPILOT_ENCRYPTION_KEY=<the base64 key from your backup>
+```
+
+The file always wins where it exists. That ordering is deliberate: a running
+install must never have its key silently replaced by a stale environment
+variable.
+
+---
+
+## Things CashPilot refuses to do, and why
+
+Three refusals you may run into. All three are the software declining to destroy
+something.
+
+**It will not overwrite an unreadable `.fernet_key`.** If the file exists but is
+corrupt or the wrong length, startup fails rather than generating a replacement —
+because generating one would destroy the only artifact that could still decrypt
+your credentials. Restore the file, or move it aside and re-enter the
+credentials, which is a real choice you are allowed to make.
+
+**It will not start if the key cannot be persisted.** A read-only or
+unwritable `/data` means every credential entered during that run becomes
+undecryptable the moment the container restarts. Failing at startup is kinder
+than failing silently, hours later.
+
+**A failed decrypt is logged as an ERROR, not a warning.** This is unattended
+software. The downstream symptom is a provider authentication failure that
+points nowhere near the real cause, so it is logged loudly, at the point where
+the cause is still visible.
+
+---
+
+## Upgrades
+
+The images pin `major.minor` in the shipped compose files, so `docker compose
+pull` picks up patch fixes and never crosses a minor boundary without an edit.
+
+Before a minor or major upgrade: **take the backup above.** Migrations are
+forward-only — there is no down migration — so the way back is a restore. The
+schema line at startup tells you whether anything actually changed.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,5 +1,12 @@
 # Backing up what cannot be replaced
 
+!!! info "Looking for the UI's own data?"
+
+    This page is about the identities your SERVICES generate. CashPilot's own
+    database and its credential-encryption key are a separate job — see
+    [Backup and Restore](backup-restore.md). Losing `.fernet_key` makes every
+    stored credential permanently undecryptable, so that page matters more.
+
 Some services keep state on your machine that **exists nowhere else**: a node
 identity, a relay key, a wallet generated inside the container on first run.
 Lose the disk and you lose the held payout balance and the node's accumulated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
     - Security Defaults: security-defaults.md
     - Network Isolation: isolation.md
   - Operations:
+    - Backup and Restore: backup-restore.md
     - Backing Up Node Identities: backup.md
     - Prometheus Metrics: guides/prometheus-metrics.md
     - Upgrade to v1.0.0: upgrade-v1.md

--- a/tests/test_beads_batch_66.py
+++ b/tests/test_beads_batch_66.py
@@ -1,0 +1,164 @@
+"""CashPilot-sfbh: migrations ran and reported nothing.
+
+Every schema change in ``init_db`` is guarded by its own ``PRAGMA table_info``
+check, and they are careful. But **nothing said what happened.** An operator
+watching ``docker logs`` through an upgrade could not tell a clean start from one
+that had just rewritten the earnings table, and a bug report could not say either.
+
+Two things are now reported at startup: the schema version, and which migrations
+actually ran on this boot.
+
+THE DESIGN DECISION THAT MATTERS: the version is REPORTED, NEVER USED AS A GATE.
+If ``user_version`` decided whether migrations ran, a database whose version said
+10 but was missing a column -- an interrupted upgrade, a restored backup, a
+hand-edited file -- could never be repaired, because the gate would say there was
+nothing to do. The ``PRAGMA table_info`` guards stay the source of truth; they are
+idempotent and cheap. The version is for the human.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app import database
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    with patch.object(database, "DB_DIR", tmp_path), patch.object(database, "DB_PATH", tmp_path / "cashpilot.db"):
+        yield tmp_path
+
+
+def _user_version() -> int:
+    async def run():
+        conn = await database._get_db()
+        cur = await conn.execute("PRAGMA user_version")
+        row = await cur.fetchone()
+        return int(row[0]) if row else 0
+
+    return asyncio.run(run())
+
+
+class TestTheVersionIsRecorded:
+    def test_a_fresh_database_ends_at_the_current_version(self, db_dir):
+        asyncio.run(database.init_db())
+        assert _user_version() == database.SCHEMA_VERSION
+
+    def test_the_constant_is_a_positive_int(self):
+        """A float or a string would be interpolated into the PRAGMA."""
+        assert isinstance(database.SCHEMA_VERSION, int)
+        assert database.SCHEMA_VERSION > 0
+
+    def test_a_second_boot_does_not_change_it(self, db_dir):
+        asyncio.run(database.init_db())
+        first = _user_version()
+        asyncio.run(database.init_db())
+        assert _user_version() == first
+
+
+class TestTheStartupLogSaysWhatHappened:
+    def test_a_fresh_database_reports_no_migration(self, db_dir, caplog):
+        """A brand-new file creates its tables from _SCHEMA; no guarded
+        migration fires, so saying one did would be false."""
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        assert any("no migration needed" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_it_always_says_something(self, db_dir, caplog):
+        """Silence is the defect being fixed. Whatever happened, one line."""
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        assert any("Schema" in (r.getMessage()) for r in caplog.records)
+
+    def test_an_upgraded_database_names_the_migrations_that_ran(self, db_dir, caplog):
+        """The case that matters. An OLD database -- one missing a column this
+        build adds -- must report exactly what was done to it."""
+
+        async def make_old():
+            conn = await database._get_db()
+            # A minimal pre-`source` earnings table, as a database written by an
+            # older build actually looks.
+            await conn.executescript(
+                """
+                CREATE TABLE earnings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    platform TEXT NOT NULL,
+                    balance REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    date TEXT NOT NULL,
+                    created_at TEXT
+                );
+                """
+            )
+            await conn.commit()
+
+        asyncio.run(make_old())
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+
+        messages = [r.getMessage() for r in caplog.records]
+        summary = next((m for m in messages if "Migrations applied this boot" in m), None)
+        assert summary, messages
+        assert "earnings.source" in summary, summary
+        assert "earnings.fx_rate_usd" in summary, summary
+
+    def test_the_upgrade_reports_the_version_it_came_from(self, db_dir, caplog):
+        """ "was 0" on anything written before this existed, including a database
+        that was otherwise fully up to date. Honest rather than alarming."""
+
+        async def make_old():
+            conn = await database._get_db()
+            await conn.executescript("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT NOT NULL);")
+            await conn.commit()
+
+        asyncio.run(make_old())
+        with caplog.at_level(logging.INFO, logger="app.database"):
+            asyncio.run(database.init_db())
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("(was 0)" in m for m in messages), messages
+
+
+class TestTheVersionNeverGatesTheMigrations:
+    """The design decision, enforced.
+
+    A database claiming the current version but MISSING a column must still be
+    repaired. Gating on the version would make that database unfixable, and the
+    shapes that produce it -- an interrupted upgrade, a restored backup -- are
+    exactly when repair matters most.
+    """
+
+    def test_a_column_is_added_even_when_the_version_already_says_current(self, db_dir):
+        async def make_lying_db():
+            conn = await database._get_db()
+            await conn.executescript(
+                """
+                CREATE TABLE earnings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    platform TEXT NOT NULL,
+                    balance REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    date TEXT NOT NULL,
+                    created_at TEXT
+                );
+                """
+            )
+            await conn.execute(f"PRAGMA user_version = {database.SCHEMA_VERSION}")
+            await conn.commit()
+
+        asyncio.run(make_lying_db())
+        asyncio.run(database.init_db())
+
+        async def columns():
+            conn = await database._get_db()
+            cur = await conn.execute("PRAGMA table_info(earnings)")
+            return {row["name"] for row in await cur.fetchall()}
+
+        cols = asyncio.run(columns())
+        assert "source" in cols, "the version gated the migration; a damaged database is unrepairable"
+        assert "fx_rate_usd" in cols

--- a/tests/test_beads_batch_67.py
+++ b/tests/test_beads_batch_67.py
@@ -1,0 +1,133 @@
+"""CashPilot-ffsf: the one loss that cannot be undone was documented as an aside.
+
+Backing up *node identities* has its own page. Restoring CashPilot's OWN `/data`
+did not: `.fernet_key` was mentioned in three files, always in passing, never as
+a procedure.
+
+Losing that key makes every stored credential permanently undecryptable. The code
+says so in three places and refuses to overwrite it for exactly that reason. It is
+the single most destructive thing an operator can do to this application, and the
+docs treated it as a footnote.
+
+These tests pin the facts the page has to keep telling the truth about, because a
+restore page that has drifted from the code is worse than none: it is followed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs" / "backup-restore.md"
+MKDOCS = ROOT / "mkdocs.yml"
+DATABASE = ROOT / "app" / "database.py"
+AUTH = ROOT / "app" / "auth.py"
+
+
+def page() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+class TestThePageExistsAndIsReachable:
+    def test_it_exists(self):
+        assert PAGE.is_file()
+
+    def test_it_is_in_the_nav(self):
+        """An orphaned page is reachable only by URL — the exact defect the docs
+        restructure fixed. Adding another one here would be poor form."""
+        assert "backup-restore.md" in MKDOCS.read_text(encoding="utf-8")
+
+    def test_the_node_identity_page_points_at_it(self):
+        """Someone looking for "backup" finds backup.md first. It is about a
+        different thing, and the more destructive loss is on this page."""
+        assert "backup-restore.md" in (ROOT / "docs" / "backup.md").read_text(encoding="utf-8")
+
+
+class TestItNamesTheFilesThatActuallyExist:
+    """Paths are quoted from the code, so a rename must break this."""
+
+    def test_the_database_path_matches_the_code(self):
+        assert 'DB_PATH = DB_DIR / "cashpilot.db"' in DATABASE.read_text(encoding="utf-8")
+        assert "cashpilot.db" in page()
+
+    def test_the_encryption_key_path_matches_the_code(self):
+        assert '_FERNET_KEY_FILE = DB_DIR / ".fernet_key"' in DATABASE.read_text(encoding="utf-8")
+        assert ".fernet_key" in page()
+
+    def test_the_session_key_path_matches_the_code(self):
+        assert 'key_file = data_dir / ".secret_key"' in AUTH.read_text(encoding="utf-8")
+        assert ".secret_key" in page()
+
+    @pytest.mark.parametrize("volume", ["cashpilot_data", "cashpilot_worker_data", "cashpilot_fleet"])
+    def test_the_volumes_it_names_are_the_shipped_ones(self, volume):
+        assert volume in (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+        assert volume in page()
+
+
+class TestItTellsTheTruthAboutTheConsequences:
+    def test_it_says_the_credentials_are_unrecoverable(self):
+        """The whole reason the page exists. Softening this to "may be affected"
+        would make it advice nobody acts on."""
+        text = page().lower()
+        assert "permanently undecryptable" in text or "permanently unreadable" in text
+
+    def test_it_distinguishes_the_two_keys(self):
+        """They differ by one word in the env var name and one does nothing
+        important. Restoring the wrong one gets you a working login and
+        unreadable credentials."""
+        text = page()
+        assert "CASHPILOT_SECRET_KEY" in text
+        assert "CASHPILOT_ENCRYPTION_KEY" in text
+
+    def test_it_warns_the_backup_is_as_sensitive_as_the_server(self):
+        """.fernet_key plus the database IS every provider credential, in a
+        directory. A backup guide that does not say so invites a git commit."""
+        assert "as sensitive as the server" in page()
+
+    def test_the_secret_key_is_documented_as_optional(self):
+        """MEASURED, not assumed: a live install had only .fernet_key in /data,
+        because .secret_key is written only when CASHPILOT_SECRET_KEY is unset.
+        The first draft's `docker cp` of it would have failed there."""
+        assert "may not exist" in page()
+        auth = AUTH.read_text(encoding="utf-8")
+        # The code path that makes it optional: an env key short-circuits before
+        # the file is ever written.
+        assert 'env_key = os.getenv("CASHPILOT_SECRET_KEY", "")' in auth
+        assert "return env_key" in auth
+
+
+class TestTheQuotedLogLinesAreReal:
+    """The page tells the reader what to look for in `docker logs`. If those
+    strings drift, the reader is hunting for something that never appears."""
+
+    def test_the_decrypt_error_is_quoted_accurately(self):
+        assert "Failed to decrypt a stored credential" in DATABASE.read_text(encoding="utf-8")
+        assert "Failed to decrypt a stored credential" in page()
+
+    def test_the_schema_lines_are_quoted_accurately(self):
+        db = DATABASE.read_text(encoding="utf-8")
+        assert "Schema now at version %d (was %d)" in db
+        assert "Schema at version %d; no migration needed this boot." in db
+        text = page()
+        assert "Schema now at version" in text
+        assert "no migration needed this boot" in text
+
+
+class TestTheCommandsAreShapedidempotently:
+    def test_the_restore_does_not_hard_require_the_optional_key(self):
+        """The live install has no .secret_key, so an unconditional `cp` of it
+        aborts the whole restore under `&&`."""
+        restore = page()[page().index("## Restore") :]
+        assert "/backup/.secret_key" in restore
+        assert "[ -f /backup/.secret_key ]" in restore, "the optional key is copied unconditionally"
+
+    def test_the_backup_tolerates_a_missing_secret_key(self):
+        backup = page()[page().index("## Backup") : page().index("## Restore")]
+        line = next(ln for ln in backup.splitlines() if ".secret_key" in ln and "docker cp" in ln)
+        assert "2>/dev/null" in line, line
+
+    def test_it_verifies_the_backup_rather_than_assuming_it(self):
+        """An untested backup is a hope."""
+        assert "integrity_check" in page()


### PR DESCRIPTION
Closes `CashPilot-ffsf`.

## The gap

Backing up *node identities* had its own page. Restoring CashPilot's **own** `/data` did not — `.fernet_key` was mentioned in three files, always in passing, never as a procedure.

That key is the single most destructive thing an operator can lose. Every stored credential is encrypted with it, the plaintext exists nowhere else, and the code refuses to overwrite the file for exactly that reason. It was documented as a footnote.

## The commands were tested, not written from memory — and the test found a bug

I ran the documented backup against the live install. **`/data` there holds `.fernet_key` and nothing else.**

`.secret_key` is only written when `CASHPILOT_SECRET_KEY` is *unset*, and it is set in that deployment (`app/auth.py` short-circuits on the env var before the file is ever created). So my first draft's `docker cp` of it would have failed — and in the restore, sitting under `&&`, it would have **aborted the whole restore**. Both commands now tolerate its absence and explain why it may not be there.

The backup itself ran end to end: 57 MB copied, `integrity_check: ok`, 1535 earnings rows. It writes to `/tmp` and removes it, so nothing was disturbed.

This is the difference between documentation and a guess that looks like documentation.

## What the page covers

- What each file in `/data` is, and what losing it actually costs.
- The two keys that differ by one word and do completely different things — restoring the wrong one gets you a working login and unreadable credentials.
- A backup that doesn't require stopping anything, and a verification step, because an untested backup is a hope.
- What the logs should say afterwards, quoted from the code.
- The three things CashPilot **refuses** to do, and why each refusal is the software declining to destroy something.

## Verification

18 tests pin the page to the code: file paths, volume names, both quoted log lines, and that the consequence is stated as permanent rather than softened. A restore page that has drifted from the code is worse than none — it gets followed.

Four negative controls, all failing: softening the unrecoverable warning, dropping the optional-key guard from the restore, removing the page from the nav, and letting a quoted log line drift.

3679 tests pass, coverage 95.51%.