### PR TITLE
feat: tell the operator when a newer release exists

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -52,6 +52,7 @@ from app import (
     preflight,
     producer_state,
     setup_token,
+    update_check,
     version,
 )
 from app.worker_proxy import _pin_url_to_ip, _validate_worker_url
@@ -888,6 +889,21 @@ async def lifespan(app: FastAPI):
         id="db_vacuum",
         max_instances=1,
         coalesce=True,
+        misfire_grace_time=300,
+    )
+    # Once a day. A release is not urgent, and a self-hosted app polling a third
+    # party more often than that is rude. Every failure mode inside refresh()
+    # lands on UNKNOWN, so a firewalled install produces no noise at all.
+    scheduler.add_job(
+        update_check.refresh,
+        "interval",
+        hours=24,
+        id="update_check",
+        max_instances=1,
+        coalesce=True,
+        # 300 like every other job here rather than a carve-out. A missed daily
+        # check simply happens tomorrow; that is not worth an exception to a
+        # convention a test enforces uniformly.
         misfire_grace_time=300,
     )
     scheduler.add_job(
@@ -3041,6 +3057,21 @@ async def api_disclosure_coverage(request: Request) -> dict[str, Any]:
     """
     _require_auth_api(request)
     return disclosure.coverage(catalog.get_services())
+
+
+@app.get("/api/update-status")
+async def api_update_status(request: Request) -> dict[str, Any]:
+    """Whether a newer CashPilot has been released (CashPilot-w0ss).
+
+    Reads the cached result only -- it never fetches on the request path, so a
+    slow or unreachable GitHub cannot make a page load slowly. The scheduler
+    refreshes it once a day.
+
+    ``known`` is the honest field. False means we do not know, which is NOT the
+    same as up to date, and the UI must not render it as reassurance.
+    """
+    _require_auth_api(request)
+    return update_check.state()
 
 
 @app.get("/api/collector-alerts")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2071,3 +2071,39 @@ img { max-width: 100%; }
 .deploy-risk-headline { font-weight: 600; font-size: 0.85rem; }
 .deploy-risk-body-text { font-size: 0.8rem; color: var(--text-secondary); margin-top: 4px; max-width: 70ch; }
 .deploy-risk-source { font-size: 0.7rem; color: var(--text-muted); margin-top: 4px; }
+
+/* A newer release is available (CashPilot-w0ss).
+   Informational, not an error: this is news, not a fault, and colouring it red
+   would train the operator to dismiss it the way they dismiss real alarms. */
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 10px;
+  background: rgba(30, 58, 138, 0.18);
+  color: #dbeafe;
+  font-size: 0.9rem;
+}
+
+.update-banner a {
+  color: #93c5fd;
+  text-decoration: underline;
+}
+
+.update-banner button {
+  margin-left: auto;
+  border: 0;
+  background: transparent;
+  color: #93c5fd;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.update-banner button:hover {
+  color: #dbeafe;
+}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3217,6 +3217,61 @@ const CP = (() => {
     // Fetch alerts now and every 60s
     loadCollectorAlerts();
     setInterval(loadCollectorAlerts, 60000);
+
+    // Once per page load. The server refreshes daily; polling more often would
+    // only re-read the same cached value.
+    checkForUpdate();
+  }
+
+  // A newer release is available (CashPilot-w0ss).
+  //
+  // Three rules, and they are what keep this from being unwelcome:
+  //   * SILENT when unknown. Offline, disabled, never-run, or a dev build all
+  //     produce `known: false`, and an unknown state renders NOTHING -- never a
+  //     spinner, an error, or a reassuring "up to date" it has not earned.
+  //   * NEVER auto-updates. It tells you; you decide.
+  //   * Dismissible PER VERSION. Dismiss 1.20.1 and it stays gone until 1.20.2
+  //     exists, so it cannot become wallpaper.
+  async function checkForUpdate() {
+    const banner = document.getElementById('update-banner');
+    if (!banner) return;
+    let state;
+    try {
+      state = await api('/api/update-status');
+    } catch (err) {
+      return; // Unknown. Say nothing at all.
+    }
+    if (!state || !state.known || !state.behind || !state.latest) return;
+
+    // Per-version dismissal. Keyed on the version so a NEW release re-appears.
+    let dismissed = null;
+    try {
+      dismissed = localStorage.getItem('cp-update-dismissed');
+    } catch (err) {
+      dismissed = null; // private mode / storage disabled: just show it
+    }
+    if (dismissed === state.latest) return;
+
+    const text = document.getElementById('update-banner-text');
+    const link = document.getElementById('update-banner-link');
+    if (text) {
+      text.textContent = `CashPilot ${state.latest} is available \u2014 you are running ${state.current}.`;
+    }
+    if (link) {
+      link.href = `https://github.com/GeiserX/CashPilot/releases/tag/${encodeURIComponent(state.latest)}`;
+    }
+    const dismiss = document.getElementById('update-banner-dismiss');
+    if (dismiss) {
+      dismiss.onclick = () => {
+        banner.hidden = true;
+        try {
+          localStorage.setItem('cp-update-dismissed', state.latest);
+        } catch (err) {
+          /* storage disabled: it will reappear next load, which is acceptable */
+        }
+      };
+    }
+    banner.hidden = false;
   }
 
   async function loadCollectorAlerts() {
@@ -3494,6 +3549,7 @@ const CP = (() => {
 
   return {
     api,
+    checkForUpdate,
     toast,
     openModal,
     closeModal,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -162,6 +162,16 @@
       </div>
     </header>
 
+    <!-- A newer release is available (CashPilot-w0ss). Hidden by default and
+         populated by CP.checkForUpdate(); it stays hidden when the check is off,
+         has not run, failed, or this build is not a release. Unknown is unknown,
+         never "up to date". -->
+    <div class="update-banner" id="update-banner" hidden>
+      <span id="update-banner-text"></span>
+      <a id="update-banner-link" href="#" target="_blank" rel="noopener noreferrer">Release notes</a>
+      <button type="button" id="update-banner-dismiss" aria-label="Dismiss">&times;</button>
+    </div>
+
     <!-- Page content -->
     <main class="page-content">
       {% block content %}{% endblock %}

--- a/app/update_check.py
+++ b/app/update_check.py
@@ -1,0 +1,154 @@
+"""Tell the operator when a newer CashPilot has been released.
+
+WHY THIS EXISTS (CashPilot-w0ss)
+--------------------------------
+A live fleet sat **33 releases** behind and nothing anywhere said so. Not the
+dashboard, not a log line, not the fleet page.
+
+Half the machinery was already here: ``app/version.py`` knows what this build is
+and ``version.skewed()`` compares it against each worker. What was missing is a
+reference point OUTSIDE the deployment -- nothing in the application had any idea
+what the newest published release was.
+
+THREE CONSTRAINTS, and they are the difference between a useful feature and an
+unwelcome one:
+
+* **Degrade silently when offline.** An air-gapped or firewalled install must not
+  show an error, a spinner, or a warning about the check itself. Unknown is
+  unknown -- the same rule the rest of this codebase follows for absent data.
+* **Never auto-update.** This deploys containers and holds credentials. It tells
+  you; you decide.
+* **Answerable.** ``CASHPILOT_UPDATE_CHECK=off`` disables the outbound call
+  entirely, for anyone who does not want their install talking to GitHub.
+
+The check is a single unauthenticated GET to the public releases endpoint, once a
+day. It sends no telemetry: GitHub learns an IP asked what the latest release is,
+and nothing else. There is no request body, no identifier, and no version
+reported upstream.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from app import version
+
+logger = logging.getLogger(__name__)
+
+#: The public releases endpoint. Unauthenticated, and deliberately the "latest"
+#: single-object form rather than a paginated list: it is one small response and
+#: it cannot be made expensive by a repository with a long release history.
+LATEST_URL = "https://api.github.com/repos/GeiserX/CashPilot/releases/latest"
+
+#: Once a day. A release is not urgent, and a self-hosted app polling a third
+#: party more often than that is rude.
+CHECK_INTERVAL_SECONDS = 24 * 60 * 60
+
+_HTTP_TIMEOUT = 10.0
+
+#: Cached result. `tag` is None for UNKNOWN -- never for "up to date", which is a
+#: different statement and is carried by `known`.
+_latest_tag: str | None = None
+_checked_at: float = 0.0
+
+
+def enabled() -> bool:
+    """Whether the outbound check is allowed at all.
+
+    On by default, matching how comparable self-hosted projects behave, and how
+    this application already reaches CoinGecko and Frankfurter. Off is one
+    environment variable away, and when off NOTHING is fetched -- the banner
+    simply never appears rather than showing an error.
+    """
+    return os.getenv("CASHPILOT_UPDATE_CHECK", "").strip().lower() not in {"0", "off", "false", "no"}
+
+
+def _parse_tag(payload: Any) -> str | None:
+    """The tag name from a releases payload, or None if it is not one.
+
+    Validated rather than trusted: this is third-party JSON, and a tag that is
+    not a real version would otherwise be rendered to the operator as one.
+    """
+    if not isinstance(payload, dict):
+        return None
+    tag = str(payload.get("tag_name") or "").strip()
+    return tag if version.series(tag) else None
+
+
+async def refresh(*, force: bool = False) -> str | None:
+    """Fetch the newest published release tag. Returns it, or None for unknown.
+
+    Never raises. Every failure mode -- offline, DNS, rate limit, a 500, a body
+    that is not JSON, a tag that is not a version -- lands on the same answer:
+    UNKNOWN. That is what makes the banner safe on an air-gapped install.
+    """
+    global _latest_tag, _checked_at
+
+    if not enabled():
+        return None
+    if not force and _checked_at and (time.time() - _checked_at) < CHECK_INTERVAL_SECONDS:
+        return _latest_tag
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.get(LATEST_URL, headers={"Accept": "application/vnd.github+json"})
+            response.raise_for_status()
+            tag = _parse_tag(response.json())
+    except Exception as exc:  # noqa: BLE001 - every failure means the same thing
+        # DEBUG, not WARNING. A firewalled install would otherwise log a warning
+        # every day forever about a feature its operator never asked for, and a
+        # log full of harmless warnings is a log nobody reads.
+        logger.debug("Update check could not reach %s: %s", LATEST_URL, exc)
+        _checked_at = time.time()  # do not hammer a host that is refusing us
+        return _latest_tag
+
+    _latest_tag = tag
+    _checked_at = time.time()
+    if tag:
+        logger.debug("Newest published release is %s", tag)
+    return tag
+
+
+def state() -> dict[str, Any]:
+    """What the UI needs to decide whether to say anything.
+
+    ``known`` is the honest three-valued part: False means we do not know, which
+    is NOT the same as "up to date" and must not be rendered as reassurance.
+    """
+    running = version.current()
+    running_series = version.series(running)
+    latest_series = version.series(_latest_tag)
+
+    behind = False
+    if running_series and latest_series:
+        behind = _tuple(latest_series) > _tuple(running_series)
+
+    return {
+        "enabled": enabled(),
+        # Unknown whenever the check is off, has not run, failed, or this build
+        # is not a release (a dev checkout must not be told it is behind).
+        "known": bool(_latest_tag and running_series),
+        "current": running,
+        "latest": _latest_tag,
+        "behind": behind,
+    }
+
+
+def _tuple(series_text: str) -> tuple[int, ...]:
+    """MAJOR.MINOR as integers, so 1.9 sorts BELOW 1.10.
+
+    String comparison gets this backwards, and it would do so exactly once a
+    project reaches its tenth minor -- which this one has.
+    """
+    return tuple(int(part) for part in series_text.split("."))
+
+
+def _reset_for_tests() -> None:
+    """Clear the module cache. Tests only."""
+    global _latest_tag, _checked_at
+    _latest_tag, _checked_at = None, 0.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ defensible on its own; together they are impossible to guess.
 | `CASHPILOT_VERSION` | `dev` | Set by the image build. Shown in the sidebar. | — |
 | `CASHPILOT_METRICS_ENABLED` | `false` | Serve `/metrics`. | — |
 | `CASHPILOT_METRICS_TOKEN` | unset | Require `Authorization: Bearer` on `/metrics`. | — |
+| `CASHPILOT_UPDATE_CHECK` | `on` | Set to `off` to disable the once-a-day check for a newer release. See below. |
 | `CASHPILOT_NTFY_URL` | unset | ntfy endpoint for alerts. | — |
 | `CASHPILOT_WEBHOOK_URL` | unset | Generic webhook for alerts. | — |
 | `CASHPILOT_TELEGRAM_BOT_TOKEN` | unset | Telegram alerts. | — |
@@ -148,3 +149,31 @@ These are read by the compose files, not by CashPilot itself.
 |---|---|---|
 | `CASHPILOT_BIND_ADDR` | `127.0.0.1` | Which host interface publishes the **UI** port. |
 | `CASHPILOT_WORKER_BIND_ADDR` | `127.0.0.1` | Which host interface publishes the **worker** port, in the fleet compose. The worker holds the Docker socket — root-equivalent on the host — so publish it only on an interface the UI needs, never `0.0.0.0`. |
+
+## Update check
+
+CashPilot asks GitHub once a day whether a newer release exists, and shows a
+dismissible banner if there is one. A fleet running 33 releases behind with no
+indication anywhere is the problem this solves.
+
+Three things it deliberately does not do:
+
+- **It never updates anything.** It tells you; you decide. This application
+  deploys containers and holds credentials, and nothing about that should happen
+  because a version number changed.
+- **It never says "up to date".** Offline, firewalled, disabled, or simply not
+  run yet all produce *unknown*, and unknown renders nothing at all — no error,
+  no spinner, and no reassurance it has not earned.
+- **It sends nothing about you.** One unauthenticated `GET` to the public
+  releases endpoint. No request body, no identifier, and your version is not
+  reported upstream. GitHub learns that an IP asked what the latest release is.
+
+Turn it off entirely and no connection is made:
+
+```yaml
+environment:
+  - CASHPILOT_UPDATE_CHECK=off
+```
+
+The banner is dismissible per version — dismiss `v1.20.1` and it stays gone until
+there is a `v1.20.2`, so it cannot become wallpaper.

--- a/tests/test_beads_batch_68.py
+++ b/tests/test_beads_batch_68.py
@@ -1,0 +1,188 @@
+"""CashPilot-w0ss: a fleet 33 releases behind, and nothing said so.
+
+Half the machinery already existed -- ``version.skewed()`` compares this build
+against each worker -- but nothing knew what the newest PUBLISHED release was, so
+there was no reference point outside the deployment.
+
+Three constraints separate a useful feature from an unwelcome one, and all three
+are tested here:
+
+* **Silent when unknown.** Offline, disabled, never-run, or a dev build must
+  produce nothing at all -- no error, no spinner, and above all no reassuring
+  "up to date" that was never earned. Unknown is unknown.
+* **Never auto-updates.** This deploys containers and holds credentials.
+* **Answerable.** ``CASHPILOT_UPDATE_CHECK=off`` stops the outbound call dead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app import update_check
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    update_check._reset_for_tests()
+    yield
+    update_check._reset_for_tests()
+
+
+def _response(payload, status=200):
+    request = httpx.Request("GET", update_check.LATEST_URL)
+    return httpx.Response(status, json=payload, request=request)
+
+
+def _refresh_with(response_or_exc, *, version_env="1.16.0", force=True):
+    """Drive refresh() against a stubbed transport."""
+    with patch.dict("os.environ", {"CASHPILOT_VERSION": version_env}, clear=False):
+        client = AsyncMock()
+        if isinstance(response_or_exc, Exception):
+            client.get.side_effect = response_or_exc
+        else:
+            client.get.return_value = response_or_exc
+        client.__aenter__.return_value = client
+        with patch("app.update_check.httpx.AsyncClient", return_value=client):
+            return asyncio.run(update_check.refresh(force=force))
+
+
+class TestItStaysSilentWhenItDoesNotKnow:
+    """The rule that makes this safe on an air-gapped install."""
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            httpx.ConnectError("no route to host"),
+            httpx.ReadTimeout("timed out"),
+            httpx.HTTPStatusError("rate limited", request=None, response=None),
+            ValueError("not json"),
+        ],
+    )
+    def test_every_failure_means_unknown_not_an_error(self, failure):
+        assert _refresh_with(failure) is None
+        state = update_check.state()
+        assert state["known"] is False
+        assert state["behind"] is False, "an unreachable check must never claim you are behind"
+
+    def test_a_failure_does_not_raise(self):
+        """refresh() runs on the scheduler. Raising would fire the job-error
+        listener and alert on a firewall rule."""
+        _refresh_with(httpx.ConnectError("offline"))  # would raise if it did
+
+    def test_never_checked_is_unknown_rather_than_up_to_date(self):
+        """The state before the first run must not read as reassurance."""
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.16.0"}, clear=False):
+            state = update_check.state()
+        assert state["known"] is False
+        assert state["behind"] is False
+
+    def test_a_dev_build_is_never_told_it_is_behind(self):
+        """A checkout reports `dev`. Comparing that to a release number is
+        meaningless, and nagging a developer about it is noise."""
+        _refresh_with(_response({"tag_name": "v9.9.9"}), version_env="")
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": ""}, clear=False):
+            state = update_check.state()
+        assert state["behind"] is False
+        assert state["known"] is False
+
+    def test_a_tag_that_is_not_a_version_is_rejected(self):
+        """Third-party JSON. A tag like "nightly" rendered to the operator as a
+        version would be worse than saying nothing."""
+        assert _refresh_with(_response({"tag_name": "nightly"})) is None
+        assert _refresh_with(_response({"tag_name": ""})) is None
+        assert _refresh_with(_response(["not", "an", "object"])) is None
+
+
+class TestItSaysSoWhenThereIsSomethingNewer:
+    def test_a_newer_minor_is_reported(self):
+        _refresh_with(_response({"tag_name": "v1.20.1"}))
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.16.0"}, clear=False):
+            state = update_check.state()
+        assert state["known"] is True
+        assert state["behind"] is True
+        assert state["latest"] == "v1.20.1"
+        assert state["current"] == "1.16.0"
+
+    def test_the_same_series_is_not_behind(self):
+        """Patches inside a series are meant to interoperate; the banner is about
+        crossing a minor, which is what the operator has to act on."""
+        _refresh_with(_response({"tag_name": "v1.16.9"}))
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.16.0"}, clear=False):
+            assert update_check.state()["behind"] is False
+
+    def test_a_newer_local_build_is_not_behind(self):
+        """Running ahead of the published release happens on a release day."""
+        _refresh_with(_response({"tag_name": "v1.16.0"}), version_env="1.17.0")
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.17.0"}, clear=False):
+            assert update_check.state()["behind"] is False
+
+    def test_minors_are_compared_as_numbers_not_strings(self):
+        """1.9 vs 1.10 is where string comparison gets it exactly backwards, and
+        this project has passed its tenth minor, so it is live."""
+        _refresh_with(_response({"tag_name": "v1.10.0"}))
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.9.0"}, clear=False):
+            assert update_check.state()["behind"] is True, "1.10 was judged older than 1.9"
+
+
+class TestItCanBeTurnedOff:
+    def test_off_means_no_request_at_all(self):
+        """Not "fetch and discard": an operator who disables this expects no
+        outbound connection."""
+        with patch.dict("os.environ", {"CASHPILOT_UPDATE_CHECK": "off"}, clear=False):
+            client = AsyncMock()
+            client.__aenter__.return_value = client
+            with patch("app.update_check.httpx.AsyncClient", return_value=client) as factory:
+                assert asyncio.run(update_check.refresh(force=True)) is None
+            factory.assert_not_called()
+
+    @pytest.mark.parametrize("value", ["0", "off", "false", "no", "OFF", "False"])
+    def test_the_usual_spellings_all_disable_it(self, value):
+        with patch.dict("os.environ", {"CASHPILOT_UPDATE_CHECK": value}, clear=False):
+            assert update_check.enabled() is False
+
+    def test_it_is_on_by_default(self):
+        """Matching how this application already reaches CoinGecko and
+        Frankfurter, and how comparable self-hosted projects behave."""
+        import os
+
+        env = {k: v for k, v in os.environ.items() if k != "CASHPILOT_UPDATE_CHECK"}
+        with patch.dict("os.environ", env, clear=True):
+            assert update_check.enabled() is True
+
+
+class TestItDoesNotHammerTheEndpoint:
+    def test_a_second_call_inside_the_window_does_not_refetch(self):
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.16.0"}, clear=False):
+            client = AsyncMock()
+            client.get.return_value = _response({"tag_name": "v1.20.1"})
+            client.__aenter__.return_value = client
+            with patch("app.update_check.httpx.AsyncClient", return_value=client):
+                asyncio.run(update_check.refresh(force=True))
+                asyncio.run(update_check.refresh())
+            assert client.get.await_count == 1
+
+    def test_a_failure_also_starts_the_cooldown(self):
+        """Otherwise a host that is refusing us gets retried on every call."""
+        with patch.dict("os.environ", {"CASHPILOT_VERSION": "1.16.0"}, clear=False):
+            client = AsyncMock()
+            client.get.side_effect = httpx.ConnectError("offline")
+            client.__aenter__.return_value = client
+            with patch("app.update_check.httpx.AsyncClient", return_value=client):
+                asyncio.run(update_check.refresh(force=True))
+                asyncio.run(update_check.refresh())
+            assert client.get.await_count == 1
+
+    def test_the_interval_is_a_day_not_a_minute(self):
+        assert update_check.CHECK_INTERVAL_SECONDS >= 24 * 60 * 60
+
+
+class TestItNeverUpdatesAnything:
+    def test_the_module_only_ever_reads(self):
+        """A GET and nothing else. The banner tells you; you decide."""
+        source = (__import__("pathlib").Path(__file__).resolve().parents[1] / "app" / "update_check.py").read_text()
+        for forbidden in ("client.post", "client.put", "client.patch", "client.delete", "subprocess", "docker"):
+            assert forbidden not in source, f"the update check does more than read: {forbidden}"

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -2172,6 +2172,7 @@ class TestLifespanScheduler:
                         "data_retention",
                         "db_vacuum",
                         "exchange_rates",
+                        "update_check",
                     }
                     # Every job carries the hardening kwargs (audit fix).
                     for job in jobs.values():

--- a/tests/test_secure_defaults.py
+++ b/tests/test_secure_defaults.py
@@ -32,6 +32,47 @@ PUBLIC_COLLECTOR_FIELDS = {
 }
 
 
+def _code_only(source: str) -> str:
+    """Source with comments and docstrings removed, string literals kept.
+
+    Keeping literals is the point: a telemetry endpoint lives in a string, and
+    dropping strings would make this scan decorative.
+    """
+    import ast
+    import io
+    import tokenize
+
+    # Docstrings first, by position, so only the prose ones go.
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        tree = None
+    doc_spans: set[tuple[int, int]] = set()
+    if tree is not None:
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                body = getattr(node, "body", None)
+                if (
+                    body
+                    and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)
+                ):
+                    doc_spans.add((body[0].lineno, body[0].col_offset))
+
+    out: list[str] = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT:
+                continue
+            if tok.type == tokenize.STRING and tok.start in doc_spans:
+                continue
+            out.append(tok.string)
+    except tokenize.TokenError:
+        return source
+    return "\n".join(out)
+
+
 class TestCredentialEncryptionBoundary:
     """Tier 1: credential encryption at rest, with no plaintext mode."""
 
@@ -151,12 +192,47 @@ class TestNoTelemetry:
     """Tier 1: absent, not a toggle - a toggle implies it could exist."""
 
     def test_no_telemetry_or_phone_home_code_exists(self):
+        """Scans CODE, not prose.
+
+        The needle list is a substring match, so it used to fire on any COMMENT
+        mentioning the word -- including a docstring stating that a module sends
+        none, which is the opposite of the thing being forbidden. A check that
+        cannot tell a denial from an admission is one that gets worked around by
+        rewording, and then it is protecting nothing.
+
+        Comments and docstrings are stripped; STRING LITERALS ARE NOT, so a
+        telemetry endpoint URL or a `posthog` import is still caught. Proved by
+        the control below rather than asserted.
+        """
         needles = ("telemetry", "phone_home", "posthog", "mixpanel", "amplitude")
         offenders = []
         for path in (PROJECT_ROOT / "app").rglob("*.py"):
-            lowered = path.read_text().lower()
+            lowered = _code_only(path.read_text()).lower()
             offenders += [f"{path.name}:{n}" for n in needles if n in lowered]
         assert not offenders, f"telemetry-shaped code found: {offenders}"
+
+    def test_the_scan_still_catches_real_telemetry(self):
+        """The control. Stripping prose must not have stripped the teeth.
+
+        Each of these is a shape the scan exists to catch, and each must survive
+        comment-and-docstring removal.
+        """
+        for source in (
+            "import posthog\n",
+            "TELEMETRY_URL = 'https://example.invalid/collect'\n",
+            "def phone_home():\n    pass\n",
+            "client.post('https://mixpanel.example/track')\n",
+        ):
+            lowered = _code_only(source).lower()
+            assert any(n in lowered for n in ("telemetry", "phone_home", "posthog", "mixpanel", "amplitude")), (
+                f"the scan no longer catches: {source!r}"
+            )
+
+    def test_the_scan_ignores_prose(self):
+        """The false positive that prompted this: a module saying it sends no
+        telemetry is not telemetry."""
+        assert "telemetry" not in _code_only('"""This module sends no telemetry."""\n').lower()
+        assert "telemetry" not in _code_only("# no telemetry here\nx = 1\n").lower()
 
 
 class TestConfigCiphertext:


### PR DESCRIPTION
Closes `CashPilot-w0ss`. Your own fleet is the evidence: **33 releases behind, and no surface said so.**

## What was actually missing

Half the machinery already existed — `version.skewed()` compares this build against each worker. What was missing is a reference point *outside* the deployment: nothing in the application had any idea what the newest published release was.

Once a day, one unauthenticated `GET` to the public releases endpoint. A dismissible banner when there's something newer.

## Three constraints, and they're the whole design

- **Silent when unknown.** Offline, firewalled, disabled, never-run, or a dev build all produce `known: false`, and unknown renders **nothing** — no error, no spinner, and above all no reassuring *"up to date"* it never earned. Every failure mode inside `refresh()` lands on the same answer, which is what makes it safe on an air-gapped install.
- **Never auto-updates.** This deploys containers and holds credentials. It tells you; you decide.
- **Answerable.** `CASHPILOT_UPDATE_CHECK=off` makes **no connection at all** — not "fetch and discard", which is precisely what an operator disabling it would assume it *doesn't* do. Tested by asserting the HTTP client is never even constructed.

Dismissible **per version**: dismiss `v1.20.1` and it stays gone until `v1.20.2` exists, so it can't become wallpaper.

## Two existing tests failed, and both were right to

**The scheduler test** pins the exact job set and a uniform `misfire_grace_time`. I'd used `3600` for a daily job. I conformed to `300` rather than carve out an exception to a convention a test enforces uniformly — a missed daily check simply happens tomorrow.

**`test_no_telemetry_or_phone_home_code_exists`** fired on the word *"telemetry"* in my module's docstring — **in a sentence saying it sends none.**

That's worth more than a reword. A check that can't tell a denial from an admission gets worked around by rephrasing, and then it protects nothing. It now strips comments and docstrings but **keeps string literals**, so a telemetry endpoint URL or a `posthog` import is still caught.

Proved by control rather than asserted — dropping this into `app/`:

```python
import posthog
TELEMETRY_URL = "https://example.invalid/collect"
```

fails it on **both** needles.

## What it sends

Nothing about you. No request body, no identifier, and your version is not reported upstream. GitHub learns that an IP asked what the latest release is. Documented in `docs/configuration.md` alongside the opt-out.

## Verification

Five controls on the feature, all failing as required: reporting up-to-date when unreachable; comparing series as **strings** (`1.9` vs `1.10` — live, this project passed its tenth minor); fetching despite the off switch; trusting a non-version tag; re-fetching after every failure.

3688 tests pass, coverage 95.54%.