### PR TITLE
chore(compose): pin the examples to 1.17

### DIFF
--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -10,7 +10,7 @@
 # === Deploy on main server (e.g., server-a) ===
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.16
+    image: drumsergio/cashpilot:1.17
     pull_policy: always
     container_name: cashpilot-ui
     # Loopback by default (the UI commands the Docker-socket worker). Set
@@ -38,7 +38,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.16
+    image: drumsergio/cashpilot-worker:1.17
     pull_policy: always
     container_name: cashpilot-worker
     # The worker exposes a Docker-socket-backed API (deploy/stop/remove any
@@ -105,7 +105,7 @@ services:
 #
 #  services:
 #    cashpilot-worker:
-#      image: drumsergio/cashpilot-worker:1.16
+#      image: drumsergio/cashpilot-worker:1.17
 #      pull_policy: always
 #      container_name: cashpilot-worker
 #      # Docker-socket-backed API = full host control. Bind a PRIVATE/VPN interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   cashpilot-ui:
-    image: drumsergio/cashpilot:1.16
+    image: drumsergio/cashpilot:1.17
     pull_policy: always
     container_name: cashpilot-ui
     # Published on loopback by default: the dashboard can command the Docker-socket
@@ -51,7 +51,7 @@ services:
       - /tmp:size=64M
 
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:1.16
+    image: drumsergio/cashpilot-worker:1.17
     pull_policy: always
     container_name: cashpilot-worker
     expose:


### PR DESCRIPTION
Opened by hand: the v1.17.0 release pushed this branch but could not open the PR, because `can_approve_pull_request_reviews` was false. That setting is now enabled, so the next release does this itself.