### PR TITLE
feat(catalog): declare where every service actually pays out

### DIFF
--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -136,6 +136,50 @@
 #   currency: USD
 #   notes: "Additional cashout instructions or caveats"
 
+# payout:
+#   WHERE THE MONEY ACTUALLY GOES. `cashout` says how to WITHDRAW; this says
+#   where the funds live and whether there is an address at all (CashPilot-luj).
+#
+#   model: external | internal | minted | unknown        (REQUIRED)
+#     - external: the USER supplies an address they already own. CashPilot never
+#         holds a key. There IS an address to show.
+#     - internal: the service keeps an off-chain balance and pays out on
+#         request. There is NO address to register, and no chain to watch, until
+#         the user withdraws. Showing a blank address field here would read as
+#         "you forgot to configure this" when nothing is configurable — which is
+#         exactly why the model is a first-class field rather than an empty slot.
+#     - minted:   the container generates its own wallet on first run and
+#         accrues to it. The user has typically never seen the address, let
+#         alone backed up the seed.
+#     - unknown:  not yet determined. A DELIBERATE value, not a placeholder: the
+#         registry must flag what it does not know rather than render a blank
+#         that reads as "nothing to see here".
+#
+#   chain: ethereum | polygon | solana | none | ...
+#     `none` means NO on-chain surface exists at all, ever — Salad pays PayPal
+#     and gift cards only. Tier 2 (on-chain reconciliation) must skip these
+#     rather than fail to find an address for them.
+#     Omit entirely when the chain is chosen per-withdrawal and there is no
+#     persistent on-chain identity (Traffmonetizer picks Arbitrum/Tron/Solana/TON
+#     at withdrawal time).
+#
+#   address_env: WALLET
+#     `external` only, and only when the address is carried by an env var on the
+#     container — so the registry can read it from the deployed spec instead of
+#     asking the user to retype it.
+#
+#   address_source: env | manual | app
+#     Where the address is actually set. `manual` covers post-deploy
+#     configuration (Mysterium's beneficiary via TequilAPI, Anyone's anonrc);
+#     `app` covers a wallet linked inside the provider's own site.
+#
+#   notes: "Caveats worth showing the user."
+#     e.g. URnetwork forfeits payout after 30 days with no wallet linked.
+#
+#   NO PRIVATE KEYS. This block is a registry of PUBLIC addresses and payout
+#   mechanics, and nothing else. That is precisely why it comes first: it
+#   delivers most of the "where is my money" answer at zero custody risk.
+
 # platforms: [windows, macos, linux, android, ios, docker, browser_extension]
 
 # collector:

--- a/services/bandwidth/bitping.yml
+++ b/services/bandwidth/bitping.yml
@@ -73,3 +73,9 @@ collector:
   type: api
   notes: "Dashboard at app.bitping.com. Credentials persisted in /root/.bitping volume."
   credential_hint: "Use your Bitping account email and password (same as <a href='https://nodes.bitping.com' target='_blank'>nodes.bitping.com</a>)."
+
+payout:
+  model: internal
+  chain: solana
+  address_source: app
+  notes: "Solana-only now, and the address is typed in AT WITHDRAWAL TIME rather than stored."

--- a/services/bandwidth/bytebenefit.yml
+++ b/services/bandwidth/bytebenefit.yml
@@ -51,3 +51,7 @@ platforms: [windows, android]
 collector:
   type: manual
   notes: "No Docker image or public API."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/bytelixir.yml
+++ b/services/bandwidth/bytelixir.yml
@@ -68,3 +68,7 @@ collector:
   type: manual
   notes: "No public API. Dashboard at dash.bytelixir.com uses email/password auth. Scraping possible."
   credential_hint: "Log in at <a href='https://dash.bytelixir.com' target='_blank'>dash.bytelixir.com</a> <b>ticking Remember Me</b>, press F12 → Application → expand <b>Cookies</b> in the left sidebar → click <code>https://dash.bytelixir.com</code>, then copy three values: <b>bytelixir_session</b>, <b>remember_web_…</b> (the long one starting with that prefix) and <b>XSRF-TOKEN</b>. The session cookie alone expires about two hours after you copy it, so collection stops the same afternoon; the remember_web cookie lasts a year and is what keeps it working."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/earnapp.yml
+++ b/services/bandwidth/earnapp.yml
@@ -72,3 +72,7 @@ collector:
   type: api
   notes: "Dashboard API at /dashboard/api/money/. Auth via OAuth refresh token cookie. Returns balance in USD."
   credential_hint: "Log in at <a href='https://earnapp.com' target='_blank'>earnapp.com</a>, press F12 → Application → Cookies, copy the <b>oauth-refresh-token</b> value."
+
+payout:
+  model: internal
+  notes: "Balance held by EarnApp; redeemed to Amazon/Wise/PayPal."

--- a/services/bandwidth/earncc.yml
+++ b/services/bandwidth/earncc.yml
@@ -55,3 +55,7 @@ platforms: [windows, macos, linux]
 collector:
   type: manual
   notes: "No info available. Signup broken."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/earnfm.yml
+++ b/services/bandwidth/earnfm.yml
@@ -63,3 +63,7 @@ collector:
   type: api
   notes: "Supabase email/password auth. Docker client uses separate EARNFM_TOKEN (UUID) for bandwidth sharing only."
   credential_hint: "Use your Earn.fm account email and password (same as <a href='https://app.earn.fm' target='_blank'>app.earn.fm</a> login)."
+
+payout:
+  model: internal
+  notes: "Balance held by Earn.fm; withdrawn on request."

--- a/services/bandwidth/ebesucher.yml
+++ b/services/bandwidth/ebesucher.yml
@@ -55,3 +55,7 @@ platforms: [browser-extension]
 collector:
   type: manual
   notes: "Browser extension only. No API. Earnings visible in Ebesucher dashboard only."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/honeygain.yml
+++ b/services/bandwidth/honeygain.yml
@@ -77,3 +77,7 @@ collector:
   type: api
   notes: "JWT auth via /v1/users/me and /v2/earnings endpoints"
   credential_hint: "Use your Honeygain account email and password (same as <a href='https://dashboard.honeygain.com' target='_blank'>dashboard.honeygain.com</a>)."
+
+payout:
+  model: internal
+  notes: "Balance held by Honeygain; withdrawn on request."

--- a/services/bandwidth/iproyal.yml
+++ b/services/bandwidth/iproyal.yml
@@ -82,3 +82,7 @@ collector:
   type: api
   notes: "JWT auth via POST /api/v1/users/tokens (email+password), then GET /api/v1/users/me/balance-dashboard"
   credential_hint: "Use your IPRoyal Pawns account email and password (same as <a href='https://pawns.app' target='_blank'>pawns.app</a>)."
+
+payout:
+  model: internal
+  notes: "Balance held by IPRoyal Pawns; withdrawn on request."

--- a/services/bandwidth/mysterium.yml
+++ b/services/bandwidth/mysterium.yml
@@ -99,3 +99,9 @@ disclosure:
     before running it.
   account_rules: >-
     Unlimited devices per account and per IP.
+
+payout:
+  model: external
+  chain: polygon
+  address_source: manual
+  notes: "The beneficiary wallet is set AFTER deploy, via TequilAPI or the node WebUI -- not by an env var, so it cannot be read from the container spec."

--- a/services/bandwidth/packetshare.yml
+++ b/services/bandwidth/packetshare.yml
@@ -62,3 +62,7 @@ platforms: [docker, windows, macos, linux]
 collector:
   type: manual
   notes: "No known public API for earnings. Check dashboard manually."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/packetstream.yml
+++ b/services/bandwidth/packetstream.yml
@@ -63,3 +63,7 @@ collector:
   type: scrape
   notes: "Dashboard is CAPTCHA-protected. May need manual JWT from browser session for API access."
   credential_hint: "Log in at <a href='https://packetstream.io' target='_blank'>packetstream.io</a>, press F12 → Application → Cookies, copy the <b>auth</b> cookie value (it’s a JWT)."
+
+payout:
+  model: internal
+  notes: "Balance held by PacketStream; withdrawn on request."

--- a/services/bandwidth/peer2profit.yml
+++ b/services/bandwidth/peer2profit.yml
@@ -57,3 +57,7 @@ platforms: [docker, windows, macos, linux, android]
 collector:
   type: api
   notes: "Dashboard at peer2profit.com. API endpoints undocumented."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/proxybase-xyz.yml
+++ b/services/bandwidth/proxybase-xyz.yml
@@ -99,3 +99,7 @@ disclosure:
   account_rules: >-
     unknown - the provider does not publish a per-account or per-IP device
     limit, and the catalog does not declare one.
+
+payout:
+  model: minted
+  notes: "The client mints its own wallet on first run. See tier 3."

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -67,3 +67,7 @@ platforms: [docker, windows, linux]
 collector:
   type: manual
   notes: "No known public API for earnings."
+
+payout:
+  model: minted
+  notes: "The client mints its own wallet on first run. See tier 3."

--- a/services/bandwidth/proxylite.yml
+++ b/services/bandwidth/proxylite.yml
@@ -60,3 +60,7 @@ platforms: [docker, windows, linux]
 collector:
   type: api
   notes: "Dashboard at lk.proxylite.ru. User ID based authentication."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/proxyrack.yml
+++ b/services/bandwidth/proxyrack.yml
@@ -77,3 +77,7 @@ collector:
   type: api
   notes: "Dashboard behind Cloudflare. May need API key from browser session. Per-device earnings visible."
   credential_hint: "Log in at <a href='https://peer.proxyrack.com' target='_blank'>peer.proxyrack.com</a>, press F12 → Network, find any API request and copy the <b>Api-Key</b> header value."
+
+payout:
+  model: internal
+  notes: "Balance held by ProxyRack; withdrawn on request."

--- a/services/bandwidth/repocket.yml
+++ b/services/bandwidth/repocket.yml
@@ -71,3 +71,7 @@ collector:
   type: api
   notes: "Earnings collector authenticates separately via Firebase (account email/password) to read the balance — distinct from the container's RP_API_KEY. Per-device earnings visible."
   credential_hint: "Use your Repocket account email and password (same as <a href='https://app.repocket.com' target='_blank'>app.repocket.com</a>)."
+
+payout:
+  model: internal
+  notes: "Balance held by Repocket; withdrawn on request."

--- a/services/bandwidth/speedshare.yml
+++ b/services/bandwidth/speedshare.yml
@@ -64,3 +64,7 @@ platforms: [docker, windows, macos, linux]
 collector:
   type: manual
   notes: "No official API. Community Docker image. Manual earnings tracking via dashboard."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/spide.yml
+++ b/services/bandwidth/spide.yml
@@ -60,3 +60,7 @@ platforms: [windows, linux]
 collector:
   type: manual
   notes: "No official Docker image or public API found."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/bandwidth/traffmonetizer.yml
+++ b/services/bandwidth/traffmonetizer.yml
@@ -73,3 +73,7 @@ collector:
   type: api
   notes: "reCAPTCHA blocks programmatic login. Token extracted from browser Local Storage at app.traffmonetizer.com (same as deployment token)."
   credential_hint: "Log in at <a href='https://app.traffmonetizer.com' target='_blank'>app.traffmonetizer.com</a>, press F12 → Application → Local Storage → <b>token</b> value (a long JWT starting with <code>eyJ</code>)."
+
+payout:
+  model: internal
+  notes: "USDT, but the CHAIN IS CHOSEN PER WITHDRAWAL (Arbitrum/Tron/Solana/TON), so there is no persistent on-chain identity to register."

--- a/services/bandwidth/urnetwork.yml
+++ b/services/bandwidth/urnetwork.yml
@@ -61,3 +61,9 @@ platforms: [docker, windows, macos, linux]
 collector:
   type: manual
   notes: "No known public earnings API."
+
+payout:
+  model: external
+  chain: solana
+  address_source: app
+  notes: "Wallet is linked inside the URnetwork app. AN UNLINKED WALLET FORFEITS PAYOUT AFTER 30 DAYS."

--- a/services/bandwidth/wizardgain.yml
+++ b/services/bandwidth/wizardgain.yml
@@ -56,3 +56,7 @@ platforms: [docker, windows, linux]
 collector:
   type: manual
   notes: "No known public API for earnings."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/compute/flux.yml
+++ b/services/compute/flux.yml
@@ -54,3 +54,7 @@ platforms: [linux]
 collector:
   type: manual
   notes: "FluxOS dashboard. On-chain earnings."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/compute/golem.yml
+++ b/services/compute/golem.yml
@@ -57,3 +57,7 @@ platforms: [linux]
 collector:
   type: api
   notes: "Yagna REST API at localhost:7465. Provider earnings queryable via /payment/invoices. GLM on Polygon for on-chain tracking."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/compute/ionet.yml
+++ b/services/compute/ionet.yml
@@ -54,3 +54,7 @@ platforms: [linux]
 collector:
   type: manual
   notes: "Dashboard at cloud.io.net. GPU provider signup process unclear."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/compute/nosana.yml
+++ b/services/compute/nosana.yml
@@ -57,3 +57,8 @@ platforms: [linux]
 collector:
   type: api
   notes: "Nosana explorer API on Solana. Node earnings queryable via Solana RPC and Nosana dashboard."
+
+payout:
+  model: minted
+  chain: solana
+  notes: "Mints a Solana wallet by default. The user has typically never seen the address. See tier 3."

--- a/services/compute/salad.yml
+++ b/services/compute/salad.yml
@@ -55,3 +55,8 @@ collector:
   type: api
   notes: "API at app-api.salad.com/api/v1/profile/balance. Auth via 'auth' cookie + X-XSRF-TOKEN header (double-submit). Returns currentBalance (USD) and lifetimeBalance."
   credential_hint: "Log in at <a href='https://app.salad.io' target='_blank'>app.salad.io</a>, press F12 → Application → Cookies, copy the <b>auth</b> cookie value."
+
+payout:
+  model: internal
+  chain: none
+  notes: "PayPal and gift cards ONLY -- no crypto whatsoever. Has no on-chain surface for tier 2 to reconcile."

--- a/services/compute/vast-ai.yml
+++ b/services/compute/vast-ai.yml
@@ -59,3 +59,7 @@ platforms: [linux]
 collector:
   type: api
   notes: "REST API at https://console.vast.ai/api/v0/. API key auth. Endpoints for machine stats and earnings."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -106,3 +106,9 @@ disclosure:
     No account is needed at all, so there is nothing to limit per account. The
     project does not publish a per-IP relay limit, and the catalog does not
     declare one.
+
+payout:
+  model: external
+  chain: ethereum
+  address_source: manual
+  notes: "Set as ContactInfo in anonrc, prefixed '@anon:0x...'."

--- a/services/depin/blockmesh.yml
+++ b/services/depin/blockmesh.yml
@@ -56,3 +56,7 @@ platforms: [browser-extension]
 collector:
   type: scrape
   notes: "Dashboard at app.blockmesh.xyz. Solana wallet auth. Points tracking via web UI."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/dawn.yml
+++ b/services/depin/dawn.yml
@@ -56,3 +56,7 @@ platforms: [browser-extension]
 collector:
   type: scrape
   notes: "Points visible in extension popup and web dashboard. No public API documented."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/deeper-network.yml
+++ b/services/depin/deeper-network.yml
@@ -54,3 +54,7 @@ platforms: []
 collector:
   type: manual
   notes: "Hardware device dashboard. Requires Deeper Connect device."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/gaganode.yml
+++ b/services/depin/gaganode.yml
@@ -54,3 +54,7 @@ platforms: [windows, macos, linux, android]
 collector:
   type: api
   notes: "Dashboard API at dashboard.gaganode.com. Token-based auth. Earnings and node status endpoints."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/gradient.yml
+++ b/services/depin/gradient.yml
@@ -56,3 +56,7 @@ platforms: [browser-extension]
 collector:
   type: scrape
   notes: "Points visible at app.gradient.network dashboard. No public API documented."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/grass.yml
+++ b/services/depin/grass.yml
@@ -63,3 +63,7 @@ collector:
   type: api
   notes: "Dashboard API at app.grass.io. Auth via session token. Points visible in dashboard."
   credential_hint: "Log in at <a href='https://app.getgrass.io' target='_blank'>app.getgrass.io</a>, press F12 → Application → Local Storage, copy the <b>accessToken</b> value."
+
+payout:
+  model: internal
+  notes: "Accrues POINTS; GRASS is claimed from the Grass dashboard during periodic airdrops."

--- a/services/depin/helium.yml
+++ b/services/depin/helium.yml
@@ -54,3 +54,7 @@ platforms: []
 collector:
   type: api
   notes: "Helium Explorer API for network stats. Individual earnings via wallet on-chain."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/koii.yml
+++ b/services/depin/koii.yml
@@ -54,3 +54,7 @@ platforms: [windows, macos, linux]
 collector:
   type: manual
   notes: "Service paused. No collection possible."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/network3.yml
+++ b/services/depin/network3.yml
@@ -57,3 +57,7 @@ platforms: [windows, macos, linux]
 collector:
   type: manual
   notes: "Site unreachable due to expired certificate. No collection possible."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/nodepay.yml
+++ b/services/depin/nodepay.yml
@@ -56,3 +56,7 @@ platforms: [browser-extension]
 collector:
   type: scrape
   notes: "Behind Cloudflare. API access may require browser session cookies. Dashboard at app.nodepay.ai."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/nodle.yml
+++ b/services/depin/nodle.yml
@@ -55,3 +55,7 @@ platforms: [ios, android]
 collector:
   type: manual
   notes: "Mobile app only. No API documented."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/passiveapp.yml
+++ b/services/depin/passiveapp.yml
@@ -51,3 +51,7 @@ platforms: [windows, linux, android, ios]
 collector:
   type: manual
   notes: "No official Docker image or public API."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/presearch.yml
+++ b/services/depin/presearch.yml
@@ -61,3 +61,9 @@ platforms: [docker, linux]
 collector:
   type: api
   notes: "Node dashboard at nodes.presearch.com. Shows earnings, uptime, and reliability score."
+
+payout:
+  model: external
+  chain: ethereum
+  address_source: app
+  notes: "Requires staking 4,000 PRE from the user's own wallet. Staking lives entirely on presearch.com and is out of reach of the container."

--- a/services/depin/sentinel-dvpn.yml
+++ b/services/depin/sentinel-dvpn.yml
@@ -54,3 +54,7 @@ platforms: [linux]
 collector:
   type: manual
   notes: "Cosmos blockchain-based. Earnings tracked on-chain. Node Spawner tool available for automated setup."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/teneo.yml
+++ b/services/depin/teneo.yml
@@ -56,3 +56,7 @@ platforms: [browser-extension]
 collector:
   type: scrape
   notes: "Points visible in dashboard.teneo.pro. Websocket-based connection tracking."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/theta-edge.yml
+++ b/services/depin/theta-edge.yml
@@ -54,3 +54,7 @@ platforms: [windows, macos, linux]
 collector:
   type: manual
   notes: "Desktop app shows earnings. No headless/Docker mode available."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/titan.yml
+++ b/services/depin/titan.yml
@@ -57,3 +57,7 @@ platforms: [windows, macos, android]
 collector:
   type: api
   notes: "Dashboard at edge.titannet.io. Node status and earnings visible via web UI. API details sparse."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/uprock.yml
+++ b/services/depin/uprock.yml
@@ -53,3 +53,7 @@ platforms: [browser-extension, android]
 collector:
   type: manual
   notes: "No official Docker image or public API."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/depin/wipter.yml
+++ b/services/depin/wipter.yml
@@ -53,3 +53,7 @@ platforms: [windows, macos, linux, android]
 collector:
   type: scrape
   notes: "Dashboard at wipter.com. Earnings visible in account panel. No public API documented."
+
+payout:
+  model: unknown
+  notes: "Not yet determined. Flagged rather than shown blank -- see CashPilot-luj."

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -139,3 +139,10 @@ disclosure:
   account_rules: >-
     Unlimited nodes, but nodes on the same /24 subnet share allocation, so
     several on one connection earn less each.
+
+payout:
+  model: external
+  chain: ethereum
+  address_env: WALLET
+  address_source: env
+  notes: "Paid monthly in STORJ (ERC-20) to the address in WALLET."

--- a/tests/test_beads_batch_70.py
+++ b/tests/test_beads_batch_70.py
@@ -1,0 +1,172 @@
+"""CashPilot-luj, tier 1: where does my money actually go?
+
+A user could not answer the most basic financial question about their own
+installation. Payout destinations existed only inside container env vars and
+config files, scattered across every worker, with no screen listing them.
+
+This is the CATALOG foundation: every service declares its payout MODEL, and
+where applicable the address and how it is set. The catalog stays the source of
+truth, so adding a service is one YAML block rather than an edit to a route.
+
+THE DESIGN DECISION THAT SHAPES EVERYTHING: the model is a first-class field, not
+an address that happens to be empty. Three real payout mechanisms exist and they
+are not variations of one thing —
+
+  * external: the user supplies an address they own. There IS one to show.
+  * internal: the service holds an off-chain balance and pays out on request.
+    There is NO address, and a blank field would read as "you forgot to
+    configure this" when nothing is configurable.
+  * minted:   the container generates its own wallet and accrues to it. The user
+    has typically never seen it.
+
+and a fourth value that is deliberate rather than a placeholder:
+
+  * unknown:  not yet determined. The acceptance criteria ask for this
+    explicitly — "visibly flagged, not silently blank".
+
+STRICTLY NO PRIVATE KEYS. This tier is a registry of public addresses and payout
+mechanics. That is why it comes first: most of the answer, zero custody risk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_FILES = sorted(p for p in (ROOT / "services").glob("*/*.yml") if not p.name.startswith("_"))
+MODELS = {"external", "internal", "minted", "unknown"}
+
+
+def service(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def payout(path: Path) -> dict:
+    return service(path).get("payout") or {}
+
+
+def ids(paths):
+    return [f"{p.parent.name}/{p.stem}" for p in paths]
+
+
+class TestEveryServiceDeclaresWhereMoneyGoes:
+    def test_the_catalog_is_not_empty(self):
+        """Otherwise every parametrised test below is vacuously true."""
+        assert len(SERVICE_FILES) >= 40
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_it_has_a_payout_block(self, path):
+        assert payout(path), f"{path.name} declares no payout model"
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_the_model_is_one_of_the_four(self, path):
+        model = payout(path).get("model")
+        assert model in MODELS, f"{path.name}: model={model!r} is not one of {sorted(MODELS)}"
+
+
+class TestTheModelAndTheFieldsAgree:
+    """A model that contradicts its own fields would make the screen lie."""
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_only_an_external_payout_names_an_address_env(self, path):
+        block = payout(path)
+        if "address_env" in block:
+            assert block["model"] == "external", (
+                f"{path.name}: only an external payout has a user-supplied address to read from an env var"
+            )
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_an_address_env_actually_exists_on_the_service(self, path):
+        """Naming an env var the container never receives would send the registry
+        looking for an address that is never set."""
+        block = payout(path)
+        env_name = block.get("address_env")
+        if not env_name:
+            return
+        # docker.env is a LIST of {key, label, ...}, which is where a service
+        # actually declares what the container receives. My first version looked
+        # under credentials.fields and docker.environment -- neither of which
+        # exists in this schema -- so it found nothing and failed storj, which is
+        # the one service that genuinely does declare WALLET. The test was right
+        # to fail; the lookup was wrong.
+        declared = {
+            str(item.get("key"))
+            for item in ((service(path).get("docker") or {}).get("env") or [])
+            if isinstance(item, dict)
+        }
+        assert env_name in declared, f"{path.name}: address_env={env_name!r} is not a field this service declares"
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_an_internal_payout_registers_no_address(self, path):
+        """There is nothing to register until the user withdraws. Claiming
+        otherwise is the exact error this model exists to prevent."""
+        block = payout(path)
+        if block.get("model") == "internal":
+            assert "address_env" not in block, f"{path.name}: an internal balance has no address to read"
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_an_unknown_payout_claims_nothing_else(self, path):
+        """`unknown` must not carry a chain or an address, or it is not unknown."""
+        block = payout(path)
+        if block.get("model") == "unknown":
+            for field in ("chain", "address_env", "address_source"):
+                assert field not in block, f"{path.name}: model=unknown but it declares {field}"
+
+
+class TestTheThingsTheResearchEstablished:
+    """Spot-checks on the services whose payout mechanics were actually
+    researched, so a careless bulk edit cannot quietly flatten them."""
+
+    @staticmethod
+    def _payout(slug: str) -> dict:
+        path = next(p for p in SERVICE_FILES if p.stem == slug)
+        return payout(path)
+
+    def test_storj_reads_its_address_from_the_wallet_env_var(self):
+        block = self._payout("storj")
+        assert block["model"] == "external"
+        assert block["address_env"] == "WALLET"
+
+    def test_mysterium_is_external_but_not_readable_from_the_spec(self):
+        """The beneficiary is set AFTER deploy via TequilAPI, so there is no env
+        var to read -- and pretending there is would show a permanent blank."""
+        block = self._payout("mysterium")
+        assert block["model"] == "external"
+        assert block["address_source"] == "manual"
+        assert "address_env" not in block
+
+    def test_salad_is_marked_as_having_no_chain_at_all(self):
+        """Called out explicitly in the research: PayPal and gift cards only, so
+        tier 2 must never try to reconcile it on-chain."""
+        block = self._payout("salad")
+        assert block["model"] == "internal"
+        assert block["chain"] == "none"
+
+    def test_traffmonetizer_declares_no_chain(self):
+        """The chain is picked per withdrawal, so there is no persistent
+        on-chain identity. Naming one would be a fabrication."""
+        block = self._payout("traffmonetizer")
+        assert block["model"] == "internal"
+        assert "chain" not in block
+
+    def test_urnetwork_warns_about_the_thirty_day_forfeit(self):
+        """A user who never links a wallet LOSES the money. That is the single
+        most valuable sentence in this registry."""
+        assert "30 days" in self._payout("urnetwork").get("notes", "").lower()
+
+    def test_the_minted_services_are_marked_for_tier_three(self):
+        for slug in ("proxybase", "nosana"):
+            assert self._payout(slug)["model"] == "minted", slug
+
+
+class TestNoPrivateKeyIsEverDeclared:
+    """The custody boundary, enforced. This tier is public addresses only."""
+
+    @pytest.mark.parametrize("path", SERVICE_FILES, ids=ids(SERVICE_FILES))
+    def test_the_payout_block_names_no_secret(self, path):
+        text = " ".join(f"{k} {v}" for k, v in payout(path).items()).lower()
+        for forbidden in ("private_key", "privatekey", "seed_phrase", "mnemonic", "secret_key", "keystore"):
+            assert forbidden not in text, f"{path.name}: the payout registry must never reference {forbidden}"


### PR DESCRIPTION
The catalog foundation for `CashPilot-luj` (tier 1 of the wallet work). Not the screen yet — this is the data model the screen needs, and it's the half that has to be right.

## The problem

A user could not answer the most basic financial question about their own installation: **which addresses do my services pay to?** That lived only inside container env vars and config files, scattered across every worker.

## The design decision

**The model is a first-class field, not an address that happens to be empty.** Three real mechanisms exist, and they aren't variations of one thing:

| Model | Meaning |
|---|---|
| `external` | The user supplies an address they own. There **is** one to show. |
| `internal` | The service holds an off-chain balance and pays on request. There is **no** address until withdrawal — a blank field here reads as *"you forgot to configure this"* when nothing is configurable. |
| `minted` | The container generates its own wallet and accrues to it. The user has typically never seen it. (Tier 3.) |
| `unknown` | Not yet determined — **deliberate, not a placeholder.** The acceptance criteria ask for exactly this: *"visibly flagged, not silently blank."* |

Today: **5 external, 11 internal, 3 minted, 31 unknown.** The unknowns are honest, and they're what the screen will flag.

## Three cases a careless bulk edit would flatten

Each pinned by its own test:

- **Mysterium** is `external`, but its beneficiary is set *after deploy* via TequilAPI — there is no env var to read, and claiming one would show a permanent blank.
- **Traffmonetizer** declares **no chain**. It's USDT, but the chain is chosen per withdrawal, so there is no persistent on-chain identity to name. Naming one would be a fabrication.
- **Salad** is `chain: none` — PayPal and gift cards only — so tier 2 must never try to reconcile it on-chain.

And the one line in here worth real money: **URnetwork forfeits payout after 30 days** if no wallet is linked.

## No private keys

Enforced by a test rejecting `private_key`, `mnemonic`, `seed_phrase`, `keystore` and friends anywhere in a payout block. That custody boundary is *why this tier comes first*: most of the "where is my money" answer at zero custody risk.

## One of my tests failed and was right to

`test_an_address_env_actually_exists_on_the_service` looked for declared env vars under `credentials.fields` and `docker.environment` — **neither exists in this schema.** It found nothing and failed `storj`, the one service that genuinely declares `WALLET`. The lookup was wrong, not the assertion; it now reads `docker.env`.

Worth noting because a laxer version would have passed silently and let a future service name an env var the container never receives.

## Verification

357 new assertions; 4074 tests pass overall, coverage 95.54%.

Five controls, all failing: a missing payout block, an `address_env` naming a var the container never gets, an `internal` service claiming an address, Salad's `chain: none` removed, and a private key added.

## Next

The screen itself, and reading actual addresses from deployed specs.