### PR TITLE
docs: stop publishing the internal growth playbook as a page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,17 @@ exclude_docs: |
   # docs/guides/proxybase.md) rather than to the site tree — which is also why
   # --strict fails on them if they are published.
   changelog-0.x-handwritten.md
+  # An internal working checklist, not a product page. It opens "Track status of
+  # each action here", lists promotion tactics in candid internal wording, and
+  # ticks off features that do not exist yet. Publishing it told visitors what we
+  # do to acquire them, and a checklist published as a page is a checklist nobody
+  # updates. It was reachable at /growth-strategy/ (verified 200) even though no
+  # nav entry linked it.
+  #
+  # This stops it being a PAGE. It does NOT make it private: the repository is
+  # public, so the file is still readable on GitHub. Removing it from history is
+  # a separate, deliberate decision.
+  growth-strategy.md
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Closes **CashPilot-1qvz**.

`docs/growth-strategy.md` is a working checklist, not a product page. It opens *"Track status of each action here"*, lists promotion tactics in candid internal wording, and ticks off features that do not exist yet.

**It was live.** `https://geiserx.github.io/CashPilot/growth-strategy/` returned **200** — reachable by URL even though no nav entry linked it. So visitors could read what we do to acquire them, on the very site we send them to. A checklist published as a page is also a checklist nobody updates.

## What this does

Adds it to the `exclude_docs` block that already carries `GOAL.md`, `AUTOPILOT-WORKLOG.md` and the changelog. The file stays in the repository, where it is still useful beside the code.

## What this does NOT do

**It does not make the content private.** The repository is public, so the file remains readable on GitHub. Taking it out of history is a separate, deliberate decision — flagging it rather than assuming it.

## Verification

- `mkdocs build --strict` passes
- the built site contains **0** files matching `*growth*`
- the search index has **0** hits for it (an exclusion that still leaks via search is not an exclusion)
- control: the other **66** pages still build, so the check is not passing because the build is empty