### PR TITLE
feat: read on-chain balances, honestly (dv6 tier 2, first slice)

### DIFF
--- a/app/onchain.py
+++ b/app/onchain.py
@@ -91,8 +91,44 @@ _cache: dict[str, tuple[float, dict[str, Any]]] = {}
 _backoff_until: dict[str, float] = {}
 
 
+#: A ceiling so a long-lived process cannot grow the cache without bound even if
+#: every entry is somehow live. Far above any real fleet's address count.
+MAX_CACHE_ENTRIES = 512
+
+
 def _now() -> float:
     return time.monotonic()
+
+
+def _cache_get(key: str) -> dict[str, Any] | None:
+    """A COPY of the cached result, or None.
+
+    Returning the stored dict itself would let any caller that mutates what it
+    got corrupt every later read — and this module's entire contract is that
+    ``amount`` is None unless ``state`` is ``known``, so a mutated cache entry
+    is exactly the lie the module exists to prevent.
+    """
+    hit = _cache.get(key)
+    if hit and hit[0] > _now():
+        return dict(hit[1])
+    return None
+
+
+def _cache_put(key: str, value: dict[str, Any]) -> None:
+    now = _now()
+    # Expired entries are only ever noticed on read, so without this sweep they
+    # accumulate for the life of the process: one entry per address ever asked
+    # about, never released.
+    for k in [k for k, (expires, _) in _cache.items() if expires <= now]:
+        del _cache[k]
+    # Evict DOWN TO the ceiling, not by one. Dropping a single entry leaves an
+    # over-full cache over-full forever, which is how a "capped" cache quietly
+    # is not one.
+    if len(_cache) >= MAX_CACHE_ENTRIES:
+        by_expiry = sorted(_cache, key=lambda k: _cache[k][0])
+        for k in by_expiry[: len(_cache) - MAX_CACHE_ENTRIES + 1]:
+            del _cache[k]
+    _cache[key] = (now + CACHE_TTL, dict(value))
 
 
 def address_looks_valid(chain: str, address: str) -> bool:
@@ -170,9 +206,9 @@ async def balance(chain: str, address: str, *, client: httpx.AsyncClient | None 
 
     address = address.strip()
     key = f"{slug}:{address}"
-    cached = _cache.get(key)
-    if cached and cached[0] > _now():
-        return cached[1]
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
 
     if _backoff_until.get(spec.rpc, 0) > _now():
         # Deliberately NOT cached: the moment backoff expires we should try again.
@@ -191,7 +227,7 @@ async def balance(chain: str, address: str, *, client: httpx.AsyncClient | None 
             await client.aclose()
 
     out = _result(KNOWN, slug, amount=amount)
-    _cache[key] = (_now() + CACHE_TTL, out)
+    _cache_put(key, out)
     return out
 
 

--- a/app/onchain.py
+++ b/app/onchain.py
@@ -62,6 +62,8 @@ INVALID = "invalid"
 _EVM_ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
 # Base58 excludes 0, O, I and l precisely so they cannot be confused visually.
 _SOLANA_ADDRESS = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+# An Ethereum JSON-RPC QUANTITY: a 0x-prefixed hex string, and nothing else.
+_EVM_QUANTITY = re.compile(r"0x[0-9a-fA-F]+")
 
 
 @dataclass(frozen=True)
@@ -184,14 +186,37 @@ async def _rpc(client: httpx.AsyncClient, url: str, method: str, params: list[An
 
 
 async def _read(spec: Chain, address: str, client: httpx.AsyncClient) -> Decimal:
+    """Parse a balance, refusing anything that is not exactly the documented shape.
+
+    Being strict here is the whole point. A tolerant parser turns a malformed
+    response into a CONFIDENT WRONG NUMBER, which this module reports as
+    ``known`` — the one outcome worse than admitting we could not read the
+    chain. Three ways that happened before this was tightened:
+
+    * ``int(str(raw), 16)`` accepted the JSON *number* ``10`` and read it as
+      hex, reporting 16 wei as fact.
+    * ``isinstance(value, int)`` is True for ``True``, so a boolean became a
+      balance of 1e-9 SOL.
+    * nothing rejected a negative, so ``-5000000000`` rendered as -5 SOL.
+
+    Every rejection raises, and the caller turns that into ``unreachable``.
+    """
     if spec.kind == "evm":
         raw = await _rpc(client, spec.rpc, "eth_getBalance", [address, "latest"])
-        return _scale(int(str(raw), 16), spec.decimals)
+        # A hex STRING, not merely something str() can render.
+        if not isinstance(raw, str) or not _EVM_QUANTITY.fullmatch(raw):
+            raise ValueError(f"unexpected eth_getBalance result: {str(raw)[:120]}")
+        return _scale(int(raw, 16), spec.decimals)
+
     result = await _rpc(client, spec.rpc, "getBalance", [address])
-    # Solana nests the number under `value`; a bare int would be a protocol change.
-    value = result.get("value") if isinstance(result, dict) else result
-    if not isinstance(value, int):
+    # Solana nests the number under `value`; a bare int is a protocol change,
+    # not something to accept quietly.
+    if not isinstance(result, dict):
         raise ValueError(f"unexpected getBalance shape: {str(result)[:120]}")
+    value = result.get("value")
+    # `type(...) is not int` rather than isinstance: bool subclasses int.
+    if type(value) is not int or value < 0:
+        raise ValueError(f"unexpected getBalance value: {str(result)[:120]}")
     return _scale(value, spec.decimals)
 
 

--- a/app/onchain.py
+++ b/app/onchain.py
@@ -1,0 +1,214 @@
+"""Read-only on-chain balances (CashPilot-dv6, tier 2).
+
+Once tier 1 knows WHERE a service pays, this reads what actually arrived. It
+handles no private key, constructs no transaction and signs nothing — the only
+operation is "what is the balance at this public address?".
+
+THE RULE THIS MODULE EXISTS TO ENFORCE, and it is the same rule as everywhere
+else in this codebase: **absent is not zero**. A chain we could not reach must
+never render as a balance of 0. Zero is a fact about an address; unreachable is
+a fact about us. Showing the second as the first tells a user their money is
+gone when the truth is that a public RPC rate-limited us.
+
+So every read returns a STATE, never a bare number:
+
+    known          we asked and got an answer. ``amount`` is real, 0 included.
+    unreachable    the RPC failed, timed out, or answered nonsense.
+    unsupported    we have no endpoint for that chain.
+    invalid        the address is not well formed for that chain, so we did
+                   not ask at all. Never send a malformed address to a public
+                   endpoint just to see what happens.
+
+Public RPCs are a courtesy, not an entitlement. Results are cached and a failing
+endpoint is backed off, because a dashboard that polls hard gets blocked — and a
+blocked endpoint degrades every user of this feature, not just the impatient one.
+
+No API keys. Every endpoint here is keyless by choice; a chain that needs a key
+stays ``unsupported`` until the user supplies one, and a shared key is never
+shipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+#: How long a successful read is reused. Balances move slowly relative to a
+#: dashboard refresh, and this is the main thing keeping us welcome on a free RPC.
+CACHE_TTL = 300
+
+#: After a failure, do not retry that endpoint for this long. Hammering an RPC
+#: that just rate-limited us is how the block becomes permanent.
+BACKOFF = 120
+
+#: Deliberately short. A slow chain must not hold up a page render; the caller
+#: gets "unreachable" and the UI says so.
+TIMEOUT = 8.0
+
+KNOWN = "known"
+UNREACHABLE = "unreachable"
+UNSUPPORTED = "unsupported"
+INVALID = "invalid"
+
+_EVM_ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+# Base58 excludes 0, O, I and l precisely so they cannot be confused visually.
+_SOLANA_ADDRESS = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+
+
+@dataclass(frozen=True)
+class Chain:
+    """One supported chain and the keyless endpoint we read it from."""
+
+    slug: str
+    name: str
+    symbol: str
+    decimals: int
+    rpc: str
+    kind: str  # "evm" or "solana"
+
+
+#: Only chains actually declared by a catalogued service. Adding an endpoint we
+#: have no use for is a dependency on someone else's free infrastructure for no
+#: benefit.
+CHAINS: dict[str, Chain] = {
+    "ethereum": Chain("ethereum", "Ethereum", "ETH", 18, "https://ethereum-rpc.publicnode.com", "evm"),
+    "polygon": Chain("polygon", "Polygon", "POL", 18, "https://polygon-bor-rpc.publicnode.com", "evm"),
+    "solana": Chain("solana", "Solana", "SOL", 9, "https://api.mainnet-beta.solana.com", "solana"),
+}
+
+# slug -> (expires_at, result)
+_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+# rpc url -> time until which we do not retry it
+_backoff_until: dict[str, float] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def address_looks_valid(chain: str, address: str) -> bool:
+    """Whether ``address`` is well formed for ``chain``.
+
+    Checked BEFORE any network call. This is not a claim that the address
+    exists — only that asking about it is meaningful.
+    """
+    spec = CHAINS.get((chain or "").lower())
+    if not spec or not address:
+        return False
+    if spec.kind == "evm":
+        return bool(_EVM_ADDRESS.match(address.strip()))
+    return bool(_SOLANA_ADDRESS.match(address.strip()))
+
+
+def _result(state: str, chain: str, *, amount: Decimal | None = None, detail: str | None = None) -> dict[str, Any]:
+    spec = CHAINS.get(chain)
+    return {
+        "state": state,
+        "chain": chain,
+        "symbol": spec.symbol if spec else None,
+        # None, never 0.0, for every state except `known`. A caller that
+        # formats this without checking `state` will render an em dash, not a
+        # figure — which is the failure mode we want.
+        "amount": amount if state == KNOWN else None,
+        "detail": detail,
+    }
+
+
+def _scale(raw: int, decimals: int) -> Decimal:
+    """Integer base units -> a decimal amount, exactly.
+
+    Decimal rather than float: 18 decimals of wei does not survive a float, and
+    a balance that is wrong in the last places is a balance nobody trusts.
+    """
+    return Decimal(raw) / (Decimal(10) ** decimals)
+
+
+async def _rpc(client: httpx.AsyncClient, url: str, method: str, params: list[Any]) -> Any:
+    response = await client.post(
+        url,
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+        headers={"content-type": "application/json"},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict) or "error" in payload:
+        raise ValueError(f"RPC error: {str(payload)[:200]}")
+    if "result" not in payload:
+        raise ValueError("RPC response carried no result")
+    return payload["result"]
+
+
+async def _read(spec: Chain, address: str, client: httpx.AsyncClient) -> Decimal:
+    if spec.kind == "evm":
+        raw = await _rpc(client, spec.rpc, "eth_getBalance", [address, "latest"])
+        return _scale(int(str(raw), 16), spec.decimals)
+    result = await _rpc(client, spec.rpc, "getBalance", [address])
+    # Solana nests the number under `value`; a bare int would be a protocol change.
+    value = result.get("value") if isinstance(result, dict) else result
+    if not isinstance(value, int):
+        raise ValueError(f"unexpected getBalance shape: {str(result)[:120]}")
+    return _scale(value, spec.decimals)
+
+
+async def balance(chain: str, address: str, *, client: httpx.AsyncClient | None = None) -> dict[str, Any]:
+    """The balance at ``address`` on ``chain``, or an honest reason why not."""
+    slug = (chain or "").lower()
+    spec = CHAINS.get(slug)
+    if not spec:
+        return _result(UNSUPPORTED, slug, detail="No keyless endpoint is configured for this chain.")
+    if not address_looks_valid(slug, address):
+        return _result(INVALID, slug, detail="That address is not well formed for this chain.")
+
+    address = address.strip()
+    key = f"{slug}:{address}"
+    cached = _cache.get(key)
+    if cached and cached[0] > _now():
+        return cached[1]
+
+    if _backoff_until.get(spec.rpc, 0) > _now():
+        # Deliberately NOT cached: the moment backoff expires we should try again.
+        return _result(UNREACHABLE, slug, detail="Backing off after a recent failure from this endpoint.")
+
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=TIMEOUT)
+    try:
+        amount = await _read(spec, address, client)
+    except Exception as exc:  # noqa: BLE001 - every failure is the same answer: we do not know
+        _backoff_until[spec.rpc] = _now() + BACKOFF
+        logger.warning("Could not read %s balance for %s: %s", slug, address[:10] + "...", exc)
+        return _result(UNREACHABLE, slug, detail=f"{type(exc).__name__} while reading the chain.")
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    out = _result(KNOWN, slug, amount=amount)
+    _cache[key] = (_now() + CACHE_TTL, out)
+    return out
+
+
+async def balances(pairs: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    """Read several addresses, sharing one client.
+
+    Runs concurrently because the chains are independent, but note the per-chain
+    backoff is shared state: one failing endpoint stops the others queueing
+    behind it rather than each waiting out its own timeout.
+    """
+    if not pairs:
+        return []
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        return list(await asyncio.gather(*(balance(c, a, client=client) for c, a in pairs)))
+
+
+def reset_state() -> None:
+    """Clear the cache and backoff. For tests, and for a config reload."""
+    _cache.clear()
+    _backoff_until.clear()

--- a/tests/test_beads_batch_73.py
+++ b/tests/test_beads_batch_73.py
@@ -1,0 +1,237 @@
+"""CashPilot-dv6 tier 2: reading balances on-chain, honestly.
+
+THE DISTINCTION THIS WHOLE MODULE EXISTS FOR: an address holding nothing and a
+chain we could not reach are DIFFERENT ANSWERS. Both are "no number to show",
+and collapsing them tells a user their money is gone when the truth is that a
+public RPC rate-limited us.
+
+So the tests below care much less about arithmetic than about which state comes
+back, and several assert that ``amount`` is None rather than 0.
+
+Driven through httpx.MockTransport rather than patching internals, so the real
+request-building, real status handling and real JSON parsing all run. A test
+that patched ``_read`` would prove only that the wrapper returns what the mock
+said.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from app import onchain
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    onchain.reset_state()
+    yield
+    onchain.reset_state()
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _ok(result):
+    return lambda request: httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": result})
+
+
+EVM_ADDR = "0x" + "ab" * 20
+SOL_ADDR = "So11111111111111111111111111111111111111112"
+
+
+class TestAddressValidation:
+    def test_a_well_formed_evm_address_passes(self):
+        assert onchain.address_looks_valid("ethereum", EVM_ADDR) is True
+
+    def test_a_short_evm_address_fails(self):
+        assert onchain.address_looks_valid("ethereum", "0xdeadbeef") is False
+
+    def test_an_evm_address_is_not_valid_on_solana(self):
+        """Chains do not share an address format, and sending one to the other
+        is how you get a confident wrong answer."""
+        assert onchain.address_looks_valid("solana", EVM_ADDR) is False
+
+    def test_base58_excludes_the_ambiguous_characters(self):
+        """0, O, I and l are excluded from base58 on purpose."""
+        assert onchain.address_looks_valid("solana", "0" * 40) is False
+
+    def test_an_unknown_chain_is_never_valid(self):
+        assert onchain.address_looks_valid("dogecoin", EVM_ADDR) is False
+
+
+class TestTheFourStates:
+    @pytest.mark.anyio
+    async def test_a_real_balance_is_known(self):
+        # 1 ETH in wei, hex, as an RPC really returns it.
+        async with _client(_ok(hex(10**18))) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.KNOWN
+        assert out["amount"] == Decimal(1)
+
+    @pytest.mark.anyio
+    async def test_a_genuine_zero_is_known_and_zero(self):
+        """The counterpart to the test below. An address really holding nothing
+        IS a fact, and must be reported as one."""
+        async with _client(_ok("0x0")) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.KNOWN
+        assert out["amount"] == Decimal(0)
+
+    @pytest.mark.anyio
+    async def test_an_unreachable_chain_is_NOT_zero(self):
+        """THE test. A failed read must not look like an empty wallet."""
+
+        def boom(request):
+            raise httpx.ConnectError("no route to host")
+
+        async with _client(boom) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+        assert out["amount"] != 0
+
+    @pytest.mark.anyio
+    async def test_an_rpc_error_payload_is_unreachable_not_a_balance(self):
+        """A 200 response carrying an `error` object is still a failure. Reading
+        `result` off it would raise, or worse, silently produce None."""
+
+        def errored(request):
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32005, "message": "limit"}})
+
+        async with _client(errored) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+
+    @pytest.mark.anyio
+    async def test_a_500_is_unreachable(self):
+        async with _client(lambda r: httpx.Response(500, text="upstream boom")) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+
+    @pytest.mark.anyio
+    async def test_an_unsupported_chain_says_so(self):
+        async with _client(_ok("0x0")) as client:
+            out = await onchain.balance("dogecoin", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNSUPPORTED
+        assert out["amount"] is None
+
+    @pytest.mark.anyio
+    async def test_a_malformed_address_is_never_sent_to_the_endpoint(self):
+        """We do not use someone else's free RPC as a validator."""
+        calls = []
+
+        def record(request):
+            calls.append(request)
+            return httpx.Response(200, json={"result": "0x0"})
+
+        async with _client(record) as client:
+            out = await onchain.balance("ethereum", "not-an-address", client=client)
+        assert out["state"] == onchain.INVALID
+        assert calls == [], "a malformed address reached the network"
+
+
+class TestSolana:
+    @pytest.mark.anyio
+    async def test_it_reads_the_nested_value(self):
+        async with _client(_ok({"context": {"slot": 1}, "value": 2_500_000_000})) as client:
+            out = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert out["state"] == onchain.KNOWN
+        assert out["amount"] == Decimal("2.5")
+
+    @pytest.mark.anyio
+    async def test_an_unexpected_shape_is_unreachable_not_a_guess(self):
+        async with _client(_ok({"context": {"slot": 1}})) as client:
+            out = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+
+
+class TestPrecision:
+    @pytest.mark.anyio
+    async def test_wei_survives_exactly(self):
+        """18 decimals does not survive a float. 0.1 + 0.2 arithmetic in a
+        balance is how a wallet loses trust."""
+        async with _client(_ok(hex(123456789012345678))) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["amount"] == Decimal("0.123456789012345678")
+        assert isinstance(out["amount"], Decimal)
+
+
+class TestCachingAndBackoff:
+    @pytest.mark.anyio
+    async def test_a_second_read_is_served_from_cache(self):
+        calls = []
+
+        def counting(request):
+            calls.append(1)
+            return httpx.Response(200, json={"result": "0x0"})
+
+        async with _client(counting) as client:
+            await onchain.balance("ethereum", EVM_ADDR, client=client)
+            await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert len(calls) == 1, "the cache did not prevent a second call"
+
+    @pytest.mark.anyio
+    async def test_a_failure_backs_the_endpoint_off(self):
+        calls = []
+
+        def failing(request):
+            calls.append(1)
+            raise httpx.ConnectError("down")
+
+        async with _client(failing) as client:
+            first = await onchain.balance("ethereum", EVM_ADDR, client=client)
+            second = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert first["state"] == second["state"] == onchain.UNREACHABLE
+        assert len(calls) == 1, "backoff did not stop the second attempt"
+
+    @pytest.mark.anyio
+    async def test_a_failure_is_not_cached_as_a_result(self):
+        """CONTROL: if a failure were cached like a success, it would outlive the
+        backoff and keep reporting unreachable after the chain recovered."""
+        onchain.reset_state()
+        assert onchain._cache == {}
+
+        def failing(request):
+            raise httpx.ConnectError("down")
+
+        async with _client(failing) as client:
+            await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert onchain._cache == {}, "a failure was written into the success cache"
+
+    @pytest.mark.anyio
+    async def test_backoff_is_per_endpoint_not_global(self):
+        """A failing Ethereum RPC must not silence Solana."""
+        onchain._backoff_until[onchain.CHAINS["ethereum"].rpc] = onchain._now() + 999
+        async with _client(_ok({"value": 1_000_000_000})) as client:
+            eth = await onchain.balance("ethereum", EVM_ADDR, client=client)
+            sol = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert eth["state"] == onchain.UNREACHABLE
+        assert sol["state"] == onchain.KNOWN
+
+
+class TestTheContract:
+    def test_no_state_but_known_ever_carries_an_amount(self):
+        """CONTROL over the helper itself. If this ever passes an amount through
+        for a non-known state, every honesty test above becomes decorative."""
+        for state in (onchain.UNREACHABLE, onchain.UNSUPPORTED, onchain.INVALID):
+            out = onchain._result(state, "ethereum", amount=Decimal(5))
+            assert out["amount"] is None, f"{state} leaked an amount"
+
+    def test_known_does_carry_its_amount(self):
+        """The negative control for the test above: if _result dropped every
+        amount, the assertions there would pass for the wrong reason."""
+        assert onchain._result(onchain.KNOWN, "ethereum", amount=Decimal(5))["amount"] == Decimal(5)
+
+    def test_every_configured_chain_is_keyless(self):
+        """A shared API key must never ship. If an endpoint ever needs one, the
+        chain stays unsupported until the user supplies it."""
+        for spec in onchain.CHAINS.values():
+            assert "key=" not in spec.rpc.lower()
+            assert "apikey" not in spec.rpc.lower()
+            assert spec.rpc.startswith("https://")

--- a/tests/test_beads_batch_73.py
+++ b/tests/test_beads_batch_73.py
@@ -296,3 +296,59 @@ class TestTheCacheCannotBeCorruptedOrGrowForever:
             await onchain.balance("ethereum", "0x" + "ef" * 20, client=client)
 
         assert len(onchain._cache) <= onchain.MAX_CACHE_ENTRIES
+
+
+class TestAMalformedRpcResultIsNeverReportedAsABalance:
+    """A tolerant parser turns a malformed response into a CONFIDENT WRONG
+    NUMBER, reported as `known` -- the one outcome worse than admitting we could
+    not read the chain. All three of these produced a fake balance before the
+    parser was tightened (CodeRabbit, #273).
+    """
+
+    @pytest.mark.anyio
+    async def test_a_json_number_is_not_read_as_hex(self):
+        """`int(str(10), 16)` is 16. A decimal 10 became 16 wei, reported as
+        fact."""
+        async with _client(_ok(10)) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+
+    @pytest.mark.anyio
+    async def test_a_non_hex_string_is_rejected(self):
+        async with _client(_ok("banana")) as client:
+            out = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+
+    @pytest.mark.anyio
+    async def test_a_bool_is_not_a_solana_balance(self):
+        """isinstance(True, int) is True, so a boolean became 1e-9 SOL."""
+        async with _client(_ok({"value": True})) as client:
+            out = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+
+    @pytest.mark.anyio
+    async def test_a_negative_balance_is_impossible_and_rejected(self):
+        async with _client(_ok({"value": -5_000_000_000})) as client:
+            out = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+        assert out["amount"] is None
+
+    @pytest.mark.anyio
+    async def test_a_bare_integer_result_is_a_protocol_change_not_a_balance(self):
+        async with _client(_ok(2_500_000_000)) as client:
+            out = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert out["state"] == onchain.UNREACHABLE
+
+    @pytest.mark.anyio
+    async def test_control_the_documented_shapes_still_work(self):
+        """The negative control. If the parser now rejected EVERYTHING, every
+        assertion above would pass for the wrong reason."""
+        async with _client(_ok(hex(10**18))) as client:
+            evm = await onchain.balance("ethereum", EVM_ADDR, client=client)
+        onchain.reset_state()
+        async with _client(_ok({"context": {"slot": 1}, "value": 2_500_000_000})) as client:
+            sol = await onchain.balance("solana", SOL_ADDR, client=client)
+        assert evm["state"] == onchain.KNOWN and evm["amount"] == Decimal(1)
+        assert sol["state"] == onchain.KNOWN and sol["amount"] == Decimal("2.5")

--- a/tests/test_beads_batch_73.py
+++ b/tests/test_beads_batch_73.py
@@ -235,3 +235,64 @@ class TestTheContract:
             assert "key=" not in spec.rpc.lower()
             assert "apikey" not in spec.rpc.lower()
             assert spec.rpc.startswith("https://")
+
+
+class TestTheCacheCannotBeCorruptedOrGrowForever:
+    """Both of these were REAL defects in the first draft of this module, found
+    by self-review rather than by any test, and fixed before it shipped."""
+
+    @pytest.mark.anyio
+    async def test_a_caller_mutating_its_result_does_not_poison_the_cache(self):
+        """The cache used to hand out the stored dict itself. A caller that
+        modified what it got corrupted every later read -- and since this
+        module's whole contract is "amount is None unless state is known", a
+        mutated entry is exactly the lie it exists to prevent.
+        """
+        async with _client(_ok(hex(10**18))) as client:
+            first = await onchain.balance("ethereum", EVM_ADDR, client=client)
+            first["amount"] = "TAMPERED"
+            first["state"] = "nonsense"
+            second = await onchain.balance("ethereum", EVM_ADDR, client=client)
+
+        assert second["state"] == onchain.KNOWN
+        assert second["amount"] == Decimal(1)
+        assert second is not first, "the cache handed back the same object twice"
+
+    @pytest.mark.anyio
+    async def test_control_the_cache_is_actually_being_used(self):
+        """Negative control for the test above. If caching were simply broken,
+        it would pass for the wrong reason -- every read would be fresh."""
+        calls = []
+
+        def counting(request):
+            calls.append(1)
+            return httpx.Response(200, json={"result": hex(10**18)})
+
+        async with _client(counting) as client:
+            await onchain.balance("ethereum", EVM_ADDR, client=client)
+            await onchain.balance("ethereum", EVM_ADDR, client=client)
+        assert len(calls) == 1, "not a cache hit, so the poisoning test proves nothing"
+
+    @pytest.mark.anyio
+    async def test_expired_entries_do_not_accumulate_forever(self):
+        """Expiry was only ever noticed on read, so entries piled up for the life
+        of the process -- one per address ever asked about, never released."""
+        for i in range(600):
+            onchain._cache[f"ethereum:0x{i:040x}"] = (0.0, {})  # all long expired
+
+        async with _client(_ok(hex(1))) as client:
+            await onchain.balance("ethereum", "0x" + "cd" * 20, client=client)
+
+        assert len(onchain._cache) == 1, f"expired entries survived: {len(onchain._cache)}"
+
+    @pytest.mark.anyio
+    async def test_live_entries_are_capped_rather_than_grown_without_bound(self):
+        """Even if every entry is live, there is a ceiling."""
+        future = onchain._now() + 9999
+        for i in range(onchain.MAX_CACHE_ENTRIES + 50):
+            onchain._cache[f"ethereum:0x{i:040x}"] = (future, {"state": "known"})
+
+        async with _client(_ok(hex(1))) as client:
+            await onchain.balance("ethereum", "0x" + "ef" * 20, client=client)
+
+        assert len(onchain._cache) <= onchain.MAX_CACHE_ENTRIES


### PR DESCRIPTION
First slice of **CashPilot-dv6**. Handles no private key, builds no transaction, signs nothing — the only operation is *"what is the balance at this public address?"*.

## The rule it enforces

The one this codebase already lives by: **absent is not zero.**

A chain we could not reach must never render as a balance of `0`. Zero is a fact about an address; unreachable is a fact about *us*. Showing the second as the first tells someone their money is gone when a public RPC merely rate-limited us.

So every read returns a **state**, and `amount` is `None` unless the state is `known`:

| State | Meaning |
|---|---|
| `known` | we asked and got an answer — **`0` included, because a real zero is a fact** |
| `unreachable` | the RPC failed, timed out, or answered nonsense |
| `unsupported` | no keyless endpoint is configured for that chain |
| `invalid` | the address is malformed, so we never asked |

A caller that formats `amount` without checking `state` gets an em dash, not a figure. That is deliberate.

## Scope and constraints

- **Ethereum, Polygon, Solana** — the only chains any catalogued service declares. Adding an endpoint we have no use for is a dependency on someone else's free infrastructure for no benefit.
- **Keyless by choice.** No shared key ships, and a test asserts every configured endpoint is keyless and HTTPS.
- **`httpx` only**, no chain SDK — the image budget is untouched.
- **`Decimal`, not float.** 18 decimals of wei does not survive a float, and a balance wrong in the last places is a balance nobody trusts.
- **Cached, and backed off per-endpoint.** Public RPCs are a courtesy; a dashboard that polls hard gets blocked, and that degrades every user of the feature.
- **A malformed address never reaches the network** — we do not use someone else's free RPC as a validator.

## Verification

Driven through `httpx.MockTransport` rather than patching internals, so real request building, status handling and JSON parsing all run. A test that patched `_read` would prove only that the wrapper returns what the mock said.

Controls that matter:

- a genuine `0x0` balance is `known` **and** `0`; an unreachable chain is `None` — the two cases that must never merge
- a `200` carrying an RPC `error` object is `unreachable`, not a balance
- a failure is **not** written into the success cache (or it would outlive the backoff and keep reporting failure after recovery)
- backoff is per-endpoint: a failing Ethereum RPC does not silence Solana
- `_result()` itself is asserted to drop any amount passed for a non-`known` state — without that, every honesty test above would be decorative
- the async tests were confirmed to genuinely execute by breaking one deliberately

4096 passed, `app/onchain.py` at 94%, total coverage 95.51%.

## Still open

`dv6` stays **open**. This is the reader. Reconciliation against recorded earnings — *"the service said it paid me, did it land?"* — and the UI come once tier 1 (#269/#270) has merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only balance lookups for Ethereum, Polygon, and Solana.
  - Supports checking individual addresses or multiple addresses concurrently.
  - Validates addresses before attempting lookups.
  - Reports clear results for valid balances, unavailable networks, unsupported chains, and invalid addresses.
  - Preserves exact decimal precision and distinguishes unavailable balances from zero.
  - Reuses successful results to improve response speed and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->