### PR TITLE
feat: the payout screen — where your money actually goes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Host resource columns
         run: node scripts/host_resources_check.mjs
 
+      # The four payout states. The regression this guards is "internal" (there
+      # is no address, by design) rendering like "not set" (money may be going
+      # nowhere). Both are a cell with no address in it; only the output tells
+      # them apart, so only running the renderer can check it.
+      - name: Payout destination states
+        run: node scripts/payout_registry_check.mjs
+
       # From the LOCKFILE, which is what Docker ships (`uv sync --frozen` in the
       # Dockerfile) and what release.yml verifies against. Installing from the
       # unpinned requirements.txt meant the suite ran against a resolution

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -54,6 +54,23 @@ async def page_settings(request: Request):
     return deps.templates.TemplateResponse(request, "settings.html", {"user": user})
 
 
+@router.get("/payouts", response_class=HTMLResponse)
+async def page_payouts(request: Request):
+    """Where every service pays out (CashPilot-luj, tier 1).
+
+    OWNER-ONLY, matching ``/api/payout-registry`` exactly. The page is useless
+    without that endpoint, so a laxer gate here would only produce a screen that
+    renders its own 403 — and it would advertise to a viewer that the owner's
+    wallet map exists.
+    """
+    user = auth_module.get_current_user(request)
+    if not user:
+        return deps._login_redirect()
+    if not auth_module.require_role(user, "owner"):
+        raise HTTPException(status_code=403, detail="Owner access required")
+    return deps.templates.TemplateResponse(request, "payouts.html", {"user": user})
+
+
 @router.get("/fleet", response_class=HTMLResponse)
 async def page_fleet(request: Request):
     user = auth_module.get_current_user(request)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2107,3 +2107,30 @@ img { max-width: 100%; }
 .update-banner button:hover {
   color: #dbeafe;
 }
+
+/* Payout destinations (CashPilot-luj tier 1).
+   Four states, kept deliberately distinct. The failure this styling exists to
+   prevent is "internal" and "not set" looking alike: one is nothing to do, the
+   other is money going nowhere. */
+.payout-address {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.8rem;
+  word-break: break-all;
+  color: var(--text-primary);
+}
+/* Actionable: a deployed service that expects an address and has none. */
+.payout-missing {
+  color: var(--warning, #f59e0b);
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+/* NOT a warning. There is no address to show, and that is correct. Muted so it
+   never reads as a value the user failed to supply. */
+.payout-na {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-style: italic;
+}
+.payout-row-actionable {
+  background: var(--warning-soft, rgba(245, 158, 11, 0.08));
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -76,6 +76,14 @@
         Service Catalog
       </a>
       {% if user and user.r == 'owner' %}
+      <!-- Owner-only, matching /payouts and /api/payout-registry. This view maps
+           one person to all of their wallets at once. -->
+      <a href="/payouts" class="sidebar-link {% if active_page == 'payouts' %}active{% endif %}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12V7H5a2 2 0 010-4h14v4"/><path d="M3 5v14a2 2 0 002 2h16v-5"/><path d="M18 12a2 2 0 000 4h4v-4z"/>
+        </svg>
+        Payouts
+      </a>
       <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/>

--- a/app/templates/payouts.html
+++ b/app/templates/payouts.html
@@ -1,0 +1,181 @@
+{% extends "base.html" %}
+
+{% block title %}Payouts - CashPilot{% endblock %}
+{% block page %}payouts{% endblock %}
+{% block topbar_title %}Payout Destinations{% endblock %}
+
+{% block content %}
+<h2 class="section-title" style="margin-bottom: 8px;">Where your money goes</h2>
+<p class="settings-section-desc" style="margin-bottom: 24px; max-width: 70ch;">
+  Every service in the catalog and the address it pays to. Addresses are read from
+  the spec each container was <em>actually deployed</em> with &mdash; not from the
+  catalog default &mdash; so what you see here is what your machines are really using.
+  Undeployed services are listed too, because the time to learn a service needs a
+  wallet is <em>before</em> you deploy it.
+</p>
+
+<div class="stats-grid" style="margin-bottom: 24px;">
+  <div class="stat-card">
+    <div class="stat-label">Services</div>
+    <div class="stat-value" id="payout-total">&mdash;</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Deployed</div>
+    <div class="stat-value" id="payout-deployed">&mdash;</div>
+  </div>
+  <!-- The only number on this page that asks the user to DO something. -->
+  <div class="stat-card">
+    <div class="stat-label">Need an address</div>
+    <div class="stat-value" id="payout-needs-address">&mdash;</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Not classified</div>
+    <div class="stat-value" id="payout-unclassified">&mdash;</div>
+  </div>
+</div>
+
+<div class="card" id="payout-actionable-card" style="display:none; border-color: var(--warning, #f59e0b);">
+  <h3 class="settings-section-title">Deployed, earning, and paying to nowhere</h3>
+  <p class="settings-section-desc">
+    These services are running and expect an address you have not given them.
+    Whatever they earn may be going somewhere you cannot reach.
+  </p>
+  <div id="payout-actionable-body"></div>
+</div>
+
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">All services</h3>
+    <input type="search" id="payout-filter" class="form-input" placeholder="Filter by name, chain or address&hellip;"
+           style="max-width: 280px;" aria-label="Filter payout destinations">
+  </div>
+  <div id="payout-table-container">
+    <p style="color: var(--text-muted); font-size: 0.85rem;">Loading&hellip;</p>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce(request) }}">
+(function () {
+  'use strict';
+
+  // Addresses come from a deployed container's environment, which is user
+  // supplied. Everything interpolated below goes through this.
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c];
+    });
+  }
+
+  // THE RULE THIS PAGE EXISTS TO HOLD: four payout states are genuinely
+  // different and must never collapse into one another.
+  //
+  //   external + an address   -> show it
+  //   external + nothing      -> "Not set", and it is ACTIONABLE
+  //   internal                -> there is NO address, BY DESIGN. A blank here
+  //                              would read as "you forgot something" when
+  //                              nothing is configurable.
+  //   minted                  -> the container made a wallet the user has
+  //                              probably never seen. Say so; do not fake an
+  //                              address we have not read.
+  //   unknown                 -> OUR gap in the catalog. Never phrased as the
+  //                              user's mistake.
+  //
+  // Returns an HTML string and touches no DOM, so scripts/payout_registry_check.mjs
+  // can run it for real.
+  function payoutAddressCell(entry) {
+    var model = entry && entry.model;
+    if (model === 'external') {
+      if (entry.address) {
+        return '<code class="payout-address" title="' + esc(entry.address) + '">'
+             + esc(entry.address) + '</code>';
+      }
+      return '<span class="payout-missing">Not set</span>';
+    }
+    if (model === 'internal') {
+      return '<span class="payout-na">Held by the service until you withdraw</span>';
+    }
+    if (model === 'minted') {
+      return '<span class="payout-na">The container generates its own wallet</span>';
+    }
+    return '<span class="payout-na">Not classified yet</span>';
+  }
+
+  function payoutRow(entry) {
+    var chain = entry.chain ? esc(entry.chain) : '<span class="payout-na">&mdash;</span>';
+    var deployed = entry.deployed
+      ? '<span class="badge badge-deployed">Deployed</span>'
+      : '<span class="badge badge-unknown">Not deployed</span>';
+    // Only a DEPLOYED service with a missing address is urgent. An undeployed
+    // one is information, not a problem to solve today.
+    var rowClass = (entry.address_missing && entry.deployed) ? ' class="payout-row-actionable"' : '';
+    return '<tr' + rowClass + ' data-slug="' + esc(entry.slug) + '">'
+      + '<td>' + esc(entry.name || entry.slug) + '</td>'
+      + '<td>' + deployed + '</td>'
+      + '<td><span class="badge badge-category">' + esc(entry.model || 'unknown') + '</span></td>'
+      + '<td>' + chain + '</td>'
+      + '<td>' + payoutAddressCell(entry) + '</td>'
+      + '</tr>';
+  }
+
+  function renderTable(entries) {
+    if (!entries.length) {
+      return '<p style="color: var(--text-muted); font-size: 0.85rem;">Nothing matches that filter.</p>';
+    }
+    return '<div style="overflow-x:auto;"><table class="breakdown-table"><thead><tr>'
+      + '<th>Service</th><th>Status</th><th>Payout model</th><th>Chain</th><th>Address</th>'
+      + '</tr></thead><tbody>'
+      + entries.map(payoutRow).join('')
+      + '</tbody></table></div>';
+  }
+
+  var _entries = [];
+
+  function applyFilter() {
+    var q = (document.getElementById('payout-filter').value || '').trim().toLowerCase();
+    var rows = !q ? _entries : _entries.filter(function (e) {
+      return [e.name, e.slug, e.chain, e.address, e.model]
+        .some(function (v) { return v && String(v).toLowerCase().indexOf(q) !== -1; });
+    });
+    document.getElementById('payout-table-container').innerHTML = renderTable(rows);
+  }
+
+  async function loadPayouts() {
+    var container = document.getElementById('payout-table-container');
+    try {
+      var data = await CP.api('/api/payout-registry');
+      var summary = data.summary || {};
+      _entries = data.entries || [];
+
+      document.getElementById('payout-total').textContent = summary.total || 0;
+      document.getElementById('payout-deployed').textContent = summary.deployed || 0;
+      document.getElementById('payout-needs-address').textContent = summary.needs_an_address || 0;
+      document.getElementById('payout-unclassified').textContent = summary.unclassified || 0;
+
+      var actionable = _entries.filter(function (e) { return e.address_missing && e.deployed; });
+      var card = document.getElementById('payout-actionable-card');
+      if (actionable.length) {
+        document.getElementById('payout-actionable-body').innerHTML = renderTable(actionable);
+        card.style.display = '';
+      } else {
+        card.style.display = 'none';
+      }
+
+      applyFilter();
+    } catch (err) {
+      // Say the registry could not be read. Never render an empty table, which
+      // would look like "no services pay you anything".
+      container.innerHTML = '<p style="color: var(--error);">Could not load payout destinations: '
+        + esc((err && err.message) || 'error') + '</p>';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    if (document.body.dataset.page !== 'payouts') return;
+    document.getElementById('payout-filter').addEventListener('input', applyFilter);
+    loadPayouts();
+  });
+})();
+</script>
+{% endblock %}

--- a/scripts/payout_registry_check.mjs
+++ b/scripts/payout_registry_check.mjs
@@ -1,0 +1,142 @@
+// Run the REAL payouts.html renderers and check what each payout state produces.
+//
+// CashPilot-luj tier 1. The registry distinguishes four states, and the whole
+// value of the page is that they stay distinguishable on screen:
+//
+//   external + an address  -> show it
+//   external + nothing     -> "Not set", and it is ACTIONABLE (money may be
+//                             going nowhere)
+//   internal               -> there is NO address, BY DESIGN
+//   minted                 -> the container made a wallet the user has never seen
+//   unknown                -> OUR gap in the catalog, never the user's mistake
+//
+// Collapsing "internal" into "not set" is the specific regression this guards.
+// One is nothing to do; the other is a service earning into an address the user
+// never supplied. They must not render alike.
+//
+// pytest cannot see any of this: the renderers live inside a <script> block in a
+// Jinja template, and asserting that the template *contains* a string would only
+// prove a literal is present, not which state produces it. So the functions are
+// extracted and run for real, and the OUTPUT is inspected.
+//
+// No browser needed: these renderers build strings and touch no DOM.
+//   node scripts/payout_registry_check.mjs
+// Exits non-zero on any mismatch.
+import {readFileSync} from 'node:fs';
+
+const html = readFileSync('app/templates/payouts.html', 'utf8');
+
+function extract(name) {
+  const start = html.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`payouts.html no longer defines ${name}() — this check is stale`);
+  let i = html.indexOf('{', start), depth = 0;
+  for (let j = i; j < html.length; j++) {
+    if (html[j] === '{') depth++;
+    else if (html[j] === '}' && --depth === 0) return html.slice(start, j + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name}()`);
+}
+
+// Evaluate the real esc/payoutAddressCell/payoutRow together, since they call
+// one another. A stub for esc() here would let escaping break while this stayed
+// green — exactly the failure these harnesses exist to catch.
+const src = [extract('esc'), extract('payoutAddressCell'), extract('payoutRow')].join('\n');
+const {payoutAddressCell, payoutRow} = new Function(
+  `${src}; return {payoutAddressCell, payoutRow};`
+)();
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (cond) return;
+  failures++;
+  console.error(`FAIL: ${label}${detail ? `\n      ${detail}` : ''}`);
+}
+
+// ---------------------------------------------------------------------------
+// The four states must be distinguishable from one another.
+// ---------------------------------------------------------------------------
+const external = payoutAddressCell({model: 'external', address: '0xabc123'});
+const missing = payoutAddressCell({model: 'external', address: null});
+const internal = payoutAddressCell({model: 'internal', address: null});
+const minted = payoutAddressCell({model: 'minted', address: null});
+const unknown = payoutAddressCell({model: 'unknown', address: null});
+
+check('a resolved external address is shown', external.includes('0xabc123'), external);
+
+check('an unset external address says "Not set"', /not set/i.test(missing), missing);
+
+check(
+  'internal does NOT render as "Not set" — nothing is missing',
+  !/not set/i.test(internal),
+  `internal rendered: ${internal}`
+);
+check('internal explains the balance is held', /held by the service/i.test(internal), internal);
+
+check('minted does not claim an address', !/0x/.test(minted) && !/not set/i.test(minted), minted);
+check('minted says the container generates one', /generates its own/i.test(minted), minted);
+
+check('unknown is phrased as our gap', /not classified/i.test(unknown), unknown);
+check('unknown is not an accusation', !/not set/i.test(unknown), unknown);
+
+// All five states must be pairwise distinct strings, or the page is lying by
+// omission somewhere.
+const states = {external, missing, internal, minted, unknown};
+for (const [a, av] of Object.entries(states)) {
+  for (const [b, bv] of Object.entries(states)) {
+    if (a < b) check(`"${a}" and "${b}" render differently`, av !== bv, `both: ${av}`);
+  }
+}
+
+// The actionable state must be visually louder than the by-design ones.
+check(
+  'only the actionable state uses the warning class',
+  missing.includes('payout-missing')
+    && !internal.includes('payout-missing')
+    && !minted.includes('payout-missing')
+    && !unknown.includes('payout-missing'),
+  `missing=${missing}\n      internal=${internal}`
+);
+
+// ---------------------------------------------------------------------------
+// Row-level: urgency belongs to DEPLOYED services only.
+// ---------------------------------------------------------------------------
+const deployedMissing = payoutRow({slug: 'storj', name: 'Storj', model: 'external', address: null, address_missing: true, deployed: true});
+const undeployedMissing = payoutRow({slug: 'storj', name: 'Storj', model: 'external', address: null, address_missing: true, deployed: false});
+
+check('a deployed service with no address is flagged', deployedMissing.includes('payout-row-actionable'), deployedMissing);
+check(
+  'an UNDEPLOYED service with no address is NOT flagged — it is information, not a problem',
+  !undeployedMissing.includes('payout-row-actionable'),
+  undeployedMissing
+);
+
+// ---------------------------------------------------------------------------
+// Escaping. The address comes out of a deployed container's environment.
+// ---------------------------------------------------------------------------
+const hostile = payoutRow({
+  slug: 's', name: '<img src=x onerror=alert(1)>', model: 'external',
+  address: '"><script>alert(1)</script>', address_missing: false, deployed: true,
+});
+check('a hostile name is escaped', !hostile.includes('<img src=x'), hostile);
+check('a hostile address is escaped', !hostile.includes('<script>'), hostile);
+check('the escaped form is still present', hostile.includes('&lt;script&gt;'), hostile);
+
+// ---------------------------------------------------------------------------
+// Negative controls. A control that PASSES means the check above it is wrong.
+// ---------------------------------------------------------------------------
+check(
+  'CONTROL: internal must not accidentally satisfy the "shows an address" test',
+  !internal.includes('0xabc123'),
+  internal
+);
+check(
+  'CONTROL: an absent model falls through to unknown, never to external',
+  !/not set/i.test(payoutAddressCell({})) && /not classified/i.test(payoutAddressCell({})),
+  payoutAddressCell({})
+);
+
+if (failures) {
+  console.error(`\n${failures} payout-registry render check(s) failed`);
+  process.exit(1);
+}
+console.log('payout registry render checks passed');

--- a/tests/test_beads_batch_71.py
+++ b/tests/test_beads_batch_71.py
@@ -223,3 +223,75 @@ class TestNoSecretIsEverExposed:
 def test_every_documented_model_is_accepted(model):
     row = payout_registry.entry({"slug": "x", "payout": {"model": model}}, None, deployed=False)
     assert row["model"] == model
+
+
+class TestThePayoutPage:
+    """The screen for the registry above (CashPilot-luj tier 1).
+
+    OWNER-ONLY, matching /api/payout-registry. The page is useless without that
+    endpoint, so a laxer gate here would render a screen that 403s against its
+    own data -- and would tell a viewer that the owner's wallet map exists.
+
+    The RENDERING rules (four states staying distinguishable) are not testable
+    from here: they live in a <script> block, and asserting the template contains
+    a string proves only that a literal is present, never which state produces
+    it. scripts/payout_registry_check.mjs runs those functions for real.
+    """
+
+    @staticmethod
+    def _client():
+        """NOT used as a context manager, deliberately.
+
+        Entering the context runs the app lifespan, which installs a SIGHUP
+        handler for catalog reload, and ``signal()`` raises "only works in main
+        thread" under pytest. Routing works fine without startup here because
+        these tests never touch the scheduler or the database.
+        """
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    @staticmethod
+    def _as(role: str | None):
+        user = None if role is None else {"u": "sergio", "r": role}
+        return patch("app.main.auth.get_current_user", return_value=user)
+
+    def test_the_owner_can_open_it(self):
+        client = self._client()
+        with self._as("owner"):
+            assert client.get("/payouts").status_code == 200
+
+    def test_a_viewer_is_refused(self):
+        client = self._client()
+        with self._as("viewer"):
+            assert client.get("/payouts").status_code == 403
+
+    def test_a_writer_is_refused(self):
+        """Writer can deploy containers; that is not the same as being handed
+        every address the owner is paid at."""
+        client = self._client()
+        with self._as("writer"):
+            assert client.get("/payouts").status_code == 403
+
+    def test_anonymous_is_sent_to_login_not_403(self):
+        client = self._client()
+        with self._as(None):
+            assert client.get("/payouts", follow_redirects=False).status_code == 303
+
+    def test_the_nav_link_is_owner_only(self):
+        """Rendered OUTPUT, not the template source: a viewer loading a page they
+        ARE allowed to see must not be shown a link to this one."""
+        client = self._client()
+        with self._as("viewer"):
+            body = client.get("/catalog").text
+        assert 'href="/payouts"' not in body
+
+    def test_the_owner_does_get_the_nav_link(self):
+        """The negative control for the test above. If this fails, the assertion
+        above passes for the wrong reason -- the link missing everywhere."""
+        client = self._client()
+        with self._as("owner"):
+            body = client.get("/catalog").text
+        assert 'href="/payouts"' in body


### PR DESCRIPTION
Completes **CashPilot-luj tier 1**. Rebuilds #270, which GitHub auto-closed when #269 merged with `--delete-branch` and removed its base. Same change, cherry-picked onto the merged API.

#269 landed the registry API; nothing rendered it, so a user still could not answer *"which addresses do my services pay to?"* without reading env vars on every worker.

## The rule this page holds

Five payout states are genuinely different and must never render alike:

| State | Renders as | Why |
|---|---|---|
| `external` + an address | the address, monospace | it is known |
| `external` + nothing | **"Not set"**, warning-coloured | ACTIONABLE — money may be going nowhere |
| `internal` | *"Held by the service until you withdraw"*, muted | there is **no** address by design; a blank would read as "you forgot something" |
| `minted` | *"The container generates its own wallet"*, muted | the user has probably never seen it |
| `unknown` | *"Not classified yet"*, muted | **our** gap in the catalog, never phrased as user error |

Only a **deployed** service missing an address is highlighted. An undeployed one is information, not a problem to solve today — otherwise choosing what to run puts a permanent nag on the dashboard.

Owner-only, matching `/api/payout-registry` exactly. A laxer gate would render a screen that 403s against its own data, and would advertise to a viewer that the owner's wallet map exists.

## Verification

`scripts/payout_registry_check.mjs` runs the **real renderers** rather than grepping the template — a string assertion could only prove a literal exists, never which state produces it. Wired into `test.yml`.

Mutation-tested both ways, because a harness that passes first time deserves suspicion:

- making `internal` render as `"Not set"` → **4 checks fail, exit 1**
- removing escaping → **3 checks fail**
- restored → passes, exit 0

Addresses come out of a deployed container's environment, so everything interpolated is escaped; the harness asserts a hostile name and address survive as entities.

Verified on this rebuilt branch against the merged API: **4112 passed**, coverage **95.56%**, ruff clean, render harness green.