### PR TITLE
feat: show what is actually at each payout address (dv6 tier 2)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ from app import (
     metrics,
     net_activity,
     notify,
+    onchain,
     payout_registry,
     payouts,
     power,
@@ -3070,6 +3071,49 @@ async def api_payout_registry(request: Request) -> dict[str, Any]:
     """
     _require_owner(request)
     return await payout_registry.registry()
+
+
+@app.get("/api/payout-balances")
+async def api_payout_balances(request: Request) -> dict[str, Any]:
+    """What is actually AT each payout address (CashPilot-dv6, tier 2).
+
+    OWNER-ONLY, same reasoning as the registry it builds on.
+
+    A SEPARATE endpoint from /api/payout-registry on purpose. The registry is a
+    local join and answers instantly; these are network reads against public
+    RPCs that can take seconds or time out. Folding them together would make the
+    whole payout table hostage to the slowest chain, so the page renders the
+    table first and fills these in afterwards.
+
+    Only addresses we actually hold are queried -- an `internal`, `minted` or
+    `unknown` service has no address, and asking a public RPC about nothing is
+    both pointless and rude.
+    """
+    _require_owner(request)
+    registry = await payout_registry.registry()
+
+    wanted = [
+        row
+        for row in registry["entries"]
+        if row.get("model") == "external" and row.get("address") and row.get("chain") in onchain.CHAINS
+    ]
+    results = await onchain.balances([(row["chain"], row["address"]) for row in wanted])
+
+    balances: dict[str, Any] = {}
+    for row, result in zip(wanted, results, strict=True):
+        # Decimal does not survive JSON. str() keeps every digit, which is the
+        # whole reason the reader uses Decimal in the first place -- a float here
+        # would undo it at the last step.
+        amount = result.get("amount")
+        balances[row["slug"]] = {**result, "amount": None if amount is None else str(amount)}
+
+    return {
+        "balances": balances,
+        # Named so the UI can say "3 of 5 addresses could not be checked"
+        # instead of quietly showing fewer rows than it did a moment ago.
+        "checked": len(wanted),
+        "unreadable": sum(1 for r in results if r.get("state") != onchain.KNOWN),
+    }
 
 
 @app.get("/api/update-status")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2134,3 +2134,21 @@ img { max-width: 100%; }
 .payout-row-actionable {
   background: var(--warning-soft, rgba(245, 158, 11, 0.08));
 }
+
+/* On-chain balance column (CashPilot-dv6 tier 2).
+   "could not check" must not read as a balance, and must not read as the
+   em dash used for "there was nothing to ask". Three distinct looks. */
+.payout-balance {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+/* Not an error and not a zero: we simply do not know right now. */
+.payout-unchecked {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-style: italic;
+  border-bottom: 1px dotted var(--border-color);
+  cursor: help;
+}

--- a/app/templates/payouts.html
+++ b/app/templates/payouts.html
@@ -102,6 +102,33 @@
     return '<span class="payout-na">Not classified yet</span>';
   }
 
+  // What is actually AT the address (CashPilot-dv6 tier 2).
+  //
+  // The same rule as the address column, one level down: "we could not check"
+  // must NEVER render like "the balance is zero". Zero is a fact about an
+  // address; unreachable is a fact about us, and a public RPC rate-limiting us
+  // is not news about the user's money.
+  //
+  // A row we never queried (internal, minted, unknown, or no address) gets an
+  // em dash, because there was nothing to ask.
+  function balanceCell(result) {
+    if (!result) return '<span class="payout-na">&mdash;</span>';
+    if (result.state === 'known') {
+      return '<span class="payout-balance">' + esc(result.amount)
+           + (result.symbol ? ' ' + esc(result.symbol) : '') + '</span>';
+    }
+    if (result.state === 'unreachable') {
+      return '<span class="payout-unchecked" title="' + esc(result.detail || '')
+           + '">could not check</span>';
+    }
+    if (result.state === 'invalid') {
+      return '<span class="payout-missing">address not valid</span>';
+    }
+    // unsupported: we have no keyless endpoint for that chain. Not the user's
+    // problem and not an error about their money.
+    return '<span class="payout-na">&mdash;</span>';
+  }
+
   function payoutRow(entry) {
     var chain = entry.chain ? esc(entry.chain) : '<span class="payout-na">&mdash;</span>';
     var deployed = entry.deployed
@@ -116,6 +143,8 @@
       + '<td><span class="badge badge-category">' + esc(entry.model || 'unknown') + '</span></td>'
       + '<td>' + chain + '</td>'
       + '<td>' + payoutAddressCell(entry) + '</td>'
+      + '<td class="payout-balance-cell" data-slug="' + esc(entry.slug) + '">'
+      + balanceCell(_balances[entry.slug]) + '</td>'
       + '</tr>';
   }
 
@@ -125,12 +154,14 @@
     }
     return '<div style="overflow-x:auto;"><table class="breakdown-table"><thead><tr>'
       + '<th>Service</th><th>Status</th><th>Payout model</th><th>Chain</th><th>Address</th>'
+      + '<th>On-chain</th>'
       + '</tr></thead><tbody>'
       + entries.map(payoutRow).join('')
       + '</tbody></table></div>';
   }
 
   var _entries = [];
+  var _balances = {};
 
   function applyFilter() {
     var q = (document.getElementById('payout-filter').value || '').trim().toLowerCase();
@@ -163,12 +194,30 @@
       }
 
       applyFilter();
+      loadBalances();
     } catch (err) {
       // Say the registry could not be read. Never render an empty table, which
       // would look like "no services pay you anything".
       container.innerHTML = '<p style="color: var(--error);">Could not load payout destinations: '
         + esc((err && err.message) || 'error') + '</p>';
     }
+  }
+
+  // Deliberately fired after the table exists. These are network reads against
+  // public RPCs; making the page wait on them would mean a rate-limited chain
+  // shows the user a blank screen instead of their addresses.
+  async function loadBalances() {
+    try {
+      var data = await CP.api('/api/payout-balances');
+      _balances = data.balances || {};
+    } catch (err) {
+      // Leave every cell as it was. Inventing zeroes here would be the exact
+      // failure this column is built to avoid.
+      return;
+    }
+    document.querySelectorAll('.payout-balance-cell').forEach(function (cell) {
+      cell.innerHTML = balanceCell(_balances[cell.dataset.slug]);
+    });
   }
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/scripts/payout_registry_check.mjs
+++ b/scripts/payout_registry_check.mjs
@@ -40,9 +40,11 @@ function extract(name) {
 // Evaluate the real esc/payoutAddressCell/payoutRow together, since they call
 // one another. A stub for esc() here would let escaping break while this stayed
 // green — exactly the failure these harnesses exist to catch.
-const src = [extract('esc'), extract('payoutAddressCell'), extract('payoutRow')].join('\n');
-const {payoutAddressCell, payoutRow} = new Function(
-  `${src}; return {payoutAddressCell, payoutRow};`
+const src = [extract('esc'), extract('payoutAddressCell'), extract('balanceCell'), extract('payoutRow')].join('\n');
+// payoutRow reads the module-level _balances map, so give it an empty one --
+// the balance cell is exercised directly below.
+const {payoutAddressCell, payoutRow, balanceCell} = new Function(
+  `const _balances = {}; ${src}; return {payoutAddressCell, payoutRow, balanceCell};`
 )();
 
 let failures = 0;
@@ -133,6 +135,43 @@ check(
   'CONTROL: an absent model falls through to unknown, never to external',
   !/not set/i.test(payoutAddressCell({})) && /not classified/i.test(payoutAddressCell({})),
   payoutAddressCell({})
+);
+
+// ---------------------------------------------------------------------------
+// The on-chain column (dv6 tier 2). Same rule, one level down.
+// ---------------------------------------------------------------------------
+const bKnown = balanceCell({state: 'known', amount: '1.5', symbol: 'ETH'});
+const bZero = balanceCell({state: 'known', amount: '0', symbol: 'ETH'});
+const bUnreachable = balanceCell({state: 'unreachable', detail: 'timeout'});
+const bUnsupported = balanceCell({state: 'unsupported'});
+const bInvalid = balanceCell({state: 'invalid'});
+const bNone = balanceCell(undefined);
+
+check('a known balance is shown with its symbol', bKnown.includes('1.5') && bKnown.includes('ETH'), bKnown);
+check('a real zero balance IS shown as 0', bZero.includes('0'), bZero);
+
+check(
+  'THE ONE THAT MATTERS: unreachable does not render as a number',
+  !/\d/.test(bUnreachable.replace(/[^>]*>/g, '')) && /could not check/i.test(bUnreachable),
+  bUnreachable
+);
+check(
+  'unreachable and a zero balance look different',
+  bUnreachable !== bZero && !bUnreachable.includes('payout-balance"'),
+  `unreachable=${bUnreachable}\n      zero=${bZero}`
+);
+check(
+  'a row that was never queried is an em dash, not "could not check"',
+  bNone.includes('&mdash;') && !/could not check/i.test(bNone),
+  bNone
+);
+check('unsupported is also an em dash, not an error', bUnsupported.includes('&mdash;'), bUnsupported);
+check('an invalid address says so', /not valid/i.test(bInvalid), bInvalid);
+
+check(
+  'CONTROL: a hostile amount is escaped in the balance cell',
+  !balanceCell({state: 'known', amount: '<script>x</script>', symbol: 'E'}).includes('<script>'),
+  balanceCell({state: 'known', amount: '<script>x</script>', symbol: 'E'})
 );
 
 if (failures) {

--- a/tests/test_beads_batch_74.py
+++ b/tests/test_beads_batch_74.py
@@ -1,0 +1,173 @@
+"""CashPilot-dv6 tier 2: /api/payout-balances, the endpoint behind the column.
+
+Two properties matter more than the arithmetic:
+
+* We only ask about addresses we actually hold. An `internal`, `minted` or
+  `unknown` service has no address, and putting a public RPC to work on nothing
+  is both pointless and rude to infrastructure we do not pay for.
+* A Decimal does not survive JSON. Serialising it as a float would undo, at the
+  very last step, the exact precision the reader uses Decimal to preserve.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _client():
+    """Not a context manager: entering it runs the lifespan, which installs a
+    SIGHUP handler, and signal() raises "only works in main thread" here."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _as(role):
+    user = None if role is None else {"u": "sergio", "r": role}
+    return patch("app.main.auth.get_current_user", return_value=user)
+
+
+#: One of each shape the registry can produce.
+REGISTRY = {
+    "entries": [
+        {"slug": "storj", "model": "external", "chain": "ethereum", "address": "0x" + "ab" * 20},
+        {
+            "slug": "nosana",
+            "model": "external",
+            "chain": "solana",
+            "address": "So11111111111111111111111111111111111111112",
+        },
+        # Should NOT be queried: no address, wrong model, or a chain we cannot read.
+        {"slug": "honeygain", "model": "internal", "chain": None, "address": None},
+        {"slug": "minty", "model": "minted", "chain": "solana", "address": None},
+        {"slug": "mystery", "model": "unknown", "chain": None, "address": None},
+        {"slug": "offchain", "model": "external", "chain": "dogecoin", "address": "D" + "x" * 33},
+        {"slug": "noaddr", "model": "external", "chain": "ethereum", "address": None},
+    ],
+    "summary": {},
+}
+
+
+class TestOnlyAddressesWeHoldAreQueried:
+    def test_it_asks_about_exactly_the_readable_external_addresses(self):
+        seen = {}
+
+        async def fake_balances(pairs):
+            seen["pairs"] = pairs
+            return [
+                {"state": "known", "chain": c, "symbol": "X", "amount": Decimal("1"), "detail": None} for c, _ in pairs
+            ]
+
+        client = _client()
+        with (
+            _as("owner"),
+            patch("app.main.payout_registry.registry", new_callable=AsyncMock, return_value=REGISTRY),
+            patch("app.main.onchain.balances", side_effect=fake_balances),
+        ):
+            resp = client.get("/api/payout-balances")
+
+        assert resp.status_code == 200
+        # storj and nosana only: the rest have no address, no readable chain, or
+        # a payout model that has no address at all.
+        assert [c for c, _ in seen["pairs"]] == ["ethereum", "solana"]
+        assert set(resp.json()["balances"]) == {"storj", "nosana"}
+
+    def test_a_service_with_no_address_is_never_asked_about(self):
+        """CONTROL for the test above: `noaddr` is external and on a supported
+        chain, so only the missing address excludes it."""
+        seen = {}
+
+        async def fake_balances(pairs):
+            seen["pairs"] = pairs
+            return [
+                {"state": "known", "chain": c, "symbol": "X", "amount": Decimal("1"), "detail": None} for c, _ in pairs
+            ]
+
+        client = _client()
+        with (
+            _as("owner"),
+            patch("app.main.payout_registry.registry", new_callable=AsyncMock, return_value=REGISTRY),
+            patch("app.main.onchain.balances", side_effect=fake_balances),
+        ):
+            client.get("/api/payout-balances")
+
+        assert all(addr is not None for _, addr in seen["pairs"])
+
+
+class TestTheResponseSurvivesJson:
+    def test_a_decimal_is_serialised_without_losing_digits(self):
+        """A float here would undo, at the last step, the precision the reader
+        uses Decimal to keep."""
+        exact = Decimal("0.123456789012345678")
+
+        async def fake_balances(pairs):
+            return [{"state": "known", "chain": c, "symbol": "ETH", "amount": exact, "detail": None} for c, _ in pairs]
+
+        client = _client()
+        with (
+            _as("owner"),
+            patch("app.main.payout_registry.registry", new_callable=AsyncMock, return_value=REGISTRY),
+            patch("app.main.onchain.balances", side_effect=fake_balances),
+        ):
+            body = client.get("/api/payout-balances").text
+
+        assert "0.123456789012345678" in body
+        assert json.loads(body)["balances"]["storj"]["amount"] == "0.123456789012345678"
+
+    def test_an_unreachable_chain_serialises_as_null_not_zero(self):
+        """The whole point, carried through JSON."""
+
+        async def fake_balances(pairs):
+            return [
+                {"state": "unreachable", "chain": c, "symbol": "ETH", "amount": None, "detail": "timeout"}
+                for c, _ in pairs
+            ]
+
+        client = _client()
+        with (
+            _as("owner"),
+            patch("app.main.payout_registry.registry", new_callable=AsyncMock, return_value=REGISTRY),
+            patch("app.main.onchain.balances", side_effect=fake_balances),
+        ):
+            data = client.get("/api/payout-balances").json()
+
+        assert data["balances"]["storj"]["amount"] is None
+        assert data["balances"]["storj"]["amount"] != 0
+        assert data["unreadable"] == 2
+        assert data["checked"] == 2
+
+
+class TestItIsOwnerOnly:
+    @pytest.mark.parametrize("role", ["viewer", "writer"])
+    def test_a_non_owner_is_refused(self, role):
+        client = _client()
+        with _as(role):
+            assert client.get("/api/payout-balances").status_code == 403
+
+    def test_anonymous_is_refused(self):
+        client = _client()
+        with _as(None):
+            assert client.get("/api/payout-balances").status_code in (401, 403)
+
+    def test_control_the_owner_is_allowed(self):
+        """Without this, the refusals above could pass because the endpoint is
+        broken for everyone."""
+
+        async def fake_balances(pairs):
+            return [
+                {"state": "known", "chain": c, "symbol": "X", "amount": Decimal("1"), "detail": None} for c, _ in pairs
+            ]
+
+        client = _client()
+        with (
+            _as("owner"),
+            patch("app.main.payout_registry.registry", new_callable=AsyncMock, return_value=REGISTRY),
+            patch("app.main.onchain.balances", side_effect=fake_balances),
+        ):
+            assert client.get("/api/payout-balances").status_code == 200


### PR DESCRIPTION
Tier 1 answered *"where does my money go?"*. This answers *"and what is there?"*.

## Why a separate endpoint

`/api/payout-balances` is deliberately **not** folded into `/api/payout-registry`. The registry is a local join and answers instantly; these are network reads against public RPCs that can take seconds or time out. Folding them together makes the whole payout table hostage to the slowest chain — so the page renders the table first and fills this column in afterwards.

Only addresses we actually hold get queried. An `internal`, `minted` or `unknown` service has no address, and putting a public RPC to work on nothing is both pointless and rude to infrastructure we do not pay for.

## The rule, one level down

Same rule as the address column: **"could not check" must never render like "the balance is zero."** Zero is a fact about an address; unreachable is a fact about *us*, and a public RPC rate-limiting us is not news about the user's money.

Three distinct looks:

| State | Renders as |
|---|---|
| `known` | the amount and symbol — **`0` included, because a real zero is a fact** |
| `unreachable` | *"could not check"*, italic, reason on hover |
| nothing asked | an em dash — there was no address to ask about |

`Decimal` is serialised as a **string**. A float at this last step would undo exactly the precision the reader uses `Decimal` to preserve.

## Verification

Both halves mutation-tested, because passing first time proves nothing:

- **Render:** the harness now runs `balanceCell` for real. Making `unreachable` render as `0` → **2 checks fail, exit 1**.
- **Endpoint:** removing the supported-chain condition from the address filter → **2 tests fail**.
- Plus a control that a hostile amount is escaped, and one that the owner *is* allowed (or the 403 tests would pass on a broken endpoint).

**4159 passed**, coverage **95.56%**, ruff check + `ruff format --check` clean, all six render harnesses green.

## Still open on dv6

Reconciliation — *"the service said it paid me, did it land?"* — is **not** in this PR, and I want to flag why rather than quietly skip it. A balance alone cannot prove a service failed to pay: the user may simply have moved the funds. Proving receipt needs incoming-transfer history, which keyless public RPCs do not offer. I will file the epistemics as its own bead rather than ship a comparison that looks conclusive and is not.