### PR TITLE
fix(catalog): proxybase pays to an account, not a minted wallet

### DIFF
--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -69,5 +69,10 @@ collector:
   notes: "No known public API for earnings."
 
 payout:
-  model: minted
-  notes: "The client mints its own wallet on first run. See tier 3."
+  model: internal
+  notes: >-
+    Earnings accrue to the ProxyBase ACCOUNT the Access Token belongs to, and
+    are withdrawn from the dashboard on request. The peer client holds no
+    wallet and the container keeps no state -- docker.volumes is empty.
+    Not to be confused with proxybase-xyz (ProxyBase Markets, same org), which
+    genuinely does mint a local wallet and declares it a critical volume.

--- a/tests/test_beads_batch_70.py
+++ b/tests/test_beads_batch_70.py
@@ -158,8 +158,20 @@ class TestTheThingsTheResearchEstablished:
         assert "30 days" in self._payout("urnetwork").get("notes", "").lower()
 
     def test_the_minted_services_are_marked_for_tier_three(self):
-        for slug in ("proxybase", "nosana"):
+        """CORRECTED. This originally asserted `proxybase` was minted, which
+        encoded a mistake I made in #267: the payout block was carried across
+        from its similarly named sibling `proxybase-xyz` (same org, opposite
+        model). The peer-cli client authenticates with an account access token,
+        cashes out by dashboard redirect, and mounts no volumes at all — that is
+        the `internal` model, and the test was asserting the bug rather than
+        catching it.
+
+        `proxybase-xyz` is the one that genuinely mints a local wallet, and it
+        declares the volume holding it as critical.
+        """
+        for slug in ("proxybase-xyz", "nosana"):
             assert self._payout(slug)["model"] == "minted", slug
+        assert self._payout("proxybase")["model"] == "internal"
 
 
 class TestNoPrivateKeyIsEverDeclared:

--- a/tests/test_beads_batch_75.py
+++ b/tests/test_beads_batch_75.py
@@ -1,0 +1,100 @@
+"""A service that MINTS a wallet must declare the volume holding it.
+
+Found while starting tier 3 (CashPilot-e8u), which is about minted wallets, so
+the mislabel was directly in the way: services/bandwidth/proxybase.yml declared
+``payout.model: minted`` while authenticating with an account access token,
+cashing out by dashboard redirect, and mounting no volumes at all. It pays to an
+ACCOUNT. I introduced that error myself in #267 by carrying the payout block
+across from its similarly named sibling.
+
+THE INVARIANT THAT MAKES THE CLASS IMPOSSIBLE TO REINTRODUCE:
+
+    a DEPLOYABLE service declared `minted` must declare `critical_volumes`
+
+because minting a wallet means irreplaceable local state, and a wallet with no
+persisted, flagged volume dies with the container — taking the money with it.
+Either the label is wrong (as here) or the service is one recreate away from
+destroying funds. Both are worth failing a build over.
+
+Services with an empty ``docker.image`` are exempt: the catalog lists those as
+present but not Docker-deployable (app/catalog.py, the "Extension/app-only
+services" branch), so there is no container and no volume to speak of.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVICES = sorted(Path("services").glob("*/*.yml"))
+
+
+def _load(path: Path) -> dict:
+    with path.open() as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def _minted_and_deployable() -> list[tuple[Path, dict]]:
+    out = []
+    for path in SERVICES:
+        if path.name.startswith("_"):
+            continue
+        data = _load(path)
+        payout = data.get("payout") or {}
+        docker = data.get("docker") or {}
+        if payout.get("model") == "minted" and (docker.get("image") or "").strip():
+            out.append((path, data))
+    return out
+
+
+def test_the_catalog_still_has_minted_services():
+    """CONTROL. If nothing were classified `minted`, the invariant below would
+    hold vacuously and prove nothing at all — which is exactly how this kind of
+    check rots into decoration."""
+    assert _minted_and_deployable(), "no deployable minted service found; the test below is vacuous"
+
+
+@pytest.mark.parametrize("path", [p for p, _ in _minted_and_deployable()], ids=lambda p: p.stem)
+def test_a_minted_service_declares_the_volume_that_holds_the_wallet(path):
+    data = _load(path)
+    critical = (data.get("docker") or {}).get("critical_volumes")
+    assert critical, (
+        f"{path} declares payout.model 'minted' but no docker.critical_volumes. "
+        "Either it does not actually mint a wallet — check whether it authenticates "
+        "with an account credential and cashes out via a dashboard, which is the "
+        "'internal' model — or it does, and every container recreate destroys the "
+        "funds."
+    )
+
+
+@pytest.mark.parametrize("path", [p for p, _ in _minted_and_deployable()], ids=lambda p: p.stem)
+def test_the_critical_volume_is_actually_mounted(path):
+    """Declaring a volume critical while never mounting it protects nothing.
+
+    The delete guard reads `critical_volumes` (app/catalog.py), so a target that
+    appears in neither `volumes` nor the mount list is a warning about a path
+    the container does not have.
+    """
+    docker = _load(path).get("docker") or {}
+    mounted = " ".join(str(v) for v in (docker.get("volumes") or []))
+    for entry in docker.get("critical_volumes") or []:
+        target = (entry or {}).get("target")
+        assert target, f"{path}: a critical_volumes entry has no target"
+        assert target in mounted, f"{path}: critical volume {target!r} is not among docker.volumes ({mounted!r})"
+
+
+def test_proxybase_and_proxybase_xyz_are_not_confused_for_each_other():
+    """The specific regression. Same org, similar names, opposite payout models:
+    peer-cli pays an ACCOUNT, Markets mints a local wallet."""
+    peer = _load(Path("services/bandwidth/proxybase.yml"))
+    markets = _load(Path("services/bandwidth/proxybase-xyz.yml"))
+
+    assert peer["payout"]["model"] == "internal", "proxybase (peer-cli) pays to an account, not a minted wallet"
+    assert markets["payout"]["model"] == "minted", "proxybase-xyz (Markets) does mint its own wallet"
+    # And the evidence for that split, so a future edit has to confront it.
+    assert not (peer.get("docker") or {}).get("volumes"), (
+        "peer-cli keeps no state; a volume would contradict 'internal'"
+    )
+    assert (markets.get("docker") or {}).get("critical_volumes"), "Markets' wallet volume must stay flagged critical"


### PR DESCRIPTION
Found while starting tier 3 (`e8u`), which is *about* minted wallets — so the mislabel was directly in the way. **I introduced it myself in #267**, by carrying the payout block across from its similarly named sibling.

`proxybase` (peer-cli) and `proxybase-xyz` (ProxyBase Markets) are the same org with **opposite** payout models.

## The evidence that peer-cli is `internal`

- authenticates with an **Access Token** from an account dashboard (`docker.env ID`, secret)
- cashout is `method: redirect` to `peer.proxybase.org/dashboard`, minimum $1
- its guide states *"Payout frequency: On request"*
- `docker.volumes` is `[]` — there is no persistence at all

That is the textbook `internal` model. If it genuinely minted a wallet with no volume, every container recreate would destroy the money — a far more serious bug, but nothing supports that reading.

**Harm while it stood:** the payout screen told the user *"The container generates its own wallet"* for a service where no such wallet exists — sending them looking for something that is not there, and implying a backup obligation they do not have.

## The durable part

A **deployable** service declared `minted` must now declare `critical_volumes`.

Minting a wallet means irreplaceable local state, so a wallet with no persisted, flagged volume dies with the container. Either the label is wrong (as here) or the service is one recreate away from destroying funds — both are worth failing a build over. Services with an empty `docker.image` are exempt: the catalog lists those as present but not Docker-deployable.

## Verification

- **mutation-tested**: restoring `minted` on proxybase fails **2 of the new tests** — so this guard would have caught my original error
- carries a **control** asserting the catalog still *has* a deployable minted service, without which the invariant holds vacuously and rots into decoration
- a second check that a declared critical volume is actually **mounted** — flagging a path the container does not have protects nothing
- also corrects `tests/test_beads_batch_70.py`, which asserted proxybase was minted: it was **encoding the bug rather than catching it**

4163 passed, coverage 95.56%, ruff check + format clean.