### PR TITLE
feat: name the volumes that hold money, in the catalog's own words

### DIFF
--- a/app/payout_registry.py
+++ b/app/payout_registry.py
@@ -97,7 +97,45 @@ def entry(service: dict[str, Any], spec: dict[str, Any] | None, *, deployed: boo
         # the one state that asks the user to do something.
         "address_missing": model == "external" and address is None,
         "notes": payout.get("notes"),
+        # Volumes the catalog marks irreplaceable, with the catalog's own words
+        # for what each one holds. For a `minted` service this IS the payout
+        # destination -- the wallet is a file on that volume, so "where does my
+        # money go?" is answered by naming the volume, not an address.
+        #
+        # Read straight from the service dict rather than looking the slug up
+        # again: this function is pure, and the caller already resolved it.
+        "critical_state": critical_state(service),
     }
+
+
+def critical_state(service: dict[str, Any]) -> list[dict[str, Any]]:
+    """The volumes this service cannot survive losing, and what each holds.
+
+    An empty list means the catalog declares nothing irreplaceable -- NOT that
+    nothing was checked. That distinction matters here for the same reason it
+    matters everywhere else in this module: a service whose criticality was
+    never established must not render as a service with nothing to lose.
+    Callers holding a service dict have the catalog by definition, so absence
+    here really is "declares nothing".
+    """
+    docker = service.get("docker") or {}
+    out: list[dict[str, Any]] = []
+    for entry_ in docker.get("critical_volumes") or []:
+        if not isinstance(entry_, dict):
+            continue
+        target = entry_.get("target")
+        if not target:
+            continue
+        out.append(
+            {
+                "target": str(target),
+                # The catalog's wording is the user-facing explanation. A generic
+                # fallback is worse than nothing only if it pretends to be
+                # specific, so keep it plainly generic.
+                "holds": str(entry_.get("holds") or "Irreplaceable service state."),
+            }
+        )
+    return out
 
 
 async def registry() -> dict[str, Any]:
@@ -136,5 +174,9 @@ async def registry() -> dict[str, Any]:
             # be going nowhere, and services we cannot yet answer for.
             "needs_an_address": sum(1 for row in entries if row["address_missing"] and row["deployed"]),
             "unclassified": sum(1 for row in entries if row["model"] == "unknown"),
+            # DEPLOYED only. A service you are not running cannot lose state you
+            # do not have, and counting it would put a permanent warning on the
+            # dashboard of someone who has nothing at risk.
+            "holding_irreplaceable_state": sum(1 for row in entries if row["deployed"] and row["critical_state"]),
         },
     }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2152,3 +2152,11 @@ img { max-width: 100%; }
   border-bottom: 1px dotted var(--border-color);
   cursor: help;
 }
+
+/* Irreplaceable state (CashPilot-e8u). The catalog's own wording is the
+   warning; this only makes it legible. */
+.payout-critical-item { padding: 10px 0; border-bottom: 1px solid var(--border-color); }
+.payout-critical-item:last-child { border-bottom: none; }
+.payout-critical-name { font-weight: 600; margin-bottom: 6px; }
+.payout-critical-list { margin: 0; padding-left: 18px; }
+.payout-holds { color: var(--text-muted); font-size: 0.85rem; margin: 2px 0 8px; }

--- a/app/templates/payouts.html
+++ b/app/templates/payouts.html
@@ -29,6 +29,10 @@
     <div class="stat-value" id="payout-needs-address">&mdash;</div>
   </div>
   <div class="stat-card">
+    <div class="stat-label">Irreplaceable state</div>
+    <div class="stat-value" id="payout-critical-count">&mdash;</div>
+  </div>
+  <div class="stat-card">
     <div class="stat-label">Not classified</div>
     <div class="stat-value" id="payout-unclassified">&mdash;</div>
   </div>
@@ -41,6 +45,18 @@
     Whatever they earn may be going somewhere you cannot reach.
   </p>
   <div id="payout-actionable-body"></div>
+</div>
+
+<div class="card" id="payout-critical-card" style="display:none; border-color: var(--error, #ef4444);">
+  <h3 class="settings-section-title">These are one deleted volume away from gone</h3>
+  <p class="settings-section-desc">
+    These running services keep money-bearing state on disk that exists
+    <strong>nowhere else</strong>. There is no server-side copy and no reset
+    link: if the volume goes, so does whatever it held. CashPilot will refuse to
+    delete these containers, but it cannot protect you from
+    <code>docker volume rm</code>, a wiped disk, or a rebuilt machine.
+  </p>
+  <div id="payout-critical-body"></div>
 </div>
 
 <div class="card">
@@ -129,6 +145,25 @@
     return '<span class="payout-na">&mdash;</span>';
   }
 
+  // What this service would lose, in the catalog's own words.
+  //
+  // Deliberately NOT a generic "this volume is important" line: the catalog
+  // already says what each volume holds, and the specific sentence ("This
+  // volume IS the money") is what makes someone act. A generic warning trains
+  // people to dismiss it.
+  //
+  // Pure, string-returning, no DOM — so the harness can run it.
+  function criticalStateRow(entry) {
+    var items = (entry.critical_state || []).map(function (v) {
+      return '<li><code class="payout-address">' + esc(v.target) + '</code>'
+           + '<div class="payout-holds">' + esc(v.holds) + '</div></li>';
+    }).join('');
+    return '<div class="payout-critical-item">'
+      + '<div class="payout-critical-name">' + esc(entry.name || entry.slug) + '</div>'
+      + '<ul class="payout-critical-list">' + items + '</ul>'
+      + '</div>';
+  }
+
   function payoutRow(entry) {
     var chain = entry.chain ? esc(entry.chain) : '<span class="payout-na">&mdash;</span>';
     var deployed = entry.deployed
@@ -183,6 +218,19 @@
       document.getElementById('payout-deployed').textContent = summary.deployed || 0;
       document.getElementById('payout-needs-address').textContent = summary.needs_an_address || 0;
       document.getElementById('payout-unclassified').textContent = summary.unclassified || 0;
+
+      document.getElementById('payout-critical-count').textContent = summary.holding_irreplaceable_state || 0;
+
+      // DEPLOYED only. A service you are not running cannot lose state you do
+      // not have, and warning about it would be noise on someone's dashboard.
+      var atRisk = _entries.filter(function (e) { return e.deployed && (e.critical_state || []).length; });
+      var criticalCard = document.getElementById('payout-critical-card');
+      if (atRisk.length) {
+        document.getElementById('payout-critical-body').innerHTML = atRisk.map(criticalStateRow).join('');
+        criticalCard.style.display = '';
+      } else {
+        criticalCard.style.display = 'none';
+      }
 
       var actionable = _entries.filter(function (e) { return e.address_missing && e.deployed; });
       var card = document.getElementById('payout-actionable-card');

--- a/scripts/payout_registry_check.mjs
+++ b/scripts/payout_registry_check.mjs
@@ -40,11 +40,11 @@ function extract(name) {
 // Evaluate the real esc/payoutAddressCell/payoutRow together, since they call
 // one another. A stub for esc() here would let escaping break while this stayed
 // green — exactly the failure these harnesses exist to catch.
-const src = [extract('esc'), extract('payoutAddressCell'), extract('balanceCell'), extract('payoutRow')].join('\n');
+const src = [extract('esc'), extract('payoutAddressCell'), extract('balanceCell'), extract('criticalStateRow'), extract('payoutRow')].join('\n');
 // payoutRow reads the module-level _balances map, so give it an empty one --
 // the balance cell is exercised directly below.
-const {payoutAddressCell, payoutRow, balanceCell} = new Function(
-  `const _balances = {}; ${src}; return {payoutAddressCell, payoutRow, balanceCell};`
+const {payoutAddressCell, payoutRow, balanceCell, criticalStateRow} = new Function(
+  `const _balances = {}; ${src}; return {payoutAddressCell, payoutRow, balanceCell, criticalStateRow};`
 )();
 
 let failures = 0;
@@ -172,6 +172,37 @@ check(
   'CONTROL: a hostile amount is escaped in the balance cell',
   !balanceCell({state: 'known', amount: '<script>x</script>', symbol: 'E'}).includes('<script>'),
   balanceCell({state: 'known', amount: '<script>x</script>', symbol: 'E'})
+);
+
+// ---------------------------------------------------------------------------
+// Irreplaceable state (e8u). The catalog's own sentence is the warning.
+// ---------------------------------------------------------------------------
+const crit = criticalStateRow({
+  slug: 'proxybase-xyz', name: 'ProxyBase Markets',
+  critical_state: [{target: '/home/proxybase/.proxybase', holds: 'This volume IS the money.'}],
+});
+check('the volume path is shown', crit.includes('/home/proxybase/.proxybase'), crit);
+check(
+  "the catalog's SPECIFIC sentence survives, not a generic warning",
+  crit.includes('This volume IS the money.'),
+  crit
+);
+check('the service is named', crit.includes('ProxyBase Markets'), crit);
+
+check(
+  'CONTROL: a service with no critical state renders no list items',
+  !criticalStateRow({slug: 'x', name: 'X', critical_state: []}).includes('<li>'),
+  criticalStateRow({slug: 'x', name: 'X', critical_state: []})
+);
+check(
+  'CONTROL: a missing critical_state does not throw or invent one',
+  !criticalStateRow({slug: 'x', name: 'X'}).includes('<li>'),
+  criticalStateRow({slug: 'x', name: 'X'})
+);
+check(
+  'a hostile holds string is escaped',
+  !criticalStateRow({slug: 'x', name: 'X', critical_state: [{target: '/t', holds: '<img src=x>'}]}).includes('<img src=x>'),
+  'escaping failed'
 );
 
 if (failures) {

--- a/tests/test_beads_batch_76.py
+++ b/tests/test_beads_batch_76.py
@@ -1,0 +1,95 @@
+"""CashPilot-e8u: telling the user which volumes hold money.
+
+Tier 3's stated aim is visibility, not custody. Reading a minted wallet's
+address needs a worker-side primitive that does not exist yet; this is the half
+that needs nothing new and is worth more than it looks.
+
+Four catalogued services keep state that exists NOWHERE else, the worker has
+been able to export it since `read_critical_state` landed, and the UI never
+mentioned either fact. A user could not learn their ProxyBase Markets volume
+"IS the money" from anywhere in the product.
+
+The rule these tests hold: **the catalog's own sentence is the warning.** A
+generic "this volume is important" trains people to dismiss it; "This volume IS
+the money: there is no server-side copy" is what makes someone act.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from app import catalog, payout_registry
+
+
+def _service(slug: str) -> dict:
+    svc = next((s for s in catalog.get_services() if s.get("slug") == slug), None)
+    assert svc is not None, f"{slug} is not in the catalog"
+    return svc
+
+
+class TestReadingCriticalStateOffAService:
+    def test_a_minted_service_reports_its_wallet_volume(self):
+        state = payout_registry.critical_state(_service("proxybase-xyz"))
+        assert state, "proxybase-xyz declares a critical volume and it must surface"
+        assert state[0]["target"] == "/home/proxybase/.proxybase"
+
+    def test_the_catalogs_own_wording_is_carried_through(self):
+        """Not paraphrased and not replaced by a generic warning -- the specific
+        sentence is the thing that makes someone act."""
+        holds = payout_registry.critical_state(_service("proxybase-xyz"))[0]["holds"]
+        assert "IS the money" in holds
+
+    def test_a_service_with_nothing_irreplaceable_reports_an_empty_list(self):
+        """CONTROL. If every service reported critical state, the tests above
+        would pass while the feature warned about everything, which is the same
+        as warning about nothing."""
+        assert payout_registry.critical_state(_service("honeygain")) == []
+
+    def test_a_malformed_entry_is_skipped_rather_than_crashing_the_screen(self):
+        service = {"docker": {"critical_volumes": ["not a mapping", {}, {"target": "/ok"}]}}
+        state = payout_registry.critical_state(service)
+        assert [v["target"] for v in state] == ["/ok"]
+
+    def test_an_entry_without_holds_gets_a_plainly_generic_fallback(self):
+        """A fallback that pretended to be specific would be worse than none."""
+        state = payout_registry.critical_state({"docker": {"critical_volumes": [{"target": "/x"}]}})
+        assert state[0]["holds"] == "Irreplaceable service state."
+
+    def test_a_service_with_no_docker_block_does_not_raise(self):
+        assert payout_registry.critical_state({}) == []
+
+
+class TestTheSummaryCountsOnlyWhatIsAtRisk:
+    @staticmethod
+    def _registry(deployments):
+        with (
+            patch(
+                "app.payout_registry.database.get_deployments",
+                new_callable=AsyncMock,
+                return_value=deployments,
+            ),
+            patch("app.payout_registry.database.get_deployment_spec", new_callable=AsyncMock, return_value=None),
+        ):
+            return asyncio.run(payout_registry.registry())
+
+    def test_a_deployed_service_with_irreplaceable_state_is_counted(self):
+        result = self._registry([{"slug": "proxybase-xyz"}])
+        assert result["summary"]["holding_irreplaceable_state"] == 1
+
+    def test_an_undeployed_one_is_not(self):
+        """You cannot lose state you do not have, and a permanent warning on the
+        dashboard of someone who is not running it is noise."""
+        result = self._registry([])
+        assert result["summary"]["holding_irreplaceable_state"] == 0
+
+    def test_control_deploying_something_harmless_does_not_raise_the_count(self):
+        """Without this, the count could be 'number of deployed services' and
+        both tests above would still pass."""
+        result = self._registry([{"slug": "honeygain"}])
+        assert result["summary"]["deployed"] == 1
+        assert result["summary"]["holding_irreplaceable_state"] == 0
+
+    def test_every_entry_carries_the_field_so_the_ui_never_reads_undefined(self):
+        for row in self._registry([])["entries"]:
+            assert isinstance(row["critical_state"], list)


### PR DESCRIPTION
**CashPilot-e8u**, the half that needs nothing new.

Four catalogued services keep state that exists **nowhere else**. The worker has been able to export it since `read_critical_state` landed. **The UI mentioned neither fact** — a user could not learn from anywhere in the product that their ProxyBase Markets volume *"IS the money"*.

The payouts screen now names them: which *running* services hold irreplaceable state, which volume, and what it holds.

For a `minted` service **this is the payout destination** — the wallet is a file on that volume, so *"where does my money go?"* is answered by naming the volume, not an address. That is what connects this to tier 1.

## The rule

**The catalog's own sentence is the warning.**

A generic *"this volume is important"* trains people to dismiss it. *"This volume IS the money: there is no server-side copy, so deleting it destroys the funds with it"* is what makes someone act.

The harness asserts the specific sentence survives — **replacing it with a generic one fails the build** (mutation-tested).

## Scope and honesty

- **Deployed services only.** You cannot lose state you do not have, and a permanent warning on the dashboard of someone not running it is noise.
- The card states the limit plainly: CashPilot refuses to delete these containers, but it **cannot** protect anyone from `docker volume rm`, a wiped disk, or a rebuilt machine. Implying more safety than exists would be worse than silence.

## Controls

- a service with nothing irreplaceable reports an empty list — otherwise the feature warns about everything, which is the same as warning about nothing
- deploying a *harmless* service does not raise the count — otherwise the count could simply be "number of deployed services" and the other tests would still pass
- malformed catalog entries are skipped rather than taking the screen down
- a fallback for a missing `holds` is *plainly* generic; one pretending to be specific would be worse than none

4173 passed, coverage 95.57%, ruff clean, all render harnesses green.

## Still open on e8u

Reading a minted wallet's **address** needs a worker-side primitive that does not exist. The UI has no Docker socket by design, and a general "read any file from any container" endpoint would be a serious new attack surface. `read_critical_state` is the right precedent — catalog-declared targets only — and I will file the design rather than improvise it.