### PR TITLE
test: refuse to run against a tree contaminated by another branch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,3 +175,88 @@ def _unpollute_catalog(_real_catalog_slugs):
     if catalog._by_slug and set(catalog._by_slug) != _real_catalog_slugs:
         catalog._services = []
         catalog._by_slug = {}
+
+
+# ---------------------------------------------------------------------------
+# CashPilot-ixjx: refuse to run against a contaminated working tree.
+#
+# The repos on this machine are two-way rsynced against a hub that keeps files
+# the local side deleted (no --delete, by design). A branch checkout removes a
+# file; the next sync copies it straight back as an UNTRACKED stray. The tree
+# then holds a mixture of two branches.
+#
+# THE FAILING CASE IS THE LUCKY ONE. On 2026-08-06 four files from two feature
+# branches reappeared on a third, and five tests failed loudly. But an EARLIER
+# run on that same branch had reported 4096 PASSED while silently including
+# another branch's tests -- a green suite measuring the wrong tree, which
+# nothing announces and nobody double-checks.
+#
+# So: a stray is any untracked file that HAS COMMIT HISTORY somewhere. A file
+# nobody ever committed is ordinary new work and is ignored.
+# ---------------------------------------------------------------------------
+
+#: Only these affect what the suite measures. An untracked note or scratch file
+#: is nobody's business.
+_RESULT_BEARING = ("app/", "tests/", "scripts/", "services/")
+
+
+def _git(*args: str) -> str | None:
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), *args],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def find_stray_files() -> list[str]:
+    """Untracked, result-bearing files that were committed somewhere else.
+
+    Returns [] when git is unavailable or this is not a repository — the guard
+    must never be the reason a suite cannot run, only a reason it refuses to
+    lie about what it measured.
+    """
+    status = _git("status", "--porcelain")
+    if status is None:
+        return []
+
+    strays = []
+    for line in status.splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[3:].strip().strip('"')
+        if not path.startswith(_RESULT_BEARING):
+            continue
+        # Commit history anywhere means this file belongs to some branch, so its
+        # presence here as untracked is resurrection rather than new work.
+        history = _git("rev-list", "--all", "--max-count=1", "--", path)
+        if history and history.strip():
+            strays.append(path)
+    return strays
+
+
+def pytest_sessionstart(session):  # noqa: ARG001 - pytest hook signature
+    if os.environ.get("CASHPILOT_ALLOW_STRAY_FILES"):
+        return
+    strays = find_stray_files()
+    if not strays:
+        return
+    listing = "\n".join(f"  {p}" for p in strays)
+    raise pytest.UsageError(
+        "Refusing to run: the working tree holds untracked files that are committed on\n"
+        "another branch. The suite would measure a mixture of two branches, and the\n"
+        "dangerous outcome is not a failure but a PASS that means nothing.\n\n"
+        f"{listing}\n\n"
+        "These are almost certainly cmux-sync resurrecting files a branch checkout\n"
+        "removed (CashPilot-ixjx). Verify each is identical to its committed version\n"
+        "before removing it:\n"
+        "  git show <branch>:<path> | diff - <path>\n\n"
+        "Set CASHPILOT_ALLOW_STRAY_FILES=1 to run anyway."
+    )

--- a/tests/test_beads_batch_77.py
+++ b/tests/test_beads_batch_77.py
@@ -1,0 +1,109 @@
+"""CashPilot-ixjx: the suite refuses to run against a contaminated tree.
+
+These repos are two-way rsynced against a hub that keeps files the local side
+deleted (no ``--delete``, deliberately). A branch checkout removes a file; the
+next sync copies it back as an UNTRACKED stray, and the tree then holds a
+mixture of two branches.
+
+THE FAILING CASE IS THE LUCKY ONE. When it bit on 2026-08-06, five tests failed
+loudly — but an earlier run on the same branch had reported **4096 passed**
+while silently including another branch's tests. A green suite measuring the
+wrong tree announces nothing, and nobody re-checks a pass.
+
+The classification these tests pin down:
+
+    untracked + has commit history  -> a stray, refuse to run
+    untracked + no history          -> ordinary new work, ignore
+    outside app|tests|scripts|services -> not our business either way
+
+The middle case matters most: every new test file is untracked before it is
+committed, so a guard that blocked on those would be turned off within a day.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests import conftest as ct
+
+
+@pytest.fixture
+def fake_git(monkeypatch):
+    """Drive the real find_stray_files() against scripted git output.
+
+    Patching ``_git`` rather than building a temp repository keeps the CLASSIFY
+    logic under test — which is where the bugs live — instead of testing git.
+    """
+
+    def install(status: str, with_history: set[str]):
+        def _fake(*args: str):
+            if args[0] == "status":
+                return status
+            if args[0] == "rev-list":
+                path = args[-1]
+                return "9490fc3\n" if path in with_history else ""
+            return ""
+
+        monkeypatch.setattr(ct, "_git", _fake)
+
+    return install
+
+
+class TestWhatCountsAsAStray:
+    def test_an_untracked_file_with_history_is_a_stray(self, fake_git):
+        fake_git("?? app/federation.py\n", {"app/federation.py"})
+        assert ct.find_stray_files() == ["app/federation.py"]
+
+    def test_an_untracked_file_with_NO_history_is_ordinary_new_work(self, fake_git):
+        """The case that decides whether anyone leaves this guard enabled: a new
+        test file is untracked until it is committed."""
+        fake_git("?? tests/test_brand_new.py\n", set())
+        assert ct.find_stray_files() == []
+
+    def test_a_modified_tracked_file_is_not_a_stray(self, fake_git):
+        """Only '??' lines. A modified file is your own work in progress."""
+        fake_git(" M app/main.py\n", {"app/main.py"})
+        assert ct.find_stray_files() == []
+
+    def test_a_staged_file_is_not_a_stray(self, fake_git):
+        fake_git("A  app/new_thing.py\n", {"app/new_thing.py"})
+        assert ct.find_stray_files() == []
+
+    @pytest.mark.parametrize("path", ["NOTES.md", "docs/scratch.md", ".env.local"])
+    def test_files_outside_the_result_bearing_dirs_are_ignored(self, fake_git, path):
+        """A stray note cannot change what the suite measures."""
+        fake_git(f"?? {path}\n", {path})
+        assert ct.find_stray_files() == []
+
+    @pytest.mark.parametrize("path", ["app/x.py", "tests/x.py", "scripts/x.mjs", "services/bandwidth/x.yml"])
+    def test_every_result_bearing_directory_is_covered(self, fake_git, path):
+        fake_git(f"?? {path}\n", {path})
+        assert ct.find_stray_files() == [path]
+
+    def test_a_quoted_path_is_unquoted(self, fake_git):
+        """git quotes paths containing spaces; an un-stripped quote would never
+        match the history lookup and the stray would slip through."""
+        fake_git('?? "app/with space.py"\n', {"app/with space.py"})
+        assert ct.find_stray_files() == ["app/with space.py"]
+
+    def test_several_strays_are_all_reported(self, fake_git):
+        fake_git("?? app/a.py\n?? tests/b.py\n?? NOTES.md\n", {"app/a.py", "tests/b.py", "NOTES.md"})
+        assert ct.find_stray_files() == ["app/a.py", "tests/b.py"]
+
+
+class TestTheGuardNeverBlocksTheSuiteByAccident:
+    def test_it_returns_nothing_when_git_is_unavailable(self, monkeypatch):
+        """Not a repository, no git binary, a timeout -- the guard must never be
+        the reason a suite cannot run, only a reason it refuses to lie."""
+        monkeypatch.setattr(ct, "_git", lambda *a: None)
+        assert ct.find_stray_files() == []
+
+    def test_a_clean_tree_yields_nothing(self, fake_git):
+        """CONTROL. If find_stray_files() always returned [], every assertion in
+        the class above would pass for the wrong reason."""
+        fake_git("", set())
+        assert ct.find_stray_files() == []
+
+    def test_control_the_detector_can_actually_return_something(self, fake_git):
+        fake_git("?? app/federation.py\n", {"app/federation.py"})
+        assert ct.find_stray_files(), "the detector never fires; the clean-tree test proves nothing"


### PR DESCRIPTION
Closes **CashPilot-ixjx**.

These repos are two-way rsynced against a hub that keeps files the local side deleted (no `--delete`, deliberately). A branch checkout removes a file; the next sync copies it back as an **untracked stray**, and the tree then holds a mixture of two branches.

## Why this is worth a guard

**The failing case is the lucky one.** When this bit on 2026-08-06, four files from two feature branches reappeared on a third and five tests failed loudly — which is how it got noticed.

But an *earlier* run on that same branch had reported **4096 passed while silently including another branch's tests**. A green suite measuring the wrong tree announces nothing, and nobody re-checks a pass.

## The classification

| Condition | Verdict |
|---|---|
| untracked **and has commit history** | a stray — refuse to run |
| untracked, no history | ordinary new work — ignore |
| outside `app/ tests/ scripts/ services/` | cannot change what is measured — ignore |

The middle row decides whether anyone leaves this enabled. Every new test file is untracked until committed, so a guard that blocked on those would be switched off within a day.

## Verified against the real repository, not only in unit tests

- recreating a path that genuinely does not exist in `HEAD` but has history → pytest **refuses**, lists the paths, and prints the `git show <branch>:<path> | diff - <path>` command to check them
- a brand-new file → runs normally
- an untracked note outside those directories → runs normally
- `CASHPILOT_ALLOW_STRAY_FILES=1` → runs normally
- git unavailable → returns nothing; **this must never be the reason a suite cannot run**, only a reason it refuses to lie

16 unit tests cover the classification, including a control that the detector can actually fire — without it, the clean-tree assertions would pass for the wrong reason.

4186 passed, coverage 95.57%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pytest now detects unexpected untracked result files that match paths previously tracked in Git.
  * Test runs provide clear verification guidance when stray files are found.
  * Git or repository errors no longer block test execution.

* **Tests**
  * Added coverage for stray-file detection, path handling, exclusions, multiple files, and graceful failure scenarios.
  * Added an environment-variable override for intentionally allowing stray files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->