### PR TITLE
docs: act on the healthcheck the images already declare

### DIFF
--- a/docker-compose.fleet.yml
+++ b/docker-compose.fleet.yml
@@ -31,6 +31,17 @@ services:
       - CASHPILOT_ALLOW_EPHEMERAL_KEY=${CASHPILOT_ALLOW_EPHEMERAL_KEY:-false}
       - CASHPILOT_API_KEY=${CASHPILOT_API_KEY}
     init: true
+    # The image declares its own HEALTHCHECK, so `docker ps` will show
+    # "(unhealthy)" when the app stops answering. NOTHING ACTS ON THAT BY
+    # DEFAULT: `restart: unless-stopped` restarts a container that EXITS, and a
+    # container failing its healthcheck is still running. It will sit there
+    # unhealthy indefinitely. (Docker Swarm reschedules unhealthy tasks; plain
+    # Compose does not.)
+    #
+    # To act on it, either alert on it -- see the CashPilotDown rule in
+    # docs/guides/prometheus-metrics.md -- or add an autoheal sidecar, which is
+    # documented in the same place along with the fact that it needs the Docker
+    # socket, i.e. root on the host.
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,17 @@ services:
       - CASHPILOT_API_KEY=${CASHPILOT_API_KEY:-}
       - CASHPILOT_ADMIN_API_KEY=${CASHPILOT_ADMIN_API_KEY:-}
     init: true
+    # The image declares its own HEALTHCHECK, so `docker ps` will show
+    # "(unhealthy)" when the app stops answering. NOTHING ACTS ON THAT BY
+    # DEFAULT: `restart: unless-stopped` restarts a container that EXITS, and a
+    # container failing its healthcheck is still running. It will sit there
+    # unhealthy indefinitely. (Docker Swarm reschedules unhealthy tasks; plain
+    # Compose does not.)
+    #
+    # To act on it, either alert on it -- see the CashPilotDown rule in
+    # docs/guides/prometheus-metrics.md -- or add an autoheal sidecar, which is
+    # documented in the same place along with the fact that it needs the Docker
+    # socket, i.e. root on the host.
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -133,7 +133,67 @@ groups:
           severity: warning
         annotations:
           summary: "No successful earnings collection in 2+ hours"
+
+      # THE ONE THAT WATCHES THE WATCHER. Every alert above is computed FROM
+      # CashPilot's own metrics, so if CashPilot itself stops, none of them
+      # fire -- there is simply no data, and silence reads exactly like health.
+      # This is the only rule here that survives the thing it monitors dying.
+      - alert: CashPilotDown
+        expr: up{job="cashpilot"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus cannot scrape CashPilot — every other CashPilot alert is now blind"
 ```
+
+## The container can be "up" and failing
+
+Both images declare a `HEALTHCHECK`, so Docker knows whether the app inside is
+actually answering:
+
+```bash
+docker ps --format '{{.Names}}\t{{.Status}}'
+# cashpilot-ui   Up 2 hours (unhealthy)
+```
+
+**Nothing acts on that by default, and that surprises people.**
+`restart: unless-stopped` restarts a container that *exits*. A container that
+stays running while failing its own healthcheck is not exiting, so it is never
+restarted — it sits there, `unhealthy`, indefinitely. (Docker **Swarm** does
+reschedule unhealthy tasks; plain Docker and Compose do not.)
+
+Three ways to close that, in increasing order of effort:
+
+**1. Alert on it.** If you already run Prometheus, the `CashPilotDown` rule
+above covers the case that matters: a failing healthcheck almost always means
+the HTTP endpoint stopped answering, which is the same thing a failed scrape
+detects.
+
+**2. Restart it automatically.** A small sidecar watches the Docker socket and
+restarts anything that goes unhealthy:
+
+```yaml
+  autoheal:
+    image: willfarrell/autoheal:1.2.0
+    restart: unless-stopped
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Then label the containers you want it to manage with `autoheal: "true"`.
+
+!!! warning "This sidecar holds the Docker socket"
+
+    The socket is root on the host. You are trading one risk for another, and
+    on a single-user home server that is usually a reasonable trade — but make
+    it deliberately, not by copy-paste. If you would not give a third-party
+    image root, alert instead of autohealing.
+
+**3. Watch it by hand.** `docker ps` shows the health state, and it costs
+nothing to look at after an upgrade.
 
 ## Grafana Dashboard
 


### PR DESCRIPTION
Closes **CashPilot-kc5e**.

Both images declare a `HEALTHCHECK`, so Docker knows whether the app inside is answering — and **neither compose file mentioned it, in either direction**. Zero matches before this change.

## The surprise worth naming

`restart: unless-stopped` restarts a container that **exits**. A container failing its own healthcheck is still *running*, so it is never restarted — it sits there `unhealthy` indefinitely.

```
docker ps
# cashpilot-ui   Up 2 hours (unhealthy)
```

(Docker **Swarm** reschedules unhealthy tasks; plain Compose does not.)

The compose files now say this **at the restart policy** — which is exactly where someone looks when they expect a restart and do not get one.

## The sharper half, which the bead did not name

The four existing example alerts are all computed **from CashPilot's own metrics**. If CashPilot stops, none of them fire — there is no data, and **silence reads exactly like health**.

Added a `CashPilotDown` rule on `up == 0`: the only rule in that file that survives the thing it monitors dying.

## Honest about the sidecar

`autoheal` is documented as an option, with the trade stated plainly: **it needs the Docker socket, which is root on the host.** Worth making deliberately rather than by copy-paste — and if you would not give a third-party image root, alert instead.

## A correction to the bead

It asked for a Prometheus + Alertmanager recipe as item 1. **That already existed** (`## Example Alerts`), so this change is narrower and more useful than the bead described — the gap was the compose side, plus the missing watch-the-watcher rule.

## Verified

- both compose files still parse, and both services keep their `restart` policies
- `mkdocs build --strict` passes
- 4189 passed, coverage 95.57%, ruff clean