### PR TITLE
fix(docs): stop telling people to publish the worker API on every interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,18 @@ On each additional server, deploy only a worker pointing to the UI:
 ```yaml
 services:
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:latest
+    image: drumsergio/cashpilot-worker:1.19
     pull_policy: always
     container_name: cashpilot-worker
     ports:
-      - "8081:8081"
+      # The worker's API is backed by the Docker socket -- deploy, stop or
+      # remove ANY container -- so publishing it is publishing full control of
+      # this host. It binds LOOPBACK by default for that reason.
+      #
+      # A remote UI does need to reach it, so set CASHPILOT_WORKER_BIND_ADDR to
+      # this server's PRIVATE or VPN address (a Tailscale IP, say). Never a
+      # public one, and never 0.0.0.0.
+      - "${CASHPILOT_WORKER_BIND_ADDR:-127.0.0.1}:8081:8081"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - cashpilot_worker_data:/data

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -114,7 +114,7 @@ On each additional server, deploy only a worker pointing back to the UI:
 ```yaml
 services:
   cashpilot-worker:
-    image: drumsergio/cashpilot-worker:latest
+    image: drumsergio/cashpilot-worker:1.19
     pull_policy: always
     container_name: cashpilot-worker
     # The worker's API is Docker-socket-backed (= root on the host). Bind it to a

--- a/tests/test_docs_do_not_contradict_the_shipped_files.py
+++ b/tests/test_docs_do_not_contradict_the_shipped_files.py
@@ -113,3 +113,85 @@ class TestTheAdvertiseOnlyPortIsDescribedCorrectlyEverywhere:
     def test_the_listen_port_really_is_fixed_by_the_image(self):
         """The correction is only right while this stays true."""
         assert '"--port", "8081"' in (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CashPilot-o6mu: the same defect survived in README.md, which is the file most
+# people read FIRST.
+#
+# The two checks above were written against GETTING_STARTED by name. So when
+# `docs/getting-started.md` was fixed, README.md's "Adding remote workers"
+# snippet kept telling people to run `image: ...:latest` with a bare
+# `"8081:8081"` -- publishing an API that can deploy, stop or remove any
+# container on the host, to every interface.
+#
+# Naming one page was the bug. These check EVERY doc that ships a compose
+# snippet.
+# ---------------------------------------------------------------------------
+
+
+#: Docs a user might copy from. CHANGELOG is excluded on purpose: it records
+#: what WAS true at a point in time, and rewriting history to satisfy a linter
+#: would make it useless.
+def _shipped_docs() -> list[Path]:
+    paths = sorted(ROOT.glob("*.md")) + sorted((ROOT / "docs").rglob("*.md"))
+    return [p for p in paths if p.name != "CHANGELOG.md" and "changelog" not in p.name.lower()]
+
+
+#: A ports entry with NO bind address in front of it. Docker reads that as
+#: 0.0.0.0, so it is the difference between "reachable from this machine" and
+#: "reachable from the whole network".
+_UNBOUND_WORKER_PORT = re.compile(r'^\s*-\s*"?8081:8081"?\s*$', re.MULTILINE)
+_LATEST_IMAGE = re.compile(r"image:\s*drumsergio/\S+:latest")
+
+
+@pytest.mark.parametrize("path", _shipped_docs(), ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_doc_tells_the_user_to_publish_the_worker_api(path):
+    """The worker API is root on that host. A doc that publishes it on 0.0.0.0
+    is worse than no doc at all, because the reader trusts it."""
+    text = path.read_text(encoding="utf-8")
+    found = _UNBOUND_WORKER_PORT.findall(text)
+    assert not found, (
+        f"{path.relative_to(ROOT)} publishes the worker API on every interface: {found}. "
+        'Bind it: "${CASHPILOT_WORKER_BIND_ADDR:-127.0.0.1}:8081:8081"'
+    )
+
+
+@pytest.mark.parametrize("path", _shipped_docs(), ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_doc_pins_latest_for_a_cashpilot_image(path):
+    text = path.read_text(encoding="utf-8")
+    found = _LATEST_IMAGE.findall(text)
+    assert not found, (
+        f"{path.relative_to(ROOT)} pins :latest ({found}), which SECURITY.md says makes what you "
+        "are running unknowable. Pin the major.minor series like the shipped compose files."
+    )
+
+
+class TestTheseChecksCanActuallyFail:
+    """CONTROLS. Both patterns above must match the real defect, or the sweep is
+    decoration -- and a decorative security check is worse than none, because it
+    is cited as evidence."""
+
+    def test_the_port_pattern_matches_a_bare_publish(self):
+        assert _UNBOUND_WORKER_PORT.search('    ports:\n      - "8081:8081"\n')
+        assert _UNBOUND_WORKER_PORT.search("    ports:\n      - 8081:8081\n")
+
+    def test_the_port_pattern_accepts_an_address_scoped_publish(self):
+        assert not _UNBOUND_WORKER_PORT.search('      - "${CASHPILOT_WORKER_BIND_ADDR:-127.0.0.1}:8081:8081"\n')
+        assert not _UNBOUND_WORKER_PORT.search('      - "127.0.0.1:8081:8081"\n')
+
+    def test_the_port_pattern_ignores_prose_mentioning_the_port(self):
+        """A table row or sentence naming 8081 is not a publish instruction."""
+        assert not _UNBOUND_WORKER_PORT.search("| cashpilot-worker | 8081 | Docker agent |\n")
+        assert not _UNBOUND_WORKER_PORT.search("reach it at http://server-b:8081\n")
+
+    def test_the_latest_pattern_matches_a_real_image_line(self):
+        assert _LATEST_IMAGE.search("    image: drumsergio/cashpilot-worker:latest\n")
+
+    def test_the_latest_pattern_ignores_prose_about_latest(self):
+        """SECURITY.md discusses `:latest` in order to warn about it. Flagging
+        that would force the docs to stop naming the thing they warn about."""
+        assert not _LATEST_IMAGE.search("`:latest` is published but deliberately not used\n")
+
+    def test_the_latest_pattern_accepts_a_pinned_image(self):
+        assert not _LATEST_IMAGE.search("    image: drumsergio/cashpilot-worker:1.19\n")


### PR DESCRIPTION
Found while checking `9fg`'s "do any docs carry stale pins?" question. **The pin was the small half.**

## The defect

README's *"Adding remote workers"* snippet told the reader to run:

```yaml
    image: drumsergio/cashpilot-worker:latest
    ports:
      - "8081:8081"
```

Docker reads a bare `"8081:8081"` as **0.0.0.0**. The worker's API is backed by the Docker socket — deploy, stop or remove **any** container — so anyone following the README to add a remote worker **exposed full control of that host to their entire network**.

The shipped `docker-compose.fleet.yml` has bound it to `${CASHPILOT_WORKER_BIND_ADDR:-127.0.0.1}:8081:8081` all along, with a comment saying it must never be published.

## This was fixed once already, in the wrong place

`docs/getting-started.md` had the **identical** defect, was corrected, and is guarded by two tests:

- `test_the_page_no_longer_publishes_the_worker_port`
- `test_the_page_no_longer_pins_latest`

Both read `GETTING_STARTED` **by name**. So the file most people read *first* was never covered, and kept the defect.

**Naming one page was the bug.** The checks now sweep every shipped doc — and found a third instance immediately: `docs/fleet.md` was still pinning `:latest`.

## Also

Pins corrected to the `1.19` series, matching the shipped compose files and SECURITY.md, which says `:latest` *"makes what you are running unknowable and can carry a breaking change into a routine pull"*.

`CHANGELOG` is excluded from the sweep on purpose: it records what *was* true, and rewriting history to satisfy a linter would make it useless.

## Controls

Six of them, because **a decorative security check is worse than none** — it gets cited as evidence. They prove the port pattern matches a bare publish, *accepts* an address-scoped one, and ignores prose naming the port; and that the `:latest` pattern matches a real `image:` line while ignoring SECURITY.md discussing `:latest` in order to warn about it.

**Mutation-tested:** reintroducing the bare publish in README fails the sweep.

4347 passed, coverage 95.57%, `mkdocs --strict` builds, ruff clean.

## Filed separately, not bundled

`unraid/cashpilot.xml` and `unraid/cashpilot-worker.xml` both declare `<Repository>...:latest</Repository>`. That may well be defensible — Community Applications is how unraid users receive updates at all — but it contradicts the same rule and deserves its own decision rather than being swept in here.