### PR TITLE
docs: correct a fabricated bead reference

### DIFF
--- a/tests/test_docs_do_not_contradict_the_shipped_files.py
+++ b/tests/test_docs_do_not_contradict_the_shipped_files.py
@@ -116,7 +116,7 @@ class TestTheAdvertiseOnlyPortIsDescribedCorrectlyEverywhere:
 
 
 # ---------------------------------------------------------------------------
-# CashPilot-o6mu: the same defect survived in README.md, which is the file most
+# CashPilot-wqkd: the same defect survived in README.md, which is the file most
 # people read FIRST.
 #
 # The two checks above were written against GETTING_STARTED by name. So when


### PR DESCRIPTION
The comment introduced in #280 cites `CashPilot-o6mu`, which does not exist — I wrote the ID from memory instead of reading it back. The bead is **`CashPilot-wqkd`**.

A wrong ID is worse than no ID: it sends the next reader looking for a record that was never there, and it looks authoritative while doing it.