### PR TITLE
docs(unraid): say why the CA templates use :latest on purpose

### DIFF
--- a/tests/test_unraid_latest_is_deliberate.py
+++ b/tests/test_unraid_latest_is_deliberate.py
@@ -1,0 +1,57 @@
+"""The unraid templates use :latest ON PURPOSE, and that has to be legible.
+
+Everywhere else this project pins a major.minor series, and #280 added a sweep
+that fails any doc shipping `image: drumsergio/...:latest`. The unraid
+Community Applications templates are the one deliberate exception.
+
+THE REASONING, so this test is not just a lock on an arbitrary state:
+CA is how unraid users receive updates at all. A template pinned to 1.19 leaves
+every CA user on 1.19 until the template itself is re-published -- trading
+"unknowable version" for "silently frozen version", which is worse for an app
+whose whole job is to keep earning.
+
+Decided 2026-08-07 (CashPilot-3c2n). These assertions exist so that a later
+reader tidying `:latest` out of the repository finds a failing test explaining
+why, rather than quietly changing how every unraid user gets updates.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES = sorted((ROOT / "unraid").glob("*.xml"))
+
+
+def test_there_are_templates_to_check():
+    """CONTROL. If the directory were empty or renamed, every assertion below
+    would hold vacuously."""
+    assert TEMPLATES, "no unraid templates found; the checks below prove nothing"
+
+
+@pytest.mark.parametrize("path", TEMPLATES, ids=lambda p: p.name)
+def test_the_template_is_valid_xml(path):
+    """A malformed template is rejected by CA with no useful message."""
+    ET.parse(path)
+
+
+@pytest.mark.parametrize("path", TEMPLATES, ids=lambda p: p.name)
+def test_it_uses_latest(path):
+    repo = ET.parse(path).getroot().findtext("Repository") or ""
+    assert repo.endswith(":latest"), (
+        f"{path.name} no longer uses :latest. That may be right, but it changes how every "
+        "unraid user receives updates -- a pinned template freezes them until it is "
+        "re-published. Read CashPilot-3c2n before changing this."
+    )
+
+
+@pytest.mark.parametrize("path", TEMPLATES, ids=lambda p: p.name)
+def test_it_explains_why(path):
+    """The tag alone looks like an oversight. Without the comment beside it,
+    the next person to tidy the repository removes it in good faith."""
+    text = path.read_text(encoding="utf-8")
+    assert "DELIBERATE" in text, f"{path.name} uses :latest with no explanation next to it"
+    assert "CashPilot-3c2n" in text, f"{path.name} does not point at the decision record"

--- a/unraid/cashpilot-worker.xml
+++ b/unraid/cashpilot-worker.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>cashpilot-worker</Name>
+  <!-- :latest is DELIBERATE here, and only here.
+       Everywhere else in this project pins a major.minor series, because
+       SECURITY.md is right that a floating tag makes what you are running
+       unknowable. Community Applications is the exception: CA is how unraid
+       users receive updates at all, and a template pinned to 1.19 leaves every
+       CA user on 1.19 until the template itself is re-published. That trades
+       "unknowable version" for "silently frozen version", which is worse for
+       an app whose whole job is to keep earning.
+       Decided 2026-08-07. Do not "fix" this to a pinned tag without changing
+       how CA users are meant to upgrade. See CashPilot-3c2n. -->
   <Repository>drumsergio/cashpilot-worker:latest</Repository>
   <Registry>https://hub.docker.com/r/drumsergio/cashpilot-worker</Registry>
   <Network>bridge</Network>

--- a/unraid/cashpilot.xml
+++ b/unraid/cashpilot.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>cashpilot</Name>
+  <!-- :latest is DELIBERATE here, and only here.
+       Everywhere else in this project pins a major.minor series, because
+       SECURITY.md is right that a floating tag makes what you are running
+       unknowable. Community Applications is the exception: CA is how unraid
+       users receive updates at all, and a template pinned to 1.19 leaves every
+       CA user on 1.19 until the template itself is re-published. That trades
+       "unknowable version" for "silently frozen version", which is worse for
+       an app whose whole job is to keep earning.
+       Decided 2026-08-07. Do not "fix" this to a pinned tag without changing
+       how CA users are meant to upgrade. See CashPilot-3c2n. -->
   <Repository>drumsergio/cashpilot:latest</Repository>
   <Registry>https://hub.docker.com/r/drumsergio/cashpilot</Registry>
   <Network>bridge</Network>


### PR DESCRIPTION
Closes **CashPilot-3c2n**. You chose to keep `:latest`, so the work is making that choice *legible* rather than changing it.

## The reasoning, recorded beside the tag

Community Applications is how unraid users receive updates **at all**. A template pinned to `1.19` leaves every CA user on 1.19 until the template itself is re-published — trading *"unknowable version"* for *"silently frozen version"*, which is worse for an app whose whole job is to keep earning.

Everywhere else still pins `major.minor`, and #280's sweep still fails any **doc** shipping `:latest`. This is the one deliberate exception.

## Why a test, not just a comment

The tag alone reads as an oversight. Without the explanation beside it, the next person tidying `:latest` out of the repository removes it in good faith — and quietly changes how every unraid user upgrades.

So the test asserts both that the templates **use** `:latest` **and** that they **explain why** and point at the decision record.

**Controlled:** pinning one template to `1.19` fails with a message explaining what that would do. Also asserts the templates parse as XML (a malformed one is rejected by CA with no useful message) and that there *are* templates to check — otherwise every assertion holds vacuously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanations to Unraid templates documenting the deliberate use of the floating `:latest` image tag, including update behavior and security considerations.

* **Tests**
  * Added validation to ensure Unraid templates exist, contain valid XML, use `:latest`, and include the required decision rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->