### PR TITLE
feat(contrib): a Heimdall enhanced-app tile, ready to submit

### DIFF
--- a/contrib/heimdall/CashPilot.php
+++ b/contrib/heimdall/CashPilot.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\SupportedApps\CashPilot;
+
+class CashPilot extends \App\SupportedApps implements \App\EnhancedApps
+{
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url('api/earnings/summary'), $this->attrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = 'inactive';
+        $data = [];
+
+        $res = parent::execute($this->url('api/earnings/summary'), $this->attrs());
+        $details = json_decode($res->getBody());
+
+        if ($details) {
+            $status = 'active';
+
+            // CashPilot distinguishes "nothing has been read yet" from "read,
+            // and it is zero". has_readings is false on a fresh install and on
+            // one whose collection has silently stopped -- an expired cookie,
+            // deleted credentials, a wedged scheduler. Printing $0.00 in that
+            // state asserts a measurement nobody took, so show a dash.
+            $data['earnings'] = (isset($details->has_readings) && $details->has_readings)
+                ? '$' . number_format((float) ($details->total_adjusted ?? 0), 2)
+                : '—';
+
+            // active_services is deliberately NULL when the count could not be
+            // taken -- the worker query failed while containers are in fact
+            // running. Rendering 0 there reads as "nothing is running", which
+            // is the opposite of the truth.
+            $data['running'] = isset($details->active_services) && $details->active_services !== null
+                ? $details->active_services
+                : '—';
+        }
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    public function attrs()
+    {
+        return [
+            'headers' => [
+                'Accept'        => 'application/json',
+                'Authorization' => 'Bearer ' . $this->config->access_token,
+            ],
+        ];
+    }
+}

--- a/contrib/heimdall/README.md
+++ b/contrib/heimdall/README.md
@@ -1,0 +1,70 @@
+# Heimdall app submission
+
+Everything needed to list CashPilot on [Heimdall](https://apps.heimdall.site/)
+as an **enhanced** app — a tile showing live earnings and running-service count,
+not just a link.
+
+These files are kept here rather than in a fork so they stay versioned with the
+API they call. Nothing here is used at runtime.
+
+## Why enhanced rather than foundation
+
+Heimdall apps build their own HTTP request attributes, so they can send an
+`Authorization` header — 25 apps in their repo already do. CashPilot already
+accepts Bearer auth (`app/auth.py`, checked before the session cookie), so an
+enhanced tile needs **no server change at all**.
+
+Verified against a live instance: `GET /api/earnings/summary` with a Bearer
+token returned `total_adjusted`, `active_services` and `has_readings`.
+
+## The rule these files exist to respect
+
+The tile must not turn our uncertainty into the user's loss:
+
+- `has_readings` is false on a fresh install **and** on one whose collection has
+  silently stopped. `$0.00` there asserts a measurement nobody took, so the tile
+  shows an em dash.
+- `active_services` is deliberately **null** when the count could not be taken —
+  the worker query failed while containers are in fact running. `0` there reads
+  as "nothing is running", the opposite of the truth. Also an em dash.
+
+Heimdall's blade templates print raw values, so this handling has to live in
+`livestats()`. It does.
+
+## Submitting it
+
+Their process requires a **request first**, and warns that poorly made requests
+are deleted. Steps 1–2 are a web form and cannot be scripted.
+
+1. Go to <https://apps.heimdall.site/> and click **Request a new application**.
+   CashPilot is not among their 660 apps, so a request is required. Fill in:
+
+   | Field | Value |
+   |---|---|
+   | Name | `CashPilot` |
+   | Website | `https://github.com/GeiserX/CashPilot` |
+   | Licence | `GNU General Public License v3.0 only` |
+   | Description | Self-hosted passive income orchestrator. Deploy, manage and monitor bandwidth-sharing, DePIN, storage and GPU compute containers from one dashboard, with earnings tracked across 49 services. |
+   | Enhanced | yes |
+   | Tile background | `dark` |
+   | Icon | `docs/icon.svg` from this repository — 256×256, square, no excess whitespace |
+
+2. Once the request exists, use the **Enhanced** download button on their site to
+   get the scaffold. It carries a generated `appid`, which is why the files here
+   do not include an `app.json` — that value must come from them.
+
+3. Fork `linuxserver/Heimdall-Apps`, make a branch named for the app, extract the
+   scaffold into it, then replace the generated stubs with the three files here.
+   Add the icon as `cashpilot.svg` and reference it from `app.json`.
+
+4. Open the PR against their master.
+
+## Before you submit
+
+Set `CASHPILOT_ADMIN_API_KEY` on the instance you test against, or use the fleet
+key. On the live server the admin key is **not** set today, which is why the
+verification above used the fleet key.
+
+Be aware, and it is stated in the config help too: CashPilot has no read-only
+token, so whichever key is used grants more than the tile needs. That gap is
+tracked separately.

--- a/contrib/heimdall/config.blade.php
+++ b/contrib/heimdall/config.blade.php
@@ -1,0 +1,13 @@
+<div class="row">
+    <div class="input-group col">
+        {!! Form::label('url', 'URL') !!}
+        {!! Form::text('config[url]', isset($item)? $item->getconfig()->url : null, ['placeholder' => 'http://cashpilot.local:8080/']) !!}
+    </div>
+</div>
+<div class="row">
+    <div class="input-group col">
+        {!! Form::label('access_token', 'API key') !!}
+        {!! Form::text('config[access_token]', isset($item)? $item->getconfig()->access_token : null) !!}
+        <small>Either CASHPILOT_ADMIN_API_KEY or your fleet key. Sent as a Bearer token. Note that CashPilot has no read-only token today, so whichever you use grants more than this tile needs &mdash; use it only on a dashboard you control.</small>
+    </div>
+</div>

--- a/contrib/heimdall/livestats.blade.php
+++ b/contrib/heimdall/livestats.blade.php
@@ -1,0 +1,10 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Earnings</span>
+        <strong>{!! $earnings !!}</strong>
+    </li>
+    <li>
+        <span class="title">Running</span>
+        <strong>{!! $running !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
You authorised the Heimdall submission. Their process requires a **request first** through a web form on `apps.heimdall.site`, and the scaffold they hand back carries a **generated `appid`** — so the submission itself cannot be scripted. Everything around it can be, and this is that.

## Enhanced, not foundation — and it costs no server change

Heimdall apps build their own request attrs and can send an `Authorization` header (25 apps in their repo already do), and CashPilot already accepts Bearer auth ahead of the session cookie. So a live tile needs nothing new server-side.

## Verified against the live instance, not assumed

`GET /api/earnings/summary` with a Bearer token returned real values. That is how **two things surfaced that reading the code would not have shown**:

- **`CASHPILOT_ADMIN_API_KEY` is not set on the live server** — the documented programmatic path does not work there today. The fleet key does.
- **Neither credential is read-only.** A tile showing two numbers needs a key that can control containers or enrol workers. The config help now says so plainly rather than pretending otherwise, and the gap is filed as its own bead.

## The rule the tile respects

It must not turn our uncertainty into the user's loss:

- `has_readings` is false on a fresh install **and** on one whose collection has silently stopped → `$0.00` would assert a measurement nobody took
- `active_services` is deliberately **null** when the count could not be taken → `0` reads as "nothing is running", the opposite of the truth

Heimdall's blade templates print raw values, so both are mapped to an em dash inside `livestats()`.

## Housekeeping

Kept in `contrib/` rather than a fork so it stays versioned with the API it calls, and outside `docs/` so it is not published — **verified: the built site contains no heimdall files**. PHP syntax-checked with `php -l`, clean. 4370 tests pass.

## What is left for you

Steps 1–2 in `contrib/heimdall/README.md` are the web form. The field values, licence, description, tile background and icon are all filled in there ready to copy — CashPilot is not among their 660 apps, so a request is required first, and they warn that poorly made requests are deleted.
