### PR TITLE
feat: a read-only API token, so a dashboard need not hold the keys

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -159,6 +159,16 @@ def get_current_user(request: Request) -> dict[str, Any] | None:
     # Check Bearer token — admin key gets owner, fleet key gets fleet (limited)
     auth_header = request.headers.get("Authorization", "")
     if auth_header:
+        # Checked FIRST, before the admin key, deliberately. If an operator sets
+        # both variables to the same value that is a misconfiguration either way,
+        # and the two possible resolutions are not equally bad: resolving it to
+        # "owner" would silently hand full container control to whatever they
+        # pasted into a dashboard widget. Resolving it to "reader" merely stops
+        # the admin path working, which is loud and harmless. Fail toward less
+        # privilege.
+        readonly_key = os.getenv("CASHPILOT_READONLY_API_KEY", "")
+        if readonly_key and hmac.compare_digest(auth_header.encode(), f"Bearer {readonly_key}".encode()):
+            return {"uid": 0, "u": "readonly", "r": "reader"}
         admin_key = os.getenv("CASHPILOT_ADMIN_API_KEY", "")
         if admin_key and hmac.compare_digest(auth_header.encode(), f"Bearer {admin_key}".encode()):
             return {"uid": 0, "u": "api", "r": "owner"}

--- a/app/deps.py
+++ b/app/deps.py
@@ -24,6 +24,7 @@ __all__ = [
     "templates",
     "_login_redirect",
     "_require_auth_api",
+    "_require_reader",
     "_require_writer",
     "_require_owner",
     "_require_private_network",
@@ -63,7 +64,33 @@ def _login_redirect() -> RedirectResponse:
 
 
 def _require_auth_api(request: Request) -> dict[str, Any]:
-    """Return user dict or raise 401 for API routes."""
+    """Return user dict or raise 401 for API routes.
+
+    The read-only role is REFUSED here, and that refusal is the whole security
+    model. An allowlist fails silently and in the direction of passing, so the
+    reader must not be granted by the guard that ~40 endpoints already share --
+    it has to be opted into, one endpoint at a time, via _require_reader below.
+
+    The practical consequence is the one that matters: an endpoint added next
+    year, by someone who has never read this file, denies the read-only token by
+    default. Forgetting to think about it produces a 403, not a leak.
+    """
+    user = auth.get_current_user(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user.get("r") == "reader":
+        raise HTTPException(status_code=403, detail="Read-only token")
+    return user
+
+
+def _require_reader(request: Request) -> dict[str, Any]:
+    """Allow the read-only token, plus every role that already outranks it.
+
+    Use ONLY on GET endpoints that report state and expose no credential. A
+    dashboard tile, a Grafana panel or the Home Assistant sensors need exactly
+    this and nothing more; today they can only be wired up with a credential
+    that also deploys containers or enrols workers.
+    """
     user = auth.get_current_user(request)
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/app/main.py
+++ b/app/main.py
@@ -1067,6 +1067,7 @@ from app.deps import (  # noqa: E402
     _require_first_run_access,  # noqa: F401  (re-exported for app.main.* router surface)
     _require_owner,
     _require_private_network,  # noqa: F401  (re-exported for app.main.* router surface)
+    _require_reader,
     _require_writer,
     client_ip,  # noqa: F401  (re-exported for app.main.* router surface)
     templates,  # noqa: F401  (re-exported for app.main.* router/test surface)
@@ -1171,7 +1172,7 @@ async def api_services_deployed(request: Request) -> list[dict[str, Any]]:
     single row with summed CPU/memory, an instance count, and per-instance
     details for the expandable sub-row UI.
     """
-    _require_auth_api(request)
+    _require_reader(request)
     statuses: list[dict[str, Any]] = await _get_all_worker_containers()
 
     # Get latest earnings per platform for balance display
@@ -2047,7 +2048,7 @@ async def api_earnings(request: Request) -> list[dict[str, Any]]:
 @app.get("/api/earnings/summary")
 async def api_earnings_summary(request: Request) -> dict[str, Any]:
     """Aggregated earnings stats for the dashboard."""
-    _require_auth_api(request)
+    _require_reader(request)
     summary = await database.get_earnings_dashboard_summary()
 
     # Load config for signup bonus offsets
@@ -2146,7 +2147,7 @@ async def api_earnings_daily(request: Request, days: int = 7) -> list[dict[str, 
 @app.get("/api/earnings/breakdown")
 async def api_earnings_breakdown(request: Request) -> list[dict[str, Any]]:
     """Per-service earnings breakdown with cashout eligibility."""
-    _require_auth_api(request)
+    _require_reader(request)
     rows = await database.get_earnings_per_service()
 
     # Load config for per-service signup bonus offsets
@@ -2237,7 +2238,7 @@ async def api_earnings_history(request: Request, period: str = "week") -> list[d
 @app.get("/api/health/scores")
 async def api_health_scores(request: Request, days: int = 7) -> list[dict[str, Any]]:
     """Health scores for all services."""
-    _require_auth_api(request)
+    _require_reader(request)
     if days < 1 or days > 90:
         raise HTTPException(status_code=400, detail="days must be between 1 and 90")
     scores = await database.get_health_scores(days)
@@ -4184,7 +4185,7 @@ async def api_worker_command(request: Request, worker_id: int, body: WorkerComma
 @app.get("/api/fleet/summary")
 async def api_fleet_summary(request: Request) -> dict[str, Any]:
     """Aggregate fleet stats across local + all workers."""
-    _require_auth_api(request)
+    _require_reader(request)
 
     workers = await database.list_workers()
     total_services = 0

--- a/contrib/heimdall/config.blade.php
+++ b/contrib/heimdall/config.blade.php
@@ -8,6 +8,6 @@
     <div class="input-group col">
         {!! Form::label('access_token', 'API key') !!}
         {!! Form::text('config[access_token]', isset($item)? $item->getconfig()->access_token : null) !!}
-        <small>Either CASHPILOT_ADMIN_API_KEY or your fleet key. Sent as a Bearer token. Note that CashPilot has no read-only token today, so whichever you use grants more than this tile needs &mdash; use it only on a dashboard you control.</small>
+        <small>Use <strong>CASHPILOT_READONLY_API_KEY</strong> &mdash; it is scoped to reporting endpoints and cannot deploy, stop or remove anything. Sent as a Bearer token. The admin or fleet key also works, but both grant far more than this tile needs.</small>
     </div>
 </div>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ defensible on its own; together they are impossible to guess.
 | `CASHPILOT_ALLOW_EPHEMERAL_KEY` | `false` | Allow starting when the encryption key cannot be persisted. | — |
 | `CASHPILOT_API_KEY` | from `/fleet` | Shared **enrolment** key. Not an ongoing credential — see [Fleet](fleet.md). | Env, else `/fleet/.fleet_key`, else generated there. |
 | `CASHPILOT_ADMIN_API_KEY` | unset | Bearer token for API access without a session. Grants **owner**: it can deploy, stop and remove containers and read stored credentials. | — |
-| `CASHPILOT_READONLY_API_KEY` | unset | Bearer token for **reporting only**. Accepted on a small allowlist of GET endpoints (earnings summary and breakdown, fleet summary, health scores, deployed services) and refused everywhere else, including on endpoints added in future. Use this for a dashboard tile, a Grafana panel or Home Assistant sensors rather than handing them a key that controls containers. | — |
+| `CASHPILOT_READONLY_API_KEY` | unset | Bearer token for **reporting only**. Accepted on a small allowlist of GET endpoints (earnings summary and breakdown, fleet summary, health scores, deployed services) and refused everywhere else, including on endpoints added in the future. Use this for a dashboard tile, a Grafana panel or Home Assistant sensors rather than handing them a key that controls containers. | — |
 | `CASHPILOT_DATA_DIR` | `/data` | Where the database and keys live. | — |
 | `CASHPILOT_FLEET_DIR` | `/fleet` | Where the shared enrolment key lives. | — |
 | `CASHPILOT_BASE_URL` | unset | Absolute base URL, for links in notifications. | — |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,8 @@ defensible on its own; together they are impossible to guess.
 | `CASHPILOT_ENCRYPTION_KEY` | generated | Fernet key for credentials at rest. | **File wins.** An existing `/data/.fernet_key` beats this; the env key is adopted only when no file exists. |
 | `CASHPILOT_ALLOW_EPHEMERAL_KEY` | `false` | Allow starting when the encryption key cannot be persisted. | — |
 | `CASHPILOT_API_KEY` | from `/fleet` | Shared **enrolment** key. Not an ongoing credential — see [Fleet](fleet.md). | Env, else `/fleet/.fleet_key`, else generated there. |
-| `CASHPILOT_ADMIN_API_KEY` | unset | Bearer token for API access without a session. | — |
+| `CASHPILOT_ADMIN_API_KEY` | unset | Bearer token for API access without a session. Grants **owner**: it can deploy, stop and remove containers and read stored credentials. | — |
+| `CASHPILOT_READONLY_API_KEY` | unset | Bearer token for **reporting only**. Accepted on a small allowlist of GET endpoints (earnings summary and breakdown, fleet summary, health scores, deployed services) and refused everywhere else, including on endpoints added in future. Use this for a dashboard tile, a Grafana panel or Home Assistant sensors rather than handing them a key that controls containers. | — |
 | `CASHPILOT_DATA_DIR` | `/data` | Where the database and keys live. | — |
 | `CASHPILOT_FLEET_DIR` | `/fleet` | Where the shared enrolment key lives. | — |
 | `CASHPILOT_BASE_URL` | unset | Absolute base URL, for links in notifications. | — |

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -224,6 +224,7 @@ If a worker goes offline (no heartbeat for 180 seconds):
 | `CASHPILOT_SECRET_KEY` | *(auto-generated)* | Signing key for login sessions. Persisted at `/data/.secret_key`. **Does not encrypt credentials** |
 | `CASHPILOT_ENCRYPTION_KEY` | *(auto-generated)* | Fernet key encrypting stored credentials at rest. Persisted at `/data/.fernet_key`; adopted only when that file is absent |
 | `CASHPILOT_ADMIN_API_KEY` | -- | Optional separate key granting full owner access (for integrations) |
+| `CASHPILOT_READONLY_API_KEY` | -- | Optional read-only key for dashboards. Reporting GETs only; refused everywhere else |
 | `CASHPILOT_WORKER_URL_POLICY` | `permissive` | Worker URL validation policy: `permissive` (LAN + Tailscale work out of the box) or `strict` (allowlist only) |
 | `CASHPILOT_WORKER_ALLOWED_HOSTS` | -- | Comma-separated CIDRs and `*.suffix` hostnames allowed in `strict` mode, e.g. `192.168.10.0/24,100.64.0.0/10,*.ts.net` |
 | `CASHPILOT_WORKER_ALLOW_METADATA` | `false` | Escape hatch to permit cloud-metadata IPs as worker targets (leave `false`) |

--- a/tests/test_beads_batch_19.py
+++ b/tests/test_beads_batch_19.py
@@ -39,6 +39,7 @@ async def _summary(earnings_rows):
 
     with (
         patch.object(main, "_require_auth_api", lambda r: None),
+        patch.object(main, "_require_reader", lambda r: None),
         patch.object(
             main.database,
             "get_earnings_dashboard_summary",

--- a/tests/test_beads_batch_28.py
+++ b/tests/test_beads_batch_28.py
@@ -91,6 +91,7 @@ class TestTheEndpointReportsIt:
 
         with (
             patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_require_reader", lambda r: None),
             patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=containers)),
             patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
             patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),

--- a/tests/test_beads_batch_4.py
+++ b/tests/test_beads_batch_4.py
@@ -49,6 +49,7 @@ class TestTheTotalUsesTheRateTheReadingWasRecordedAt:
 
         with (
             patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_require_reader", lambda r: None),
             patch.object(
                 database,
                 "get_earnings_dashboard_summary",

--- a/tests/test_beads_batch_40.py
+++ b/tests/test_beads_batch_40.py
@@ -79,6 +79,7 @@ class TestTheAggregateDoesNotCountUnknownAsZero:
 
         with (
             patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_require_reader", lambda r: None),
             patch.object(main, "_get_all_worker_containers", AsyncMock(return_value=instances)),
             patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
             patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),

--- a/tests/test_beads_batch_41.py
+++ b/tests/test_beads_batch_41.py
@@ -42,6 +42,7 @@ async def _summary(*, worker_read_fails):
     )
     with (
         patch.object(main, "_require_auth_api", lambda r: None),
+        patch.object(main, "_require_reader", lambda r: None),
         patch.object(main.database, "get_earnings_dashboard_summary", AsyncMock(return_value={"total": 0})),
         patch.object(main.database, "get_config", AsyncMock(return_value={})),
         patch.object(main.database, "get_earnings_summary", AsyncMock(return_value=[])),
@@ -82,6 +83,7 @@ class TestTheBellDoesNotClaimUncheckedHealth:
 
         with (
             patch.object(main, "_require_auth_api", lambda r: None),
+            patch.object(main, "_require_reader", lambda r: None),
             patch.object(main, "_collector_alerts", alerts),
             patch.object(main, "_collection_has_run", has_run),
         ):

--- a/tests/test_readonly_token.py
+++ b/tests/test_readonly_token.py
@@ -1,0 +1,185 @@
+"""The read-only API token, and the refusal that makes it safe. CashPilot-c99d.
+
+A dashboard tile needs to read two numbers. Before this token the only ways to
+authenticate that were the admin key (which deploys, stops and removes
+containers, and reads stored credentials) or the fleet key (which enrols
+workers). Neither is close to least privilege for showing a balance.
+
+The token itself is the easy half. The half that has to be tested is the
+REFUSAL: an allowlist fails silently, and it fails in the direction of passing.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+from app import auth, deps  # noqa: E402
+
+READONLY = "readonly-secret"
+
+# The endpoints a reporting integration is allowed to reach. Deliberately small:
+# widening it later is easy, narrowing it is a breaking change for whoever wired
+# a dashboard against it.
+ALLOWLIST = {
+    "/api/earnings/summary",
+    "/api/earnings/breakdown",
+    "/api/fleet/summary",
+    "/api/health/scores",
+    "/api/services/deployed",
+}
+
+
+def _request(headers=None, cookies=None):
+    req = MagicMock()
+    req.headers = headers or {}
+    req.cookies = cookies or {}
+    return req
+
+
+class TestTokenRecognition:
+    def test_readonly_key_returns_reader_role(self):
+        with patch.dict(os.environ, {"CASHPILOT_READONLY_API_KEY": READONLY}):
+            user = auth.get_current_user(_request({"Authorization": f"Bearer {READONLY}"}))
+            assert user is not None
+            assert user["r"] == "reader"
+
+    def test_unset_readonly_key_grants_nothing(self):
+        """An empty env var must not make an empty/absent Bearer authenticate."""
+        with patch.dict(os.environ, {"CASHPILOT_READONLY_API_KEY": ""}):
+            assert auth.get_current_user(_request({"Authorization": "Bearer "})) is None
+            assert auth.get_current_user(_request({"Authorization": "Bearer "})) is None
+
+    def test_ambiguous_config_resolves_to_LESS_privilege(self):
+        """Both variables set to one value is a misconfiguration either way.
+
+        The two resolutions are not equally bad. Resolving to owner would hand
+        full container control to whatever the operator pasted into a dashboard
+        widget; resolving to reader merely stops the admin path working, which
+        is loud and harmless.
+        """
+        both = "same-value-by-mistake"
+        with patch.dict(
+            os.environ,
+            {"CASHPILOT_READONLY_API_KEY": both, "CASHPILOT_ADMIN_API_KEY": both},
+        ):
+            user = auth.get_current_user(_request({"Authorization": f"Bearer {both}"}))
+            assert user is not None
+            assert user["r"] == "reader", "ambiguity must resolve DOWN, never up to owner"
+
+    def test_admin_key_still_returns_owner_when_distinct(self):
+        with patch.dict(
+            os.environ,
+            {"CASHPILOT_READONLY_API_KEY": READONLY, "CASHPILOT_ADMIN_API_KEY": "admin-secret"},
+        ):
+            user = auth.get_current_user(_request({"Authorization": "Bearer admin-secret"}))
+            assert user is not None and user["r"] == "owner"
+
+
+class TestGuards:
+    """_require_auth_api must REFUSE the reader. That refusal is the model."""
+
+    def test_shared_guard_refuses_reader(self):
+        with patch.object(auth, "get_current_user", return_value={"uid": 0, "u": "readonly", "r": "reader"}):
+            with pytest.raises(HTTPException) as exc:
+                deps._require_auth_api(_request())
+            assert exc.value.status_code == 403
+
+    def test_reader_guard_accepts_reader(self):
+        with patch.object(auth, "get_current_user", return_value={"uid": 0, "u": "readonly", "r": "reader"}):
+            assert deps._require_reader(_request())["r"] == "reader"
+
+    @pytest.mark.parametrize("role", ["owner", "writer", "fleet"])
+    def test_reader_guard_still_accepts_higher_roles(self, role):
+        """Opting an endpoint in must not lock out the roles that already had it."""
+        with patch.object(auth, "get_current_user", return_value={"uid": 1, "u": "x", "r": role}):
+            assert deps._require_reader(_request())["r"] == role
+
+    def test_both_guards_still_401_when_unauthenticated(self):
+        with patch.object(auth, "get_current_user", return_value=None):
+            for guard in (deps._require_auth_api, deps._require_reader):
+                with pytest.raises(HTTPException) as exc:
+                    guard(_request())
+                assert exc.value.status_code == 401
+
+    def test_writer_and_owner_reject_reader(self):
+        """They delegate to _require_auth_api, so the refusal must reach them too."""
+        with patch.object(auth, "get_current_user", return_value={"uid": 0, "u": "readonly", "r": "reader"}):
+            for guard in (deps._require_writer, deps._require_owner):
+                with pytest.raises(HTTPException) as exc:
+                    guard(_request())
+                assert exc.value.status_code == 403
+
+
+class TestFailsClosed:
+    """The test that has to survive people who never read this file.
+
+    Walks the app's own route table rather than any hand-kept list, so an
+    endpoint added later is covered the day it is added. If someone opts a new
+    endpoint into the reader without widening ALLOWLIST here, this fails.
+    """
+
+    def _api_get_routes(self):
+        from app.main import app as fastapi_app
+
+        routes = []
+        for route in fastapi_app.routes:
+            path = getattr(route, "path", "")
+            methods = getattr(route, "methods", set()) or set()
+            if not path.startswith("/api/"):
+                continue
+            if "GET" not in methods:
+                continue
+            if "{" in path:  # path params need fixtures; covered by the unit guards above
+                continue
+            routes.append(path)
+        return sorted(set(routes))
+
+    def test_allowlist_entries_all_exist(self):
+        """A typo in ALLOWLIST would silently weaken every assertion below."""
+        found = set(self._api_get_routes())
+        missing = ALLOWLIST - found
+        assert not missing, f"ALLOWLIST names routes that do not exist: {sorted(missing)}"
+
+    def test_there_are_endpoints_outside_the_allowlist(self):
+        """Negative control. If this ever passes trivially the sweep proves nothing."""
+        outside = set(self._api_get_routes()) - ALLOWLIST
+        assert len(outside) > 5, f"sweep would be vacuous, only found {sorted(outside)}"
+
+    def test_reader_is_refused_everywhere_outside_the_allowlist(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app as fastapi_app
+
+        headers = {"Authorization": f"Bearer {READONLY}"}
+        leaked = []
+        with patch.dict(os.environ, {"CASHPILOT_READONLY_API_KEY": READONLY}):
+            client = TestClient(fastapi_app, raise_server_exceptions=False)
+            for path in self._api_get_routes():
+                if path in ALLOWLIST:
+                    continue
+                resp = client.get(path, headers=headers)
+                # 403 is the intended refusal. Anything 2xx means the read-only
+                # token reached an endpoint nobody reviewed.
+                if resp.status_code < 300:
+                    leaked.append(f"{path} -> {resp.status_code}")
+        assert not leaked, "read-only token reached non-allowlisted endpoints: " + ", ".join(leaked)
+
+    def test_reader_is_accepted_on_the_allowlist(self):
+        """The mirror image: the refusal must not be so broad it blocks the point."""
+        from fastapi.testclient import TestClient
+
+        from app.main import app as fastapi_app
+
+        headers = {"Authorization": f"Bearer {READONLY}"}
+        refused = []
+        with patch.dict(os.environ, {"CASHPILOT_READONLY_API_KEY": READONLY}):
+            client = TestClient(fastapi_app, raise_server_exceptions=False)
+            for path in sorted(ALLOWLIST):
+                resp = client.get(path, headers=headers)
+                if resp.status_code in (401, 403):
+                    refused.append(f"{path} -> {resp.status_code}")
+        assert not refused, "allowlisted endpoints refused the read-only token: " + ", ".join(refused)


### PR DESCRIPTION
## Found by actually integrating something

Wiring a Heimdall tile to a live install surfaced this. To display two numbers,
a user must hand over a credential that either controls their containers or
enrols workers:

| credential | what it grants |
|---|---|
| `CASHPILOT_ADMIN_API_KEY` | **owner** — deploy, stop, remove containers; read stored credentials |
| the fleet key | the **enrolment** credential — anything holding it can enrol a worker |

Neither is close to least privilege for showing a balance. And on the reference
install the admin key **is not set**, so in practice the documented programmatic
path was the fleet key.

## The refusal is the design, not the token

Adding a `reader` role is the easy half. **An allowlist fails silently, and it
fails in the direction of passing** — so the reader is *refused* by
`_require_auth_api`, the guard ~40 endpoints already share, and must be opted
into one endpoint at a time via `_require_reader`.

The consequence worth having: **an endpoint added next year, by someone who has
never read this file, denies the read-only token by default.** Forgetting to
think about it produces a 403, not a leak.

This mirrors an existing decision in the codebase — the fleet role deliberately
does not satisfy writer, for the same reason.

## What is opted in

Chosen from what the Home Assistant integration actually reads, not invented:

`/api/earnings/summary` · `/api/earnings/breakdown` · `/api/fleet/summary` ·
`/api/health/scores` · `/api/services/deployed`

Deliberately small: widening later is easy, narrowing breaks whoever wired a
dashboard against it. Note HA also performs control actions (`collect`,
`start`/`stop`/`restart`), so it still needs a stronger credential — this covers
its read path.

## Ambiguity resolves downward

The read-only key is checked **before** the admin key, on purpose. Setting both
to one value is a misconfiguration either way, but the resolutions are not
equally bad:

- resolving to **owner** silently hands container control to whatever was pasted
  into a dashboard widget;
- resolving to **reader** merely stops the admin path working — loud, harmless.

## Tests

The sweep walks **the app's own route table**, not a hand-kept list, so an
endpoint added later is covered the day it is added:

- **28** `/api/` GET endpoints outside the allowlist must all refuse the reader —
  including `/api/config`, `/api/credentials/health`, `/api/compose`;
- the **5** inside must all accept it (a refusal so broad it blocks the point is
  also a failure);
- a **negative control** asserts the sweep is not vacuous, so it cannot quietly
  degrade into proving nothing.

Both mutations behave:

| mutation | what fails |
|---|---|
| drop the reader refusal in `_require_auth_api` | the 28-endpoint sweep |
| check the token *after* the admin key | the ambiguity test |

Five existing test files stubbed `_require_auth_api` for these handlers and now
stub both guards. I found those by enumerating every file that stubs the guard
*and* calls one of the five handlers — my first pass fixed only the files a
truncated log had shown me, and missed two.

`ruff check` + `ruff format --check` clean · `node --check` · currency and fleet
staleness checks pass · **4385 passed, coverage 95.57%** (gate 90%).

Closes CashPilot-c99d.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only API key for reporting dashboards and GET-only analytics.
  * Enabled read-only access to service, earnings, health, and fleet summary reports.
  * Preserved broader access for administrator and fleet credentials.

* **Security**
  * Read-only credentials are rejected from write, deployment, and owner-level operations.
  * Ambiguous credentials now resolve to the lower-privilege read-only role.

* **Documentation**
  * Documented read-only and administrator API key scopes and configuration options.

* **Tests**
  * Added coverage for credential recognition, access restrictions, and reporting endpoint permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->