### PR TITLE
fix(catalog): say which ProxyBase holds the wallet

### DIFF
--- a/services/bandwidth/proxybase-xyz.yml
+++ b/services/bandwidth/proxybase-xyz.yml
@@ -10,7 +10,7 @@ description: >
   both direct (own bandwidth) and upstream (resell external proxies) modes with
   auto-reconnect. Buyers purchase proxy sessions by country, ISP, and bandwidth.
   Payments flow through the Micropayments Protocol (MPP) on Tempo Chain.
-short_description: SOCKS5 proxy marketplace for AI agents - USDC payout, CLI daemon
+short_description: proxybase.xyz - SOCKS5 marketplace for AI agents, USDC payout. Generates a wallet whose volume holds the only copy of the key
 
 referral:
   signup_url: "https://proxybase.xyz?referral=nXzS3c6iTO"

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -8,7 +8,7 @@ description: >
   sharing their unused internet connection. You authenticate the peer client with an
   Access Token from your dashboard. Residential IPs earn the most, but datacenter IPs
   are also supported. Official multi-arch Docker image (amd64/arm64/armv7).
-short_description: Bandwidth sharing - crypto payout, Access Token auth
+short_description: proxybase.org - bandwidth sharing, crypto payout, Access Token auth. No wallet is generated
 
 referral:
   signup_url: "https://peer.proxybase.org?referral=nXzS3c6iTO"

--- a/tests/test_confusable_services.py
+++ b/tests/test_confusable_services.py
@@ -1,0 +1,110 @@
+"""Two services that are easy to confuse must not hide which one holds money.
+
+CashPilot-cp5g. The catalog ships "ProxyBase" and "ProxyBase Markets" as
+separate deployable services. They are genuinely different products --
+different domains, different container images, different payout models -- but
+only ONE of them generates a wallet whose volume is the sole copy of the key,
+and the catalog's own text says deleting that volume "destroys the funds with
+it".
+
+I confused the two myself while reading the code, which is what makes this
+worth a test rather than a comment: the failure mode on a wrong guess is
+permanent loss of funds, and the names differ by a single word.
+
+The invariant is deliberately general, not a proxybase special case: whenever
+one service's name is a prefix of another's, and exactly one of the pair holds
+irreplaceable state, the one that does must say so where a user choosing
+between them will read it.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+SERVICES = pathlib.Path(__file__).resolve().parent.parent / "services"
+
+
+def _load_all():
+    out = []
+    for f in sorted(SERVICES.rglob("*.yml")):
+        if f.name.startswith("_"):
+            continue
+        try:
+            d = yaml.safe_load(f.read_text())
+        except yaml.YAMLError:  # schema tests elsewhere own malformed YAML
+            continue
+        if isinstance(d, dict) and d.get("slug"):
+            out.append((f, d))
+    return out
+
+
+def _holds_irreplaceable_state(entry: dict) -> bool:
+    return bool((entry.get("docker") or {}).get("critical_volumes"))
+
+
+def _confusable_pairs():
+    """Pairs whose display names collide at a glance: one is a prefix of the other."""
+    services = _load_all()
+    pairs = []
+    for fa, a in services:
+        for fb, b in services:
+            if a["slug"] >= b["slug"]:
+                continue
+            na, nb = (a.get("name") or "").strip(), (b.get("name") or "").strip()
+            if not na or not nb:
+                continue
+            lo, hi = sorted([na, nb], key=len)
+            if hi.lower().startswith(lo.lower()):
+                pairs.append(((fa, a), (fb, b)))
+    return pairs
+
+
+def test_there_is_at_least_one_confusable_pair():
+    """Negative control.
+
+    If the catalog ever contains no confusable pair, the test below passes
+    without checking anything. That would be a real change worth noticing
+    rather than a silent pass, so it is asserted explicitly.
+    """
+    pairs = _confusable_pairs()
+    assert pairs, (
+        "no name-prefix collisions found -- either the catalog changed shape or "
+        "the detector is broken; the invariant below would be vacuous"
+    )
+
+
+@pytest.mark.parametrize(
+    "pair",
+    _confusable_pairs(),
+    ids=lambda p: f"{p[0][1]['slug']}|{p[1][1]['slug']}",
+)
+def test_confusable_pair_says_which_one_holds_money(pair):
+    (fa, a), (fb, b) = pair
+    holders = [x for x in (a, b) if _holds_irreplaceable_state(x)]
+
+    # Both or neither holding state is not the dangerous shape -- the danger is
+    # a pair where one is destructive to get wrong and the other is not.
+    if len(holders) != 1:
+        pytest.skip("pair does not mix a state-holding service with a stateless one")
+
+    holder = holders[0]
+    other = b if holder is a else a
+    desc = (holder.get("short_description") or "").lower()
+
+    assert desc, f"{holder['slug']} has no short_description to distinguish it"
+
+    # It must reference the state it holds. A user choosing between two
+    # near-identical names has nothing else to go on at that moment.
+    assert any(word in desc for word in ("wallet", "key", "seed")), (
+        f"{holder['slug']} generates irreplaceable state but its short_description "
+        f"does not mention it, while {other['slug']} has a near-identical name "
+        f"({holder.get('name')!r} vs {other.get('name')!r}). Deleting the wrong "
+        f"one destroys funds permanently."
+    )
+
+    # And the two descriptions must not themselves be interchangeable.
+    assert (holder.get("short_description") or "") != (other.get("short_description") or ""), (
+        f"{holder['slug']} and {other['slug']} share a short_description, so the "
+        f"catalog offers no way to tell them apart"
+    )


### PR DESCRIPTION
The catalog ships **two separately deployable** ProxyBase services whose names differ by one word:

| slug | name | domain | wallet? |
|---|---|---|---|
| `proxybase` | ProxyBase | proxybase.org | no volumes at all |
| `proxybase-xyz` | ProxyBase Markets | proxybase.xyz | **generates one; the volume is the only copy of the key** |

They are genuinely different products — different domains, different container images (`proxybaseorg/peer-cli` vs `proxybasehq/proxybase-cli`), different payout models. Not a duplicate to delete.

But nothing at the point of *choosing between them* said which is which. Both descriptions led with what the service does; neither with the domain, and neither mentioned that one holds funds whose loss is permanent — a fact the catalog states plainly in its own `critical_volumes` text.

## This is not hypothetical

I conflated the two while reading the code and briefly concluded a live deployment was about to destroy a wallet. It was not: the running container is labelled `cashpilot.service=proxybase`, the entry with `volumes: []`, `MOUNTCOUNT=0`, and no such volume on the host.

**The label settles which catalog entry a container came from. The container name does not.**

If reading carefully lands there, someone scanning a catalog list can certainly get it wrong — and the cost of the wrong guess is irreversible.

## The test is general, not a special case

> Whenever one service's display name is a prefix of another's, and exactly one of the pair holds irreplaceable state, the one that does must say so.

A **negative control** asserts at least one such pair exists, so the invariant cannot quietly go vacuous if the catalog changes shape. Both assertions were mutation-checked and fail on different lines:

| mutation | fails at |
|---|---|
| revert the wallet mention | the "must mention it" assertion |
| make both descriptions identical | the "must not be interchangeable" assertion |

**Referral links untouched** — both keep their own `signup_url` and code.

4387 passed. Closes CashPilot-cp5g.