### PR TITLE
feat: reconcile payouts against receipts, and make the wrong version unbuildable

### DIFF
--- a/app/payout_reconcile.py
+++ b/app/payout_reconcile.py
@@ -1,0 +1,186 @@
+"""Reconcile recorded earnings against payout RECEIPTS, never against a balance.
+
+CashPilot-l09j. This module exists mainly to make one specific wrong feature
+hard to build, so the reasoning is here rather than in a commit message.
+
+THE TEMPTING VERSION: compare recorded earnings against the on-chain balance
+and flag a shortfall as "this service is reporting money it is not sending".
+**That inference does not hold.** A low or zero balance is equally consistent
+with the user having withdrawn or moved the funds, which is the normal thing to
+do with money. Shipping it would produce confident accusations against services
+that paid correctly.
+
+So this module never looks at a balance at all. The only question it can answer
+is "did anything ever ARRIVE at this address, and when", and the only claim it
+will make is the one receipts actually support.
+
+The distinction the whole module turns on:
+
+    receipts is None  -> we could not look. Says NOTHING about the service.
+    receipts == []    -> we looked, and nothing has ever arrived.
+
+Those are different claims and only the second can support a finding. This is
+the same three-valued rule the rest of the codebase runs on -- absent is not
+zero, and it is not true either -- applied to receipts rather than to money.
+
+Reconciliation needs a real explorer API (incoming transfer history), which
+needs a key the user supplies themselves; keyless public JSON-RPC cannot answer
+it. Until then `receipts` is None everywhere and this reports NO_KEY, which is
+an honest "not checked", not a clean bill of health.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+# --- verdicts -------------------------------------------------------------
+# Only ONE of these is a finding about the service. The rest describe the state
+# of our own knowledge, and must never be rendered as if they described theirs.
+
+NO_KEY = "no_key"
+"""No explorer key, so no receipts could be fetched. Not a finding."""
+
+NOT_APPLICABLE = "not_applicable"
+"""No payout address is known for this service. Not a finding."""
+
+INSUFFICIENT_HISTORY = "insufficient_history"
+"""Too few earnings observations to say anything. Not a finding."""
+
+NO_EARNINGS_CLAIMED = "no_earnings_claimed"
+"""Recorded earnings never rose, so there is nothing to reconcile."""
+
+RECEIPTS_SEEN = "receipts_seen"
+"""Money has arrived at the address. The service is paying."""
+
+NOTHING_EVER_ARRIVED = "nothing_ever_arrived"
+"""THE ONLY FINDING. Earnings rose over a sustained window and the address has
+received nothing, ever. Never emitted from a balance, and never from a
+shortfall."""
+
+#: Minimum number of earnings observations before any verdict beyond
+#: INSUFFICIENT_HISTORY. A single snapshot cannot support a claim about time.
+MIN_OBSERVATIONS = 3
+
+#: Minimum span, in days, over which earnings must have risen before silence at
+#: the address means anything. A service that started earning yesterday has not
+#: had a chance to pay.
+MIN_SPAN_DAYS = 7
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One recorded earnings reading: a cumulative balance at a point in time."""
+
+    day: str
+    amount: Decimal
+
+
+def _rose_over_window(observations: list[Observation]) -> bool:
+    """True when recorded earnings genuinely increased across the window.
+
+    Uses first vs last rather than any-increase: a single blip that reverted
+    is not a sustained claim of accrual, and reconciling against it would
+    manufacture findings out of noise.
+    """
+    if len(observations) < MIN_OBSERVATIONS:
+        return False
+    ordered = sorted(observations, key=lambda o: o.day)
+    return ordered[-1].amount > ordered[0].amount
+
+
+def _span_days(observations: list[Observation]) -> int:
+    """Calendar span between the first and last observation, in whole days."""
+    if len(observations) < 2:
+        return 0
+    ordered = sorted(observations, key=lambda o: o.day)
+    from datetime import date
+
+    try:
+        first = date.fromisoformat(ordered[0].day)
+        last = date.fromisoformat(ordered[-1].day)
+    except ValueError:
+        # An unparseable day is a reason to say nothing, never a reason to
+        # assume the window is wide enough.
+        return 0
+    return (last - first).days
+
+
+def reconcile(
+    *,
+    address: str | None,
+    observations: list[Observation] | None,
+    receipts: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Return a verdict about whether a service has ever actually paid.
+
+    `receipts` is the load-bearing argument and its three states are distinct:
+
+    * ``None``  -- not checked (no key, lookup failed, chain unsupported).
+    * ``[]``    -- checked, and nothing has ever arrived.
+    * non-empty -- money has arrived.
+
+    A balance is deliberately not a parameter. There is no way to pass one in,
+    which is the point: the wrong inference cannot be expressed through this
+    interface.
+    """
+    if not address:
+        return _verdict(NOT_APPLICABLE, "No payout address is known for this service.")
+
+    # Not checked. This must never collapse into "nothing arrived" -- that is
+    # the single most damaging confusion available here, because it turns our
+    # own missing key into an accusation against the service.
+    if receipts is None:
+        return _verdict(
+            NO_KEY,
+            "Not checked. Reading incoming transfers needs an explorer API key, "
+            "which you supply yourself; free public endpoints cannot answer it.",
+        )
+
+    if receipts:
+        return _verdict(
+            RECEIPTS_SEEN,
+            f"{len(receipts)} incoming transfer(s) recorded at this address.",
+        )
+
+    # From here on, receipts is a CONFIRMED empty list.
+    obs = observations or []
+    if len(obs) < MIN_OBSERVATIONS:
+        return _verdict(
+            INSUFFICIENT_HISTORY,
+            f"Only {len(obs)} earnings observation(s); at least {MIN_OBSERVATIONS} "
+            "are needed before silence at the address means anything.",
+        )
+
+    if not _rose_over_window(obs):
+        return _verdict(
+            NO_EARNINGS_CLAIMED,
+            "Recorded earnings did not rise over this window, so there is nothing to reconcile.",
+        )
+
+    span = _span_days(obs)
+    if span < MIN_SPAN_DAYS:
+        return _verdict(
+            INSUFFICIENT_HISTORY,
+            f"Earnings rose, but only over {span} day(s); a service needs longer "
+            f"than {MIN_SPAN_DAYS} days before silence is meaningful.",
+        )
+
+    return _verdict(
+        NOTHING_EVER_ARRIVED,
+        f"Recorded earnings rose over {span} days, but nothing has ever arrived at this payout address.",
+    )
+
+
+def _verdict(state: str, detail: str) -> dict[str, Any]:
+    """Shape every result identically, and mark which one is a finding.
+
+    `is_finding` is computed here rather than by each caller so that a new
+    verdict added later defaults to NOT being an accusation.
+    """
+    return {
+        "state": state,
+        "detail": detail,
+        "is_finding": state == NOTHING_EVER_ARRIVED,
+    }

--- a/tests/test_payout_reconcile.py
+++ b/tests/test_payout_reconcile.py
@@ -1,0 +1,162 @@
+"""The reconciliation module must be incapable of the accusation it exists to avoid.
+
+CashPilot-l09j. The tempting feature -- "your balance is lower than your
+recorded earnings, so this service is not paying you" -- is wrong, because
+withdrawing money produces exactly that picture. These tests pin the refusal
+rather than the happy path, because the refusal is the whole point.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app import payout_reconcile as pr
+
+
+def obs(*pairs):
+    return [pr.Observation(day=d, amount=Decimal(str(a))) for d, a in pairs]
+
+
+RISING_LONG = obs(("2026-07-01", 0), ("2026-07-10", 5), ("2026-07-20", 12))
+
+
+class TestItCannotSeeABalanceAtAll:
+    def test_reconcile_takes_no_balance_parameter(self):
+        """The wrong inference must not be expressible through the interface.
+
+        This is a structural guarantee, not a stylistic one: if a balance can
+        never be passed in, no caller can ask this module to compare against
+        one, however much they want to.
+        """
+        import inspect
+
+        params = set(inspect.signature(pr.reconcile).parameters)
+        assert params == {"address", "observations", "receipts"}
+        assert not any("balance" in p or "amount" in p for p in params)
+
+
+class TestAbsentIsNotEmpty:
+    """receipts=None (could not look) and receipts=[] (looked, nothing) differ."""
+
+    def test_none_receipts_is_never_a_finding(self):
+        v = pr.reconcile(address="0xabc", observations=RISING_LONG, receipts=None)
+        assert v["state"] == pr.NO_KEY
+        assert v["is_finding"] is False
+
+    def test_empty_receipts_with_the_same_inputs_IS_a_finding(self):
+        """The control that gives the test above its meaning.
+
+        Identical address and identical earnings history; only the receipts
+        argument changes from None to []. If these two ever returned the same
+        verdict, the module would be treating "we did not look" as "nothing
+        arrived" -- the exact confusion it is built to prevent.
+        """
+        v = pr.reconcile(address="0xabc", observations=RISING_LONG, receipts=[])
+        assert v["state"] == pr.NOTHING_EVER_ARRIVED
+        assert v["is_finding"] is True
+
+    def test_the_two_differ(self):
+        a = pr.reconcile(address="0xabc", observations=RISING_LONG, receipts=None)
+        b = pr.reconcile(address="0xabc", observations=RISING_LONG, receipts=[])
+        assert a["state"] != b["state"]
+        assert a["is_finding"] != b["is_finding"]
+
+
+class TestWithdrawalIsNotEvidenceOfNonPayment:
+    def test_receipts_present_is_never_a_finding_however_small(self):
+        """A user who withdrew everything still has receipts.
+
+        This is the scenario the tempting feature gets wrong: the address holds
+        nothing now, yet the service paid correctly. Because this module reads
+        receipts and not balances, the case cannot even arise -- but it is
+        asserted so that a future change reintroducing a balance is caught.
+        """
+        v = pr.reconcile(
+            address="0xabc",
+            observations=RISING_LONG,
+            receipts=[{"hash": "0x1", "value": "1"}],
+        )
+        assert v["state"] == pr.RECEIPTS_SEEN
+        assert v["is_finding"] is False
+
+    def test_one_ancient_receipt_still_suppresses_the_finding(self):
+        """ "Has it EVER arrived" is the question, so any receipt answers yes."""
+        v = pr.reconcile(
+            address="0xabc",
+            observations=RISING_LONG,
+            receipts=[{"hash": "0x1", "day": "2020-01-01"}],
+        )
+        assert v["is_finding"] is False
+
+
+class TestItRefusesToSpeakTooSoon:
+    def test_too_few_observations(self):
+        v = pr.reconcile(
+            address="0xabc",
+            observations=obs(("2026-07-01", 0), ("2026-07-20", 9)),
+            receipts=[],
+        )
+        assert v["state"] == pr.INSUFFICIENT_HISTORY
+        assert v["is_finding"] is False
+
+    def test_rose_but_over_too_short_a_span(self):
+        """A service that started earning yesterday has not had a chance to pay."""
+        v = pr.reconcile(
+            address="0xabc",
+            observations=obs(("2026-07-01", 0), ("2026-07-02", 3), ("2026-07-03", 6)),
+            receipts=[],
+        )
+        assert v["state"] == pr.INSUFFICIENT_HISTORY
+        assert v["is_finding"] is False
+
+    def test_flat_earnings_are_nothing_to_reconcile(self):
+        v = pr.reconcile(
+            address="0xabc",
+            observations=obs(("2026-07-01", 4), ("2026-07-10", 4), ("2026-07-20", 4)),
+            receipts=[],
+        )
+        assert v["state"] == pr.NO_EARNINGS_CLAIMED
+        assert v["is_finding"] is False
+
+    def test_a_blip_that_reverted_is_not_a_sustained_claim(self):
+        """Ends where it started: no accrual was actually claimed."""
+        v = pr.reconcile(
+            address="0xabc",
+            observations=obs(("2026-07-01", 5), ("2026-07-10", 9), ("2026-07-20", 5)),
+            receipts=[],
+        )
+        assert v["state"] == pr.NO_EARNINGS_CLAIMED
+        assert v["is_finding"] is False
+
+    def test_unparseable_days_refuse_rather_than_assume(self):
+        """A bad date must not be treated as a wide enough window."""
+        v = pr.reconcile(
+            address="0xabc",
+            observations=obs(("not-a-date", 0), ("also-bad", 5), ("still-bad", 12)),
+            receipts=[],
+        )
+        assert v["is_finding"] is False
+
+
+class TestNoAddress:
+    @pytest.mark.parametrize("addr", [None, ""])
+    def test_no_address_is_not_applicable(self, addr):
+        v = pr.reconcile(address=addr, observations=RISING_LONG, receipts=[])
+        assert v["state"] == pr.NOT_APPLICABLE
+        assert v["is_finding"] is False
+
+
+class TestExactlyOneVerdictAccuses:
+    def test_only_nothing_ever_arrived_is_a_finding(self):
+        """A verdict added later must default to not being an accusation.
+
+        Enumerated from the module rather than a hand-kept list, so a new
+        constant is covered the day it is added.
+        """
+        states = {
+            v
+            for k, v in vars(pr).items()
+            if k.isupper() and isinstance(v, str) and not k.startswith("_") and not k.startswith("MIN_")
+        }
+        accusing = {s for s in states if pr._verdict(s, "x")["is_finding"]}
+        assert accusing == {pr.NOTHING_EVER_ARRIVED}, f"exactly one verdict may be a finding; got {accusing}"


### PR DESCRIPTION
The tempting feature is to compare recorded earnings against the on-chain balance and flag a shortfall as *"this service is reporting money it is not sending"*.

**That inference does not hold.** A low or zero balance is equally consistent with the user having **withdrawn** the funds — which is the normal thing to do with money. Shipping it would produce confident accusations against services that paid correctly: the same class of error the whole wallet tier was built to avoid, one level up.

## So the module cannot see a balance

There is no parameter through which one could be passed, and a test asserts the signature stays that way:

```python
params = set(inspect.signature(pr.reconcile).parameters)
assert params == {"address", "observations", "receipts"}
```

That is a structural guarantee rather than a stylistic one. No caller can ask this module to compare against a balance, however much they might want to.

## Three states of `receipts`, not two

| value | meaning |
|---|---|
| `None` | we could not look — says **nothing** about the service |
| `[]` | we looked, and nothing has ever arrived |
| non-empty | money has arrived |

Collapsing the first into the second would turn *our own missing API key* into an accusation. It is the same absent-is-not-zero rule the codebase already runs on, applied to receipts instead of money.

The test for this is paired with its control: identical address, identical earnings history, **only** `receipts` changing from `None` to `[]` — and the two must produce different verdicts. Without the control, the first test would pass against a module that never accuses anyone at all.

## Exactly one of six verdicts accuses

`is_finding` is computed centrally, not by each caller, so **a verdict added later defaults to not being an accusation**. A test enumerates the verdicts from the module itself rather than a hand-kept list, so a new one is covered the day it is added.

It also refuses to speak too soon — fewer than 3 observations, a rise spanning under 7 days, flat earnings, a blip that reverted, or an unparseable date all return "not enough to say".

## Verification

Everything passed first time, so each guard was mutated:

| mutation | tests that fail |
|---|---|
| treat "not checked" as "nothing arrived" | both `AbsentIsNotEmpty` assertions |
| drop the minimum-span guard | the short-span and unparseable-date tests |
| let a second verdict accuse | both withdrawal tests + the enumeration test |

6 verdicts enumerated, so the enumeration test is not vacuous. **4401 passed**, ruff clean.

## Scope

Inert until the user supplies their own explorer key — keyless public JSON-RPC cannot return transfer history, and a shared key never ships. `NO_KEY` is an honest *"not checked"*, not a clean bill of health.

Part of CashPilot-l09j; the fetching half still needs a key.