### PR TITLE
fix: answer 401 before parsing an unauthenticated request body

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ from typing import Any
 import httpx
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_MISSED
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -1475,8 +1475,13 @@ class DeployRequest(BaseModel):
 
 
 @app.post("/api/deploy/{slug}")
-async def api_deploy(request: Request, slug: str, body: DeployRequest, worker_id: int | None = None) -> dict[str, str]:
-    _require_owner(request)
+async def api_deploy(
+    request: Request,
+    slug: str,
+    body: DeployRequest,
+    worker_id: int | None = None,
+    _auth: dict[str, Any] = Depends(_require_owner),
+) -> dict[str, str]:
     worker_id = await _resolve_worker_id(worker_id)
     svc = catalog.get_service(slug)
     if not svc:
@@ -2015,9 +2020,12 @@ class ComposeMultiRequest(BaseModel):
 
 
 @app.post("/api/compose", response_class=PlainTextResponse)
-async def api_compose_multi(request: Request, body: ComposeMultiRequest):
+async def api_compose_multi(
+    request: Request,
+    body: ComposeMultiRequest,
+    _auth: dict[str, Any] = Depends(_require_auth_api),
+):
     """Export a docker-compose.yml for multiple services."""
-    _require_auth_api(request)
     try:
         return compose_generator.generate_compose_multi(body.slugs)
     except ValueError as exc:
@@ -3320,8 +3328,9 @@ class PreferencesUpdate(BaseModel):
 
 
 @app.post("/api/preferences")
-async def api_set_preferences(request: Request, body: PreferencesUpdate) -> dict[str, str]:
-    user = _require_auth_api(request)
+async def api_set_preferences(
+    request: Request, body: PreferencesUpdate, user: dict[str, Any] = Depends(_require_auth_api)
+) -> dict[str, str]:
     if body.setup_mode is not None and body.setup_mode not in ("fresh", "monitoring", "mixed"):
         raise HTTPException(status_code=400, detail="setup_mode must be fresh, monitoring, or mixed")
 
@@ -3497,8 +3506,9 @@ def _sanitize_credential(value: str) -> str:
 
 
 @app.post("/api/config")
-async def api_set_config(request: Request, body: ConfigUpdate) -> dict[str, str]:
-    _require_owner(request)
+async def api_set_config(
+    request: Request, body: ConfigUpdate, _auth: dict[str, Any] = Depends(_require_owner)
+) -> dict[str, str]:
     sanitized = {k: _sanitize_credential(v) for k, v in body.data.items()}
     await database.set_config_bulk(sanitized)
 
@@ -3595,9 +3605,10 @@ class AdminPasswordSet(BaseModel):
 
 
 @app.post("/api/users/me/password")
-async def api_change_own_password(request: Request, body: PasswordChange) -> JSONResponse:
+async def api_change_own_password(
+    request: Request, body: PasswordChange, user: dict[str, Any] = Depends(_require_auth_api)
+) -> JSONResponse:
     """Change the authenticated user's own password (verifies current password)."""
-    user = _require_auth_api(request)
     uid = user["uid"]
     if uid == 0:
         raise HTTPException(status_code=400, detail="API-key sessions cannot change a password")
@@ -3621,9 +3632,10 @@ async def api_change_own_password(request: Request, body: PasswordChange) -> JSO
 
 
 @app.post("/api/users/{user_id}/password")
-async def api_admin_set_password(request: Request, user_id: int, body: AdminPasswordSet) -> dict[str, str]:
+async def api_admin_set_password(
+    request: Request, user_id: int, body: AdminPasswordSet, _auth: dict[str, Any] = Depends(_require_owner)
+) -> dict[str, str]:
     """Owner resets another user's password (no current-password check, no re-mint)."""
-    _require_owner(request)
     target = await database.get_user_by_id(user_id)
     if not target:
         raise HTTPException(status_code=404, detail="User not found")

--- a/tests/test_auth_precedes_body_validation.py
+++ b/tests/test_auth_precedes_body_validation.py
@@ -1,0 +1,90 @@
+"""An unauthenticated caller must be told 401, not handed the request schema.
+
+CashPilot-nz4d. Guards used to be called inside handler bodies:
+
+    @app.post("/api/config")
+    async def api_set_config(request: Request, body: ConfigUpdate):
+        _require_owner(request)
+
+FastAPI validates `body` BEFORE the function runs, so a malformed body from an
+entirely unauthenticated caller returned 422 with the field-level schema:
+
+    {"detail":[{"type":"missing","loc":["body","data"],"msg":"Field required"}]}
+
+Authentication still held -- nothing was read or written -- but the write
+surface could be enumerated and its schemas learned without credentials, and
+Pydantic parsed untrusted input before anyone was identified.
+
+Moving the guard into Depends() resolves auth first. Verified in isolation
+before the change was made:
+
+    in-body guard   malformed+noauth -> 422    valid+noauth -> 401
+    Depends() guard malformed+noauth -> 401    valid+noauth -> 401
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+#: Endpoints whose guard was moved into a dependency. Each takes a Pydantic
+#: body and an UNCONDITIONAL guard.
+CONVERTED = [
+    ("post", "/api/deploy/honeygain"),
+    ("post", "/api/compose"),
+    ("post", "/api/preferences"),
+    ("post", "/api/config"),
+    ("post", "/api/users/me/password"),
+    ("post", "/api/users/1/password"),
+]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(("method", "path"), CONVERTED, ids=[p for _, p in CONVERTED])
+def test_malformed_body_unauthenticated_is_401_not_422(client, method, path):
+    """The finding itself: a schema error must not precede the auth error."""
+    resp = getattr(client, method)(path, json={"deliberately": "wrong"})
+    assert resp.status_code == 401, (
+        f"{path} returned {resp.status_code}; a 422 here hands the request schema "
+        f"to an unauthenticated caller. Body: {resp.text[:200]}"
+    )
+
+
+@pytest.mark.parametrize(("method", "path"), CONVERTED, ids=[p for _, p in CONVERTED])
+def test_valid_body_unauthenticated_is_also_401(client, method, path):
+    """The control that stops the test above passing for the wrong reason.
+
+    If an endpoint were simply broken, misrouted, or removed, the malformed
+    case could return 401 (or 404) while proving nothing about ordering. This
+    asserts the endpoint is genuinely reachable and genuinely guarded: a
+    WELL-FORMED request from an unauthenticated caller must also be refused,
+    and refused with the same status.
+    """
+    body = {"data": {}, "slugs": [], "current_password": "x", "new_password": "y", "password": "z"}
+    resp = getattr(client, method)(path, json=body)
+    assert resp.status_code == 401, f"{path} returned {resp.status_code}: {resp.text[:200]}"
+
+
+def test_the_schema_is_not_leaked_to_an_unauthenticated_caller(client):
+    """No field-level validation detail may appear in an unauthenticated reply."""
+    resp = client.post("/api/config", json={})
+    assert resp.status_code == 401
+    text = resp.text.lower()
+    for leaked in ("field required", '"loc"', "body", "missing"):
+        assert leaked not in text, f"unauthenticated 401 body leaked {leaked!r}: {resp.text[:200]}"
+
+
+def test_a_conditional_guard_endpoint_is_deliberately_not_converted(client):
+    """/api/workers/{id}/command decides its guard FROM the body.
+
+    Deploy requires owner, everything else requires writer, so the body must be
+    parsed before the right guard is known. It therefore cannot be hoisted into
+    a dependency, and this records that as a deliberate exception rather than an
+    oversight -- while still asserting it refuses an unauthenticated caller.
+    """
+    resp = client.post("/api/workers/1/command", json={"command": "deploy"})
+    assert resp.status_code in (401, 403), f"got {resp.status_code}: {resp.text[:200]}"

--- a/tests/test_beads_batch_3.py
+++ b/tests/test_beads_batch_3.py
@@ -172,7 +172,6 @@ class TestAViewerCannotTriggerAFleetCollection:
 
         async def run():
             with (
-                patch.object(main, "_require_auth_api", lambda r: {"uid": 1, "u": "x", "r": role}),
                 patch.object(main.database, "get_user_preferences", AsyncMock(return_value={})),
                 patch.object(main.database, "save_user_preferences", AsyncMock()),
                 patch.object(main, "_spawn", lambda coro: (spawned.append(1), coro.close())),
@@ -182,7 +181,7 @@ class TestAViewerCannotTriggerAFleetCollection:
                 body.selected_categories = None
                 body.timezone = None
                 body.setup_mode = None
-                await main.api_set_preferences(request, body)
+                await main.api_set_preferences(request, body, {"uid": 1, "u": "x", "r": role})
             return spawned
 
         return asyncio.run(run())
@@ -217,7 +216,23 @@ class TestTheDeployButtonMatchesTheServerGate:
         assert "Owner access required" in source
 
     def test_the_server_really_does_require_owner(self):
-        """If this changes, the button should follow it — not the other way round."""
-        source = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
-        idx = source.index('@app.post("/api/deploy/{slug}")')
-        assert "_require_owner(request)" in source[idx : idx + 600]
+        """If this changes, the button should follow it — not the other way round.
+
+        Asserted by CALLING the endpoint, not by grepping main.py for the guard.
+        The previous version matched the literal string "_require_owner(request)"
+        near the decorator, and broke when that guard moved into a FastAPI
+        dependency -- a change that made the endpoint strictly more secure
+        (CashPilot-nz4d). A test that fails on a hardening is not measuring the
+        thing it claims to.
+        """
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        # No credentials at all: the deploy route must refuse, and must do so
+        # before it will even discuss the request body.
+        assert client.post("/api/deploy/honeygain", json={}).status_code == 401
+        # And a well-formed body is refused identically, so the assertion above
+        # cannot be satisfied by the endpoint merely being broken.
+        assert client.post("/api/deploy/honeygain", json={"env": {}}).status_code == 401


### PR DESCRIPTION
Guards were called *inside* handler bodies, so FastAPI validated the request body first and an unauthenticated caller got the schema back:

```
POST /api/config   malformed body, no auth -> 422
{"detail":[{"type":"missing","loc":["body","data"],"msg":"Field required","input":{}}]}

POST /api/config   valid body,     no auth -> 401
```

**Authentication held** — nothing read, nothing written. Confirmed on the shipped `1.22` image: a read-only token POSTing a distinctly-named key got 403 and that key was **absent** afterwards, while an admin-written key **was** present (so the read-back works and the absence means something).

What leaked was *structure*: the write surface could be enumerated and its schemas learned without credentials, and Pydantic parsed untrusted input before anyone was identified.

## The mechanism was verified, not assumed

Before touching anything, in an isolated app:

| guard style | malformed + no auth | valid + no auth |
|---|---|---|
| called in the body | **422** | 401 |
| `Depends()` | **401** | 401 |

## Scope: six endpoints

`deploy`, `compose`, `preferences`, `config`, and both password routes — every write endpoint that takes a Pydantic body **and** checks auth unconditionally at the top of the body.

**`/api/workers/{id}/command` is deliberately not converted.** It chooses its guard *from* the body — deploy requires owner, everything else writer — so the body must be parsed before the right guard is known. An earlier mechanical pass hoisted it anyway, deleted the conditional and left an empty `if`. That is why this is an explicit list rather than a pattern match, and the exception is asserted in the tests so it reads as a decision rather than an oversight.

I also over-counted at first: a loose regex matched `Request` as a Pydantic model and reported 16 candidates. The real number is 9, of which 6 are safely convertible.

## Two existing tests changed, both worth it

- The preference tests call the handler **directly**, bypassing FastAPI, so a `Depends` default never resolves. They now pass the user explicitly — honest, since the dependency is part of the signature.
- `test_the_server_really_does_require_owner` **asserted on source text**: it grepped `main.py` for `"_require_owner(request)"` near the decorator. It broke on a change that made the endpoint *strictly more secure* — the clearest possible demonstration that it was never testing behaviour. It now calls the endpoint.

## Tests

Every converted endpoint is checked both ways, and the second is the control: if an endpoint were simply broken or misrouted, the malformed case could return 401 while proving nothing about ordering. A **well-formed** unauthenticated request must be refused identically.

Mutating `/api/config` back to an in-body guard fails exactly two tests — and the control keeps passing, confirming it measures something different.

**4415 passed**, ruff clean. Closes CashPilot-nz4d.