### PR TITLE
fix(ui): modal buttons were painted in the link colour and underlined

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1322,13 +1322,19 @@ img { max-width: 100%; }
   flex: 1;
 }
 
-.modal-body a {
+/* Prose links inside a modal. Scoped with :not(.btn) because an anchor styled
+   as a BUTTON is not a link to be underlined -- it already carries its own
+   background and text colour. Without the exclusion this rule (0,1,1) outranks
+   .btn-success (0,1,0) and repaints every modal button's label in the link
+   colour: the "Go to Dashboard" button rendered cyan-on-green with an
+   underline, effectively invisible against its own background. */
+.modal-body a:not(.btn) {
   color: var(--accent-secondary);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.modal-body a:hover {
+.modal-body a:not(.btn):hover {
   color: var(--accent-secondary);
   opacity: 0.8;
 }


### PR DESCRIPTION
The **Go to Dashboard** button in the claim modal rendered as cyan text with an underline on its own green background — barely readable, and it read as a broken link rather than a button.

## Cause is specificity, not colour choice

```css
.modal-body a { color: var(--accent-secondary); text-decoration: underline; }  /* (0,1,1) */
.btn-success  { background: var(--success); color: #fff; }                     /* (0,1,0) */
```

`.modal-body a` outranks `.btn-success`, so the link colour and underline won over the button’s own white.

That rule is **right for prose links** inside a modal and **wrong for an anchor styled as a button** — a button already carries its own background and text colour, and underlining it means nothing. Scoping it with `:not(.btn)` fixes **every button in every modal at once** (app.js renders 41 of them) rather than patching this one call site.

## Verified in a browser, with a control

Rendered the real markup against the real stylesheet, before and after.

**Before** — cyan, underlined, on green:
> `Go to Dashboard` in `--accent-secondary` (#22d3ee) over `--success` (#22c55e)

**After** — white on green, no underline.

The control is the second half: a prose link in the same `.modal-body` **stays cyan and underlined**. Without checking that, the "fix" could equally have been *stop styling links in modals*, which would have been wrong in the other direction.

## Not covered by a test, and I want to be straight about that

There is no browser-driven CSS regression coverage in this repo, so nothing would have caught this and nothing will catch the next one. I did not fake it with a source-text assertion — this repo has already been bitten by tests that matched their own prose, and a grep for `:not(.btn)` would prove only that a string exists, not that the button is legible.

Worth deciding separately whether a computed-style check is worth a browser in CI.

CSS only; `node --check` clean on `app.js` (untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal buttons inheriting link colors and underlining.
  * Preserved link styling for regular links within modal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->