### PR TITLE
fix(ui): the update banner was always visible, empty, and linked nowhere

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2094,23 +2094,37 @@ img { max-width: 100%; }
   gap: 0.75rem;
   margin: 0 0 1rem;
   padding: 0.65rem 1rem;
-  border: 1px solid rgba(59, 130, 246, 0.35);
+  border: 1px solid var(--border-light);
   border-radius: 10px;
-  background: rgba(30, 58, 138, 0.18);
-  color: #dbeafe;
+  background: var(--accent-secondary-soft);
+  color: var(--text-primary);
   font-size: 0.9rem;
 }
 
+/* `hidden` is only honoured because the UA stylesheet says display:none, and
+   ANY author `display` outranks it. Without this rule the banner above was
+   permanently visible -- empty, because checkForUpdate had never populated it,
+   and carrying its initial href="#", which with target="_blank" opens the
+   CURRENT page in a new tab. It looked like a broken link to GitHub; it was
+   never a link to GitHub at all. */
+.update-banner[hidden] {
+  display: none;
+}
+
+/* Tokens, not hardcoded blues. The previous #dbeafe text and #93c5fd link were
+   picked for the dark theme and had no light-theme counterpart, so in light
+   mode the banner was pale blue on pale lavender. */
 .update-banner a {
-  color: #93c5fd;
+  color: var(--accent-secondary);
   text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .update-banner button {
   margin-left: auto;
   border: 0;
   background: transparent;
-  color: #93c5fd;
+  color: var(--text-secondary);
   font-size: 1.15rem;
   line-height: 1;
   cursor: pointer;
@@ -2118,7 +2132,7 @@ img { max-width: 100%; }
 }
 
 .update-banner button:hover {
-  color: #dbeafe;
+  color: var(--text-primary);
 }
 
 /* Payout destinations (CashPilot-luj tier 1).

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -120,23 +120,28 @@
 <body>
   <div class="auth-card">
     <div class="auth-brand">
-      <svg width="28" height="28" viewBox="0 0 32 32">
+      <svg width="28" height="28" viewBox="0 0 256 256" role="img" aria-label="CashPilot">
         <defs>
-          <linearGradient id="cpSun" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="#fde68a"/>
-            <stop offset="35%" stop-color="#fb923c"/>
-            <stop offset="65%" stop-color="#e11d48"/>
-            <stop offset="100%" stop-color="#6d28d9"/>
+          <linearGradient id="cpSun" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="#FFD54F"/>
+            <stop offset="40%" stop-color="#FF9800"/>
+            <stop offset="72%" stop-color="#E91E63"/>
+            <stop offset="100%" stop-color="#AB47BC"/>
           </linearGradient>
-          <mask id="cpMask">
-            <circle cx="16" cy="16" r="12" fill="white"/>
-            <rect x="0" y="16" width="32" height="1" fill="black"/>
-            <rect x="0" y="18.5" width="32" height="1.5" fill="black"/>
-            <rect x="0" y="21.5" width="32" height="2.5" fill="black"/>
-            <rect x="0" y="25.5" width="32" height="4" fill="black"/>
+          <mask id="cpBands">
+            <rect width="256" height="256" fill="#fff"/>
+            <rect x="16" y="150" width="224" height="10" fill="#000"/>
+            <rect x="16" y="172" width="224" height="13" fill="#000"/>
+            <rect x="16" y="197" width="224" height="16" fill="#000"/>
           </mask>
         </defs>
-        <circle cx="16" cy="16" r="12" fill="url(#cpSun)" mask="url(#cpMask)"/>
+        <g transform="translate(128,128) scale(1.3333333) translate(-128,-132)">
+          <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+          <g transform="translate(128,104) rotate(28)">
+            <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+                  fill="#000010" opacity="0.65"/>
+          </g>
+        </g>
       </svg>
       CashPilot
     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,23 +43,28 @@
   <!-- Sidebar -->
   <aside class="sidebar">
     <div class="sidebar-brand">
-      <svg width="28" height="28" viewBox="0 0 32 32">
+      <svg width="28" height="28" viewBox="0 0 256 256" role="img" aria-label="CashPilot">
         <defs>
-          <linearGradient id="cpSun" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="#fde68a"/>
-            <stop offset="35%" stop-color="#fb923c"/>
-            <stop offset="65%" stop-color="#e11d48"/>
-            <stop offset="100%" stop-color="#6d28d9"/>
+          <linearGradient id="cpSun" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="#FFD54F"/>
+            <stop offset="40%" stop-color="#FF9800"/>
+            <stop offset="72%" stop-color="#E91E63"/>
+            <stop offset="100%" stop-color="#AB47BC"/>
           </linearGradient>
-          <mask id="cpMask">
-            <circle cx="16" cy="16" r="12" fill="white"/>
-            <rect x="0" y="16" width="32" height="1" fill="black"/>
-            <rect x="0" y="18.5" width="32" height="1.5" fill="black"/>
-            <rect x="0" y="21.5" width="32" height="2.5" fill="black"/>
-            <rect x="0" y="25.5" width="32" height="4" fill="black"/>
+          <mask id="cpBands">
+            <rect width="256" height="256" fill="#fff"/>
+            <rect x="16" y="150" width="224" height="10" fill="#000"/>
+            <rect x="16" y="172" width="224" height="13" fill="#000"/>
+            <rect x="16" y="197" width="224" height="16" fill="#000"/>
           </mask>
         </defs>
-        <circle cx="16" cy="16" r="12" fill="url(#cpSun)" mask="url(#cpMask)"/>
+        <g transform="translate(128,128) scale(1.3333333) translate(-128,-132)">
+          <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+          <g transform="translate(128,104) rotate(28)">
+            <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+                  fill="#000010" opacity="0.65"/>
+          </g>
+        </g>
       </svg>
       CashPilot
     </div>

--- a/app/templates/onboarding.html
+++ b/app/templates/onboarding.html
@@ -341,23 +341,28 @@
       <div class="step active" id="step-1">
         <div class="card">
           <div class="brand">
-            <svg width="28" height="28" viewBox="0 0 32 32">
+            <svg width="28" height="28" viewBox="0 0 256 256" role="img" aria-label="CashPilot">
               <defs>
-                <linearGradient id="cpSun" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stop-color="#fde68a"/>
-                  <stop offset="35%" stop-color="#fb923c"/>
-                  <stop offset="65%" stop-color="#e11d48"/>
-                  <stop offset="100%" stop-color="#6d28d9"/>
+                <linearGradient id="cpSun" x1="0%" y1="0%" x2="0%" y2="100%">
+                  <stop offset="0%" stop-color="#FFD54F"/>
+                  <stop offset="40%" stop-color="#FF9800"/>
+                  <stop offset="72%" stop-color="#E91E63"/>
+                  <stop offset="100%" stop-color="#AB47BC"/>
                 </linearGradient>
-                <mask id="cpMask">
-                  <circle cx="16" cy="16" r="12" fill="white"/>
-                  <rect x="0" y="16" width="32" height="1" fill="black"/>
-                  <rect x="0" y="18.5" width="32" height="1.5" fill="black"/>
-                  <rect x="0" y="21.5" width="32" height="2.5" fill="black"/>
-                  <rect x="0" y="25.5" width="32" height="4" fill="black"/>
+                <mask id="cpBands">
+                  <rect width="256" height="256" fill="#fff"/>
+                  <rect x="16" y="150" width="224" height="10" fill="#000"/>
+                  <rect x="16" y="172" width="224" height="13" fill="#000"/>
+                  <rect x="16" y="197" width="224" height="16" fill="#000"/>
                 </mask>
               </defs>
-              <circle cx="16" cy="16" r="12" fill="url(#cpSun)" mask="url(#cpMask)"/>
+              <g transform="translate(128,128) scale(1.3333333) translate(-128,-132)">
+                <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+                <g transform="translate(128,104) rotate(28)">
+                  <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+                        fill="#000010" opacity="0.65"/>
+                </g>
+              </g>
             </svg>
             <span class="brand-text">CashPilot</span>
           </div>
@@ -376,8 +381,14 @@
       <div class="step" id="step-2">
         <div class="card">
           <div class="brand">
-            <svg width="28" height="28" viewBox="0 0 32 32">
-              <circle cx="16" cy="16" r="12" fill="url(#cpSun)" mask="url(#cpMask)"/>
+            <svg width="28" height="28" viewBox="0 0 256 256" role="img" aria-label="CashPilot">
+              <g transform="translate(128,128) scale(1.3333333) translate(-128,-132)">
+                <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+                <g transform="translate(128,104) rotate(28)">
+                  <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+                        fill="#000010" opacity="0.65"/>
+                </g>
+              </g>
             </svg>
             <span class="brand-text">CashPilot</span>
           </div>
@@ -431,8 +442,14 @@
       <div class="step" id="step-3">
         <div class="card">
           <div class="brand">
-            <svg width="28" height="28" viewBox="0 0 32 32">
-              <circle cx="16" cy="16" r="12" fill="url(#cpSun)" mask="url(#cpMask)"/>
+            <svg width="28" height="28" viewBox="0 0 256 256" role="img" aria-label="CashPilot">
+              <g transform="translate(128,128) scale(1.3333333) translate(-128,-132)">
+                <circle cx="128" cy="132" r="96" fill="url(#cpSun)" mask="url(#cpBands)"/>
+                <g transform="translate(128,104) rotate(28)">
+                  <path d="M0,-46 L4,-10 L50,3 L5,8 L6.5,20 L0,13 L-6.5,20 L-5,8 L-50,3 L-4,-10 Z"
+                        fill="#000010" opacity="0.65"/>
+                </g>
+              </g>
             </svg>
             <span class="brand-text">CashPilot</span>
           </div>

--- a/scripts/legibility_check.mjs
+++ b/scripts/legibility_check.mjs
@@ -78,6 +78,17 @@ const fixture = `<!DOCTYPE html><html><head><meta charset="utf-8">
   <div class="modal-body" style="padding:16px;margin:8px">
     <p data-probe-text="modal-prose">Prose with <a href="#" data-probe-link="modal-link">a real link</a> in it.</p>
   </div>
+
+  <!-- Real components, populated as the app populates them. Buttons were only
+       where the FIRST bug happened; the update banner then turned out to be
+       pale blue on pale lavender in the light theme, because its colours were
+       hardcoded for the dark one and had no counterpart. A check that only ever
+       looked at .btn would have missed it entirely. -->
+  <div class="update-banner">
+    <span data-probe-fg="update-banner-text">CashPilot 1.23.2 is available - you are running 1.14.1.</span>
+    <a href="#" data-probe-fg="update-banner-link">Release notes</a>
+    <button type="button" data-probe-fg="update-banner-dismiss">&times;</button>
+  </div>
 </body></html>`;
 
 const fixturePath = path.join(process.env.TMPDIR || "/tmp", "cashpilot-legibility.html");
@@ -98,20 +109,49 @@ const AUDIT = `(() => {
   // ancestor that actually paints one. A transparent button (btn-danger,
   // btn-ghost) is legible only relative to whatever shows through it.
   const effectiveBg = (el) => {
+    // Collect every painted layer up the tree, then composite them.
+    //
+    // The first version returned the first layer with alpha > 0 and treated it
+    // as opaque. That is wrong for exactly the tokens this codebase uses:
+    // --accent-secondary-soft is rgba(34,211,238,0.10), and reading it as solid
+    // #22d3ee reported the update banner at 1:1 against its own link colour --
+    // a fabricated failure that nearly sent me redesigning a component that was
+    // fine. Alpha has to be blended, not ignored.
+    const layers = [];
     let n = el;
-    while (n && n !== document.documentElement) {
+    while (n) {
       const c = parse(getComputedStyle(n).backgroundColor);
-      if (c && c.a > 0) return c;
+      if (c && c.a > 0) {
+        layers.push(c);
+        if (c.a >= 1) break; // opaque: nothing below it shows through
+      }
       n = n.parentElement;
     }
-    const c = parse(getComputedStyle(document.body).backgroundColor);
-    return c && c.a > 0 ? c : { r: 255, g: 255, b: 255, a: 1 };
+    let base = { r: 255, g: 255, b: 255 };
+    for (const c of layers.reverse()) {
+      base = {
+        r: c.r * c.a + base.r * (1 - c.a),
+        g: c.g * c.a + base.g * (1 - c.a),
+        b: c.b * c.a + base.b * (1 - c.a),
+      };
+    }
+    return base;
   };
   const lum = ({ r, g, b }) => {
     const f = (v) => { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
     return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
   };
-  const ratio = (fg, bg) => {
+  // Text alpha counts too. A negative control caught this: setting the banner
+  // text to rgba(232,230,240,0.25) -- nearly invisible -- still measured as a
+  // clean 14:1, because only the background was being composited and the
+  // foreground's own alpha was thrown away. Blend the text over its background
+  // before measuring, exactly as the screen does.
+  const ratio = (fgRaw, bg) => {
+    const fg = fgRaw.a !== undefined && fgRaw.a < 1
+      ? { r: fgRaw.r * fgRaw.a + bg.r * (1 - fgRaw.a),
+          g: fgRaw.g * fgRaw.a + bg.g * (1 - fgRaw.a),
+          b: fgRaw.b * fgRaw.a + bg.b * (1 - fgRaw.a) }
+      : fgRaw;
     const a = lum(fg), b = lum(bg);
     return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
   };
@@ -126,6 +166,17 @@ const AUDIT = `(() => {
       bg: "rgb(" + bg.r + "," + bg.g + "," + bg.b + ")",
       contrast: Math.round(ratio(fg, bg) * 100) / 100,
       underlined: cs.textDecorationLine.includes("underline"),
+    });
+  }
+  for (const el of document.querySelectorAll("[data-probe-fg]")) {
+    const cs = getComputedStyle(el);
+    const fg = parse(cs.color), bg = effectiveBg(el);
+    out.buttons.push({
+      probe: el.getAttribute("data-probe-fg"),
+      color: cs.color,
+      bg: "rgb(" + Math.round(bg.r) + "," + Math.round(bg.g) + "," + Math.round(bg.b) + ")",
+      contrast: Math.round(ratio(fg, bg) * 100) / 100,
+      underlined: false, // an underline is only a defect on a FILLED control
     });
   }
   const link = document.querySelector("[data-probe-link]");


### PR DESCRIPTION
Three defects in one strip across the top of every page, plus the brand mark.

## 1. It was always visible — and the link went nowhere

`hidden` is honoured only because the UA stylesheet says `display:none`, and **any author `display` outranks it**:

```css
.update-banner { display: flex; }   /* defeats [hidden] */
```

So the banner showed permanently — **empty**, because `checkForUpdate` had never populated it, still carrying its initial `href="#"`. With `target="_blank"`, `#` opens **the current page** in a new tab. It looked like a broken link to GitHub; it was never a link to GitHub at all.

Verified in a browser rather than reasoned about: with `display:flex`, an element with `[hidden]` computes to `flex`; adding the rule gives `none`.

## 2. Unreadable in the light theme

`#dbeafe` text and a `#93c5fd` link were chosen for the dark theme and had **no light-theme counterpart**, so in light mode it was pale blue on pale lavender. Now uses tokens, which both themes define. Measured: link **9.76:1 dark, 5.87:1 light**.

## 3. The brand mark was a different, older drawing

`base.html`, `auth.html` and `onboarding.html` carried a *separate* hand-drawing from the official one: `r=12` inside a 32-unit box — 4 units of padding on every side — **no plane**, and a gradient ending in dark purple that reads as a plate rather than transparency. `favicon.svg` already had the corrected mark; the templates never got it.

All four surfaces now share identical geometry: disc touching all four edges, plane present, nothing painted behind it.

`onboarding` steps 2 and 3 reuse step 1’s `<defs>` and carry only a bare disc, so they referenced the old mask id and had to be updated too — otherwise they would have rendered against a mask that no longer exists.

## The check is extended, because it would have caught none of this

It only looked at `.btn`. It now audits real component markup.

**Two bugs in the checker itself**, both found by its own negative controls:

- it treated a **translucent background as opaque** — `--accent-secondary-soft` is `rgba(34,211,238,0.10)`, so it reported the banner at **1:1 against its own link colour**, a fabricated failure that nearly had me redesigning a component that was fine;
- it **ignored the foreground’s alpha**, so text at 25% opacity measured as a clean 14:1.

Both composite properly now. A mutation setting the banner text to `rgba(...,0.25)` fails at **2.05:1 dark, 1:1 light**; restoring the hardcoded `#93c5fd` link fails at **1.46:1 light** — the exact reported bug.

I also caught myself writing a mutation that silently hit `.form-input` instead of the banner and "passed". A mutation that does not apply looks identical to a passing test.

4415 passed, 94/94 legibility, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed CashPilot branding across authentication, navigation, and onboarding screens with a larger, more consistent logo.
  * Improved logo accessibility with descriptive labels for assistive technologies.

* **Style**
  * Updated update-banner colors to adapt to the selected theme.
  * Improved banner link styling and close-button appearance.
  * Hidden banners no longer occupy space in the page layout.
  * Enhanced readability and contrast for update-banner content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->