### PR TITLE
fix: judge an Android client against Android releases, not against the server

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -908,6 +908,18 @@ async def lifespan(app: FastAPI):
         # convention a test enforces uniformly.
         misfire_grace_time=300,
     )
+    # The Android client's own release track, on the same daily cadence and with
+    # the same failure contract. Separate job rather than folded into the one
+    # above so a GitHub hiccup fetching one cannot suppress the other.
+    scheduler.add_job(
+        update_check.refresh_android,
+        "interval",
+        hours=24,
+        id="update_check_android",
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=300,
+    )
     scheduler.add_job(
         exchange_rates.refresh,
         "interval",
@@ -919,6 +931,15 @@ async def lifespan(app: FastAPI):
     )
     scheduler.start()
     await exchange_rates.refresh()
+    # Kick both release checks NOW rather than waiting out the first 24-hour
+    # interval. APScheduler's interval trigger does not fire on start, and this
+    # container is recreated on every deploy -- so on an install that ships more
+    # often than daily the check would never run at all, and the update banner
+    # would sit permanently at known=false. Spawned, not awaited: a slow or
+    # unreachable GitHub must not delay startup, and every failure inside these
+    # already lands on UNKNOWN.
+    _spawn(update_check.refresh())
+    _spawn(update_check.refresh_android())
     _spawn(_run_collection())
     logger.info("CashPilot UI started (container ops via workers)")
 
@@ -4058,7 +4079,22 @@ async def api_list_workers(request: Request) -> list[dict[str, Any]]:
         # known releases for this to be True, so an older worker that predates
         # version reporting reads as unknown, not as a mismatch.
         w["ui_version"] = ui_version
-        w["version_skew"] = version.skewed(ui_version, (w.get("system_info") or {}).get("version"))
+        # An Android client ships on its OWN release track, so the UI's version
+        # is the wrong yardstick: a phone on 0.3.0 against a UI on 1.24.1 is not
+        # skew, it is two different products, and comparing them flagged EVERY
+        # Android device permanently. Compare a phone against the newest
+        # CashPilot-android release instead.
+        #
+        # reference_version is what the worker was actually judged against, so
+        # the UI can say so rather than always claiming "UI vX".
+        si = w.get("system_info") or {}
+        is_android = str(si.get("os") or "").strip().lower() == "android"
+        reference = update_check.android_latest() if is_android else ui_version
+        w["reference_version"] = reference
+        # Unknown reference -> no skew. version.skewed() already returns False
+        # when either side is unknown, which is what keeps an offline install
+        # (or a GitHub outage) from lighting a warning on every phone.
+        w["version_skew"] = version.skewed(reference, si.get("version"))
         # The per-machine power settings the running-costs card needs, read the
         # SAME way api_fleet_economics reads them — client_id first, row id as
         # the fallback for values written before that changed. Returning them

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -367,7 +367,20 @@ CASHPILOT_WORKER_NAME=server-name</code>
                         style="font-size:0.7rem; padding:1px 6px;">Save</button>
               </span>
               ${sysInfo.version
-                ? `<span${w.version_skew ? ` style="color:var(--warning); font-weight:600;" title="This worker is on a different release series from the UI (${esc(w.ui_version || '?')}). Update whichever is behind — on Unraid the UI and the worker are two separate apps, so updating one leaves the other."` : ''}>v${esc(sysInfo.version)}${w.version_skew ? ` \u2260 UI v${esc(w.ui_version || '?')}` : ''}</span>`
+                ? (() => {
+                    // What this worker was actually judged against. An Android
+                    // client is compared to the newest CashPilot-android
+                    // release, not to the UI: the two ship on separate tracks,
+                    // so "v0.3.0 != UI v1.24.1" was never skew, it was two
+                    // different products, and it flagged every phone forever.
+                    const isAndroid = String(sysInfo.os || '').toLowerCase() === 'android';
+                    const ref = w.reference_version || w.ui_version || '?';
+                    const refLabel = isAndroid ? `latest v${esc(ref)}` : `UI v${esc(ref)}`;
+                    const why = isAndroid
+                      ? `This phone is on an older CashPilot Android release than the newest published one (${esc(ref)}). Install the newer APK from the GitHub releases page.`
+                      : `This worker is on a different release series from the UI (${esc(ref)}). Update whichever is behind — on Unraid the UI and the worker are two separate apps, so updating one leaves the other.`;
+                    return `<span${w.version_skew ? ` style="color:var(--warning); font-weight:600;" title="${why}"` : ''}>v${esc(sysInfo.version)}${w.version_skew ? ` \u2260 ${refLabel}` : ''}</span>`;
+                  })()
                 : `<span title="This worker predates version reporting, so CashPilot cannot tell which release it is. Update it to find out.">version unknown</span>`}
             </div>
             ${isAndroid && items.length > 0 ? renderApps(items, isOnline, w.last_heartbeat) : ''}

--- a/app/update_check.py
+++ b/app/update_check.py
@@ -45,6 +45,12 @@ logger = logging.getLogger(__name__)
 #: it cannot be made expensive by a repository with a long release history.
 LATEST_URL = "https://api.github.com/repos/GeiserX/CashPilot/releases/latest"
 
+#: The Android client ships on its OWN release track and its versions will never
+#: match the server's. Comparing a phone running 0.3.0 against a UI running
+#: 1.24.1 flagged EVERY Android device as skewed, permanently, which is noise
+#: that teaches the operator to ignore the one warning that matters.
+ANDROID_LATEST_URL = "https://api.github.com/repos/GeiserX/CashPilot-android/releases/latest"
+
 #: Once a day. A release is not urgent, and a self-hosted app polling a third
 #: party more often than that is rude.
 CHECK_INTERVAL_SECONDS = 24 * 60 * 60
@@ -55,6 +61,12 @@ _HTTP_TIMEOUT = 10.0
 #: different statement and is carried by `known`.
 _latest_tag: str | None = None
 _checked_at: float = 0.0
+
+#: Same shape, for the Android client. Kept separate rather than folded into a
+#: dict so the existing server path cannot be perturbed by a failure fetching
+#: the Android one.
+_android_tag: str | None = None
+_android_checked_at: float = 0.0
 
 
 def enabled() -> bool:
@@ -114,6 +126,46 @@ async def refresh(*, force: bool = False) -> str | None:
     return tag
 
 
+async def refresh_android(*, force: bool = False) -> str | None:
+    """The newest published CashPilot-android release tag, or None for unknown.
+
+    Same contract as refresh(): never raises, and every failure lands on
+    UNKNOWN. That matters more here than for the server check, because this
+    value feeds a WARNING on the fleet page -- an unreachable GitHub must make
+    the warning disappear, never make every phone look out of date.
+    """
+    global _android_tag, _android_checked_at
+
+    if not enabled():
+        return None
+    if not force and _android_checked_at and (time.time() - _android_checked_at) < CHECK_INTERVAL_SECONDS:
+        return _android_tag
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.get(ANDROID_LATEST_URL, headers={"Accept": "application/vnd.github+json"})
+            response.raise_for_status()
+            tag = _parse_tag(response.json())
+    except Exception as exc:  # noqa: BLE001 - every failure means the same thing
+        logger.debug("Android update check could not reach %s: %s", ANDROID_LATEST_URL, exc)
+        _android_checked_at = time.time()
+        return _android_tag
+
+    _android_tag = tag
+    _android_checked_at = time.time()
+    return _android_tag
+
+
+def android_latest() -> str | None:
+    """The cached Android release tag, or None when it is not known.
+
+    None is load-bearing: version.skewed() treats an unknown reference as "no
+    evidence of skew", so an install that cannot reach GitHub shows no warning
+    at all rather than a wrong one.
+    """
+    return _android_tag
+
+
 def state() -> dict[str, Any]:
     """What the UI needs to decide whether to say anything.
 
@@ -150,5 +202,6 @@ def _tuple(series_text: str) -> tuple[int, ...]:
 
 def _reset_for_tests() -> None:
     """Clear the module cache. Tests only."""
-    global _latest_tag, _checked_at
+    global _latest_tag, _checked_at, _android_tag, _android_checked_at
     _latest_tag, _checked_at = None, 0.0
+    _android_tag, _android_checked_at = None, 0.0

--- a/scripts/legibility_check.mjs
+++ b/scripts/legibility_check.mjs
@@ -68,7 +68,7 @@ const buttons = variants
   )
   .join("");
 
-const fixture = `<!DOCTYPE html><html><head><meta charset="utf-8">
+const fixtureFor = (theme) => `<!DOCTYPE html><html${theme === "light" ? ' data-theme="light"' : ""}><head><meta charset="utf-8">
 <link rel="stylesheet" href="file://${CSS}"></head>
 <body>
   <div class="card" style="padding:16px;margin:8px">
@@ -91,14 +91,27 @@ const fixture = `<!DOCTYPE html><html><head><meta charset="utf-8">
   </div>
 </body></html>`;
 
-const fixturePath = path.join(process.env.TMPDIR || "/tmp", "cashpilot-legibility.html");
-fs.writeFileSync(fixturePath, fixture);
+// One file PER THEME, each with data-theme baked into <html> so the theme is
+// in force before a single style is resolved.
+//
+// Toggling the attribute on a live page and re-measuring does not work in
+// headless Chrome: the first getComputedStyle resolves and the later attribute
+// change is not re-resolved, so the second theme silently reports the FIRST
+// theme's values. That is what made this check pass locally and fail in CI --
+// and, worse, what made a passing run meaningless. A fresh document per theme
+// has no such state to go stale.
+const fixturePaths = {};
+for (const theme of ["dark", "light"]) {
+  const fp = path.join(process.env.TMPDIR || "/tmp", `cashpilot-legibility-${theme}.html`);
+  fs.writeFileSync(fp, fixtureFor(theme));
+  fixturePaths[theme] = fp;
+}
 
 // ---------------------------------------------------------------------------
 // This runs INSIDE the page. It reports measurements; it makes no judgements,
 // so the thresholds stay here in one place rather than being scattered.
 // ---------------------------------------------------------------------------
-const AUDIT = `(() => {
+const AUDIT = (theme) => `((theme) => {
   const parse = (c) => {
     const m = c.match(/rgba?\\(([^)]+)\\)/);
     if (!m) return null;
@@ -189,8 +202,12 @@ const AUDIT = `(() => {
       contrast: Math.round(ratio(parse(lcs.color), effectiveBg(link)) * 100) / 100,
     };
   }
+  // Prove the switch actually took effect. A partially-applied theme produced
+  // the CI failure this guards against, and silently measuring it is worse than
+  // failing: the numbers look authoritative and describe nothing real.
+  out.themeApplied = (document.documentElement.getAttribute("data-theme") || "dark") === theme;
   return JSON.stringify(out);
-})()`;
+})(${JSON.stringify(theme)})`;
 
 // ---------------------------------------------------------------------------
 const version = await fetch(`http://127.0.0.1:${PORT}/json/version`).catch(() => null);
@@ -203,7 +220,7 @@ if (!version || !version.ok) {
 }
 
 const target = await (
-  await fetch(`http://127.0.0.1:${PORT}/json/new?${encodeURIComponent("file://" + fixturePath)}`, { method: "PUT" })
+  await fetch(`http://127.0.0.1:${PORT}/json/new?about:blank`, { method: "PUT" })
 ).json();
 const ws = new WebSocket(target.webSocketDebuggerUrl);
 let id = 0;
@@ -225,15 +242,15 @@ const fail = (msg) => { failures++; console.error("FAIL  " + msg); };
 // Both themes. A palette that works in the dark one can be unreadable in the
 // other, and the light theme redefines every colour token.
 for (const theme of ["dark", "light"]) {
-  await send("Runtime.evaluate", {
-    expression:
-      theme === "light"
-        ? `document.documentElement.setAttribute("data-theme","light")`
-        : `document.documentElement.removeAttribute("data-theme")`,
-  });
-  await new Promise((r) => setTimeout(r, 120));
-  const res = await send("Runtime.evaluate", { expression: AUDIT, returnByValue: true });
+  await send("Page.navigate", { url: "file://" + fixturePaths[theme] });
+  await new Promise((r) => setTimeout(r, 400)); // let the stylesheet load
+  const res = await send("Runtime.evaluate", { expression: AUDIT(theme), returnByValue: true });
   const data = JSON.parse(res.result.value);
+  checks += 1;
+  if (!data.themeApplied) {
+    fail(`[${theme}] the theme did not apply, so every measurement below is meaningless`);
+    continue;
+  }
 
   for (const b of data.buttons) {
     checks += 2;

--- a/tests/test_android_version_skew.py
+++ b/tests/test_android_version_skew.py
@@ -125,3 +125,70 @@ class TestTheFetchNeverRaises:
         """Third-party JSON. A tag like 'nightly' must not be shown as a release."""
         assert update_check._parse_tag({"tag_name": "nightly"}) is None
         assert update_check._parse_tag({"tag_name": "v0.3.0"}) == "v0.3.0"
+
+
+class TestTheFetchSucceeds:
+    """The success and caching paths. Without these the only thing proven is
+    that the check fails safely -- not that it ever works."""
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def _client(self, payload, counter):
+        outer = self
+
+        class _C:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, *a, **k):
+                counter.append(1)
+                return outer._Resp(payload)
+
+        return lambda **k: _C()
+
+    @pytest.mark.asyncio
+    async def test_a_successful_fetch_caches_the_tag(self):
+        calls = []
+        with patch("app.update_check.httpx.AsyncClient", self._client({"tag_name": "v0.4.0"}, calls)):
+            assert await update_check.refresh_android(force=True) == "v0.4.0"
+        assert update_check.android_latest() == "v0.4.0"
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_second_call_inside_the_interval_does_not_refetch(self):
+        """Once a day. A self-hosted app polling a third party harder than that
+        is rude, and the cache is what makes the fleet page free to read."""
+        calls = []
+        with patch("app.update_check.httpx.AsyncClient", self._client({"tag_name": "v0.4.0"}, calls)):
+            await update_check.refresh_android(force=True)
+            assert await update_check.refresh_android() == "v0.4.0"
+        assert len(calls) == 1, "the cached value should have been returned without a second request"
+
+    @pytest.mark.asyncio
+    async def test_a_junk_tag_is_stored_as_unknown_not_as_a_version(self):
+        calls = []
+        with patch("app.update_check.httpx.AsyncClient", self._client({"tag_name": "nightly"}, calls)):
+            assert await update_check.refresh_android(force=True) is None
+        assert update_check.android_latest() is None
+
+    @pytest.mark.asyncio
+    async def test_a_fetched_tag_then_drives_the_comparison(self):
+        """End to end: fetch, then judge a phone against what was fetched."""
+        calls = []
+        with patch("app.update_check.httpx.AsyncClient", self._client({"tag_name": "v0.4.0"}, calls)):
+            await update_check.refresh_android(force=True)
+        si = {"os": "Android", "version": "0.3.0"}
+        assert version.skewed(_reference(si, "1.24.1"), si["version"]) is True
+        si_current = {"os": "Android", "version": "0.4.0"}
+        assert version.skewed(_reference(si_current, "1.24.1"), si_current["version"]) is False

--- a/tests/test_android_version_skew.py
+++ b/tests/test_android_version_skew.py
@@ -1,0 +1,127 @@
+"""An Android client is judged against Android releases, not against the server.
+
+Reported from the live fleet: every phone showed "v0.3.0 != UI v1.24.1",
+permanently. That was never skew. The Android client ships on its own release
+track and its versions will never match the server's, so the comparison could
+only ever be false -- and a warning that is always on is a warning that teaches
+the operator to ignore the one that matters.
+
+The rule these tests pin: compare a phone to the newest CashPilot-android
+release, compare everything else to the UI, and when the reference is unknown
+say NOTHING. That last one is the important one -- an unreachable GitHub must
+make the warning disappear, never make every phone look out of date.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+from app import update_check, version  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    update_check._reset_for_tests()
+    yield
+    update_check._reset_for_tests()
+
+
+def _reference(system_info: dict, ui_version: str) -> str | None:
+    """The reference main.py picks. Mirrors the enrichment, without a DB."""
+    is_android = str(system_info.get("os") or "").strip().lower() == "android"
+    return update_check.android_latest() if is_android else ui_version
+
+
+class TestThePhoneIsNotComparedToTheServer:
+    def test_a_current_phone_is_not_skewed_against_a_1x_ui(self):
+        """The reported bug, stated as the app actually saw it."""
+        update_check._android_tag = "v0.3.0"
+        si = {"os": "Android", "version": "0.3.0"}
+        ref = _reference(si, "1.24.1")
+        assert ref == "v0.3.0"
+        assert version.skewed(ref, si["version"]) is False
+
+    def test_the_old_behaviour_WOULD_have_flagged_it(self):
+        """Control. If comparing to the UI did not flag it, this test proves
+        nothing about the fix -- the bug has to be reproducible."""
+        assert version.skewed("1.24.1", "0.3.0") is True
+
+    def test_a_genuinely_old_phone_IS_still_flagged(self):
+        """The fix must not silence real skew, only the fabricated kind."""
+        update_check._android_tag = "v0.5.0"
+        si = {"os": "Android", "version": "0.3.0"}
+        assert version.skewed(_reference(si, "1.24.1"), si["version"]) is True
+
+    def test_a_patch_behind_is_not_skew(self):
+        """Skew is judged on major.minor; patches inside a series interoperate."""
+        update_check._android_tag = "v0.3.9"
+        si = {"os": "Android", "version": "0.3.0"}
+        assert version.skewed(_reference(si, "1.24.1"), si["version"]) is False
+
+
+class TestUnknownReferenceSaysNothing:
+    """The failure mode that must never produce a warning."""
+
+    def test_unreachable_github_means_no_warning(self):
+        update_check._android_tag = None  # never fetched, or every fetch failed
+        si = {"os": "Android", "version": "0.3.0"}
+        assert _reference(si, "1.24.1") is None
+        assert version.skewed(None, si["version"]) is False
+
+    @pytest.mark.parametrize("flag", ["0", "off", "false", "no"])
+    @pytest.mark.asyncio
+    async def test_disabled_check_fetches_nothing_and_warns_about_nothing(self, flag):
+        with patch.dict(os.environ, {"CASHPILOT_UPDATE_CHECK": flag}):
+            assert await update_check.refresh_android() is None
+            assert update_check.android_latest() is None
+            assert version.skewed(update_check.android_latest(), "0.3.0") is False
+
+
+class TestNonAndroidIsUnaffected:
+    def test_a_linux_worker_is_still_compared_to_the_ui(self):
+        update_check._android_tag = "v0.3.0"
+        si = {"os": "Linux", "version": "1.13.0"}
+        assert _reference(si, "1.24.1") == "1.24.1"
+        assert version.skewed(_reference(si, "1.24.1"), si["version"]) is True
+
+    def test_a_matching_linux_worker_is_not_skewed(self):
+        si = {"os": "Linux", "version": "1.24.1"}
+        assert version.skewed(_reference(si, "1.24.1"), si["version"]) is False
+
+    def test_os_detection_is_case_insensitive_and_whitespace_tolerant(self):
+        update_check._android_tag = "v0.3.0"
+        for spelling in ("Android", "android", "ANDROID", "  Android  "):
+            assert _reference({"os": spelling, "version": "0.3.0"}, "1.24.1") == "v0.3.0"
+
+    def test_a_worker_with_no_os_falls_back_to_the_ui(self):
+        """Absent is not Android. An unknown OS must not silently get the
+        Android yardstick, or a container would be judged against a phone."""
+        update_check._android_tag = "v0.3.0"
+        assert _reference({"version": "1.13.0"}, "1.24.1") == "1.24.1"
+
+
+class TestTheFetchNeverRaises:
+    @pytest.mark.asyncio
+    async def test_a_broken_response_lands_on_unknown(self):
+        class _Boom:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, *a, **k):
+                raise RuntimeError("no network")
+
+        with patch("app.update_check.httpx.AsyncClient", lambda **k: _Boom()):
+            assert await update_check.refresh_android(force=True) is None
+        assert update_check.android_latest() is None
+
+    @pytest.mark.asyncio
+    async def test_a_tag_that_is_not_a_version_is_rejected(self):
+        """Third-party JSON. A tag like 'nightly' must not be shown as a release."""
+        assert update_check._parse_tag({"tag_name": "nightly"}) is None
+        assert update_check._parse_tag({"tag_name": "v0.3.0"}) == "v0.3.0"

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -2173,6 +2173,11 @@ class TestLifespanScheduler:
                         "db_vacuum",
                         "exchange_rates",
                         "update_check",
+                        # The Android client's own release track. Separate job
+                        # so a GitHub hiccup fetching one cannot suppress the
+                        # other; it carries the same hardening kwargs, which the
+                        # loop below asserts for every job uniformly.
+                        "update_check_android",
                     }
                     # Every job carries the hardening kwargs (audit fix).
                     for job in jobs.values():


### PR DESCRIPTION
Every phone on the live fleet showed **`v0.3.0 ≠ UI v1.24.1`**, permanently.

That was never skew. The Android client ships on its **own release track**, so its versions will never match the server’s — the comparison could only ever be false. A warning that is always on is a warning that teaches the operator to ignore the one that matters.

## The fix

A phone is compared against the newest **CashPilot-android** release; everything else still against the UI. The API now returns `reference_version`, so the fleet page can say what it actually judged against instead of always claiming "UI vX", and a phone’s tooltip tells you to install a newer APK rather than to update a container.

**An unknown reference means silence, not suspicion.** `version.skewed()` already treats an unknown side as no evidence, so an install that cannot reach GitHub — or one with `CASHPILOT_UPDATE_CHECK` off — shows nothing rather than flagging every phone. That is the failure mode worth testing, and it has its own tests.

## A second bug the same path exposed

**Neither release check ran at startup.** APScheduler’s `interval` trigger does not fire on start, so the first run was 24 hours away — and this container is recreated on every deploy. On an install that ships more often than daily, **the check never ran at all**.

That is half the reason the update banner appeared empty: it sat permanently at `known=false`. Both checks are now kicked once at startup, spawned rather than awaited so a slow GitHub cannot delay boot, with every failure still landing on UNKNOWN.

## Verification

| mutation | what fails |
|---|---|
| compare Android to the UI again | the reported bug reproduces — 4 tests |
| treat an unknown reference as skew | exactly the silence tests |

The suite also includes the control that makes the first test mean something: `skewed("1.24.1", "0.3.0") is True`, so the bug is demonstrably reproducible rather than merely absent.

`test_main_routes` pins the exact set of scheduled jobs — a good guard — so the new job is added there deliberately.

4430 passed, 95.51% coverage, ruff clean, 94/94 legibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate Android release tracking and daily update checks.
  * Android devices now compare versions against the latest Android release.
  * Fleet displays provide Android-specific version status and upgrade guidance.
  * Desktop and Android update checks run automatically during startup.

* **Bug Fixes**
  * Improved version comparison handling for unknown, missing, invalid, or unavailable release data.
  * Preserved existing version checks for non-Android systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->