### PR TITLE
fix(catalog): Bytebenefit lives at bytebenefit.io — revive with referral link

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ These services have no Docker image. CashPilot lists them in the catalog with si
 <!-- BEGIN GENERATED: extension-services -->
 | Service | Guide | Residential IP required | VPS allowed | Devices / Acct | Devices / IP | Payout | Status |
 |---------|-------|:-:|:-:|:-:|:-:|--------|--------|
+| [Bytebenefit](https://bytebenefit.io/invited?ref=Brl4z3) | [Guide](docs/guides/bytebenefit.md) | ✅ | ❌ | ? \*\*\* | ? \*\*\* | PayPal | Active |
 | [Bytelixir](https://bytelixir.com/r/OYEIRE0VSZBZ) | [Guide](docs/guides/bytelixir.md) | ✅ | ❌ | ? \*\*\* | ? \*\*\* | Crypto | Active |
 | [Dawn Internet](https://dawninternet.com/?code=2QLQV97F) | [Guide](docs/guides/dawn.md) | ✅ | ❌ | ? \*\*\* | ? \*\*\* | Crypto | Active |
 | [Deeper Network](https://deeper.network) | [Guide](docs/guides/deeper-network.md) | ✅ | ❌ | ? \*\*\* | ? \*\*\* | Crypto | Active |
@@ -366,7 +367,6 @@ Services that were evaluated but are no longer listed in the catalog due to bein
 | Network3 | Broken | No SSL, no updates in months | Mar 2026 |
 | GagaNode | Shady | Poorly made website, untrustworthy | Mar 2026 |
 | BlockMesh (Perceptron) | Dropped | Rebranded, requires browser dev mode, shady | Mar 2026 |
-| Bytebenefit | Dead | Domain sold/parked on marketplace | Mar 2026 |
 | Wipter | Dead | Domain resolves to DNS sinkhole, infrastructure gone | Mar 2026 |
 | Filecoin | Not viable | Enterprise-only (10 TiB min, datacenter infrastructure required) | Mar 2026 |
 | AntGain | Dead | Telegram channel unavailable | Mar 2026 |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,7 +17,7 @@ Setup and configuration for every service CashPilot supports.
 | Service | Needs | Runs as | Minimum payout | Status |
 |---|---|---|---|---|
 | [Bitping](bitping.md) | — | Docker | $5 | active |
-| [Bytebenefit](bytebenefit.md) | Residential IP | App only | $5 | dead |
+| [Bytebenefit](bytebenefit.md) | Residential IP | App only | $5 | active |
 | [Bytelixir](bytelixir.md) | Residential IP | App only | $5 | active |
 | [earn.cc](earncc.md) | Residential IP | App only | — | broken |
 | [Earn.fm](earnfm.md) | Residential IP | Docker | $15 | active |

--- a/docs/guides/bytebenefit.md
+++ b/docs/guides/bytebenefit.md
@@ -1,11 +1,11 @@
 # Bytebenefit
 
-> **Category:** Bandwidth Sharing | **Status:** Dead
-> **Website:** [https://bytebenefit.com](https://bytebenefit.com)
+> **Category:** Bandwidth Sharing | **Status:** Active
+> **Website:** [https://bytebenefit.io](https://bytebenefit.io)
 
 ## Description
 
-Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe. Relatively new service with no official Docker image available yet. Desktop application is the primary client.
+Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe. No official Docker image; the Windows desktop app and Android app are the clients. The service lives at bytebenefit.io — the old bytebenefit.com domain was dropped and is now parked on a marketplace, which is why this guide once listed the service as dead.
 
 ## Earning Estimates
 
@@ -33,7 +33,7 @@ Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe. 
 
 ### 1. Create an account
 
-Sign up at [Bytebenefit](https://bytebenefit.com).
+Sign up at [Bytebenefit](https://bytebenefit.io/invited?ref=Brl4z3).
 
 ### 2. Get your credentials
 

--- a/docs/guides/bytebenefit.md
+++ b/docs/guides/bytebenefit.md
@@ -33,7 +33,7 @@ Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe. 
 
 ### 1. Create an account
 
-Sign up at [Bytebenefit](https://bytebenefit.io/invited?ref=Brl4z3).
+Sign up at [Bytebenefit](https://bytebenefit.io/invited?ref=Brl4z3) — signing up through this link gives you a **$1 (10,000 Coins) welcome bonus**.
 
 ### 2. Get your credentials
 

--- a/docs/guides/bytebenefit.md
+++ b/docs/guides/bytebenefit.md
@@ -17,7 +17,7 @@ Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe. 
 | Payout frequency | On request |
 | Payment methods | Paypal |
 
-> No Docker image available. Desktop app only.
+> No Docker image available. Windows desktop and Android apps only.
 
 ## Requirements
 

--- a/services/bandwidth/bytebenefit.yml
+++ b/services/bandwidth/bytebenefit.yml
@@ -1,16 +1,18 @@
 name: Bytebenefit
 slug: bytebenefit
 category: bandwidth
-status: dead
-website: https://bytebenefit.com
+status: active
+website: https://bytebenefit.io
 description: >
   Bytebenefit is a bandwidth-sharing service that pays through PayPal and Stripe.
-  Relatively new service with no official Docker image available yet. Desktop
-  application is the primary client.
-short_description: Bandwidth sharing - PayPal/Stripe payouts, desktop app
+  No official Docker image; the Windows desktop app and Android app are the
+  clients. The service lives at bytebenefit.io -- the old bytebenefit.com domain
+  was dropped and is parked on a marketplace, which is why it was once marked
+  dead here.
+short_description: Bandwidth sharing - PayPal/Stripe payouts, desktop/Android app
 
 referral:
-  signup_url: "https://bytebenefit.com"
+  signup_url: "https://bytebenefit.io/invited?ref=Brl4z3"
 
 docker:
   image: ""
@@ -42,7 +44,7 @@ earnings:
 
 cashout:
   method: redirect
-  dashboard_url: "https://bytebenefit.com/dashboard"
+  dashboard_url: "https://dashboard.bytebenefit.io"
   min_amount: 5.0
   currency: USD
 

--- a/services/bandwidth/bytebenefit.yml
+++ b/services/bandwidth/bytebenefit.yml
@@ -40,7 +40,7 @@ earnings:
   monthly_high: 3
   currency: USD
   per: "device"
-  notes: "No Docker image available. Desktop app only."
+  notes: "No Docker image available. Windows desktop and Android apps only."
 
 cashout:
   method: redirect


### PR DESCRIPTION
Bytebenefit was marked **dead** (Mar 2026) because `bytebenefit.com` was sold and is parked on a marketplace. Only the domain died — the service runs at **bytebenefit.io** (same product; the Play Store listing matches the `io.bytebenefit.app` package the Android companion already monitors, and `dashboard.bytebenefit.io` answers 200).

- `website`, `referral.signup_url` and `cashout.dashboard_url` now point at the live `.io` domain; signup carries the referral code.
- Status `dead` → `active`; removed from the hand-maintained Discontinued table.
- README extension-services table and docs/guides index regenerated (`generate_readme_tables.py` / `sync_docs_nav.py`, both pass `--check`).

Verified: `.com` redirects to atom.com (marketplace); `.io` root, referral URL and dashboard all 200. Full pytest: 4434 passed. ruff + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bytebenefit’s status from discontinued to active.
  * Updated links to the current bytebenefit.io website, signup page, and cashout dashboard.
  * Added current service details, including PayPal and Stripe payments and support for Windows and Android.
  * Clarified that the former .com domain is no longer in use.
  * Added Bytebenefit to the active services listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->