### PR TITLE
feat(catalog): referral registry + self-audit — a bare link can no longer hide

### DIFF
--- a/.github/workflows/catalog-check.yml
+++ b/.github/workflows/catalog-check.yml
@@ -15,6 +15,7 @@ on:
       - "services/**"
       - "README.md"
       - "scripts/generate_readme_tables.py"
+      - "scripts/referral_check.py"
       - ".github/workflows/catalog-check.yml"
   push:
     branches: [main]
@@ -51,6 +52,16 @@ jobs:
 
       - name: README service tables match the catalog
         run: python scripts/generate_readme_tables.py --check
+
+      # Referral links are revenue. This fails on regressions (a recorded code
+      # no longer anchored in its signup_url, malformed registry facts);
+      # known-program-without-code gaps and unresearched providers are printed,
+      # not failed. A contributor who updates a migrated provider's signup_url
+      # CAN trip the code check -- the error text tells them the escape hatch:
+      # leave `code` as it was and flag it, since only the account holder can
+      # re-issue the link.
+      - name: Referral links still carry their codes
+        run: python scripts/referral_check.py
 
       - name: Every service has a guide
         run: |

--- a/scripts/referral_check.py
+++ b/scripts/referral_check.py
@@ -104,7 +104,13 @@ def audit(services: list[dict]) -> dict[str, list[str]]:
             continue
 
         if code is not None:
-            if not str(code).strip():
+            if not isinstance(code, str):
+                # An unquoted YAML scalar: 0071234 arrives as the int 29340
+                # (octal), no/yes as booleans. str() would launder some of
+                # these into accidental matches, so refuse the type outright.
+                errors.append(f"{slug}: referral.code must be a quoted string, got {type(code).__name__} {code!r}")
+                continue
+            if not code.strip():
                 errors.append(
                     f"{slug}: referral.code is empty -- delete the key or record the real code; empty is not a value"
                 )
@@ -154,6 +160,11 @@ def main() -> int:
         help="catalog root to audit (tests point this at fixtures)",
     )
     args = parser.parse_args()
+
+    if not args.services_dir.is_dir():
+        # A missing directory must not audit zero files and report success.
+        print(f"services dir not found: {args.services_dir}", file=sys.stderr)
+        return 2
 
     findings = audit(load_services(args.services_dir))
 

--- a/scripts/referral_check.py
+++ b/scripts/referral_check.py
@@ -1,0 +1,181 @@
+"""Audit the catalog's referral links against the referral registry.
+
+Referral links are revenue, and nothing used to check them: a link could lose
+its code in a domain migration (ProxyBase kept earning $0 on a retired image
+for months before anyone looked), or a service could sit in the catalog with a
+bare URL while its provider ran a paying program (Bytebenefit spent ~5 months
+wrongly dead AND bare -- every signup in that window was unattributed).
+
+The registry is three-valued, because absent is not "no":
+
+    referral.code       the referral code itself. Its presence means the
+                        provider has a program AND a code exists; the checker
+                        proves the code still appears in signup_url.
+    referral.program    true  = provider verified to run a program
+                              (with no code yet, that is an ACTION item)
+                        false = provider verified NOT to run one
+                              (a bare URL is correct, not a gap)
+    (neither)           UNKNOWN: nobody has checked. Reported as the research
+                        backlog, never failed -- an unresearched fact is not
+                        an error, and failing on it would teach people to
+                        write `program: false` without checking.
+
+Exit codes: 1 on inconsistencies (always -- these are regressions), and with
+--strict also on action items. Unknowns never fail in either mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from urllib.parse import parse_qsl, urlsplit
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: Statuses whose signup links are shown to users, so gaps there cost revenue.
+#: Consistency errors are checked for EVERY status: a dead service keeps its
+#: code, so a resurrection (the Bytebenefit shape) comes back attributed.
+EARNING_STATUSES = {"active", "beta"}
+
+
+def load_services(services_dir: pathlib.Path) -> list[dict]:
+    """Load every service YAML, refusing to silently skip a broken one.
+
+    app.catalog drops invalid entries by design (the UI must boot around one
+    bad file); an *audit* must not, because a file this loader skipped would
+    simply vanish from the report and read as "nothing to fix". The glob never
+    sees services/_schema.yml -- it lives one level above the category dirs.
+    """
+    services = []
+    for path in sorted(services_dir.glob("*/*.yml")):
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            raise SystemExit(f"{path}: unparseable YAML: {exc}") from exc
+        if not isinstance(data, dict):
+            raise SystemExit(f"{path}: expected a mapping, got {type(data).__name__}")
+        data["_file"] = str(path.relative_to(services_dir.parent))
+        services.append(data)
+    return services
+
+
+def code_attributes_url(code: str, url: str) -> bool:
+    """True when the code is ANCHORED in the URL, not merely a substring.
+
+    `"grass" in "https://app.grass.io/register"` is a hostname coincidence,
+    not attribution. The code counts only where a provider would read it: a
+    query-parameter value (?ref=CODE), a bare query key (?CODE -- spide's
+    shape), or a whole path segment (/i/CODE -- uprock, earnapp, honeygain).
+    """
+    parts = urlsplit(url)
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if code == value or (value == "" and code == key):
+            return True
+    return code in parts.path.split("/")
+
+
+def audit(services: list[dict]) -> dict[str, list[str]]:
+    """Returns findings grouped as errors / actions / unknowns."""
+    errors: list[str] = []
+    actions: list[str] = []
+    unknowns: list[str] = []
+
+    for svc in services:
+        slug = svc.get("slug", svc.get("_file", "?"))
+        ref = svc.get("referral")
+        if ref is not None and not isinstance(ref, dict):
+            errors.append(f"{slug}: referral must be a mapping, got {type(ref).__name__}")
+            continue
+        ref = ref or {}
+        signup = ref.get("signup_url") or ""
+        code = ref.get("code")
+        program = ref.get("program")  # True / False / None -- three-valued
+
+        # Anything else has fallen out of YAML's booleans ("no", "TODO", 1…).
+        # It must not silently satisfy neither arm below and vanish from every
+        # bucket -- a service that vanished from the report reads as fine.
+        # Identity, not equality: `1 == True` in Python, so a membership test
+        # would wave `program: 1` through as a boolean it never was.
+        if not (program is True or program is False or program is None):
+            errors.append(f"{slug}: referral.program must be true, false, or absent -- got {program!r}")
+            continue
+
+        if code is not None:
+            if not str(code).strip():
+                errors.append(
+                    f"{slug}: referral.code is empty -- delete the key or record the real code; empty is not a value"
+                )
+            elif not signup:
+                errors.append(f"{slug}: has a referral.code but no referral.signup_url to carry it")
+            elif not code_attributes_url(str(code), signup):
+                errors.append(
+                    f"{slug}: referral.code {code!r} is not anchored in "
+                    f"signup_url {signup!r} -- the link lost its attribution. "
+                    f"If the provider migrated domains, leave code untouched "
+                    f"and flag it in the PR: only the account holder can "
+                    f"re-issue the link"
+                )
+            if program is False:
+                errors.append(f"{slug}: has a referral.code but says program: false -- one of the two is wrong")
+
+        if svc.get("status") in EARNING_STATUSES and code is None:
+            if not signup:
+                actions.append(f"{slug}: no referral.signup_url recorded -- users have nowhere to sign up from")
+            elif program is True:
+                actions.append(
+                    f"{slug}: provider runs a referral program but no code is "
+                    f"recorded -- sign up and add referral.code (lost revenue "
+                    f"until then)"
+                )
+            elif program is None:
+                unknowns.append(
+                    f"{slug}: nobody has checked whether the provider runs a "
+                    f"referral program -- research it, then record "
+                    f"program: true/false"
+                )
+
+    return {"errors": errors, "actions": actions, "unknowns": unknowns}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also fail on action items (known program, no code yet)",
+    )
+    parser.add_argument(
+        "--services-dir",
+        type=pathlib.Path,
+        default=ROOT / "services",
+        help="catalog root to audit (tests point this at fixtures)",
+    )
+    args = parser.parse_args()
+
+    findings = audit(load_services(args.services_dir))
+
+    for line in findings["errors"]:
+        print(f"ERROR   {line}")
+    for line in findings["actions"]:
+        print(f"ACTION  {line}")
+    for line in findings["unknowns"]:
+        print(f"UNKNOWN {line}")
+
+    print(
+        f"\n{len(findings['errors'])} error(s), "
+        f"{len(findings['actions'])} action item(s), "
+        f"{len(findings['unknowns'])} unresearched"
+    )
+
+    if findings["errors"]:
+        return 1
+    if args.strict and findings["actions"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -13,6 +13,19 @@
 
 # referral:
 #   signup_url: Full signup URL with referral code already embedded
+#   code: The referral code itself, ALWAYS QUOTED -- unquoted, "0071234" parses
+#         as an octal int and "no"/"yes"/"on" as booleans (YAML 1.1).
+#         scripts/referral_check.py proves it stays anchored in signup_url
+#         (query value, bare query key, or path segment), so a domain
+#         migration cannot silently strip the attribution.
+#   program: Whether the PROVIDER runs a referral program. Three-valued, and
+#            absent is not "no":
+#              true    verified to run one (true + no code = actionable gap)
+#              false   verified NOT to run one (a bare signup_url is correct)
+#              absent  nobody has checked yet (reported, never failed)
+#   bonus: (optional) what each side gets, shown on the service detail page:
+#     referrer: "20% of referral traffic earnings"
+#     referee: "$1 welcome bonus"
 
 # docker:
 #   image: Docker Hub image

--- a/services/bandwidth/bytebenefit.yml
+++ b/services/bandwidth/bytebenefit.yml
@@ -13,6 +13,10 @@ short_description: Bandwidth sharing - PayPal/Stripe payouts, desktop/Android ap
 
 referral:
   signup_url: "https://bytebenefit.io/invited?ref=Brl4z3"
+  code: "Brl4z3"
+  bonus:
+    referrer: "20% of referral traffic earnings"
+    referee: "$1 (10,000 Coins) welcome bonus"
 
 docker:
   image: ""

--- a/services/bandwidth/bytelixir.yml
+++ b/services/bandwidth/bytelixir.yml
@@ -12,6 +12,7 @@ short_description: Bandwidth sharing - $2-50/month, desktop + Android
 
 referral:
   signup_url: "https://bytelixir.com/r/OYEIRE0VSZBZ"
+  code: "OYEIRE0VSZBZ"
 
 docker:
   image: ""

--- a/services/bandwidth/earnapp.yml
+++ b/services/bandwidth/earnapp.yml
@@ -12,6 +12,7 @@ short_description: Bandwidth sharing - backed by Bright Data
 
 referral:
   signup_url: "https://earnapp.com/i/TSMD9wSm"
+  code: "TSMD9wSm"
 
 docker:
   image: fazalfarhan01/earnapp:lite

--- a/services/bandwidth/earnfm.yml
+++ b/services/bandwidth/earnfm.yml
@@ -11,6 +11,7 @@ short_description: Bandwidth sharing - email/password auth, lightweight client
 
 referral:
   signup_url: "https://earn.fm/ref/GEISYB91"
+  code: "GEISYB91"
 
 docker:
   image: earnfm/earnfm-client

--- a/services/bandwidth/ebesucher.yml
+++ b/services/bandwidth/ebesucher.yml
@@ -12,6 +12,7 @@ short_description: Traffic exchange surfbar - browser extension
 
 referral:
   signup_url: "https://www.ebesucher.com/?ref=geiserx"
+  code: "geiserx"
 
 docker:
   image: ""

--- a/services/bandwidth/honeygain.yml
+++ b/services/bandwidth/honeygain.yml
@@ -12,6 +12,7 @@ short_description: Bandwidth sharing - most established platform
 
 referral:
   signup_url: "https://dashboard.honeygain.com/ref/SERGIB4014"
+  code: "SERGIB4014"
 
 docker:
   image: honeygain/honeygain

--- a/services/bandwidth/iproyal.yml
+++ b/services/bandwidth/iproyal.yml
@@ -13,6 +13,7 @@ short_description: Bandwidth sharing - 10% lifetime referral, $3 signup bonus
 
 referral:
   signup_url: "https://pawns.app?r=19266874"
+  code: "19266874"
 
 docker:
   image: iproyal/pawns-cli

--- a/services/bandwidth/mysterium.yml
+++ b/services/bandwidth/mysterium.yml
@@ -13,6 +13,7 @@ short_description: Decentralized VPN node - blockchain-based, works on VPS
 
 referral:
   signup_url: "https://mystnodes.co/?referral_code=do7v7YOoBBpbOstKQovX2pUvZYKia4ZhH3QIdNtE"
+  code: "do7v7YOoBBpbOstKQovX2pUvZYKia4ZhH3QIdNtE"
 
 docker:
   image: mysteriumnetwork/myst

--- a/services/bandwidth/packetstream.yml
+++ b/services/bandwidth/packetstream.yml
@@ -13,6 +13,7 @@ short_description: Bandwidth sharing - simple CID-based setup
 
 referral:
   signup_url: "https://packetstream.io/?psr=7xgZ"
+  code: "7xgZ"
 
 docker:
   image: packetstream/psclient

--- a/services/bandwidth/proxybase-xyz.yml
+++ b/services/bandwidth/proxybase-xyz.yml
@@ -14,6 +14,7 @@ short_description: proxybase.xyz - SOCKS5 marketplace for AI agents, USDC payout
 
 referral:
   signup_url: "https://proxybase.xyz?referral=nXzS3c6iTO"
+  code: "nXzS3c6iTO"
 
 docker:
   image: "ghcr.io/proxybasehq/proxybase-cli@sha256:9c96a1d149a1d5b18360110be5caf7164a98656e4bb2c25f6b373b91f1c79802"

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -12,6 +12,7 @@ short_description: proxybase.org - bandwidth sharing, crypto payout, Access Toke
 
 referral:
   signup_url: "https://peer.proxybase.org?referral=nXzS3c6iTO"
+  code: "nXzS3c6iTO"
 
 docker:
   image: "ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e"

--- a/services/bandwidth/proxylite.yml
+++ b/services/bandwidth/proxylite.yml
@@ -12,6 +12,7 @@ short_description: Bandwidth sharing - 15% lifetime referral, works on VPS
 
 referral:
   signup_url: "https://proxylite.ru/?r=KMUPRZIZ"
+  code: "KMUPRZIZ"
 
 docker:
   image: proxylite/proxyservice

--- a/services/bandwidth/proxyrack.yml
+++ b/services/bandwidth/proxyrack.yml
@@ -13,6 +13,7 @@ short_description: Bandwidth sharing - UUID per device, works on VPS
 
 referral:
   signup_url: "https://peer.proxyrack.com/ref/mpwiok3xlaxeycnn5znqlg7ipjeutxyxr6xl7vmn"
+  code: "mpwiok3xlaxeycnn5znqlg7ipjeutxyxr6xl7vmn"
 
 docker:
   image: proxyrack/pop

--- a/services/bandwidth/repocket.yml
+++ b/services/bandwidth/repocket.yml
@@ -13,6 +13,7 @@ short_description: Bandwidth sharing - max 5 devices, API key auth
 
 referral:
   signup_url: "https://repocket.com/"
+  program: true
 
 docker:
   image: repocket/repocket

--- a/services/bandwidth/spide.yml
+++ b/services/bandwidth/spide.yml
@@ -11,6 +11,7 @@ short_description: Bandwidth sharing - machine ID based
 
 referral:
   signup_url: "https://spide.network/register.html?f3bc51"
+  code: "f3bc51"
 
 docker:
   image: ""

--- a/services/bandwidth/traffmonetizer.yml
+++ b/services/bandwidth/traffmonetizer.yml
@@ -13,6 +13,7 @@ short_description: Bandwidth sharing - works on VPS, token-based auth
 
 referral:
   signup_url: "https://traffmonetizer.com/?aff=2111758"
+  code: "2111758"
 
 docker:
   image: traffmonetizer/cli_v2

--- a/services/bandwidth/urnetwork.yml
+++ b/services/bandwidth/urnetwork.yml
@@ -12,6 +12,7 @@ short_description: Decentralized VPN/bandwidth - JWT auth, direct or proxy mode
 
 referral:
   signup_url: "https://ur.io/?referral_code=1Q3G19"
+  code: "1Q3G19"
 
 docker:
   image: bringyour/community-provider

--- a/services/compute/golem.yml
+++ b/services/compute/golem.yml
@@ -13,6 +13,7 @@ short_description: Decentralized compute marketplace - GLM tokens via Yagna agen
 
 referral:
   signup_url: "https://golem.network"
+  program: false
 
 docker:
   image: ""

--- a/services/compute/vast-ai.yml
+++ b/services/compute/vast-ai.yml
@@ -13,6 +13,7 @@ short_description: GPU marketplace - set your own prices, RTX 3090 ~$0.20-0.40/h
 
 referral:
   signup_url: "https://cloud.vast.ai/?ref_id=452772"
+  code: "452772"
 
 docker:
   image: ""

--- a/services/depin/anyone-protocol.yml
+++ b/services/depin/anyone-protocol.yml
@@ -13,6 +13,7 @@ short_description: Decentralized onion routing - incentivized Tor relay nodes
 
 referral:
   signup_url: "https://anyone.io"
+  program: false
 
 docker:
   image: ghcr.io/anyone-protocol/ator-protocol

--- a/services/depin/dawn.yml
+++ b/services/depin/dawn.yml
@@ -12,6 +12,7 @@ short_description: DePIN wireless network - browser extension and hardware box
 
 referral:
   signup_url: "https://dawninternet.com/?code=2QLQV97F"
+  code: "2QLQV97F"
 
 docker:
   image: ""

--- a/services/depin/gradient.yml
+++ b/services/depin/gradient.yml
@@ -12,6 +12,7 @@ short_description: DePIN network backed by Pantera Capital - browser-based node
 
 referral:
   signup_url: "https://app.gradient.network/signup?referralCode=YSKMY7"
+  code: "YSKMY7"
 
 docker:
   image: ""

--- a/services/depin/grass.yml
+++ b/services/depin/grass.yml
@@ -13,6 +13,7 @@ short_description: DePIN bandwidth sharing for AI data - earns GRASS tokens
 
 referral:
   signup_url: "https://app.grass.io/register?referralCode=kn8FNEPnUr2tMqE"
+  code: "kn8FNEPnUr2tMqE"
 
 docker:
   image: ""

--- a/services/depin/nodepay.yml
+++ b/services/depin/nodepay.yml
@@ -12,6 +12,7 @@ short_description: DePIN bandwidth sharing for AI - browser extension
 
 referral:
   signup_url: "https://app.nodepay.ai/register?ref=0wzzyznen64j9zx"
+  code: "0wzzyznen64j9zx"
 
 docker:
   image: ""

--- a/services/depin/passiveapp.yml
+++ b/services/depin/passiveapp.yml
@@ -11,6 +11,7 @@ short_description: DePIN bandwidth/compute - crypto and PayPal payouts
 
 referral:
   signup_url: "https://passiveapp.com/i/bqpC4M"
+  code: "bqpC4M"
 
 docker:
   image: ""

--- a/services/depin/presearch.yml
+++ b/services/depin/presearch.yml
@@ -12,6 +12,7 @@ short_description: Decentralized search engine - Docker nodes, PRE token rewards
 
 referral:
   signup_url: "https://presearch.com/signup?rid=4872322"
+  code: "4872322"
 
 docker:
   image: presearch/node

--- a/services/depin/sentinel-dvpn.yml
+++ b/services/depin/sentinel-dvpn.yml
@@ -11,6 +11,7 @@ short_description: Decentralized VPN on Cosmos - node operators sell bandwidth
 
 referral:
   signup_url: "https://sentinel.co"
+  program: false
 
 docker:
   image: ""

--- a/services/depin/teneo.yml
+++ b/services/depin/teneo.yml
@@ -12,6 +12,7 @@ short_description: DePIN browser extension - 2000 pts per referral
 
 referral:
   signup_url: "https://dashboard.teneo.pro/?code=CAqef"
+  code: "CAqef"
 
 docker:
   image: ""

--- a/services/depin/titan.yml
+++ b/services/depin/titan.yml
@@ -13,6 +13,7 @@ short_description: DePIN sharing IP, storage, bandwidth - $5-30/month
 
 referral:
   signup_url: "https://edge.titannet.info/signup?inviteCode=2GKKJ495"
+  code: "2GKKJ495"
 
 docker:
   image: ""

--- a/services/depin/uprock.yml
+++ b/services/depin/uprock.yml
@@ -12,6 +12,7 @@ short_description: DePIN internet sharing - crypto payout, browser extension pri
 
 referral:
   signup_url: "https://link.uprock.com/i/33e8492e"
+  code: "33e8492e"
 
 docker:
   image: ""

--- a/tests/test_referral_check.py
+++ b/tests/test_referral_check.py
@@ -77,6 +77,15 @@ class TestTheRegressionShape:
         )
         assert len(referral_check.audit([svc])["errors"]) == 1
 
+    def test_an_unquoted_numeric_code_is_a_type_error(self):
+        """`code: 123` with `?ref=123` in the URL would pass through str() --
+        but an unquoted scalar is a YAML accident waiting to differ (0071234
+        parses as octal 29340), so the type itself is refused."""
+        svc = _svc(referral={"signup_url": "https://example.com/?ref=123", "code": 123})
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "quoted string" in f["errors"][0]
+
     def test_an_empty_code_is_an_error_not_a_pass(self):
         svc = _svc(referral={"signup_url": "https://example.com/", "code": ""})
         f = referral_check.audit([svc])
@@ -223,3 +232,19 @@ class TestTheRealCatalog:
             text=True,
         )
         assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_a_missing_services_dir_is_an_error_not_a_clean_pass(self, tmp_path):
+        """Auditing zero files must never report success."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/referral_check.py",
+                "--services-dir",
+                str(tmp_path / "does-not-exist"),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "not found" in result.stderr

--- a/tests/test_referral_check.py
+++ b/tests/test_referral_check.py
@@ -1,0 +1,225 @@
+"""The referral registry audit (CashPilot-4jtc).
+
+Referral links are revenue. Two real incidents shaped these rules: ProxyBase
+migrated domains and the deployed link stopped attributing, and Bytebenefit sat
+wrongly dead with a bare URL for ~5 months of unattributed signups. The audit
+must catch the regression shape (a recorded code missing from the URL) hard,
+surface known-program-no-code as an action item, and treat "nobody checked"
+as a research list -- never as false, and never as a failure.
+"""
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_spec = importlib.util.spec_from_file_location("referral_check", ROOT / "scripts" / "referral_check.py")
+referral_check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(referral_check)
+
+
+def _svc(**over):
+    base = {
+        "slug": "example",
+        "status": "active",
+        "referral": {"signup_url": "https://example.com/?ref=MYCODE", "code": "MYCODE"},
+    }
+    base.update(over)
+    return base
+
+
+class TestTheRegressionShape:
+    def test_a_clean_coded_service_has_no_findings(self):
+        """Control: if this fixture produced findings, every test below could
+        be failing for fixture reasons rather than rule reasons."""
+        f = referral_check.audit([_svc()])
+        assert f == {"errors": [], "actions": [], "unknowns": []}
+
+    def test_a_code_missing_from_the_url_is_an_error(self):
+        """The negative control for the whole audit: strip the code from the
+        URL (the ProxyBase domain-migration shape) and the audit must go red."""
+        svc = _svc(referral={"signup_url": "https://example.com/", "code": "MYCODE"})
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "not anchored" in f["errors"][0]
+
+    def test_a_hostname_coincidence_is_not_attribution(self):
+        """`"grass" in "https://app.grass.io/register"` is True for the wrong
+        reason. Anchoring is what makes the check mean what it claims."""
+        svc = _svc(referral={"signup_url": "https://app.grass.io/register", "code": "grass"})
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "not anchored" in f["errors"][0]
+
+    def test_every_real_anchor_shape_is_accepted(self):
+        """The three shapes the live catalog actually uses."""
+        for url in (
+            "https://dashboard.honeygain.com/ref/SERGIB4014",  # path segment
+            "https://example.com/?ref=SERGIB4014",  # query value
+            "https://spide.network/register.html?SERGIB4014",  # bare query key
+        ):
+            assert referral_check.code_attributes_url("SERGIB4014", url), url
+
+    def test_a_code_with_no_signup_url_is_an_error(self):
+        svc = _svc(referral={"code": "MYCODE"})
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "no referral.signup_url" in f["errors"][0]
+
+    def test_the_error_fires_for_dead_services_too(self):
+        """A dead service keeps its code, so a resurrection comes back
+        attributed. Bytebenefit is why."""
+        svc = _svc(
+            status="dead",
+            referral={"signup_url": "https://example.com/", "code": "MYCODE"},
+        )
+        assert len(referral_check.audit([svc])["errors"]) == 1
+
+    def test_an_empty_code_is_an_error_not_a_pass(self):
+        svc = _svc(referral={"signup_url": "https://example.com/", "code": ""})
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "empty" in f["errors"][0]
+
+    def test_code_with_program_false_is_a_contradiction(self):
+        svc = _svc(
+            referral={
+                "signup_url": "https://example.com/?ref=MYCODE",
+                "code": "MYCODE",
+                "program": False,
+            }
+        )
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "program: false" in f["errors"][0]
+
+
+class TestThreeValuedProgram:
+    """Absent is not "no", and unknown is not a failure."""
+
+    def test_known_program_without_code_is_an_action_item(self):
+        svc = _svc(referral={"signup_url": "https://example.com", "program": True})
+        f = referral_check.audit([svc])
+        assert f["errors"] == []
+        assert len(f["actions"]) == 1
+
+    def test_verified_no_program_bare_url_is_fully_clean(self):
+        svc = _svc(referral={"signup_url": "https://example.com", "program": False})
+        f = referral_check.audit([svc])
+        assert f == {"errors": [], "actions": [], "unknowns": []}
+
+    def test_absent_program_is_unknown_not_false_and_not_an_action(self):
+        svc = _svc(referral={"signup_url": "https://example.com"})
+        f = referral_check.audit([svc])
+        assert f["errors"] == []
+        assert f["actions"] == []
+        assert len(f["unknowns"]) == 1
+
+    def test_a_dead_bare_service_is_not_even_unknown(self):
+        """Research effort belongs on services users can see."""
+        svc = _svc(status="dead", referral={"signup_url": "https://example.com"})
+        assert referral_check.audit([svc]) == {
+            "errors": [],
+            "actions": [],
+            "unknowns": [],
+        }
+
+    def test_garbage_program_values_are_errors_not_silence(self):
+        """The vanishing bucket: `program: "no"` satisfies neither the True arm
+        nor the None arm, so without a type gate the service produces NO
+        finding at all and drops off the research backlog while the tool exits
+        0. app/catalog.py learned this same lesson with `disclosure: TODO`."""
+        for garbage in ("false", "true", "no", "yes", "TODO", 1, 0):
+            svc = _svc(referral={"signup_url": "https://example.com", "program": garbage})
+            f = referral_check.audit([svc])
+            assert len(f["errors"]) == 1, f"program={garbage!r} vanished silently"
+            assert "must be true, false, or absent" in f["errors"][0]
+
+    def test_an_active_service_with_no_signup_url_at_all_is_an_action(self):
+        """A vanished signup link is a gap users hit, not a research topic."""
+        svc = _svc(referral={})
+        f = referral_check.audit([svc])
+        assert f["errors"] == []
+        assert len(f["actions"]) == 1
+        assert "nowhere to sign up" in f["actions"][0]
+
+    def test_a_non_mapping_referral_block_is_an_error_not_a_crash(self):
+        svc = _svc(referral="TODO")
+        f = referral_check.audit([svc])
+        assert len(f["errors"]) == 1
+        assert "must be a mapping" in f["errors"][0]
+
+
+class TestTheLoaderRefusesToSkip:
+    """An audit that silently drops a broken file reports it as fine."""
+
+    def test_an_empty_yaml_file_names_itself(self, tmp_path):
+        (tmp_path / "bandwidth").mkdir()
+        bad = tmp_path / "bandwidth" / "empty.yml"
+        bad.write_text("")
+        try:
+            referral_check.load_services(tmp_path)
+        except SystemExit as exc:
+            assert "empty.yml" in str(exc)
+        else:
+            raise AssertionError("an empty file loaded as a service")
+
+    def test_unparseable_yaml_names_itself(self, tmp_path):
+        (tmp_path / "bandwidth").mkdir()
+        bad = tmp_path / "bandwidth" / "broken.yml"
+        bad.write_text("referral: [unclosed")
+        try:
+            referral_check.load_services(tmp_path)
+        except SystemExit as exc:
+            assert "broken.yml" in str(exc)
+        else:
+            raise AssertionError("unparseable YAML loaded as a service")
+
+
+class TestTheRealCatalog:
+    """The audit runs against the shipped catalog in CI; pin both modes."""
+
+    def test_the_shipped_catalog_has_no_errors(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/referral_check.py"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_strict_mode_currently_fails_on_the_repocket_gap(self):
+        """Control for --strict: it must be a genuinely harder gate. If this
+        starts passing, the repocket code was added -- move this assertion to
+        expect success rather than deleting it."""
+        result = subprocess.run(
+            [sys.executable, "scripts/referral_check.py", "--strict"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1, result.stdout
+        assert "repocket" in result.stdout
+
+    def test_strict_mode_passes_on_a_clean_catalog(self, tmp_path):
+        """The control for the control: if --strict always exited 1, the test
+        above would keep passing while the gate meant nothing."""
+        (tmp_path / "bandwidth").mkdir()
+        (tmp_path / "bandwidth" / "clean.yml").write_text(
+            'slug: clean\nstatus: active\nreferral:\n  signup_url: "https://example.com/?ref=OK"\n  code: "OK"\n'
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/referral_check.py",
+                "--strict",
+                "--services-dir",
+                str(tmp_path),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Closes the referral blind spot behind CashPilot-4jtc's story: ProxyBase's domain migration silently stripped attribution, and Bytebenefit sat wrongly dead with a bare URL for ~5 months of unattributed signups. Nothing but a human rereading YAML could catch either.

**The registry** — each `referral:` block may now carry:
- `code`: the referral code itself, proven **anchored** in `signup_url` (query value, bare query key like spide's `?f3bc51`, or path segment like `/ref/CODE` — a hostname coincidence such as `grass` in `app.grass.io` is not attribution).
- `program`: three-valued — `true` = provider verified to run a program, `false` = verified not to, absent = unknown. **Absent is not no**, and unknowns never fail: failing on them would teach people to write `program: false` without checking.

**The audit** (`scripts/referral_check.py`, wired into catalog-check):
- ERROR (always fails): code not anchored in its URL, empty code, code+`program: false`, non-boolean `program` (identity-checked — `1 == True` in Python would otherwise smuggle it through), non-mapping referral, code without signup_url. Checked for **every** status, so a dead service's code survives to any resurrection.
- ACTION (fails only `--strict`): active service, verified program, no code — currently exactly **repocket** (verified: $5 + 10% lifetime; needs the account holder to sign up).
- UNKNOWN (never fails): the 10-provider research backlog (bitping, flux, ionet, nosana, salad, deeper-network, helium, nodle, theta-edge, storj).

Registry contents: 26 codes verified anchored; golem/anyone-protocol/sentinel-dvpn `program: false` (no-account services per the repo's own docs); Bytebenefit's bonus terms fill the `service_detail.html` branch that read `referral.bonus` but had no data anywhere.

Tests: 20 in `tests/test_referral_check.py`, negative controls included (stripped code → red, hostname coincidence → red, garbage `program` values → red not silence, `--strict` pinned in both directions). Full suite 4454 passed. ruff + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added referral codes, rewards, and program status information across numerous service listings.
  - Expanded referral documentation to clarify supported fields, program states, signup links, and bonuses.

- **Bug Fixes**
  - Added automated checks to identify invalid, incomplete, contradictory, or incorrectly linked referral information.

- **Tests**
  - Added comprehensive coverage for referral validation, malformed data, missing links, and strict checking behavior.

- **Chores**
  - Catalog validation now runs automatically when referral information changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->