### PR TITLE
feat(liveness): probe dead services for resurrection — blindness to dead→alive cost 5 months of signups

### DIFF
--- a/.github/workflows/catalog-liveness.yml
+++ b/.github/workflows/catalog-liveness.yml
@@ -58,7 +58,7 @@ jobs:
             echo "Updated issue #$existing"
           else
             gh issue create \
-              --title "Catalog liveness: dead references detected" \
+              --title "Catalog liveness: action needed (dead or resurrected references)" \
               --label catalog-liveness \
               --body-file report.md
           fi

--- a/scripts/check_catalog_liveness.py
+++ b/scripts/check_catalog_liveness.py
@@ -12,6 +12,13 @@ For each ``services/**/*.yml`` it checks:
 * ``referral.signup_url`` still answers **and still carries its referral code** --
   a dead or code-stripped referral link is direct lost revenue
 * ``docker.image`` still resolves in its registry
+* dead services get the OPPOSITE probe: is the site alive again on its own
+  domain? Liveness used to skip them entirely, which made it structurally
+  blind to resurrections -- Bytebenefit ran for ~5 months while the catalog
+  said dead. A parked domain answering from another registrable domain is
+  recognised and never claimed as a resurrection, and status is never flipped
+  automatically. (dropped services stay unprobed: they were rejected on
+  judgment, so their sites being alive is expected, not news.)
 
 Exit code is 0 unless the script itself could not run. A dead link is a *finding
 to report*, not a build failure: a flaky provider must not turn the weekly run red,
@@ -34,6 +41,7 @@ import yaml
 # Statuses
 OK = "ok"
 DEAD = "dead"
+RESURRECTED = "resurrected"
 UNREACHABLE = "unreachable"
 SKIPPED = "skipped"
 
@@ -62,8 +70,12 @@ class Finding:
         those raised the problem count, the weekly issue would cry wolf most
         weeks and get ignored, which costs us the one week it is real. They are
         still reported, just in their own section.
+
+        RESURRECTED counts: a service the catalog says is dead answered alive
+        on its own domain, which is lost revenue every week it stays unlisted.
+        Bytebenefit did exactly this for ~5 months (CashPilot-lv8v).
         """
-        return self.status == DEAD
+        return self.status in (DEAD, RESURRECTED)
 
     @property
     def is_inconclusive(self) -> bool:
@@ -184,14 +196,87 @@ def load_services(services_dir: Path) -> tuple[list[dict], list[Finding]]:
     return sorted(services, key=lambda s: s["slug"]), errors
 
 
+def registrable_domain(host: str) -> str:
+    """Last two labels of a hostname, with any www. prefix dropped.
+
+    Not a public-suffix parse -- every domain in this catalog is a simple
+    two-label one (provider.com, provider.io, provider.network), and pulling in
+    a suffix list for a weekly report is not worth the dependency. If a co.uk
+    provider ever lands in the catalog this gets stricter, not looser: two
+    labels would call sibling.co.uk domains "the same", which errs toward NOT
+    claiming a resurrection.
+    """
+    labels = host.lower().lstrip(".").removeprefix("www.").split(".")
+    return ".".join(labels[-2:])
+
+
+def check_resurrection(client: httpx.Client, svc: dict) -> list[Finding]:
+    """Probe a dead/dropped service's website for signs of life.
+
+    The old behaviour skipped these entirely, which made liveness structurally
+    blind to dead->alive: Bytebenefit ran for ~5 months at bytebenefit.io while
+    the catalog said dead, because only the parked .com had been checked and
+    nothing ever looked again.
+
+    Only a live answer on the service's OWN registrable domain counts. A 200
+    that lands on a different domain is what a parked domain looks like --
+    bytebenefit.com answers 200 today by redirecting to the atom.com
+    marketplace -- so it must never be claimed as a resurrection. And a finding
+    is a prompt to a human, never an automatic status flip: this script does
+    not write catalog files, because reviving is a judgment call.
+    """
+    slug = svc["slug"]
+    website = svc.get("website", "") or ""
+    if not website:
+        return [Finding(slug, "website", "", SKIPPED, f"status: {svc['status']}, no website recorded")]
+    try:
+        resp = client.get(website)
+    except httpx.HTTPError as exc:
+        # Unreachable is CONSISTENT with dead -- not worth a weekly report row.
+        return [Finding(slug, "website", website, SKIPPED, f"still dead as recorded ({type(exc).__name__})")]
+
+    if classify_status(resp.status_code) != OK:
+        return [Finding(slug, "website", website, SKIPPED, f"still dead as recorded (HTTP {resp.status_code})")]
+
+    final = str(resp.url)
+    if registrable_domain(urlparse(final).hostname or "") != registrable_domain(urlparse(website).hostname or ""):
+        # Alive-but-elsewhere is exactly what a domain-marketplace lander does.
+        return [
+            Finding(
+                slug,
+                "website",
+                website,
+                SKIPPED,
+                f"answers but lands on a different domain ({final}) -- a parked/sold domain, not a resurrection",
+            )
+        ]
+
+    return [
+        Finding(
+            slug,
+            "resurrection",
+            website,
+            RESURRECTED,
+            f"catalog says {svc['status']}, but the site answers HTTP {resp.status_code} on its own domain "
+            f"({final}) -- verify by hand and revive the entry (status is never flipped automatically)",
+        )
+    ]
+
+
 def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> list[Finding]:
     slug = svc["slug"]
     findings: list[Finding] = []
 
-    # Services the catalog already marks as gone are expected to be dead; checking
-    # them would just generate noise the maintainer has already acted on.
-    if svc.get("status") in ("dead", "dropped"):
-        return [Finding(slug, "website", svc.get("website", ""), SKIPPED, f"status: {svc['status']}")]
+    # DEAD services get exactly one cheap probe: are they still gone? Their
+    # referral links and images stay unchecked -- that noise is what the
+    # maintainer already acted on. DROPPED is different: it means "evaluated
+    # and rejected on judgment" (shady, rebranded, dev-mode-only), so those
+    # sites being alive is expected -- gaganode answers 200 today -- and
+    # probing them would put the same non-finding in the issue every week.
+    if svc.get("status") == "dropped":
+        return [Finding(slug, "website", svc.get("website", ""), SKIPPED, "status: dropped (rejected on judgment)")]
+    if svc.get("status") == "dead":
+        return check_resurrection(client, svc)
 
     website = svc.get("website", "") or ""
     status, detail = check_url(client, website)
@@ -199,11 +284,19 @@ def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> lis
 
     signup = ((svc.get("referral") or {}).get("signup_url")) or ""
     if signup:
+        code = str((svc.get("referral") or {}).get("code") or "")
         status, detail = check_url(client, signup)
         if status == OK:
             try:
                 final = str(client.head(signup).url)
-                if referral_code_lost(signup, final):
+                if code and code in final:
+                    # The registry makes the POSITIVE case conclusive: the
+                    # recorded code is still visible where the provider reads
+                    # it. (Its absence still proves nothing -- session-capture
+                    # redirects hide a working code -- so only this direction
+                    # upgrades the verdict.)
+                    detail += " (referral code visible after redirect)"
+                elif referral_code_lost(signup, final):
                     # Inconclusive, not dead: a site that captures the code into
                     # the session and redirects to a clean URL is indistinguishable
                     # from one that dropped it. Verified against ProxyLite, where
@@ -225,7 +318,7 @@ def check_service(client: httpx.Client, svc: dict, *, check_images: bool) -> lis
 
 
 # One legend, rendered by every report shape so the two can never drift apart.
-_LEGEND = "_`unreachable` means we could not tell -- a transient provider outage, a registry rate-limit, or a referral link that redirected somewhere its code is no longer visible (which is also what a working session-capture link looks like). Reported, but not counted as a problem. `dead` means the reference answered with a client error, or a catalog file could not be read._"
+_LEGEND = "_`unreachable` means we could not tell -- a transient provider outage, a registry rate-limit, or a referral link that redirected somewhere its code is no longer visible (which is also what a working session-capture link looks like). Reported, but not counted as a problem. `dead` means the reference answered with a client error, or a catalog file could not be read. `resurrected` means a service the catalog marks dead/dropped answered alive on its own domain -- verify by hand; nothing is flipped automatically._"
 
 
 def build_report(findings: list[Finding]) -> str:
@@ -273,7 +366,22 @@ def build_report(findings: list[Finding]) -> str:
         lines += [f"| `{f.slug}` | {f.status} | {f.detail} | {f.target} |" for f in referral]
         lines += [""]
 
-    rest = [f for f in problems if f.kind not in ("referral", "catalog")]
+    resurrected = [f for f in problems if f.kind == "resurrection"]
+    if resurrected:
+        lines += [
+            "## Possibly resurrected (catalog says dead, site answers)",
+            "",
+            "Verify by hand before touching the catalog -- a parked domain can answer "
+            "too, and this check only claims same-domain life. Status is never flipped "
+            "automatically.",
+            "",
+            "| Service | Detail | URL |",
+            "|---|---|---|",
+        ]
+        lines += [f"| `{f.slug}` | {f.detail} | {f.target} |" for f in resurrected]
+        lines += [""]
+
+    rest = [f for f in problems if f.kind not in ("referral", "catalog", "resurrection")]
     if rest:
         lines += [
             "## Websites and images",

--- a/tests/test_catalog_liveness.py
+++ b/tests/test_catalog_liveness.py
@@ -126,14 +126,132 @@ class TestLoadServices:
         assert len(errors) == 1 and errors[0].is_problem
 
 
-class TestCheckService:
-    def test_dead_status_service_is_skipped(self):
+def _resp(status_code: int, url: str):
+    return MagicMock(status_code=status_code, url=url)
+
+
+class TestResurrectionProbe:
+    """Dead/dropped services get one probe: are they alive again?
+
+    Liveness used to skip them entirely, so a resurrection was invisible
+    forever -- Bytebenefit ran ~5 months at bytebenefit.io while the catalog
+    said dead (CashPilot-lv8v).
+    """
+
+    def test_alive_on_its_own_domain_is_a_finding(self):
         client = MagicMock()
+        client.get.return_value = _resp(200, "https://x.com/home")
+        findings = liveness.check_service(
+            client, {"slug": "gone", "status": "dead", "website": "https://x.com"}, check_images=False
+        )
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.kind == "resurrection"
+        assert f.status == liveness.RESURRECTED
+        assert f.is_problem, "a resurrection must reach the weekly issue"
+        assert "never flipped automatically" in f.detail
+
+    def test_a_dropped_service_is_not_probed_at_all(self):
+        """Dropped means rejected on judgment (shady, rebranded), not died.
+        gaganode's site answers 200 today -- that is expected, not news, and
+        probing it would put the same non-finding in the issue every week."""
+        client = MagicMock()
+        findings = liveness.check_service(
+            client, {"slug": "shady", "status": "dropped", "website": "https://x.com"}, check_images=False
+        )
+        assert len(findings) == 1
+        assert findings[0].status == liveness.SKIPPED
+        client.get.assert_not_called()
+        client.head.assert_not_called()
+
+    def test_the_parked_domain_control(self):
+        """The negative control, straight from the incident: bytebenefit.com
+        answers 200 today -- by redirecting to the atom.com marketplace. A 200
+        on someone ELSE'S domain must never be claimed as a resurrection."""
+        client = MagicMock()
+        client.get.return_value = _resp(200, "https://www.atom.com/name/ByteBenefit")
+        findings = liveness.check_service(
+            client, {"slug": "gone", "status": "dead", "website": "https://bytebenefit.com"}, check_images=False
+        )
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.status == liveness.SKIPPED
+        assert not f.is_problem
+        assert "parked" in f.detail
+        assert liveness.build_report(findings).splitlines()[2].startswith("All good")
+
+    def test_a_dead_site_that_is_still_dead_stays_quiet(self):
+        client = MagicMock()
+        client.get.return_value = _resp(404, "https://x.com")
+        findings = liveness.check_service(
+            client, {"slug": "gone", "status": "dead", "website": "https://x.com"}, check_images=False
+        )
+        assert findings[0].status == liveness.SKIPPED
+        assert "still dead" in findings[0].detail
+        assert not findings[0].is_problem
+        assert not findings[0].is_inconclusive, "still-dead must not clutter the weekly inconclusive section"
+
+    def test_an_unreachable_dead_site_stays_quiet_too(self):
+        client = MagicMock()
+        client.get.side_effect = liveness.httpx.ConnectError("boom")
+        findings = liveness.check_service(
+            client, {"slug": "gone", "status": "dead", "website": "https://x.com"}, check_images=False
+        )
+        assert findings[0].status == liveness.SKIPPED
+        assert not findings[0].is_problem
+
+    def test_no_website_recorded_is_skipped_without_network(self):
+        client = MagicMock()
+        findings = liveness.check_service(client, {"slug": "gone", "status": "dead"}, check_images=False)
+        assert findings[0].status == liveness.SKIPPED
+        client.get.assert_not_called()
+
+    def test_referral_and_image_are_not_checked_for_dead_services(self):
+        """The probe is one cheap GET; the rest stays retired noise."""
+        client = MagicMock()
+        client.get.return_value = _resp(200, "https://x.com/")
+        findings = liveness.check_service(
+            client,
+            {
+                "slug": "gone",
+                "status": "dead",
+                "website": "https://x.com",
+                "referral": {"signup_url": "https://x.com/?r=C"},
+                "docker": {"image": "x/y:1"},
+            },
+            check_images=True,
+        )
+        assert len(findings) == 1
+        client.head.assert_not_called()
+
+    def test_the_report_gets_its_own_section(self):
+        findings = [liveness.Finding("gone", "resurrection", "https://x.com", liveness.RESURRECTED, "answers HTTP 200")]
+        report = liveness.build_report(findings)
+        assert "Possibly resurrected" in report
+        assert "Verify by hand" in report
+        assert not report.splitlines()[2].startswith("All good")
+
+
+class TestRegistrableDomain:
+    def test_www_is_the_same_site(self):
+        assert liveness.registrable_domain("www.x.com") == liveness.registrable_domain("x.com")
+
+    def test_a_subdomain_is_the_same_site(self):
+        assert liveness.registrable_domain("dashboard.x.com") == liveness.registrable_domain("x.com")
+
+    def test_a_different_domain_is_not(self):
+        assert liveness.registrable_domain("atom.com") != liveness.registrable_domain("bytebenefit.com")
+
+
+class TestCheckService:
+    def test_dead_status_service_is_probed_for_resurrection_only(self):
+        client = MagicMock()
+        client.get.return_value = _resp(404, "https://x.com")
         findings = liveness.check_service(
             client, {"slug": "gone", "status": "dead", "website": "https://x.com"}, check_images=False
         )
         assert all(f.status == liveness.SKIPPED for f in findings)
-        client.head.assert_not_called()  # no network for a service we already retired
+        client.head.assert_not_called()  # one GET probe; no referral/image checks
 
     def test_referral_is_checked_separately_from_website(self):
         client = MagicMock()
@@ -245,6 +363,47 @@ class TestReferralCollapseIsInconclusive:
         report = liveness.build_report(findings)
         assert report.splitlines()[2].startswith("All good")
         assert "verify manually" in report
+
+    def test_a_recorded_code_visible_after_redirect_is_conclusively_ok(self):
+        """The registry upgrade: with referral.code recorded, the POSITIVE
+        direction becomes conclusive -- the code is still where the provider
+        reads it. (Absence stays inconclusive; session capture hides working
+        codes.)"""
+        client = MagicMock()
+        client.head.return_value = _resp(200, "https://p.com/welcome?ref=CODE")
+        findings = liveness.check_service(
+            client,
+            {
+                "slug": "p",
+                "status": "active",
+                "website": "https://p.com",
+                "referral": {"signup_url": "https://p.com/signup?ref=CODE", "code": "CODE"},
+            },
+            check_images=False,
+        )
+        ref = [f for f in findings if f.kind == "referral"][0]
+        assert ref.status == liveness.OK
+        assert "code visible" in ref.detail
+
+    def test_a_recorded_code_that_vanished_is_still_only_inconclusive(self):
+        """The code being INVISIBLE proves nothing -- ProxyLite's working
+        session-capture link looks exactly like this. The registry must not
+        turn a working link into a weekly 'problem'."""
+        client = MagicMock()
+        client.head.return_value = _resp(200, "https://p.com/")
+        findings = liveness.check_service(
+            client,
+            {
+                "slug": "p",
+                "status": "active",
+                "website": "https://p.com",
+                "referral": {"signup_url": "https://p.com/?r=CODE", "code": "CODE"},
+            },
+            check_images=False,
+        )
+        ref = [f for f in findings if f.kind == "referral"][0]
+        assert ref.status == liveness.UNREACHABLE
+        assert not ref.is_problem
 
     def test_footer_does_not_call_a_collapse_dead(self):
         """The footer must match the classification, or it teaches the wrong lesson."""


### PR DESCRIPTION
The weekly liveness job skipped dead/dropped services entirely (`check_service` returned SKIPPED before any network call), so it could detect alive→dead but was structurally blind to dead→alive. Bytebenefit ran ~5 months at bytebenefit.io while the catalog said dead — every signup in that window was unattributed (CashPilot-lv8v).

**What changes**
- `dead` services get exactly one cheap GET: alive on their **own registrable domain** → a `possibly resurrected` finding that reaches the weekly rollup issue (own report section, explicit "verify by hand"). Status is **never** flipped automatically — reviving is a judgment call.
- A 200 landing on a **different** domain is what a parked domain looks like (`bytebenefit.com` answers 200 today — by redirecting to the atom.com marketplace) and is never claimed as a resurrection. That exact case is the pinned negative control.
- Still-dead (4xx) and unreachable stay quiet — consistent with the recorded status, not weekly noise.
- `dropped` services stay unprobed: rejected on judgment (gaganode answers 200 today; that is expected, not news).
- Bonus from the registry PR (#304): a recorded `referral.code` visible after a redirect upgrades the collapse heuristic's POSITIVE case to a conclusive OK; absence stays inconclusive (ProxyLite's session-capture shape).

**Live evidence** from a full run against the real catalog: `speedshare.app` and `wipter.com` both answer on their own domains — two genuine resurrection candidates that will appear in the next weekly report.

51 tests in `tests/test_catalog_liveness.py` (13 new), atom.com parked-domain control included. ruff + format clean.