### PR TITLE
fix(worker): a name hit without the managed label is not ours — the worker could force-remove itself

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -85,25 +85,36 @@ def _container_name(slug: str) -> str:
 
 
 def _find_container(slug: str):
-    """Find a container by name, falling back to label-based lookup."""
+    """Find a MANAGED container by name, falling back to label-based lookup.
+
+    The name match must verify the cashpilot.managed label, not just the
+    prefix: the platform's own containers are named cashpilot-worker and
+    cashpilot-ui, so slug "worker" name-matched the worker's OWN container
+    and a writer-role command could force-remove it -- the worker deleting
+    itself, unrecoverable remotely (CashPilot-o4uw). A name hit without the
+    label is treated exactly like NotFound.
+    """
     client = _get_client()
     name = _container_name(slug)
     try:
-        return client.containers.get(name)
+        container = client.containers.get(name)
+        if (container.labels or {}).get(LABEL_MANAGED) == "true":
+            return container
     except NotFound:
-        # Fallback: find by label (handles renamed containers)
-        matches = client.containers.list(
-            all=True,
-            filters={
-                "label": [
-                    f"{LABEL_SERVICE}={slug}",
-                    f"{LABEL_MANAGED}=true",
-                ]
-            },
-        )
-        if matches:
-            return matches[0]
-        raise ValueError(f"Container for {slug} not found")
+        pass
+    # Fallback: find by label (handles renamed containers)
+    matches = client.containers.list(
+        all=True,
+        filters={
+            "label": [
+                f"{LABEL_SERVICE}={slug}",
+                f"{LABEL_MANAGED}=true",
+            ]
+        },
+    )
+    if matches:
+        return matches[0]
+    raise ValueError(f"Container for {slug} not found")
 
 
 def _normalize_resources(resources: Any) -> dict[str, Any]:

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -126,6 +126,7 @@ class TestCollectStats:
 class TestFindContainer:
     def test_finds_by_name(self):
         container = MagicMock()
+        container.labels = {LABEL_MANAGED: "true", LABEL_SERVICE: "honeygain"}
         client = MagicMock()
         client.containers.get.return_value = container
         with patch.object(orchestrator, "_get_client", return_value=client):
@@ -133,6 +134,50 @@ class TestFindContainer:
         assert result is container
         client.containers.get.assert_called_once_with("cashpilot-honeygain")
         client.containers.list.assert_not_called()
+
+    def test_a_name_hit_without_the_managed_label_is_not_ours(self):
+        """CashPilot-o4uw: the platform's own containers are cashpilot-worker
+        and cashpilot-ui, so slug 'worker' name-matched the worker's OWN
+        container and command channel 'remove' force-removed it -- the worker
+        deleting itself, unrecoverable remotely. An unlabelled name hit must
+        be invisible, exactly like NotFound."""
+        own_container = MagicMock()
+        own_container.labels = {}  # compose-created, carries no cashpilot labels
+        client = MagicMock()
+        client.containers.get.return_value = own_container
+        client.containers.list.return_value = []
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(ValueError, match="worker"),
+        ):
+            orchestrator._find_container("worker")
+        own_container.remove.assert_not_called()
+        own_container.stop.assert_not_called()
+
+    def test_an_unlabelled_name_hit_still_allows_the_label_fallback(self):
+        """Control: the guard must reroute to the label lookup, not dead-end.
+        A managed container that lost its name to an impostor is still found."""
+        impostor = MagicMock()
+        impostor.labels = {}
+        real = MagicMock()
+        client = MagicMock()
+        client.containers.get.return_value = impostor
+        client.containers.list.return_value = [real]
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            assert orchestrator._find_container("honeygain") is real
+
+    def test_none_labels_do_not_crash_the_guard(self):
+        """Docker can hand back labels=None; absent is not 'managed'."""
+        container = MagicMock()
+        container.labels = None
+        client = MagicMock()
+        client.containers.get.return_value = container
+        client.containers.list.return_value = []
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(ValueError, match="ui"),
+        ):
+            orchestrator._find_container("ui")
 
     def test_falls_back_to_label_lookup_when_renamed(self):
         container = MagicMock()


### PR DESCRIPTION
CashPilot-o4uw, found while designing managed fleet upgrades and verified on main: `_find_container` matches by NAME before its label check, and the platform's own containers share the lookup's prefix — slug `worker` resolves to `cashpilot-worker` (the worker's own container), slug `ui` to `cashpilot-ui`. Any writer-role session could send `{command: "remove", slug: "worker"}` through `/api/workers/{id}/command` and the worker would `remove(force=True)` **itself** — unrecoverable remotely; someone has to SSH in and recreate it. `stop` reached it the same way (the raw command route deliberately doesn't catalog-gate non-deploy slugs, main.py:4177).

The name match now requires `cashpilot.managed=true` — exactly the condition the label fallback has always demanded — and an unlabelled name hit is treated like NotFound, rerouting to the label lookup so a managed container that lost its name to an impostor is still found.

Tests: unlabelled name hit for `worker`/`ui` raises not-found and never touches the container (negative control asserts `remove`/`stop` uncalled); labelled containers keep resolving; `labels=None` doesn't crash; impostor-name + label-fallback control. Full suite running locally; CI will confirm.