### PR TITLE
feat(catalog): salad + deeper-network verified as running referral programs

### DIFF
--- a/services/compute/salad.yml
+++ b/services/compute/salad.yml
@@ -13,6 +13,7 @@ short_description: GPU sharing for AI - Windows only, gift card or cash payout
 
 referral:
   signup_url: "https://salad.io"
+  program: true
 
 docker:
   image: ""

--- a/services/depin/deeper-network.yml
+++ b/services/depin/deeper-network.yml
@@ -11,6 +11,7 @@ short_description: Decentralized VPN - requires proprietary hardware device
 
 referral:
   signup_url: "https://deeper.network"
+  program: true
 
 docker:
   image: ""


### PR DESCRIPTION
Burns down two of the audit's 10 unknowns with verified facts:

- **Salad**: referrer earns 50% of referee earnings (up to $1 per referral), referee gets 2x earning rate up to $4 — code lives in console.salad.com. → `program: true`, new ACTION item.
- **Deeper Network**: in-account referral code pays 7% commission per unit sold (formal affiliate program pays 15%). → `program: true`, new ACTION item.
- **io.net** and **storj** were researched too and deliberately stay unknown: only third-party or absent evidence, and the registry's `false`/`true` mean *verified*.

`scripts/referral_check.py`: 0 errors, 3 action items (repocket, salad, deeper-network), 8 unresearched. 22 referral tests green.