### PR TITLE
feat(collectors): failure taxonomy — a 401 and a timeout are different problems (CashPilot-5bdm)

### DIFF
--- a/app/collectors/base.py
+++ b/app/collectors/base.py
@@ -28,6 +28,44 @@ class EarningsResult:
     # Bytelixir's API fallback did exactly this: a valid withdrawable balance,
     # thrown away, reported as a failure.
     warning: str | None = None
+    # WHAT KIND of failure `error` describes (CashPilot-5bdm). A 401 and a
+    # timeout used to be the same free-text string, so the UI could only ever
+    # say "collection failed" — teaching the user to ignore the one alert that
+    # needs them (an expired credential earns $0 until a human acts; a provider
+    # outage fixes itself). One of KIND_AUTH / KIND_TRANSIENT / KIND_SHAPE, or
+    # None when the cause is genuinely unknown — never guess a kind: an
+    # unknown labelled "transient" teaches the user to wait for something that
+    # will not heal.
+    error_kind: str | None = None
+
+
+#: The stored credential was REJECTED (401/403/login redirect). Only a human
+#: pasting a fresh credential fixes this; every hour it stands is $0 collected.
+KIND_AUTH = "auth"
+#: Network trouble or the provider having a bad afternoon (timeout, 5xx).
+#: Self-heals; the user should NOT be told to touch their credential.
+KIND_TRANSIENT = "transient"
+#: The provider changed its page/API shape. A code problem — the user can do
+#: nothing except report it; their credential is (probably) fine.
+KIND_SHAPE = "shape"
+
+
+def classify_exception(exc: BaseException) -> str | None:
+    """Best-effort failure kind for an exception a collector did not classify.
+
+    Only claims what the exception type actually proves: transport errors and
+    5xx are transient, 401/403 are auth. Everything else stays None -- absent
+    is not transient, and a wrong "will self-heal" label is worse than none.
+    """
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError)):
+        return KIND_TRANSIENT
+    if isinstance(exc, httpx.HTTPStatusError):
+        code = exc.response.status_code
+        if code in (401, 403):
+            return KIND_AUTH
+        if code >= 500:
+            return KIND_TRANSIENT
+    return None
 
 
 class BaseCollector(abc.ABC):

--- a/app/collectors/bytelixir.py
+++ b/app/collectors/bytelixir.py
@@ -163,6 +163,7 @@ class BytelixirCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Session expired — refresh bytelixir_session cookie in Settings",
+                    error_kind=base.KIND_AUTH,
                 )
 
             if html_resp.status_code == 200:
@@ -197,6 +198,7 @@ class BytelixirCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Session expired — refresh bytelixir_session cookie in Settings",
+                    error_kind=base.KIND_AUTH,
                 )
 
             api_resp.raise_for_status()
@@ -225,4 +227,5 @@ class BytelixirCollector(BaseCollector):
                 platform=self.platform,
                 balance=0.0,
                 error=str(exc),
+                error_kind=base.classify_exception(exc),
             )

--- a/app/collectors/grass.py
+++ b/app/collectors/grass.py
@@ -172,11 +172,13 @@ class GrassCollector(BaseCollector):
                         platform=self.platform,
                         balance=0.0,
                         error="Token expired — get a new accessToken from app.grass.io Local Storage",
+                        error_kind=base.KIND_AUTH,
                     )
                 return EarningsResult(
                     platform=self.platform,
                     balance=0.0,
                     error="Cloudflare rate limit — will retry next collection cycle",
+                    error_kind=base.KIND_TRANSIENT,
                 )
 
             if settled > 0:
@@ -195,6 +197,7 @@ class GrassCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Cloudflare rate limit — will retry next collection cycle",
+                    error_kind=base.KIND_TRANSIENT,
                 )
 
             return EarningsResult(
@@ -208,4 +211,5 @@ class GrassCollector(BaseCollector):
                 platform=self.platform,
                 balance=0.0,
                 error=str(exc),
+                error_kind=base.classify_exception(exc),
             )

--- a/app/collectors/honeygain.py
+++ b/app/collectors/honeygain.py
@@ -78,7 +78,12 @@ class HoneygainCollector(BaseCollector):
             payout = data.get("data", {}).get("payout", {})
             raw = payout.get("usd_cents")
             if raw is None:
-                raise ValueError("usd_cents field missing — API shape may have changed")
+                return EarningsResult(
+                    platform=self.platform,
+                    balance=0.0,
+                    error="usd_cents field missing — API shape may have changed",
+                    error_kind=base.KIND_SHAPE,
+                )
             usd_cents = float(raw)
             balance_usd = round(usd_cents / 100, 4)
 
@@ -93,4 +98,5 @@ class HoneygainCollector(BaseCollector):
                 platform=self.platform,
                 balance=0.0,
                 error=str(exc),
+                error_kind=base.classify_exception(exc),
             )

--- a/app/collectors/packetstream.py
+++ b/app/collectors/packetstream.py
@@ -45,6 +45,7 @@ class PacketStreamCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Authentication failed — check auth JWT cookie",
+                    error_kind=base.KIND_AUTH,
                 )
 
             resp.raise_for_status()
@@ -108,6 +109,7 @@ class PacketStreamCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Could not parse balance from dashboard — page structure may have changed",
+                    error_kind=base.KIND_SHAPE,
                 )
 
             return EarningsResult(
@@ -121,4 +123,5 @@ class PacketStreamCollector(BaseCollector):
                 platform=self.platform,
                 balance=0.0,
                 error=str(exc),
+                error_kind=base.classify_exception(exc),
             )

--- a/app/collectors/salad.py
+++ b/app/collectors/salad.py
@@ -53,6 +53,7 @@ class SaladCollector(BaseCollector):
                     platform=self.platform,
                     balance=0.0,
                     error="Auth cookie expired — get a new 'auth' cookie from salad.com",
+                    error_kind=base.KIND_AUTH,
                 )
 
             resp.raise_for_status()
@@ -60,7 +61,12 @@ class SaladCollector(BaseCollector):
 
             raw = data.get("currentBalance")
             if raw is None:
-                raise ValueError("currentBalance field missing — API shape may have changed")
+                return EarningsResult(
+                    platform=self.platform,
+                    balance=0.0,
+                    error="currentBalance field missing — API shape may have changed",
+                    error_kind=base.KIND_SHAPE,
+                )
             balance = float(raw)
 
             return EarningsResult(
@@ -74,4 +80,5 @@ class SaladCollector(BaseCollector):
                 platform=self.platform,
                 balance=0.0,
                 error=str(exc),
+                error_kind=base.classify_exception(exc),
             )

--- a/app/database.py
+++ b/app/database.py
@@ -457,6 +457,11 @@ CREATE TABLE IF NOT EXISTS alerts (
     kind       TEXT    NOT NULL,
     subject    TEXT    NOT NULL,
     message    TEXT    NOT NULL DEFAULT '',
+    -- What KIND of failure the message describes: 'auth' | 'transient' |
+    -- 'shape', or NULL when the collector could not tell. NULL means unknown,
+    -- never transient -- the UI renders unknown as a plain failure, not as
+    -- "will self-heal" (CashPilot-5bdm).
+    category   TEXT,
     created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -736,7 +741,7 @@ async def _encrypt_legacy_plaintext_credentials(db: Any) -> int:
 #: missing a column -- an interrupted upgrade, a restored backup, a hand-edited
 #: file -- could never be repaired, because the gate would say there was nothing
 #: to do. The guards are idempotent and cheap; the version is for the operator.
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 
 async def init_db() -> None:
@@ -859,6 +864,15 @@ async def init_db() -> None:
         # Migrate deployments table: add spec_encrypted so an existing install starts
         # remembering what it deployed. Rows written before this stay empty and fall
         # back to the catalog, exactly as they do today.
+        # Migrate alerts table: add the failure-kind category (CashPilot-5bdm).
+        cursor = await db.execute("PRAGMA table_info(alerts)")
+        alerts_cols = {row["name"] for row in await cursor.fetchall()}
+        if "category" not in alerts_cols:
+            applied.append("alerts.category")
+            # NULL backfill is the truthful one: nothing recorded before this
+            # column existed ever knew its failure kind (CashPilot-5bdm).
+            await db.execute("ALTER TABLE alerts ADD COLUMN category TEXT")
+
         cursor = await db.execute("PRAGMA table_info(deployments)")
         deployment_cols = {row["name"] for row in await cursor.fetchall()}
         if "spec_encrypted" not in deployment_cols:
@@ -2175,6 +2189,7 @@ async def record_alert(
     subject: str,
     message: str,
     *,
+    category: str | None = None,
     cooldown_hours: int = ALERT_COOLDOWN_HOURS,
 ) -> bool:
     """Persist an alert, returning True only when the caller should notify.
@@ -2190,17 +2205,35 @@ async def record_alert(
     Call ``clear_alerts`` when a subject recovers so the next failure alerts again
     immediately instead of waiting out the window.
     """
+    # A closed enum, enforced at the boundary: `error` is carefully redacted
+    # on the line next to this call, and a future collector setting
+    # error_kind=str(exc) must not smuggle unredacted exception text (which
+    # for several providers IS the credential) into a durable, any-role table.
+    if category not in (None, "auth", "transient", "shape"):
+        category = None
     db = await _get_db()
     try:
         cursor = await db.execute(
             "SELECT id FROM alerts WHERE kind = ? AND subject = ? AND created_at > datetime('now', ?) LIMIT 1",
             (kind, subject, f"-{int(cooldown_hours)} hours"),
         )
-        if await cursor.fetchone() is not None:
+        if (row := await cursor.fetchone()) is not None:
+            # Refresh what the stored row SAYS while keeping the push
+            # suppressed. Without this the first category of a failure window
+            # is pinned for 24h: grass alternates between an expired-token
+            # error (auth) and a Cloudflare rate-limit (transient) with no
+            # success in between, so a restart could restore "transient" for a
+            # dead credential — rendered muted, with no fix button, as a blip
+            # that will never actually heal.
+            await db.execute(
+                "UPDATE alerts SET category = ?, message = ? WHERE id = ?",
+                (category, message, row["id"]),
+            )
+            await db.commit()
             return False
         await db.execute(
-            "INSERT INTO alerts (kind, subject, message) VALUES (?, ?, ?)",
-            (kind, subject, message),
+            "INSERT INTO alerts (kind, subject, message, category) VALUES (?, ?, ?, ?)",
+            (kind, subject, message, category),
         )
         await db.commit()
         return True
@@ -2213,7 +2246,7 @@ async def list_alerts(limit: int = 50) -> list[dict[str, Any]]:
     db = await _get_db()
     try:
         cursor = await db.execute(
-            "SELECT kind, subject, message, created_at FROM alerts ORDER BY id DESC LIMIT ?",
+            "SELECT kind, subject, message, category, created_at FROM alerts ORDER BY id DESC LIMIT ?",
             (limit,),
         )
         return [dict(row) for row in await cursor.fetchall()]

--- a/app/main.py
+++ b/app/main.py
@@ -439,9 +439,28 @@ async def _pending_payout_alerts(seen: set[str] | None = None) -> list[dict[str,
 
 
 async def _collect_bounded(collector) -> Any:
-    """Run a single collector's `collect()` under the shared concurrency limit."""
+    """Run a single collector's `collect()` under the shared concurrency limit.
+
+    A raised exception is converted into an EarningsResult HERE, while the
+    collector -- and with it the platform name -- is still in hand. It used to
+    propagate to the gather(), where the platform was unrecoverable: the
+    failure was logged as an anonymous line and produced no alert, no bell
+    entry and no metric. A collector that raised was invisible to the user
+    (CashPilot-5bdm).
+    """
+    from app.collectors import base as collectors_base
+
     async with _collection_semaphore:
-        return await collector.collect()
+        try:
+            return await collector.collect()
+        except Exception as exc:
+            collectors_base.log_failure(logger, collector.platform or type(collector).__name__, exc)
+            return collectors_base.EarningsResult(
+                platform=collector.platform or type(collector).__name__,
+                balance=0.0,
+                error=str(exc),
+                error_kind=collectors_base.classify_exception(exc),
+            )
 
 
 async def _flatline_check() -> list[dict[str, str]]:
@@ -526,7 +545,10 @@ async def _warm_collector_alerts() -> None:
         if key in seen:
             continue
         seen.add(key)
-        restored.append({"kind": alert["kind"], "platform": alert["subject"], "error": alert["message"]})
+        entry = {"kind": alert["kind"], "platform": alert["subject"], "error": alert["message"]}
+        if alert.get("category"):
+            entry["category"] = alert["category"]
+        restored.append(entry)
     _collector_alerts = restored
     # A restart must not make the bell claim nothing has ever been checked. Any
     # stored alert, or any earnings row, is proof that a collection ran.
@@ -630,14 +652,26 @@ async def _run_collection() -> None:
                     # providers is a live credential. The alert is now durable and readable
                     # by any authenticated role, so it must never hold a secret.
                     safe_error = notify.redact(result.error)
-                    alerts.append({"kind": "collector", "platform": result.platform, "error": safe_error})
+                    error_kind = getattr(result, "error_kind", None)
+                    entry = {"kind": "collector", "platform": result.platform, "error": safe_error}
+                    if error_kind:
+                        entry["category"] = error_kind
+                    alerts.append(entry)
                     metrics.record_collection_error(result.platform)
                     # Push out-of-band only the FIRST time this failure appears — a
                     # collector broken for a week must not notify every single hour.
-                    if await database.record_alert("collector", result.platform, safe_error):
+                    if await database.record_alert("collector", result.platform, safe_error, category=error_kind):
+                        # The push is the only channel an unattended install
+                        # has, so the taxonomy must reach it too: "rotate your
+                        # cookie" and "provider hiccup" are different asks.
+                        cause = {
+                            "auth": " (credential rejected)",
+                            "transient": " (provider unreachable)",
+                            "shape": " (page changed)",
+                        }.get(error_kind or "", "")
                         _spawn(
                             notify.send(
-                                f"CashPilot: {result.platform} collector failed",
+                                f"CashPilot: {result.platform} collector failed{cause}",
                                 safe_error,
                                 kind="collector",
                                 subject=result.platform,
@@ -3184,8 +3218,13 @@ async def api_collector_alerts(request: Request) -> dict[str, Any]:
         if len(error_msg) > _MAX_ALERT_ERROR_LEN:
             clean += "..."
         # `kind` is additive and defaults to "collector", so a frontend that
-        # does not read it behaves exactly as before.
-        sanitized.append({"kind": alert.get("kind", "collector"), "platform": alert["platform"], "error": clean})
+        # does not read it behaves exactly as before. `category` is the failure
+        # TAXONOMY (auth/transient/shape) and is only present when a collector
+        # actually classified it -- absent is unknown, never transient.
+        entry = {"kind": alert.get("kind", "collector"), "platform": alert["platform"], "error": clean}
+        if alert.get("category"):
+            entry["category"] = alert["category"]
+        sanitized.append(entry)
     return {"alerts": sanitized, "collected": _collection_has_run}
 
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3281,8 +3281,32 @@ const CP = (() => {
     if (!container || !badge || !list) return;
 
     try {
-      const payload = await api('/api/collector-alerts');
+      // Warn BEFORE the gap, not after it (CashPilot-5bdm): a credential the
+      // lifetime table says is about to lapse (or already past it, which is
+      // strictly worse and must not vanish from the bell the moment the
+      // forecast comes true) joins the bell while collection may still be
+      // working. The endpoint is any-authenticated and value-free; a failed
+      // fetch just means no early warnings, never a broken bell. A forecast
+      // gets its OWN category ('expiring') — it is a prediction, not an
+      // observed rejection, and the bell must not assert a 401 that never
+      // happened.
+      const [payload, health] = await Promise.all([
+        api('/api/collector-alerts'),
+        api('/api/credentials/health').catch(() => []),
+      ]);
       const alerts = payload.alerts || [];
+      for (const row of (Array.isArray(health) ? health : [])) {
+        if (row.status !== 'expiring_soon' && row.status !== 'likely_expired') continue;
+        if (alerts.some(a => a.platform === row.service && a.kind === 'collector')) continue;
+        alerts.push({
+          kind: 'collector',
+          category: 'expiring',
+          platform: row.service,
+          error: row.status === 'likely_expired'
+            ? `Credential is past its usual lifetime — renew it (${row.field || 'credential'})`
+            : `Credential likely expires soon — renew it before collection stops (${row.field || 'credential'})`,
+        });
+      }
       // Clear any muted "alerts unavailable" styling left over from a prior
       // failed poll now that the fetch succeeded.
       badge.style.background = '';
@@ -3303,6 +3327,12 @@ const CP = (() => {
 
       badge.style.display = '';
       badge.textContent = alerts.length;
+      // A bell full of nothing but forecasts is advice, not an incident: mute
+      // the badge so a healthy install with an ageing cookie is not shown the
+      // same red count as a broken one.
+      if (alerts.every(a => a.category === 'expiring')) {
+        badge.style.background = 'var(--text-muted)';
+      }
       // A payout is a question, not a fault. Rendering it with the warning
       // triangle and an "Update credentials" button would tell the user
       // something is broken at the exact moment they got paid.
@@ -3317,17 +3347,37 @@ const CP = (() => {
       list.innerHTML = alerts.map(a => {
         const isPayout = a.kind === 'payout';
         const isNotice = a.kind === 'notice';
-        const icon = isPayout ? PAYOUT_ICON : isNotice ? NOTICE_ICON : WARNING_ICON;
+        // The failure TAXONOMY (CashPilot-5bdm). Only 'auth' means "your
+        // credential needs replacing"; a transient provider outage self-heals
+        // and a shape change is our bug, so pointing the user at their
+        // credential for either teaches them the one alert that DOES need
+        // them is ignorable. Absent means unknown — the button stays, because
+        // unknown might be an auth failure the collector could not classify.
+        const category = a.category || '';
+        const isTransient = category === 'transient';
+        const isShape = category === 'shape';
+        const isAuth = category === 'auth';
+        const isExpiring = category === 'expiring';
+        const icon = isPayout ? PAYOUT_ICON : (isNotice || isTransient) ? NOTICE_ICON : WARNING_ICON;
+        const suffix = isPayout ? ' — payout?'
+          : isNotice ? ' — note'
+          : isAuth ? ' — credential expired'
+          : isExpiring ? ' — credential expiring'
+          : isTransient ? ' — provider unreachable'
+          : isShape ? ' — page changed (our bug)'
+          : '';
+        const muted = isNotice || isTransient;
+        const showFix = !isPayout && !isNotice && !isTransient && !isShape && _isOwner;
         return `
-        <div class="notify-item" data-platform="${escapeHtml(a.platform)}" data-kind="${escapeHtml(a.kind || 'collector')}">
-          <div class="notify-item-icon"${isNotice ? ' style="color:var(--text-muted);"' : ''}>
+        <div class="notify-item" data-platform="${escapeHtml(a.platform)}" data-kind="${escapeHtml(a.kind || 'collector')}"${category ? ` data-category="${escapeHtml(category)}"` : ''}>
+          <div class="notify-item-icon"${muted ? ' style="color:var(--text-muted);"' : ''}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${icon}</svg>
           </div>
           <div class="notify-item-body">
-            <div class="notify-item-platform">${escapeHtml(a.platform)}${isPayout ? ' — payout?' : ''}${isNotice ? ' — note' : ''}</div>
+            <div class="notify-item-platform">${escapeHtml(a.platform)}${suffix}</div>
             <div class="notify-item-msg" title="${escapeHtml(a.error)}">${escapeHtml(a.error)}</div>
           </div>
-          ${!isPayout && !isNotice && _isOwner ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">Update</button>` : ''}
+          ${showFix ? `<button class="btn btn-ghost btn-sm" data-action="openCredentialModal" data-stop="1" data-a1="${escapeHtml(a.platform)}" style="font-size:0.65rem; padding:2px 6px; white-space:nowrap; flex-shrink:0;">${isAuth ? 'Fix credential' : 'Update'}</button>` : ''}
         </div>
       `;
       }).join('');

--- a/tests/test_beads_batch_25.py
+++ b/tests/test_beads_batch_25.py
@@ -152,13 +152,19 @@ class TestTheBellRendersANoteRatherThanAFault:
         assert "a.kind === 'notice'" in self._js()
 
     def test_a_notice_does_not_offer_update_credentials(self):
-        """The button points at the one action that cannot help here."""
-        assert "!isPayout && !isNotice && _isOwner" in self._js()
+        """The button points at the one action that cannot help here.
+
+        Since CashPilot-5bdm the exclusion also covers transient and shape
+        failures: a network blip self-heals and a scrape break is our bug, so
+        pointing the user at their credential for either teaches them the one
+        alert that DOES need them is ignorable.
+        """
+        assert "!isPayout && !isNotice && !isTransient && !isShape && _isOwner" in self._js()
 
     def test_a_notice_does_not_use_the_warning_triangle(self):
         js = self._js()
         assert "NOTICE_ICON" in js
-        assert "isNotice ? NOTICE_ICON : WARNING_ICON" in js
+        assert "(isNotice || isTransient) ? NOTICE_ICON : WARNING_ICON" in js
 
     def test_a_collector_failure_still_gets_the_triangle_and_the_button(self):
         """The control: the fault path must survive intact."""

--- a/tests/test_collector_error_taxonomy.py
+++ b/tests/test_collector_error_taxonomy.py
@@ -1,0 +1,347 @@
+"""The collector failure taxonomy (CashPilot-5bdm).
+
+A 401 and a timeout used to be the same free-text string, so the bell could
+only ever say "collection failed" — teaching the user to ignore the one alert
+that needs them. An expired credential earns $0 until a human acts; a provider
+outage fixes itself. These tests pin the distinction end to end: collectors
+classify, the collection loop preserves it (and the platform name, even when a
+collector RAISES), the alerts table stores it, and the API serves it.
+
+The load-bearing negative control: a TIMEOUT must never be classified as an
+auth failure, and an UNKNOWN must never be classified as transient — a wrong
+"will self-heal" label is worse than none.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+from app.collectors import base  # noqa: E402
+
+
+def _make_async_client():
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def _mock_response(status_code=200, json_data=None, text="", url="https://example.com"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text
+    resp.url = url
+    resp.headers = {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestClassifyException:
+    def test_timeout_is_transient(self):
+        assert base.classify_exception(httpx.TimeoutException("t")) == base.KIND_TRANSIENT
+
+    def test_network_error_is_transient(self):
+        assert base.classify_exception(httpx.ConnectError("refused")) == base.KIND_TRANSIENT
+
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_auth_status_is_auth(self, code):
+        resp = MagicMock(status_code=code)
+        exc = httpx.HTTPStatusError("x", request=MagicMock(), response=resp)
+        assert base.classify_exception(exc) == base.KIND_AUTH
+
+    def test_5xx_is_transient_not_auth(self):
+        resp = MagicMock(status_code=503)
+        exc = httpx.HTTPStatusError("x", request=MagicMock(), response=resp)
+        assert base.classify_exception(exc) == base.KIND_TRANSIENT
+
+    def test_a_timeout_is_never_auth(self):
+        """The control that matters most: telling a user to rotate their
+        credential for a network blip teaches them to ignore the real one."""
+        assert base.classify_exception(httpx.TimeoutException("t")) != base.KIND_AUTH
+
+    @pytest.mark.parametrize("exc", [ValueError("parse"), RuntimeError("?"), KeyError("k")])
+    def test_unknown_exceptions_stay_unknown_not_transient(self, exc):
+        """Absent is not transient. An unknown labelled 'self-heals' hides a
+        real fault behind a promise nobody made."""
+        assert base.classify_exception(exc) is None
+
+    def test_teapot_is_unknown(self):
+        resp = MagicMock(status_code=418)
+        exc = httpx.HTTPStatusError("x", request=MagicMock(), response=resp)
+        assert base.classify_exception(exc) is None
+
+
+class TestSaladTaxonomy:
+    def test_401_is_an_auth_failure(self):
+        from app.collectors.salad import SaladCollector
+
+        resp = _mock_response(401)
+        resp.raise_for_status = MagicMock()  # 401 handled inline by the collector
+        client = _make_async_client()
+        client.get.return_value = resp
+        with patch("app.collectors.salad.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(SaladCollector(auth_cookie="expired").collect())
+        assert result.error_kind == base.KIND_AUTH
+
+    def test_timeout_is_transient_not_auth(self):
+        """Negative control for the collector, not just the classifier."""
+        from app.collectors.salad import SaladCollector
+
+        client = _make_async_client()
+        client.get.side_effect = httpx.TimeoutException("timed out")
+        with patch("app.collectors.salad.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(SaladCollector(auth_cookie="fine").collect())
+        assert result.error is not None
+        assert result.error_kind == base.KIND_TRANSIENT
+        assert result.error_kind != base.KIND_AUTH
+
+    def test_shape_change_is_shape_not_auth(self):
+        from app.collectors.salad import SaladCollector
+
+        resp = _mock_response(200, {"unexpected": "shape"})
+        client = _make_async_client()
+        client.get.return_value = resp
+        with patch("app.collectors.salad.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(SaladCollector(auth_cookie="fine").collect())
+        assert result.error_kind == base.KIND_SHAPE
+
+
+class TestPacketStreamTaxonomy:
+    def test_401_is_auth(self):
+        from app.collectors.packetstream import PacketStreamCollector
+
+        resp = _mock_response(401)
+        resp.raise_for_status = MagicMock()
+        client = _make_async_client()
+        client.get.return_value = resp
+        with patch("app.collectors.packetstream.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(PacketStreamCollector(auth_token="jwt").collect())
+        assert result.error_kind == base.KIND_AUTH
+
+    def test_unparseable_dashboard_is_shape(self):
+        from app.collectors.packetstream import PacketStreamCollector
+
+        resp = _mock_response(200, text="<html>totally new layout</html>")
+        client = _make_async_client()
+        client.get.return_value = resp
+        with patch("app.collectors.packetstream.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(PacketStreamCollector(auth_token="jwt").collect())
+        assert result.error_kind == base.KIND_SHAPE
+        assert result.error_kind != base.KIND_AUTH
+
+
+class TestBytelixirTaxonomy:
+    def test_login_redirect_is_auth(self):
+        from app.collectors.bytelixir import BytelixirCollector
+
+        resp = _mock_response(200, text="<html></html>")
+        resp.url = MagicMock()
+        resp.url.path = "/login"
+        client = _make_async_client()
+        client.get.return_value = resp
+        with patch("app.collectors.bytelixir.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(BytelixirCollector(session_cookie="stale").collect())
+        assert result.error_kind == base.KIND_AUTH
+
+
+class TestHoneygainTaxonomy:
+    def test_missing_field_is_shape(self):
+        from app.collectors.honeygain import HoneygainCollector
+
+        login = _mock_response(200, {"data": {"access_token": "tok"}})
+        balances = _mock_response(200, {"data": {"payout": {}}})
+        client = _make_async_client()
+        client.post.return_value = login
+        client.get.return_value = balances
+        with patch("app.collectors.honeygain.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(HoneygainCollector(email="e", password="p").collect())
+        assert result.error_kind == base.KIND_SHAPE
+
+
+class TestRaisedExceptionsKeepTheirPlatform:
+    """A collector that RAISES used to vanish: the exception reached the
+    gather() where the platform name was unrecoverable, so it produced no
+    alert, no bell entry and no metric — invisible exactly when broken."""
+
+    def test_collect_bounded_attributes_the_failure(self):
+        from app import main as app_main
+
+        class ExplodingCollector:
+            platform = "exploding"
+
+            async def collect(self):
+                raise httpx.ConnectError("boom")
+
+        result = asyncio.run(app_main._collect_bounded(ExplodingCollector()))
+        assert result.platform == "exploding"
+        assert result.error is not None
+        assert result.error_kind == base.KIND_TRANSIENT
+
+    def test_an_unclassifiable_crash_is_unknown_not_transient(self):
+        from app import main as app_main
+
+        class BuggyCollector:
+            platform = "buggy"
+
+            async def collect(self):
+                raise RuntimeError("logic error")
+
+        result = asyncio.run(app_main._collect_bounded(BuggyCollector()))
+        assert result.platform == "buggy"
+        assert result.error_kind is None
+
+
+class TestAlertsStoreTheCategory:
+    @pytest.mark.asyncio
+    async def test_category_roundtrips_through_the_alerts_table(self, tmp_path, monkeypatch):
+        from app import database
+
+        monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+        await database.init_db()
+        assert await database.record_alert("collector", "salad", "cookie expired", category="auth")
+        rows = await database.list_alerts()
+        assert rows[0]["category"] == "auth"
+
+    @pytest.mark.asyncio
+    async def test_an_uncategorised_alert_stays_null_not_a_default(self, tmp_path, monkeypatch):
+        from app import database
+
+        monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+        await database.init_db()
+        assert await database.record_alert("collector", "mystery", "who knows")
+        rows = await database.list_alerts()
+        assert rows[0]["category"] is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_alerts_table_gains_the_column_on_migrate(self, tmp_path, monkeypatch):
+        """An upgraded volume, not just a fresh install."""
+        import aiosqlite
+
+        from app import database
+
+        db_file = str(tmp_path / "legacy.db")
+        async with aiosqlite.connect(db_file) as db:
+            await db.execute(
+                "CREATE TABLE alerts (id INTEGER PRIMARY KEY AUTOINCREMENT, kind TEXT NOT NULL, "
+                "subject TEXT NOT NULL, message TEXT NOT NULL DEFAULT '', "
+                "created_at TEXT NOT NULL DEFAULT (datetime('now')))"
+            )
+            await db.execute("INSERT INTO alerts (kind, subject, message) VALUES ('collector', 'old', 'pre-upgrade')")
+            await db.commit()
+        monkeypatch.setattr(database, "DB_PATH", db_file)
+        await database.init_db()
+        assert await database.record_alert("collector", "salad", "expired", category="auth")
+        rows = await database.list_alerts()
+        by_subject = {r["subject"]: r for r in rows}
+        assert by_subject["salad"]["category"] == "auth"
+        assert by_subject["old"]["category"] is None, "history must not be backfilled with a guess"
+
+
+class TestTheCategoryReachesTheApi:
+    """The contract the JS depends on: `category` is PRESENT for a classified
+    alert and ABSENT (not null) for an unclassified one."""
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        # No context manager: entering it runs the app lifespan (scheduler,
+        # DB init), which this test neither needs nor can host.
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_present_when_classified_absent_when_not(self, client):
+        from app import main as app_main
+
+        original = app_main._collector_alerts
+        app_main._collector_alerts = [
+            {"kind": "collector", "platform": "salad", "error": "cookie expired", "category": "auth"},
+            {"kind": "collector", "platform": "mystery", "error": "who knows"},
+        ]
+        try:
+            with patch("app.main.auth.get_current_user", return_value={"uid": 1, "u": "admin", "r": "owner"}):
+                payload = client.get("/api/collector-alerts").json()
+        finally:
+            app_main._collector_alerts = original
+        by_platform = {a["platform"]: a for a in payload["alerts"]}
+        assert by_platform["salad"]["category"] == "auth"
+        assert "category" not in by_platform["mystery"], "unknown must be absent, not null"
+
+
+class TestTheStoredCategoryCannotGoStale:
+    """The review finding that mattered: grass alternates between an
+    expired-token error (auth) and a Cloudflare rate-limit (transient) with no
+    success in between, and the 24h dedupe pinned whichever came first. A
+    restart then restored the stale kind — a dead credential rendered as a
+    muted self-healing blip with no fix button."""
+
+    @pytest.mark.asyncio
+    async def test_a_dedupe_hit_refreshes_the_stored_kind(self, tmp_path, monkeypatch):
+        from app import database
+
+        monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+        await database.init_db()
+        assert await database.record_alert("collector", "grass", "rate limit", category="transient")
+        # Within the cooldown: push suppressed, but the row must stop lying.
+        assert not await database.record_alert("collector", "grass", "token expired", category="auth")
+        rows = await database.list_alerts()
+        assert rows[0]["category"] == "auth"
+        assert rows[0]["message"] == "token expired"
+
+    @pytest.mark.asyncio
+    async def test_the_warm_rebuild_carries_the_refreshed_kind(self, tmp_path, monkeypatch):
+        from app import database
+        from app import main as app_main
+
+        monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+        await database.init_db()
+        await database.record_alert("collector", "grass", "rate limit", category="transient")
+        await database.record_alert("collector", "grass", "token expired", category="auth")
+        original = app_main._collector_alerts
+        try:
+            await app_main._warm_collector_alerts()
+            restored = {a["platform"]: a for a in app_main._collector_alerts}
+        finally:
+            app_main._collector_alerts = original
+        assert restored["grass"]["category"] == "auth"
+
+    @pytest.mark.asyncio
+    async def test_the_category_column_is_a_closed_enum(self, tmp_path, monkeypatch):
+        """error is redacted on the neighbouring line; category must never be
+        a smuggling path for unredacted exception text."""
+        from app import database
+
+        monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+        await database.init_db()
+        assert await database.record_alert("collector", "x", "boom", category="Bearer hunter2-live-token")
+        rows = await database.list_alerts()
+        assert rows[0]["category"] is None
+
+
+class TestTheSemaphoreSurvivesTheNewExceptionPath:
+    def test_released_after_raising_collectors(self):
+        from app import main as app_main
+
+        class ExplodingCollector:
+            platform = "exploding"
+
+            async def collect(self):
+                raise RuntimeError("boom")
+
+        async def run():
+            for _ in range(3):
+                await app_main._collect_bounded(ExplodingCollector())
+            return app_main._collection_semaphore.locked()
+
+        assert asyncio.run(run()) is False


### PR DESCRIPTION
An expired credential earns $0 until a human acts; a provider outage fixes itself. They were the same free-text `error` string end to end, so the bell could only ever say "collection failed".

**Taxonomy**: `EarningsResult.error_kind` — `auth` / `transient` / `shape`, `None` = unknown and never guessed (an unknown labelled "self-heals" hides a real fault). Explicit kinds in honeygain, bytelixir, packetstream, salad, grass; `classify_exception` for unclassified escapes. Ten remaining collectors' shape-errors tracked as CashPilot-dqaf.

**Attribution fix**: a collector that RAISES is converted to an attributed result inside `_collect_bounded` — the exception used to reach the `gather()` where the platform name was unrecoverable: no alert, no bell, no metric.

**Persistence**: `alerts.category` column (guarded migration; closed enum whitelisted at the boundary so error_kind can never smuggle unredacted exception text — which for several providers IS the credential — into a durable any-role table). A dedupe hit inside the 24h window now **refreshes** the stored kind+message: grass alternates auth/transient with no success in between, and the pinned first kind meant a restart could render a dead credential as a muted self-healing blip (review HIGH). Push titles carry the cause — the only channel an unattended install has.

**Bell**: auth → "credential expired" + **Fix credential**; transient → muted, **no button** (never point a user at their credential for a network blip); shape → no button (our bug); unknown → button stays. Credentials ≥75% of known lifetime (or past it — the forecast must not vanish when it comes true) join as `expiring` — a **distinct category**, because a prediction is not an observed 401 — and the badge goes muted when forecasts are all there is.

27 new tests (negative controls: timeout-never-auth, unknown-never-transient, no history backfill, stale-kind refresh incl. the warm-rebuild path, closed-enum smuggling control, semaphore release). Full suite 4503 passed. Salad mutation (auth→transient) verified to fail the suite. Fresh review completed; all findings addressed or filed (dqaf).