### PR TITLE
fix(ci): the nightly live check never ran — a fabricated action pin killed it at setup

### DIFF
--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,0 +1,47 @@
+name: Action Pins
+
+# Every action this repo uses must exist, and its version comment must be true.
+#
+# `collector-live-check.yml` shipped a pin whose SHA shared sixteen characters
+# with a real release commit and then diverged into a commit that never
+# existed, beside a comment naming a tag that was never published. GitHub
+# resolves actions BEFORE the first step, so that job died in "Set up job"
+# every night for six nights without checking a single provider -- and its own
+# `if: failure()` alarm was a step inside that same job, so nothing was ever
+# reported. The pin was wrong in the commit that introduced the workflow, so
+# the check had never run once.
+#
+# A pinned SHA cannot be eyeballed. This is the thing that reads it.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  # A tag can be deleted or moved AFTER a pin is merged, so the audit is worth
+  # repeating on a schedule and not only at review time.
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pins:
+    runs-on: ubuntu-latest
+    steps:
+      # The ONLY action this job uses. A guard against unresolvable actions
+      # that itself depended on several would be one bad pin away from the
+      # silence it exists to prevent; the checker is stdlib-only Python, and
+      # runners ship python3, so nothing else is needed.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Every action reference resolves, and its version comment is true
+        env:
+          # Raises the API rate limit. Read-only; a fork PR's token works too.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/check_action_pins.py

--- a/.github/workflows/collector-live-check.yml
+++ b/.github/workflows/collector-live-check.yml
@@ -13,9 +13,10 @@ on:
     - cron: "17 5 * * *"
   workflow_dispatch:
 
+# Least privilege: the job that handles real provider credentials gets read
+# only. Issue-writing belongs to the reporter job alone, which declares it.
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: collector-live-check
@@ -83,37 +84,55 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Open an issue when a provider's shape changed
-        if: failure()
-        uses: actions/github-script@60a0d83039c74a4aa971cc2a0930ae7e2fe2c8bd # v7.0.4
-        with:
-          script: |
-            const title = 'Collector live check failed — a provider may have changed its API';
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner, repo: context.repo.repo,
-              state: 'open', labels: 'collector-drift',
-            });
-            const body = [
-              'The nightly live collector check failed.',
-              '',
-              'This usually means a provider renamed or moved a field, which the recorded',
-              'fixtures cannot detect on their own. Compare the failing collector against',
-              '`tests/fixtures/collectors/<slug>.json` and update BOTH the collector and its',
-              'contract.',
-              '',
-              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              '',
-              'Note: the log is deliberately not pasted here — collector failures can echo',
-              'request payloads containing credentials.',
-            ].join('\n');
-            if (existing.data.length) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: existing.data[0].number, body,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner, repo: context.repo.repo,
-                title, body, labels: ['collector-drift'],
-              });
-            }
+  # A SEPARATE JOB, not a step, and deliberately dependency-free.
+  #
+  # This alarm used to be an `if: failure()` step inside the job above. That
+  # cannot fire when the job never starts -- and for six consecutive nights it
+  # did not, because the job's own `actions/github-script` pin named a commit
+  # that does not exist, so GitHub failed the job during "Set up job", before
+  # any step ran. The check reported nothing and filed nothing while never once
+  # having checked a provider.
+  #
+  # As a job with `needs:`, this runs whenever `live` fails for ANY reason,
+  # including one that kills it at setup. It uses the preinstalled `gh` CLI
+  # rather than an action, so the path that reports a broken workflow cannot
+  # itself be broken by an unresolvable action.
+  report:
+    needs: live
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The log is deliberately never pasted: collector failures can echo
+          # request payloads containing credentials.
+          body=$(cat <<EOF
+          The nightly live collector check failed.
+
+          This usually means a provider renamed or moved a field, which the recorded
+          fixtures cannot detect on their own. Compare the failing collector against
+          \`tests/fixtures/collectors/<slug>.json\` and update BOTH the collector and its
+          contract.
+
+          If the job failed before any step ran, the cause is the workflow itself
+          (an unresolvable action pin, a missing secret) and no provider was checked.
+
+          Run: $RUN_URL
+          EOF
+          )
+          gh label create collector-drift \
+            --description "Automated collector drift findings" --color ededed 2>/dev/null || true
+          existing=$(gh issue list --state open --label collector-drift --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "Collector live check failed — a provider may have changed its API" \
+              --label collector-drift --body "$body"
+          fi

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -55,6 +55,28 @@ _USES = re.compile(
     r"@(?P<ref>[A-Za-z0-9._/-]+)\s*(?:#\s*(?P<comment>\S+))?"
 )
 _SHA = re.compile(r"^[0-9a-f]{40}$")
+#: A comment naming a full MAJOR.MINOR.PATCH is claiming one immutable release,
+#: so the pinned SHA must be that release. A bare `v4` or `v4.2` names a tag
+#: that MOVES: github/codeql-action's `v4` currently points at v4.37.6, so a
+#: pin one release behind is not a lying comment, it is just behind -- which is
+#: Dependabot's business, not a red build. Verified against two live repos that
+#: this check first reported wrongly.
+_FULL_SEMVER = re.compile(r"^v?\d+\.\d+\.\d+")
+
+
+def _tag_spellings(comment: str) -> list[str]:
+    """Both `1.24.1` and `v1.24.1`, because projects differ.
+
+    erlef/setup-beam tags `v1.24.1` while the comment beside the pin says
+    `1.24.1`; resolving only what was written called a correct pin fabricated.
+    """
+    bare = comment.lstrip("v")
+    seen: list[str] = []
+    for candidate in (comment, f"v{bare}", bare):
+        if candidate and candidate not in seen:
+            seen.append(candidate)
+    return seen
+
 
 OK = "ok"
 MISSING = "missing"
@@ -159,9 +181,19 @@ def audit(uses: list[Use], token: str | None) -> list[Finding]:
         # The ref is real. If a SHA pin also CLAIMS a version, that claim is
         # the only thing a reviewer reads, so it has to be true.
         if use.is_sha and use.comment:
-            tag_sha, tag_status = resolve(use.repo, use.comment)
+            tag_sha, tag_status = None, MISSING
+            for spelling in _tag_spellings(use.comment):
+                tag_sha, tag_status = resolve(use.repo, spelling)
+                if tag_status != MISSING:
+                    break
             if tag_status == MISSING:
                 findings.append(Finding(use, MISMATCH, f"comment claims {use.comment}, but {use.repo} has no such tag"))
+                continue
+            if tag_status == OK and not _FULL_SEMVER.match(use.comment):
+                # A floating tag. Its existence is all that can be checked --
+                # comparing SHAs would flag every pin that is one release
+                # behind the tag it names, which is not a false claim.
+                findings.append(Finding(use, OK))
                 continue
             if tag_status == UNKNOWN:
                 # The ref resolved but its VERSION CLAIM did not, so this pin is

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Every GitHub Action this repo uses must actually exist, and say so honestly.
+
+A pinned SHA is unverifiable by eye, which is exactly how a fabricated one
+survived here: `collector-live-check.yml` shipped
+
+    actions/github-script@60a0d83039c74a4aa971cc2a0930ae7e2fe2c8bd # v7.0.4
+
+where the SHA shares its first sixteen characters with the real v7.0.1 commit
+and then diverges into nothing, and the tag named in the comment was never
+released. GitHub resolves every action BEFORE the first step, so the job died
+in "Set up job" every night for six nights, having never checked a provider --
+and the workflow's own `if: failure()` alarm was a step inside that job, so it
+never fired either. Nothing was reported. The pin was wrong in the same commit
+that introduced the workflow, so the check had never once run.
+
+Two failure modes, both checked here:
+
+* the ref does not resolve at all -- a typo, a deleted tag, or an invented SHA;
+* the ref resolves but its `# vX.Y.Z` comment names a tag that does not exist,
+  or one that points at a DIFFERENT commit. A version comment is the only
+  human-readable claim about a SHA, and a lying one is how a reviewer is
+  talked past a supply-chain change.
+
+Three-valued, like everything else here: a 404 is a finding, a rate limit or a
+network failure is `unknown` and never fails the run. A check that reddens on
+someone else's outage teaches people to ignore it -- and this file exists
+precisely because an ignorable alarm is the same as no alarm.
+
+    python scripts/check_action_pins.py            # audit .github/workflows
+    python scripts/check_action_pins.py --offline  # parse only, no network
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+API = "https://api.github.com"
+
+#: `uses: owner/repo@ref` or `uses: owner/repo/sub/path@ref`, with an optional
+#: trailing `# v1.2.3` comment. Local (`./…`) and container (`docker://…`)
+#: actions are deliberately not matched: they resolve from the checkout or a
+#: registry, not from a git ref, so there is no ref to verify.
+_USES = re.compile(
+    r"^\s*-?\s*uses:\s*(?P<repo>[A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(?P<sub>(?:/[A-Za-z0-9._-]+)*)"
+    r"@(?P<ref>[A-Za-z0-9._/-]+)\s*(?:#\s*(?P<comment>\S+))?"
+)
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+OK = "ok"
+MISSING = "missing"
+MISMATCH = "mismatch"
+UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Use:
+    repo: str
+    ref: str
+    comment: str | None
+    file: str
+    line: int
+
+    @property
+    def is_sha(self) -> bool:
+        return bool(_SHA.match(self.ref))
+
+
+@dataclass
+class Finding:
+    use: Use
+    status: str
+    detail: str = ""
+
+    @property
+    def is_problem(self) -> bool:
+        """UNKNOWN is deliberately not a problem: it means we could not tell."""
+        return self.status in (MISSING, MISMATCH)
+
+
+def parse_workflows(workflow_dir: pathlib.Path) -> list[Use]:
+    """Every action reference in every workflow, in file order."""
+    uses: list[Use] = []
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        rel = str(path.relative_to(ROOT)) if path.is_relative_to(ROOT) else str(path)
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            match = _USES.match(line)
+            if not match:
+                continue
+            comment = match.group("comment")
+            # Only a version-shaped comment is a claim worth checking; a prose
+            # note next to a pin is not asserting which release it is.
+            if comment and not re.match(r"^v?\d", comment):
+                comment = None
+            uses.append(
+                Use(
+                    repo=match.group("repo"),
+                    ref=match.group("ref"),
+                    comment=comment,
+                    file=rel,
+                    line=number,
+                )
+            )
+    return uses
+
+
+def _resolve(repo: str, ref: str, token: str | None) -> tuple[str | None, str]:
+    """Return (commit sha, status) for a ref. Never raises."""
+    request = urllib.request.Request(
+        f"{API}/repos/{repo}/commits/{ref}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "CashPilot-action-pin-check",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:  # noqa: S310 - fixed https host
+            return json.load(response).get("sha"), OK
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 422):
+            return None, MISSING
+        # 401/403/429 are usually a rate limit or a token problem, and 5xx is
+        # GitHub having a bad afternoon. None of those say the action is gone.
+        return None, UNKNOWN
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None, UNKNOWN
+
+
+def audit(uses: list[Use], token: str | None) -> list[Finding]:
+    findings: list[Finding] = []
+    cache: dict[tuple[str, str], tuple[str | None, str]] = {}
+
+    def resolve(repo: str, ref: str) -> tuple[str | None, str]:
+        if (repo, ref) not in cache:
+            cache[(repo, ref)] = _resolve(repo, ref, token)
+        return cache[(repo, ref)]
+
+    for use in uses:
+        sha, status = resolve(use.repo, use.ref)
+        if status == MISSING:
+            findings.append(
+                Finding(use, MISSING, f"{use.repo}@{use.ref} does not exist (no such commit, tag or branch)")
+            )
+            continue
+        if status == UNKNOWN:
+            findings.append(Finding(use, UNKNOWN, "could not reach the GitHub API (rate limit or network)"))
+            continue
+
+        # The ref is real. If a SHA pin also CLAIMS a version, that claim is
+        # the only thing a reviewer reads, so it has to be true.
+        if use.is_sha and use.comment:
+            tag_sha, tag_status = resolve(use.repo, use.comment)
+            if tag_status == MISSING:
+                findings.append(Finding(use, MISMATCH, f"comment claims {use.comment}, but {use.repo} has no such tag"))
+                continue
+            if tag_status == OK and tag_sha != use.ref:
+                findings.append(
+                    Finding(
+                        use,
+                        MISMATCH,
+                        f"comment claims {use.comment}, which is {tag_sha}, not the pinned {use.ref}",
+                    )
+                )
+                continue
+        findings.append(Finding(use, OK))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--workflow-dir",
+        type=pathlib.Path,
+        default=ROOT / ".github" / "workflows",
+        help="directory of workflow files to audit",
+    )
+    parser.add_argument("--offline", action="store_true", help="parse only; resolve nothing")
+    args = parser.parse_args()
+
+    if not args.workflow_dir.is_dir():
+        # Auditing zero files must never look like a clean bill of health.
+        print(f"workflow dir not found: {args.workflow_dir}", file=sys.stderr)
+        return 2
+
+    uses = parse_workflows(args.workflow_dir)
+    if not uses:
+        print(
+            f"no action references found in {args.workflow_dir} — refusing to report that as healthy", file=sys.stderr
+        )
+        return 2
+
+    if args.offline:
+        print(f"{len(uses)} action reference(s) parsed; nothing resolved (--offline)")
+        return 0
+
+    findings = audit(uses, os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN"))
+    problems = [f for f in findings if f.is_problem]
+    unknown = [f for f in findings if f.status == UNKNOWN]
+
+    for finding in problems:
+        print(f"ERROR   {finding.use.file}:{finding.use.line}  {finding.detail}")
+    for finding in unknown:
+        print(f"UNKNOWN {finding.use.file}:{finding.use.line}  {finding.use.repo}@{finding.use.ref} — {finding.detail}")
+
+    checked = len(findings) - len(unknown)
+    print(f"\n{checked}/{len(findings)} reference(s) verified, {len(problems)} problem(s), {len(unknown)} inconclusive")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -163,6 +163,17 @@ def audit(uses: list[Use], token: str | None) -> list[Finding]:
             if tag_status == MISSING:
                 findings.append(Finding(use, MISMATCH, f"comment claims {use.comment}, but {use.repo} has no such tag"))
                 continue
+            if tag_status == UNKNOWN:
+                # The ref resolved but its VERSION CLAIM did not, so this pin is
+                # half-checked. Reporting it as OK would be this script telling
+                # the same kind of lie it exists to catch: "verified" for
+                # something nobody verified.
+                findings.append(
+                    Finding(
+                        use, UNKNOWN, f"ref resolves, but {use.comment} could not be checked (rate limit or network)"
+                    )
+                )
+                continue
             if tag_status == OK and tag_sha != use.ref:
                 findings.append(
                     Finding(

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -233,3 +233,72 @@ class TestAHalfCheckedPinIsNotVerified:
         monkeypatch.setattr(pins, "_resolve", lambda repo, ref, token=None: (REAL_V701, pins.OK))
         (finding,) = pins.audit([self._use()], None)
         assert finding.status == pins.OK
+
+
+class TestRealWorldCommentSpellings:
+    """Both regressions came from running this against OTHER repos, where it
+    reported two correct pins as fabricated. Neither shape exists in CashPilot,
+    which is exactly why the happy path could not have caught them."""
+
+    SETUP_BEAM = "54075bcc5e249e4758d363f27d099f55d843f124"
+
+    def test_a_comment_without_the_v_prefix_still_resolves(self, monkeypatch):
+        """erlef/setup-beam tags `v1.24.1`; the comment beside the pin says
+        `1.24.1`. Resolving only what was written called a correct pin a lie."""
+        monkeypatch.setattr(
+            pins,
+            "_resolve",
+            _resolver(
+                {
+                    ("erlef/setup-beam", self.SETUP_BEAM): (self.SETUP_BEAM, pins.OK),
+                    ("erlef/setup-beam", "v1.24.1"): (self.SETUP_BEAM, pins.OK),
+                }
+            ),
+        )
+        use = pins.Use(repo="erlef/setup-beam", ref=self.SETUP_BEAM, comment="1.24.1", file="wf.yml", line=1)
+        (finding,) = pins.audit([use], None)
+        assert finding.status == pins.OK, finding.detail
+
+    def test_a_floating_major_tag_is_not_compared_by_sha(self, monkeypatch):
+        """github/codeql-action's `v4` moves; a pin one release behind still
+        IS a v4 release, so the comment is true and must not go red."""
+        pinned, current_v4 = "8aad20d150bbac5944a9f9d289da16a4b0d87c1e", "5595ccaf912efad79be6eef63a5619ff05969be3"
+        monkeypatch.setattr(
+            pins,
+            "_resolve",
+            _resolver(
+                {
+                    ("github/codeql-action", pinned): (pinned, pins.OK),
+                    ("github/codeql-action", "v4"): (current_v4, pins.OK),
+                }
+            ),
+        )
+        use = pins.Use(repo="github/codeql-action", ref=pinned, comment="v4", file="wf.yml", line=1)
+        (finding,) = pins.audit([use], None)
+        assert finding.status == pins.OK, finding.detail
+
+    def test_but_a_floating_tag_that_does_not_exist_is_still_caught(self, monkeypatch):
+        """The control: relaxing the SHA comparison must not relax existence."""
+        pinned = "8aad20d150bbac5944a9f9d289da16a4b0d87c1e"
+        monkeypatch.setattr(pins, "_resolve", _resolver({("github/codeql-action", pinned): (pinned, pins.OK)}))
+        use = pins.Use(repo="github/codeql-action", ref=pinned, comment="v99", file="wf.yml", line=1)
+        (finding,) = pins.audit([use], None)
+        assert finding.status == pins.MISMATCH
+
+    def test_a_full_semver_comment_is_still_compared_by_sha(self, monkeypatch):
+        """The other control: vX.Y.Z names one immutable release, so the
+        original bug's shape must still be caught."""
+        other = "3a2844b7e9c422d3c10d287c895573f7108da1b3"
+        monkeypatch.setattr(
+            pins,
+            "_resolve",
+            _resolver(
+                {
+                    ("actions/github-script", REAL_V701): (REAL_V701, pins.OK),
+                    ("actions/github-script", "v9.0.0"): (other, pins.OK),
+                }
+            ),
+        )
+        use = pins.Use(repo="actions/github-script", ref=REAL_V701, comment="v9.0.0", file="wf.yml", line=1)
+        (finding,) = pins.audit([use], None)
+        assert finding.status == pins.MISMATCH

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -1,0 +1,204 @@
+"""The action-pin audit (from the fabricated `github-script` pin).
+
+`collector-live-check.yml` shipped a 40-character SHA whose first sixteen
+characters matched the real v7.0.1 commit and whose tail was invented, with a
+comment naming a tag that was never released. GitHub resolves actions before
+the first step, so the job failed in setup every night for six nights without
+checking a single provider, and the workflow's own alarm -- a step inside that
+job -- could not fire.
+
+These tests are offline and inject the resolver, so the suite stays
+deterministic: what is pinned here is the DECISION LOGIC, not GitHub's current
+tag list. The live behaviour was verified separately against the real API,
+including replaying the original broken file.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_spec = importlib.util.spec_from_file_location("check_action_pins", ROOT / "scripts" / "check_action_pins.py")
+pins = importlib.util.module_from_spec(_spec)
+# Register before exec, exactly as test_catalog_liveness.py must: the module's
+# @dataclass resolves its string annotations (PEP 563) through sys.modules,
+# which fails if the module is not there yet.
+sys.modules["check_action_pins"] = pins
+_spec.loader.exec_module(pins)
+
+#: The real v7.0.1 commit, and the invented pin that shipped beside it. Kept
+#: adjacent so the shared 16-character prefix -- the reason it looked plausible
+#: to a reviewer -- is visible.
+REAL_V701 = "60a0d83039c74a4aee543508d2ffcb1c3799cdea"
+FABRICATED = "60a0d83039c74a4aa971cc2a0930ae7e2fe2c8bd"
+
+
+def _write(tmp_path, body: str) -> pathlib.Path:
+    (tmp_path / "wf.yml").write_text(body)
+    return tmp_path
+
+
+def _resolver(table):
+    """A fake GitHub: (repo, ref) -> (sha, status). Anything absent is MISSING."""
+
+    def resolve(repo, ref, token=None):
+        return table.get((repo, ref), (None, pins.MISSING))
+
+    return resolve
+
+
+class TestParsing:
+    def test_reads_repo_ref_and_version_comment(self, tmp_path):
+        d = _write(tmp_path, f"      - uses: actions/github-script@{FABRICATED} # v7.0.4\n")
+        (use,) = pins.parse_workflows(d)
+        assert use.repo == "actions/github-script"
+        assert use.ref == FABRICATED
+        assert use.comment == "v7.0.4"
+        assert use.is_sha
+
+    def test_a_tag_ref_is_not_a_sha(self, tmp_path):
+        d = _write(tmp_path, "      - uses: actions/checkout@v7\n")
+        (use,) = pins.parse_workflows(d)
+        assert use.ref == "v7"
+        assert not use.is_sha
+
+    def test_a_subpath_action_keeps_its_owner_repo(self, tmp_path):
+        d = _write(tmp_path, "      - uses: owner/repo/sub/action@v1\n")
+        (use,) = pins.parse_workflows(d)
+        assert use.repo == "owner/repo"
+
+    def test_prose_comments_are_not_version_claims(self, tmp_path):
+        """A note beside a pin asserts nothing about which release it is, so
+        checking it as a tag would invent a failure."""
+        d = _write(tmp_path, "      - uses: actions/checkout@v7 # pinned deliberately\n")
+        (use,) = pins.parse_workflows(d)
+        assert use.comment is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "      - uses: ./.github/actions/local\n",
+            "      - uses: docker://alpine:3.20\n",
+            "      # - uses: actions/checkout@v7\n",
+        ],
+    )
+    def test_local_container_and_commented_refs_are_skipped(self, tmp_path, line):
+        assert pins.parse_workflows(_write(tmp_path, line)) == []
+
+    def test_line_numbers_point_at_the_offending_line(self, tmp_path):
+        d = _write(tmp_path, "jobs:\n  x:\n    steps:\n      - uses: actions/checkout@v7\n")
+        (use,) = pins.parse_workflows(d)
+        assert use.line == 4
+
+
+class TestVerdicts:
+    def _use(self, ref, comment=None):
+        return pins.Use(repo="actions/github-script", ref=ref, comment=comment, file="wf.yml", line=1)
+
+    def test_a_fabricated_sha_is_a_problem(self, monkeypatch):
+        """The regression: the pin that actually shipped."""
+        monkeypatch.setattr(pins, "_resolve", _resolver({}))
+        (finding,) = pins.audit([self._use(FABRICATED, "v7.0.4")], None)
+        assert finding.status == pins.MISSING
+        assert finding.is_problem
+
+    def test_a_real_pin_with_a_truthful_comment_is_clean(self):
+        """The control. If this reported a problem, every test above could be
+        passing for a reason that has nothing to do with the rule."""
+
+        def resolve(repo, ref, token=None):
+            return (REAL_V701, pins.OK)
+
+        import unittest.mock
+
+        with unittest.mock.patch.object(pins, "_resolve", resolve):
+            (finding,) = pins.audit([self._use(REAL_V701, "v7.0.1")], None)
+        assert finding.status == pins.OK
+        assert not finding.is_problem
+
+    def test_a_comment_naming_a_tag_that_does_not_exist_is_a_problem(self, monkeypatch):
+        """Exactly the shipped case's second half: v7.0.4 was never released."""
+        monkeypatch.setattr(
+            pins,
+            "_resolve",
+            _resolver({("actions/github-script", REAL_V701): (REAL_V701, pins.OK)}),
+        )
+        (finding,) = pins.audit([self._use(REAL_V701, "v7.0.4")], None)
+        assert finding.status == pins.MISMATCH
+        assert "no such tag" in finding.detail
+
+    def test_a_comment_pointing_at_a_different_commit_is_a_problem(self, monkeypatch):
+        """A lying version comment is how a reviewer is walked past a
+        supply-chain change: the SHA is real, just not what it claims."""
+        other = "3a2844b7e9c422d3c10d287c895573f7108da1b3"
+        monkeypatch.setattr(
+            pins,
+            "_resolve",
+            _resolver(
+                {
+                    ("actions/github-script", REAL_V701): (REAL_V701, pins.OK),
+                    ("actions/github-script", "v9.0.0"): (other, pins.OK),
+                }
+            ),
+        )
+        (finding,) = pins.audit([self._use(REAL_V701, "v9.0.0")], None)
+        assert finding.status == pins.MISMATCH
+        assert other in finding.detail
+
+    def test_a_tag_ref_is_not_comment_checked(self, monkeypatch):
+        """`@v7 # v7` is not a pin claim -- the ref IS the version."""
+        monkeypatch.setattr(pins, "_resolve", _resolver({("actions/github-script", "v7"): ("abc", pins.OK)}))
+        (finding,) = pins.audit([self._use("v7", "v7.0.1")], None)
+        assert finding.status == pins.OK
+
+
+class TestUnknownIsNotAFailure:
+    """A check that reddens on someone else's outage teaches people to ignore
+    it -- and an ignored alarm is the same as no alarm, which is what this
+    whole file exists to prevent."""
+
+    def test_a_rate_limit_is_inconclusive_not_a_problem(self, monkeypatch):
+        monkeypatch.setattr(pins, "_resolve", lambda repo, ref, token=None: (None, pins.UNKNOWN))
+        (finding,) = pins.audit(
+            [pins.Use(repo="actions/checkout", ref="v7", comment=None, file="wf.yml", line=1)], None
+        )
+        assert finding.status == pins.UNKNOWN
+        assert not finding.is_problem
+
+    def test_an_unresolvable_ref_is_still_a_problem_when_others_are_unknown(self, monkeypatch):
+        """The control for the control: 'inconclusive' must not become a
+        blanket amnesty that swallows a real 404."""
+        table = {("actions/checkout", "v7"): (None, pins.UNKNOWN)}
+        monkeypatch.setattr(pins, "_resolve", _resolver(table))
+        findings = pins.audit(
+            [
+                pins.Use(repo="actions/checkout", ref="v7", comment=None, file="wf.yml", line=1),
+                pins.Use(repo="actions/github-script", ref=FABRICATED, comment=None, file="wf.yml", line=2),
+            ],
+            None,
+        )
+        assert [f.is_problem for f in findings] == [False, True]
+
+
+class TestAuditingNothingIsNotHealth:
+    def test_a_missing_workflow_dir_exits_2(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["x", "--workflow-dir", str(tmp_path / "nope")])
+        assert pins.main() == 2
+
+    def test_a_directory_with_no_actions_exits_2(self, tmp_path, monkeypatch):
+        (tmp_path / "empty.yml").write_text("jobs:\n  x:\n    steps: []\n")
+        monkeypatch.setattr("sys.argv", ["x", "--workflow-dir", str(tmp_path)])
+        assert pins.main() == 2, "auditing zero references must never look like a clean bill of health"
+
+
+class TestTheShippedWorkflowsParse:
+    def test_every_workflow_reference_is_readable(self):
+        """Not a network test: it only proves the parser still finds this
+        repo's own references, so a syntax change cannot silently reduce the
+        audit to zero rows while the job stays green."""
+        uses = pins.parse_workflows(ROOT / ".github" / "workflows")
+        assert len(uses) > 20
+        assert all(use.repo.count("/") == 1 for use in uses)

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -202,3 +202,34 @@ class TestTheShippedWorkflowsParse:
         uses = pins.parse_workflows(ROOT / ".github" / "workflows")
         assert len(uses) > 20
         assert all(use.repo.count("/") == 1 for use in uses)
+
+
+class TestAHalfCheckedPinIsNotVerified:
+    """CodeRabbit's catch: the ref resolved, its version claim did not.
+
+    Reporting that as OK would be this script telling exactly the kind of lie
+    it exists to catch -- "verified" for something nobody verified. The pin
+    that started all this was half-plausible in precisely this way: a real-
+    looking SHA beside an unchecked version comment.
+    """
+
+    def _use(self):
+        return pins.Use(repo="actions/github-script", ref=REAL_V701, comment="v7.0.1", file="wf.yml", line=1)
+
+    def test_an_unresolvable_version_claim_is_unknown_not_ok(self, monkeypatch):
+        def resolve(repo, ref, token=None):
+            if ref == REAL_V701:
+                return (REAL_V701, pins.OK)
+            return (None, pins.UNKNOWN)  # the tag lookup got rate limited
+
+        monkeypatch.setattr(pins, "_resolve", resolve)
+        (finding,) = pins.audit([self._use()], None)
+        assert finding.status == pins.UNKNOWN, "a half-checked pin must not be reported as verified"
+        assert not finding.is_problem, "still inconclusive, so it must not redden the run"
+
+    def test_the_control_a_fully_resolved_claim_is_ok(self, monkeypatch):
+        """Without this, the assertion above could pass by calling everything
+        unknown."""
+        monkeypatch.setattr(pins, "_resolve", lambda repo, ref, token=None: (REAL_V701, pins.OK))
+        (finding,) = pins.audit([self._use()], None)
+        assert finding.status == pins.OK

--- a/tests/test_ci_gates_report_what_they_checked.py
+++ b/tests/test_ci_gates_report_what_they_checked.py
@@ -60,6 +60,13 @@ def _steps(job):
     return job.get("steps") or []
 
 
+def _as_list(value):
+    """`needs:` is a string for one dependency and a list for several."""
+    if value is None:
+        return []
+    return [value] if isinstance(value, str) else list(value)
+
+
 class TestTheNightlyLiveCheckAdmitsWhenItCheckedNothing:
     """It may stay green on an empty run; it may not stay silent about it."""
 
@@ -147,10 +154,50 @@ class TestTheNightlyLiveCheckAdmitsWhenItCheckedNothing:
     def test_a_real_failure_can_still_reach_the_issue_filing_step(self):
         """Masking everything would turn a masking bug into a silencing bug."""
         doc = _wf("collector-live-check.yml")
-        job = next(j for j in doc["jobs"].values() if any("pytest" in str(s.get("run", "")) for s in _steps(j)))
-        assert any(str(s.get("if", "")).strip() == "failure()" for s in _steps(job)), (
+        live_name, live_job = next(
+            (name, job)
+            for name, job in doc["jobs"].items()
+            if any("pytest" in str(s.get("run", "")) for s in _steps(job))
+        )
+        reactors = [
+            name
+            for name, job in doc["jobs"].items()
+            if live_name in _as_list(job.get("needs")) and str(job.get("if", "")).strip() == "failure()"
+        ]
+        assert reactors or any(str(s.get("if", "")).strip() == "failure()" for s in _steps(live_job)), (
             "nothing reacts to a genuine live-test failure any more"
         )
+
+    def test_the_reaction_does_not_share_a_failure_domain_with_what_it_reports(self):
+        """The reason this workflow was silent for six nights.
+
+        The alarm was an ``if: failure()`` STEP inside the live job. A step
+        cannot run when the job never starts, and this job did not start: its
+        ``actions/github-script`` pin named a commit that does not exist, so
+        GitHub failed it during "Set up job" every night while filing nothing.
+
+        A reporter must therefore be a separate job -- reached through
+        ``needs``, which fires however the watched job died -- and must not
+        reintroduce the same dependency, so it may not resolve any action
+        beyond the checkout its own steps need.
+        """
+        doc = _wf("collector-live-check.yml")
+        live_name = next(
+            name for name, job in doc["jobs"].items() if any("pytest" in str(s.get("run", "")) for s in _steps(job))
+        )
+        reporters = [
+            job
+            for job in doc["jobs"].values()
+            if live_name in _as_list(job.get("needs")) and str(job.get("if", "")).strip() == "failure()"
+        ]
+        assert reporters, "the failure reaction must be its own job, or a setup failure silences it"
+        for job in reporters:
+            for step in _steps(job):
+                uses = str(step.get("uses", ""))
+                assert not uses or uses.startswith("actions/checkout@"), (
+                    f"the reporter resolves {uses!r}; an unresolvable action there would silence "
+                    f"the alarm exactly as the original bug did"
+                )
 
 
 class TestTheTagVerifierCanTellApartMissingAndUnreachable:

--- a/tests/test_ci_gates_report_what_they_checked.py
+++ b/tests/test_ci_gates_report_what_they_checked.py
@@ -193,10 +193,13 @@ class TestTheNightlyLiveCheckAdmitsWhenItCheckedNothing:
         assert reporters, "the failure reaction must be its own job, or a setup failure silences it"
         for job in reporters:
             for step in _steps(job):
-                uses = str(step.get("uses", ""))
-                assert not uses or uses.startswith("actions/checkout@"), (
-                    f"the reporter resolves {uses!r}; an unresolvable action there would silence "
-                    f"the alarm exactly as the original bug did"
+                # Not "only checkout" -- NONE. The reporter shells out to the
+                # preinstalled gh CLI and reads no repository file, so every
+                # action it resolved would be one more way for the alarm to die
+                # at setup, which is the whole bug.
+                assert not step.get("uses"), (
+                    f"the reporter resolves {step.get('uses')!r}; it needs no action at all, and "
+                    f"an unresolvable one there would silence the alarm exactly as the original bug did"
                 )
 
 


### PR DESCRIPTION
You spotted [run 31242808822](https://github.com/GeiserX/CashPilot/actions/runs/31242808822). It is not provider drift — the job never started.

```
##[error]Unable to resolve action `actions/github-script@60a0d83039c74a4aa971cc2a0930ae7e2fe2c8bd`
```

That SHA does not exist. Beside the real one, the shape is unmistakable:

```
pinned:      60a0d83039c74a4a a971cc2a0930ae7e2fe2c8bd   # comment claimed v7.0.4
real v7.0.1: 60a0d83039c74a4a ee543508d2ffcb1c3799cdea
```

Same 16-char prefix, invented tail — and `v7.0.4` was never released (404). Written from memory rather than copied. It landed in #169, **the commit that created the workflow**, so this check has never run once; it has failed every night since 3 August.

**It was also silent.** The "open an issue" alarm was an `if: failure()` *step inside that job* — and a step cannot run when the job dies at setup. No `collector-drift` issue was ever filed. An alarm sharing a failure domain with the thing it watches is not an alarm.

### What changes
1. **The alarm becomes a separate job** (`needs: live`, `if: failure()`) so it fires however the watched job died, using the preinstalled `gh` CLI instead of an action — the reporter for "an action would not resolve" must not resolve actions. Least privilege too: the job handling real provider credentials drops to `contents: read`.
2. **`scripts/check_action_pins.py`** reads what a human cannot: fails on a ref that does not resolve, **and** on a `# vX.Y.Z` comment naming a missing tag or pointing at a different commit. Three-valued — a rate limit is `unknown` and never reddens the run, because an alarm that cries wolf is the failure mode this whole PR is about.
3. **`Action Pins` workflow** on PRs touching `.github/workflows/**`, plus weekly (a tag can move after merge). It depends on exactly one action, checkout.

### Verification
- Replayed the **original broken file** through the checker → exit 1, names the exact line.
- A real SHA with a lying comment (`v9.0.0` on the v7.1.0 commit) → exit 1.
- **46/46** references in the repo resolve today; the fabricated pin was the only bad one of 11 SHA pins.
- 18 offline tests for the checker; the pre-existing "something reacts to a failure" gate updated (it assumed the broken shape) and strengthened to forbid the reporter resolving non-checkout actions — **both mutations verified to fail it**.
- Full suite: 4522 passed.

Note: the live check will still report *"provider-drift detection is NOT active"* until a test carries `@pytest.mark.live` — that part is by design and now visible instead of hidden behind a job that never ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated auditing to verify GitHub Actions are securely pinned and include matching version information.
  * Added scheduled and on-demand checks for workflow action pins.

* **Bug Fixes**
  * Improved live-check failure reporting, including failures during setup.
  * Restricted workflow permissions to the minimum required access.

* **Tests**
  * Added coverage for action-pin validation, workflow discovery, and failure-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->