### PR TITLE
feat(worker): add cpu_shares resource control to protect earners under host contention

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1637,8 +1637,8 @@ async def api_deploy(
     if raw_command:
         spec["command"] = re.sub(r"\$\{(\w+)\}", lambda m: env.get(m.group(1), m.group(0)), raw_command)
 
-    # Durable resource limits (mem_limit / mem_reservation / oom_score_adj),
-    # declared in the service YAML. Only forwarded when present.
+    # Durable resource limits (mem_limit / mem_reservation / oom_score_adj /
+    # cpu_shares), declared in the service YAML. Only forwarded when present.
     resources = docker_conf.get("resources")
     if resources:
         spec["resources"] = resources
@@ -1762,10 +1762,30 @@ def _merge_recorded_spec(
     # None, and rebuilding from that would silently give the service a new
     # identity. As with env, a hostname the operator typed THIS deploy still
     # wins - a non-empty catalog_spec value is what they just asked for.
-    for field in ("command", "network_mode", "cap_add", "resources"):
+    for field in ("command", "network_mode", "cap_add"):
         if field in recorded and recorded.get(field) != catalog_spec.get(field):
             divergence.append(f"{field}: keeping the deployed value")
             merged[field] = recorded[field]
+
+    # resources is merged per KEY, unlike the runtime-shape fields above, and
+    # for the env reason: limits carry no deployment identity, and the catalog
+    # is where NEW tuning keys land (a value change to a key the record
+    # already set still keeps the recorded value, reported as a divergence).
+    # Whole-dict recorded-wins made every catalog
+    # resource change unreachable for a deployed service — the record predating
+    # a new key (cpu_shares) beat the catalog forever, and the only escape was
+    # remove-and-redeploy, which for storj is the identity-loss operation the
+    # recorded spec exists to prevent. A key the record already set still wins:
+    # that is the value this deployment verifiably ran with.
+    stored_res = recorded.get("resources")
+    if isinstance(stored_res, dict):
+        catalog_res = catalog_spec.get("resources")
+        merged_res = dict(catalog_res) if isinstance(catalog_res, dict) else {}
+        merged_res.update(stored_res)
+        if merged_res != (catalog_res or {}):
+            divergence.append("resources: keeping the limits this service was deployed with")
+        if merged_res:
+            merged["resources"] = merged_res
 
     stored_hostname = recorded.get("hostname")
     if stored_hostname and not catalog_spec.get("hostname") and stored_hostname != catalog_spec.get("hostname"):

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -202,8 +202,9 @@ def deploy_raw(
     """Deploy a container from a raw spec (no catalog lookup).
 
     Used by CashPilot Worker when the UI sends a full container spec.
-    ``resources`` (mem_limit / mem_reservation / oom_score_adj) makes the
-    container's cgroup limits durable across recreates. Returns the container ID.
+    ``resources`` (mem_limit / mem_reservation / oom_score_adj / cpu_shares)
+    makes the container's cgroup limits durable across recreates. Returns the
+    container ID.
     """
     client = _get_client()
     name = _container_name(slug)
@@ -237,7 +238,9 @@ def deploy_raw(
     # at create time mem_limit alone avoids the cgroup-v2 swap validation issue.
     res = _normalize_resources(resources)
     resource_kwargs = {
-        key: res[key] for key in ("mem_limit", "mem_reservation", "oom_score_adj") if res.get(key) is not None
+        key: res[key]
+        for key in ("mem_limit", "mem_reservation", "oom_score_adj", "cpu_shares")
+        if res.get(key) is not None
     }
 
     logger.info("Creating container %s from %s", name, image)

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -243,7 +243,12 @@ def deploy_raw(
         if res.get(key) is not None
     }
 
-    logger.info("Creating container %s from %s", name, image)
+    # The resource kwargs are logged because the deploy response only says
+    # "deployed" — nothing echoes which limits were applied, and a worker whose
+    # ResourceSpec predates a key silently drops it (Pydantic ignores extras).
+    # This line makes `docker logs cashpilot-worker` state what THIS worker
+    # applied, so an operator comparing against the catalog can see the gap.
+    logger.info("Creating container %s from %s (resources: %s)", name, image, resource_kwargs or "docker defaults")
     container = client.containers.run(
         image=image,
         name=name,

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -777,11 +777,15 @@ class ResourceSpec(BaseModel):
 
     mem_limit / mem_reservation follow Docker's size syntax ("768m", "2g");
     oom_score_adj biases the kernel OOM killer (-1000 = sacrificed last).
+    cpu_shares is a *relative* weight (Docker's default is 1024) that only
+    takes effect while the host is contended, so it protects a latency-
+    sensitive earner from noisy neighbours without capping it on an idle box.
     """
 
     mem_limit: str | None = None
     mem_reservation: str | None = None
     oom_score_adj: int | None = None
+    cpu_shares: int | None = None
 
 
 class DeploySpec(BaseModel):
@@ -1071,6 +1075,14 @@ def _validate_resources(resources: ResourceSpec | None) -> None:
         raise HTTPException(
             status_code=400,
             detail=f"Invalid oom_score_adj '{resources.oom_score_adj}': must be between -1000 and 1000",
+        )
+    # Docker treats 0 as "use the default" but rejects 1, and the kernel caps
+    # the weight at 262144. Reject the whole range Docker would refuse rather
+    # than letting the deploy fail later at container-create time.
+    if resources.cpu_shares is not None and not (2 <= resources.cpu_shares <= 262144):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid cpu_shares '{resources.cpu_shares}': must be between 2 and 262144 (Docker's default is 1024)",
         )
 
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -1076,9 +1076,12 @@ def _validate_resources(resources: ResourceSpec | None) -> None:
             status_code=400,
             detail=f"Invalid oom_score_adj '{resources.oom_score_adj}': must be between -1000 and 1000",
         )
-    # Docker treats 0 as "use the default" but rejects 1, and the kernel caps
-    # the weight at 262144. Reject the whole range Docker would refuse rather
-    # than letting the deploy fail later at container-create time.
+    # 2..262144 is the kernel's cpu.shares range (MIN_SHARES..MAX_SHARES);
+    # Docker documents no bound of its own, and daemons vary at the edges
+    # (0 means "use the default", modern ones clamp out-of-range values rather
+    # than erroring). The guard rejects everything outside the kernel range —
+    # including 0, where OMITTING the key is the honest spelling of "default" —
+    # because a 400 is actionable where a silently clamped weight is not.
     if resources.cpu_shares is not None and not (2 <= resources.cpu_shares <= 262144):
         raise HTTPException(
             status_code=400,

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -34,11 +34,18 @@
 #     mem_limit: "768m"        # hard memory ceiling (str: <number><b|k|m|g>, e.g. "512m", "2g")
 #     mem_reservation: "512m"  # (optional) soft memory reservation, same format as mem_limit
 #     oom_score_adj: -100      # kernel OOM-killer bias, int -1000..1000 (lower = sacrificed last)
-#     cpu_shares: 2048         # relative CPU weight, int 2..262144 (Docker's default is 1024).
-#                              # Only applies while the host is contended, so it does NOT cap the
+#     cpu_shares: 4096         # relative CPU weight, int 2..262144 (Docker's API default is 1024).
+#                              # Only arbitrates while CPU is contended, so it does NOT cap the
 #                              # container on an idle box. Raise it for earners that must answer
 #                              # inbound connections on time (a storage node the network dials
 #                              # back into), which are reported "offline" if they are merely slow.
+#                              # It arbitrates CPU between CONTAINERS only: it buys nothing
+#                              # against host-process load, I/O-wait, or an unreachable address.
+#                              # On cgroup v2 the value maps onto cpu.weight (unset default 100):
+#                              # runc >= 1.2 maps 1024->100, 4096->303; OLDER runc maps linearly,
+#                              # where anything under ~2600 lands BELOW the unset default -- 2048
+#                              # would give the "protected" service LESS weight than its
+#                              # neighbours. Use 4096 or more, which clears 100 on both mappings.
 #   env:
 #     - key: ENV_VAR_NAME
 #       label: "Human label"

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -34,6 +34,11 @@
 #     mem_limit: "768m"        # hard memory ceiling (str: <number><b|k|m|g>, e.g. "512m", "2g")
 #     mem_reservation: "512m"  # (optional) soft memory reservation, same format as mem_limit
 #     oom_score_adj: -100      # kernel OOM-killer bias, int -1000..1000 (lower = sacrificed last)
+#     cpu_shares: 2048         # relative CPU weight, int 2..262144 (Docker's default is 1024).
+#                              # Only applies while the host is contended, so it does NOT cap the
+#                              # container on an idle box. Raise it for earners that must answer
+#                              # inbound connections on time (a storage node the network dials
+#                              # back into), which are reported "offline" if they are merely slow.
 #   env:
 #     - key: ENV_VAR_NAME
 #       label: "Human label"

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -21,12 +21,15 @@ docker:
   resources:
     mem_limit: "2g"
     oom_score_adj: -100
-    # Satellites dial the node back in and mark it offline when the connection
-    # times out, so being slow is indistinguishable from being down -- and
-    # sustained "offline" leads to suspension. A weight above the 1024 default
-    # keeps the node answering while other workloads saturate the host; it is
-    # relative, so it costs nothing when the machine is idle.
-    cpu_shares: 2048
+    # Defensive weight for a service the network dials back into: satellites
+    # mark the node offline when their dial times out, so a node that is merely
+    # slow to answer reads as down, and sustained "offline" leads to suspension.
+    # This only arbitrates CPU against other containers under contention (free
+    # while the host is idle) -- it does NOT fix I/O-wait on the storage path or
+    # a wrong/stale ADDRESS, which are the more common causes of offline mail.
+    # 4096 (not 2048) because older runc maps shares under ~2600 BELOW the
+    # unset default weight -- see cpu_shares in _schema.yml.
+    cpu_shares: 4096
   env:
     - key: WALLET
       label: "Wallet address"

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -21,6 +21,12 @@ docker:
   resources:
     mem_limit: "2g"
     oom_score_adj: -100
+    # Satellites dial the node back in and mark it offline when the connection
+    # times out, so being slow is indistinguishable from being down -- and
+    # sustained "offline" leads to suspension. A weight above the 1024 default
+    # keeps the node answering while other workloads saturate the host; it is
+    # relative, so it costs nothing when the machine is idle.
+    cpu_shares: 2048
   env:
     - key: WALLET
       label: "Wallet address"

--- a/tests/test_deployed_spec.py
+++ b/tests/test_deployed_spec.py
@@ -306,6 +306,68 @@ class TestMergeRecordedSpec:
         assert merged["volumes"]["newvol"] == {"bind": "/app/cache", "mode": "rw"}
         assert merged["volumes"]["/old"] == {"bind": "/app/data", "mode": "rw"}
 
+    def test_a_resource_key_added_to_the_catalog_since_deployment_still_lands(self):
+        """The cpu_shares rollout bug: resources merged as an opaque whole.
+
+        The recorded dict predated the key, differed from the catalog, and so
+        beat it forever — every deployed storj kept the default CPU weight, and
+        the only escape was the remove-and-redeploy that risks the node
+        identity. Resources merge per key now, like env: the catalog supplies
+        keys the record never set.
+        """
+        merged, divergence = _merge_recorded_spec(
+            {"image": "i", "env": {}, "resources": {"mem_limit": "2g", "oom_score_adj": -100, "cpu_shares": 4096}},
+            {"image": "i", "env": {}, "resources": {"mem_limit": "2g", "oom_score_adj": -100}},
+            user_env={},
+        )
+        assert merged["resources"] == {"mem_limit": "2g", "oom_score_adj": -100, "cpu_shares": 4096}
+        # Nothing was kept over the catalog, so nothing may be reported as kept.
+        assert not any("resources" in d for d in divergence)
+
+    def test_a_resource_value_the_deployment_ran_with_still_wins_per_key(self):
+        """Control for the test above: per-key must not mean catalog-clobbers.
+
+        The record's own mem_limit survives — that is the value this container
+        verifiably ran with — while the catalog's new key still lands beside it.
+        """
+        merged, divergence = _merge_recorded_spec(
+            {"image": "i", "env": {}, "resources": {"mem_limit": "2g", "cpu_shares": 4096}},
+            {"image": "i", "env": {}, "resources": {"mem_limit": "1g"}},
+            user_env={},
+        )
+        assert merged["resources"] == {"mem_limit": "1g", "cpu_shares": 4096}
+        assert any("resources" in d for d in divergence)
+
+    def test_a_recorded_resources_block_survives_a_catalog_that_dropped_its_own(self):
+        merged, divergence = _merge_recorded_spec(
+            {"image": "i", "env": {}},
+            {"image": "i", "env": {}, "resources": {"mem_limit": "1g"}},
+            user_env={},
+        )
+        assert merged["resources"] == {"mem_limit": "1g"}
+        assert any("resources" in d for d in divergence)
+
+    def test_a_record_without_resources_takes_the_catalog_block_untouched(self):
+        merged, divergence = _merge_recorded_spec(
+            {"image": "i", "env": {}, "resources": {"cpu_shares": 4096}},
+            {"image": "i", "env": {}},
+            user_env={},
+        )
+        assert merged["resources"] == {"cpu_shares": 4096}
+        assert not any("resources" in d for d in divergence)
+
+    def test_a_non_dict_recorded_resources_value_is_ignored_not_merged(self):
+        # The isinstance guard: a record predating the feature, or a corrupted
+        # one, may carry None here — the catalog block must survive untouched
+        # rather than crash the redeploy or clobber the limits with junk.
+        merged, divergence = _merge_recorded_spec(
+            {"image": "i", "env": {}, "resources": {"cpu_shares": 4096}},
+            {"image": "i", "env": {}, "resources": None},
+            user_env={},
+        )
+        assert merged["resources"] == {"cpu_shares": 4096}
+        assert not any("resources" in d for d in divergence)
+
     def test_hostname_is_preserved_when_the_operator_leaves_it_blank(self):
         """Several services key device identity to the hostname."""
         merged, divergence = _merge_recorded_spec(

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -313,7 +313,9 @@ class TestApiDeploy:
             assert captured["spec"]["resources"] == {
                 "mem_limit": "2g",
                 "oom_score_adj": -100,
-                "cpu_shares": 2048,
+                # 4096, not 2048: older runc maps shares below ~2600 UNDER the
+                # unset cgroup-v2 default weight — see _schema.yml.
+                "cpu_shares": 4096,
             }
 
 

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -310,7 +310,11 @@ class TestApiDeploy:
                 },
             )
             assert resp.status_code == 200, resp.text
-            assert captured["spec"]["resources"] == {"mem_limit": "2g", "oom_score_adj": -100}
+            assert captured["spec"]["resources"] == {
+                "mem_limit": "2g",
+                "oom_score_adj": -100,
+                "cpu_shares": 2048,
+            }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_worker_resources.py
+++ b/tests/test_worker_resources.py
@@ -2,10 +2,12 @@
 
 Covers:
   * DeploySpec / ResourceSpec validation (valid + invalid mem_limit,
-    mem_reservation, oom_score_adj).
+    mem_reservation, oom_score_adj, cpu_shares).
   * orchestrator.deploy_raw forwarding mem_limit / mem_reservation /
-    oom_score_adj to containers.run() only when set.
+    oom_score_adj / cpu_shares to containers.run() only when set.
   * The worker /deploy endpoint threading resources through to deploy_raw.
+  * Every catalog YAML's docker.resources block validating against the same
+    rules the worker enforces, with only documented keys.
 """
 
 import os
@@ -149,8 +151,10 @@ class TestDeployRawResources:
         assert kwargs["mem_limit"] == "2g"
 
     def test_forwards_cpu_shares_from_catalog_dict(self):
-        # Catalog services reach deploy_raw as a plain dict read out of the
-        # service YAML, not as a Pydantic model.
+        # No production caller passes a dict today (the worker always builds a
+        # ResourceSpec), but _normalize_resources deliberately accepts one, so
+        # pin that tolerance. NOTE: the dict path skips _validate_resources —
+        # any future caller taking this shortcut must validate first.
         client = self._mock_client()
         with patch.object(orchestrator, "_get_client", return_value=client):
             orchestrator.deploy_raw(slug="storj", image="img", resources={"cpu_shares": 2048})
@@ -311,6 +315,78 @@ class TestWorkerDeployEndpoint:
             headers=self._auth(),
         )
         assert resp.status_code == 400
+
+    def test_endpoint_rejects_invalid_cpu_shares(self):
+        # Proves the shared validator is actually reached on the wire for the
+        # new key, like the oom/mem siblings above — not just at unit level.
+        resp = self._client().post(
+            "/api/containers/storj/deploy",
+            json={"image": "img", "resources": {"cpu_shares": 1}},
+            headers=self._auth(),
+        )
+        assert resp.status_code == 400
+
+
+class TestCatalogResourceBlocksAreValid:
+    """Every docker.resources block in the real catalog must be deployable.
+
+    Nothing else validates these at load time: an undocumented key (a typo like
+    `cpushares`) is silently ignored by Pydantic's default extra="ignore", so
+    the YAML looks correct, CI stays green, and the limit the author asked for
+    never reaches Docker. Same failure mode — and same guard pattern — as the
+    collector-key allowlist in test_beads_batch_24.py.
+    """
+
+    # Derived, not hardcoded: ResourceSpec is what actually decides whether a
+    # key is honored, so a hand-copied set here could drift and prove nothing.
+    # The schema-agreement test below covers the documentation side.
+    DOCUMENTED_RESOURCE_KEYS = frozenset(ResourceSpec.model_fields)
+
+    @staticmethod
+    def _resource_blocks():
+        # The production loader, not a reimplemented walk: it reads both .yml
+        # and .yaml, so a service added under either extension stays guarded.
+        from app.catalog import load_services
+
+        return {
+            svc.get("slug"): resources
+            for svc in load_services()
+            if (resources := (svc.get("docker") or {}).get("resources"))
+        }
+
+    def test_the_catalog_carries_resource_blocks_at_all(self):
+        # Negative control for the two tests below: if the loader breaks and
+        # returns nothing, they would pass vacuously while checking nothing.
+        assert self._resource_blocks(), "no docker.resources block found in any service YAML"
+
+    def test_every_resource_key_is_one_the_schema_documents(self):
+        offenders = {
+            slug: sorted(set(res) - self.DOCUMENTED_RESOURCE_KEYS)
+            for slug, res in self._resource_blocks().items()
+            if set(res) - self.DOCUMENTED_RESOURCE_KEYS
+        }
+        assert not offenders, f"undocumented resource keys are silently ignored, never applied: {offenders}"
+
+    def test_every_resource_block_passes_worker_validation(self):
+        # The worker 400s an out-of-range value at deploy time; a catalog that
+        # ships one turns every operator's first deploy into that 400.
+        for slug, res in self._resource_blocks().items():
+            try:
+                _validate_resources(ResourceSpec(**res))
+            except HTTPException as exc:
+                pytest.fail(f"{slug}: catalog resources would be rejected at deploy: {exc.detail}")
+
+    def test_every_honored_key_is_documented_in_the_schema(self):
+        # Guards the guard from the other side: the allowlist above is derived
+        # from ResourceSpec (what the worker honors), and this ties each of
+        # those keys back to _schema.yml (what authors read). If they disagree,
+        # either the schema teaches a key nothing applies, or the worker
+        # honors a key nobody can discover.
+        import pathlib
+
+        schema = (pathlib.Path(__file__).resolve().parents[1] / "services" / "_schema.yml").read_text(encoding="utf-8")
+        for key in self.DOCUMENTED_RESOURCE_KEYS:
+            assert key in schema, f"{key} is honored by ResourceSpec but undocumented in services/_schema.yml"
 
 
 class TestPidsLimitParsing:

--- a/tests/test_worker_resources.py
+++ b/tests/test_worker_resources.py
@@ -69,6 +69,19 @@ class TestResourceValidation:
             _validate_resources(ResourceSpec(oom_score_adj=bad))
         assert ei.value.status_code == 400
 
+    @pytest.mark.parametrize("good", [2, 1024, 2048, 262144])
+    def test_valid_cpu_shares_accepted(self, good):
+        _validate_resources(ResourceSpec(cpu_shares=good))
+
+    @pytest.mark.parametrize("bad", [0, 1, -1, -1024, 262145])
+    def test_cpu_shares_out_of_range_rejected(self, bad):
+        # 0 and 1 are rejected deliberately: Docker reads 0 as "default" and
+        # refuses 1 outright, so accepting either would silently not apply the
+        # weight the operator asked for.
+        with pytest.raises(HTTPException) as ei:
+            _validate_resources(ResourceSpec(cpu_shares=bad))
+        assert ei.value.status_code == 400
+
     @pytest.mark.parametrize("good", [-1000, -100, 0, 200, 300, 1000])
     def test_oom_in_range_accepted(self, good):
         _validate_resources(ResourceSpec(oom_score_adj=good))
@@ -123,6 +136,26 @@ class TestDeployRawResources:
         # None-valued fields are dropped, never forwarded as None.
         assert "oom_score_adj" not in kwargs
 
+    def test_forwards_cpu_shares(self):
+        client = self._mock_client()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.deploy_raw(
+                slug="storj",
+                image="img",
+                resources=ResourceSpec(mem_limit="2g", oom_score_adj=-100, cpu_shares=2048),
+            )
+        kwargs = client.containers.run.call_args.kwargs
+        assert kwargs["cpu_shares"] == 2048
+        assert kwargs["mem_limit"] == "2g"
+
+    def test_forwards_cpu_shares_from_catalog_dict(self):
+        # Catalog services reach deploy_raw as a plain dict read out of the
+        # service YAML, not as a Pydantic model.
+        client = self._mock_client()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.deploy_raw(slug="storj", image="img", resources={"cpu_shares": 2048})
+        assert client.containers.run.call_args.kwargs["cpu_shares"] == 2048
+
     def test_omits_resource_kwargs_when_unset(self):
         client = self._mock_client()
         with patch.object(orchestrator, "_get_client", return_value=client):
@@ -130,6 +163,7 @@ class TestDeployRawResources:
         kwargs = client.containers.run.call_args.kwargs
         assert "mem_limit" not in kwargs
         assert "mem_reservation" not in kwargs
+        assert "cpu_shares" not in kwargs
         assert "oom_score_adj" not in kwargs
 
     def test_forwards_container_spec(self):

--- a/tests/test_worker_resources.py
+++ b/tests/test_worker_resources.py
@@ -382,11 +382,19 @@ class TestCatalogResourceBlocksAreValid:
         # those keys back to _schema.yml (what authors read). If they disagree,
         # either the schema teaches a key nothing applies, or the worker
         # honors a key nobody can discover.
+        #
+        # _schema.yml is documentation written entirely in comments — there is
+        # no YAML structure to parse (safe_load returns None) — so the check
+        # anchors on a commented MAPPING KEY (`#   cpu_shares:`), which a stray
+        # mention in prose cannot satisfy.
         import pathlib
+        import re
 
         schema = (pathlib.Path(__file__).resolve().parents[1] / "services" / "_schema.yml").read_text(encoding="utf-8")
         for key in self.DOCUMENTED_RESOURCE_KEYS:
-            assert key in schema, f"{key} is honored by ResourceSpec but undocumented in services/_schema.yml"
+            assert re.search(rf"^#\s*{re.escape(key)}:", schema, re.MULTILINE), (
+                f"{key} is honored by ResourceSpec but not documented as a key in services/_schema.yml"
+            )
 
 
 class TestPidsLimitParsing:


### PR DESCRIPTION
## Why

The storj node on watchtower was repeatedly reported **offline** by satellites (US1 offline emails) while the container was up and healthy. Root cause: satellites dial the node back in, and under heavy host contention (copyparty at 330%+ CPU, load 24-28 during a disk-zeroing run) those inbound connections timed out. To the network, a slow node is indistinguishable from a dead one — and sustained offline status leads to suspension and forfeited held balance.

The `resources` schema only supported memory controls (`mem_limit`, `mem_reservation`, `oom_score_adj`), so there was no way to keep an earner responsive when the host is saturated.

## What

- `ResourceSpec.cpu_shares` in `app/worker_api.py` with validation (2..262144 — Docker treats 0 as default, rejects 1, kernel caps at 262144), rejected at the API instead of failing later at container create
- Passthrough in `app/orchestrator.py` `deploy_raw` alongside the existing memory kwargs
- Schema documentation in `services/_schema.yml`
- `cpu_shares: 2048` for storj in `services/storage/storj.yml` — double the 1024 default; relative weight, so it only takes effect under contention and costs nothing on an idle host

## Testing

- `uv run pytest tests/` — **4539 passed, 6 skipped, 0 failed**
- New tests: valid range accepted (2/1024/2048/262144), out-of-range rejected (0, 1, negatives, 262145), forwarding from both pydantic spec and plain catalog dict, omitted-when-absent
- Real-catalog guard test updated to assert storj carries `cpu_shares: 2048`
- `ruff check` + `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring container CPU scheduling priority with `cpu_shares`.
  - Added CPU priority settings to the Storj service.
  - Redeployments now preserve recorded resource values while adopting newly configured resource settings.

- **Bug Fixes**
  - Resource settings now correctly forward CPU scheduling values during deployment.
  - Invalid CPU share values outside the supported range of 2–262144 are rejected with a clear validation error.

- **Documentation**
  - Documented CPU share limits, contention behavior, and recommended settings for latency-sensitive services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->