### PR TITLE
feat(catalog): storj health signal for satellite dial-back failure + DDNS guidance

### DIFF
--- a/docs/guides/storj.md
+++ b/docs/guides/storj.md
@@ -67,7 +67,7 @@ You need an Ethereum-compatible wallet address to receive STORJ token payouts. A
 In the CashPilot web UI, find **Storj** in the service catalog and click **Deploy**. You'll be asked for:
 - **Wallet address** — your ERC-20 wallet for payouts
 - **Email** — for operator notifications
-- **External address** — your public IP or DDNS hostname with port (e.g. `84.54.27.229:28967`)
+- **External address** — a DDNS hostname with port (e.g. `mynode.ddns.net:28967`). A literal public IP works until your ISP silently re-provisions it — from that day satellites dial a dead address and count the node offline while everything looks healthy locally
 - **Storage allocation** — how much disk space to offer (e.g. `2TB`)
 - **Identity path** — host directory where your identity files are stored
 - **Storage path** — host directory on a spinning disk (HDD) for storing data
@@ -85,13 +85,14 @@ CashPilot will handle the container creation with proper volume mounts.
 |----------|-------|:--------:|:------:|-------------|
 | `WALLET` | Wallet address | Yes | No | ERC-20 wallet address for STORJ token payouts (or zkSync) |
 | `EMAIL` | Email | Yes | No | Email address for operator notifications |
-| `ADDRESS` | External address | Yes | No | Public IP or DDNS hostname with port (e.g. mynode.ddns.net:28967) |
+| `ADDRESS` | External address | Yes | No | DDNS hostname with port (e.g. mynode.ddns.net:28967) — prefer over a literal IP |
 | `STORAGE` | Storage allocation | Yes | No | Maximum disk space to allocate (e.g. 2TB) (default: `1TB`) |
 | `IDENTITY_DIR` | Identity directory | Yes | No | Host path where identity files are stored (ca.cert, identity.cert, etc.) |
 | `STORAGE_DIR` | Storage directory | Yes | No | Host path on a spinning disk (HDD) for Storj data storage |
 
 ### Important Notes
 
+- **Use a DDNS hostname for `ADDRESS`, never a literal IP.** Satellites dial your node back at exactly the address it advertises. Residential ISPs re-provision public IPs without notice, and when that happens a node advertising the old literal IP is counted offline around the clock — container healthy, dashboard green, earnings from new data at zero — until someone notices the provider's offline emails. A dynamic-DNS hostname (DuckDNS, Cloudflare DDNS, your router's DDNS client) self-heals through an IP change. If satellites cannot reach the node, CashPilot's producer state for Storj reports it with the exact reason; you can also check yourself with `curl -s http://<server>:14002/api/sno/` (`lastPinged` stale or `quicStatus: "Misconfigured"` means unreachable).
 - **No signup required**: Storj nodes are permissionless since mid-2025. No auth token, no account creation.
 - **Escrow period**: First 9 months of operation have held-back escrow (75% of storage fees held, released gradually). This incentivizes long-term operation.
 - **One node per public IP**: Storj recommends one node per public IP for optimal satellite allocation. Nodes on the same /24 subnet share data allocation.

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -36,7 +36,7 @@ docker:
       label: "External address"
       required: true
       secret: false
-      description: "Your public IP or DDNS hostname with port (e.g. 84.54.27.229:28967). Port 28967 must be forwarded (TCP+UDP)"
+      description: "DDNS hostname with port (e.g. mynode.ddns.net:28967) -- strongly preferred over a literal IP, which strands the node the day your ISP silently re-provisions it. Port 28967 must be forwarded (TCP+UDP)"
     - key: STORAGE
       label: "Storage allocation"
       required: true
@@ -69,6 +69,22 @@ docker:
         the node and forfeits the held balance.
   command: "--operator.wallet-features=zksync-era"
   network_mode: ""
+  health_signals:
+    # Seen live (Aug 2026): ~40x/hour for days while the container looked
+    # perfectly healthy -- the node advertised a stale IP after an ISP
+    # re-provision, and every satellite dial-back timed out. The line is the
+    # node relaying the satellite's own error, so it names the MECHANISM
+    # (the network cannot dial the node back), not one cause: a refused
+    # connection or an unresolvable hostname produces the same match.
+    - pattern: "ping satellite.*failed to dial storage node"
+      means: >-
+        The Storj network cannot dial your node back at its advertised
+        ADDRESS, so satellites count it offline: new data stops arriving,
+        egress income stalls, and sustained offline time leads to suspension.
+        Check that ADDRESS matches your CURRENT public IP (use a DDNS
+        hostname, not a literal IP, so an ISP re-provision cannot strand the
+        node) and that port 28967 TCP+UDP is forwarded to this machine.
+      state: failing
   stop_timeout: 300
   setup: >
     Before first run, initialize the storage node config:

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -353,3 +353,66 @@ class TestItReadsTheShapeWorkersActuallySend:
     def test_an_unrelated_container_is_not_matched(self):
         other = [{"slug": "something-else", "status": "running", "_worker_id": 1}]
         assert self._call(other)["state"] == ps.UNKNOWN
+
+
+class TestStorjDialBackSignal:
+    """The Aug 2026 incident, pinned against the real catalog entry.
+
+    The node advertised a stale IP after a silent ISP re-provision; every
+    satellite dial-back timed out (~40x/hour for days) while the container
+    looked perfectly healthy. This signal is the product-side alarm for that
+    failure, so it is tested with the verbatim live log line, not a paraphrase.
+    """
+
+    LIVE_LINE = (
+        'ERROR contact:service ping satellite failed {"error": "ping satellite: '
+        "failed to dial storage node (ID: 12kxyHQJPtNG7svApvw8P62UrzPLZFJsafpv6N1CGFxgQ5W8Nx6) "
+        "at address 84.54.25.89:28967: rpc: tcp connector failed: rpc: dial tcp "
+        '84.54.25.89:28967: i/o timeout"}'
+    )
+
+    @staticmethod
+    def _signals():
+        from app.catalog import load_services
+
+        storj = next(s for s in load_services() if s.get("slug") == "storj")
+        return ps.signals_for(storj)
+
+    def test_the_catalog_declares_the_signal(self):
+        signals = self._signals()
+        assert signals, "storj declares no health_signals"
+        for signal in signals:
+            assert signal.get("pattern")
+            assert signal.get("means")
+            assert signal.get("state", "failing") in ("failing", "idle")
+
+    def test_the_live_incident_line_matches_and_reads_failing(self):
+        hits = ps.match_log_signals(self.LIVE_LINE, self._signals())
+        assert hits, "the verbatim incident line no longer matches any declared signal"
+        assert hits[0]["state"] == ps.FAILING
+        assert "ADDRESS" in hits[0]["means"], "the remedy must name the knob to check"
+
+    def test_the_mechanism_matches_regardless_of_the_underlying_cause(self):
+        # A refused connection is the same dial-back failure as a timeout; the
+        # pattern is anchored on the mechanism, not one error string.
+        refused = self.LIVE_LINE.replace("i/o timeout", "connect: connection refused")
+        assert ps.match_log_signals(refused, self._signals())
+
+    def test_a_successful_ping_does_not_match(self):
+        # Negative control sharing the words "ping satellite": only the failure
+        # form may fire, or every healthy node reads as failing.
+        ok = (
+            "INFO contact:service ping satellite succeeded "
+            '{"Satellite ID": "12EayRS2V1kEsWESU9QMRseFhdxYxKicsiFmxrsLZHeLUtdps3S"}'
+        )
+        assert ps.match_log_signals(ok, self._signals()) == []
+
+    def test_ordinary_healthy_logs_do_not_match(self):
+        healthy = (
+            "INFO Node 12kxyHQJPtNG7svApvw8P62UrzPLZFJsafpv6N1CGFxgQ5W8Nx6 started\n"
+            "INFO quic:endpoint QUIC endpoint is listening\n"
+            "INFO piecestore download started\n"
+            "INFO contact:chore Storagenode contact chore starting up\n"
+            "INFO bandwidth Persisting bandwidth usage cache to db\n"
+        )
+        assert ps.match_log_signals(healthy, self._signals()) == []


### PR DESCRIPTION
## Why

When a storj node advertises a stale address (e.g. after a silent ISP IP re-provision), satellites dial a dead address and count the node offline — new data stops, egress income stalls, sustained offline leads to suspension. The container stays healthy and the dashboard stays green the whole time: container health is computed from restarts and crashes, and is structurally blind to reachability. In the motivating incident the failure line appeared ~40x/hour for days and the first human-visible signal was provider email.

## What

- `health_signals` on `services/storage/storj.yml`: matches the node relaying the satellite's own dial-back error, anchored on the mechanism (`ping satellite.*failed to dial storage node`) so timeout and connection-refused variants match alike. The existing producer-state machinery (`/api/services/{slug}/producer-state`) scans the last 200 worker log lines for declared signals, so this surfaces as FAILING with the exact remedy in the dashboard.
- `ADDRESS` env description and `docs/guides/storj.md` now lead with a DDNS hostname and explain why a literal IP strands the node, plus how to self-check with the node's `/api/sno/` (`lastPinged`, `quicStatus`).

## Testing

- New `TestStorjDialBackSignal` pins the real catalog entry against the **verbatim** live incident log line (not a paraphrase), plus the connection-refused variant.
- Negative controls: a successful `ping satellite succeeded` line (shares the trigger words) and ordinary healthy log lines must produce zero hits.
- Full suite: 4533 passed, 6 skipped, coverage 95.61%. `ruff check` + `ruff format --check` clean. `generate_readme_tables.py --check` and `referral_check.py` pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Storj deployment guidance to require a DDNS hostname and port for external access.
  * Added troubleshooting steps for unreachable nodes, including failure symptoms, recovery behavior, and diagnostics.

* **Bug Fixes**
  * Added clearer health reporting when satellite connections fail, including guidance for checking advertised addresses and port forwarding.

* **Tests**
  * Expanded coverage for Storj connection timeouts, refused connections, successful pings, and unrelated healthy logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->