### PR TITLE
feat(fleet): flag a dial-back service whose advertised address the machine no longer has

### DIFF
--- a/app/egress.py
+++ b/app/egress.py
@@ -308,3 +308,88 @@ def running_slugs(worker: dict[str, Any] | None) -> set[str]:
     if isinstance(apps, list):
         found |= {container_slug(a) for a in apps if isinstance(a, dict) and a.get("running")}
     return found - {""}
+
+
+def advertised_host(value: Any) -> str | None:
+    """The host part of an advertised dial-back address ("host:port" or "host").
+
+    Returns None when there is nothing usable — empty, whitespace, or a bare
+    port. A ``[v6]:port`` bracket form yields the address inside the brackets.
+    None is "no claim", never "checked and fine".
+    """
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.startswith("["):
+        host = text[1:].split("]", 1)[0].strip()
+        return host or None
+    head, sep, tail = text.rpartition(":")
+    if sep and head and tail.isdigit() and ":" not in head:
+        # Exactly one colon with digits after it is host:port. A digit tail
+        # after MORE colons is a bare IPv6 address, which stays whole.
+        return head
+    return text
+
+
+def advertised_address_verdict(
+    advertised: Any,
+    egress_ip: str | None,
+    resolved_ips: set[str] | None,
+) -> str | None:
+    """Reason string when the network appears to be dialling an address this
+    machine does not have. None is NO CLAIM — undetected egress, unparseable
+    input, or resolution unavailable — never a verdict of "fine".
+
+    ``resolved_ips`` follows the three-valued rule for a HOSTNAME:
+      - None       resolution was not attempted or failed transiently: no claim;
+      - empty set  the name definitively does not resolve: that IS a finding;
+      - non-empty  the addresses the name currently points at.
+    For an IP-literal host the verdict needs no resolution at all.
+
+    The comparison assumes the service's inbound port rides the same WAN as
+    the machine's default egress — true for every single-WAN host. An operator
+    who deliberately forwards through a second WAN gets a warning they can
+    read and dismiss; the message says which assumption produced it.
+    """
+    host = advertised_host(advertised)
+    if not host or egress_ip is None:
+        return None
+
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+
+    if literal is not None:
+        if public_ip(host) is None:
+            return (
+                f"This service advertises {host}, a private address the network cannot dial back. "
+                "Set the advertised address to your public DDNS hostname (preferred) or public IP."
+            )
+        if public_ip(host) != egress_ip:
+            return (
+                f"This service advertises {host}, but this machine's current public IP is {egress_ip} — "
+                "the network is dialling an address this machine no longer has (a silent ISP re-provision "
+                "does exactly this). Update the advertised address, and prefer a DDNS hostname so the next "
+                "IP change heals itself. If you deliberately forward this service through a different WAN "
+                "than this machine's default egress, this comparison does not apply."
+            )
+        return None
+
+    if resolved_ips is None:
+        return None
+    if not resolved_ips:
+        return (
+            f"This service advertises the hostname {host}, which does not resolve at all — "
+            "the network cannot even look it up. Check the DNS record (did the DDNS updater stop?)."
+        )
+    if egress_ip not in resolved_ips:
+        shown = ", ".join(sorted(resolved_ips)[:3])
+        return (
+            f"This service advertises {host}, which resolves to {shown}, but this machine's current "
+            f"public IP is {egress_ip} — the network is dialling an address this machine does not have. "
+            "If the IP just changed, a DDNS updater may simply be lagging; if this persists, fix the "
+            "record. If you deliberately forward this service through a different WAN than this "
+            "machine's default egress, this comparison does not apply."
+        )
+    return None

--- a/app/egress.py
+++ b/app/egress.py
@@ -323,6 +323,15 @@ def advertised_host(value: Any) -> str | None:
     if text.startswith("["):
         host = text[1:].split("]", 1)[0].strip()
         return host or None
+    # "host:" with nothing after the one colon is a typo, not part of the
+    # host — passing it through made the resolver report a confident NXDOMAIN
+    # ("the DNS record is broken") about a name that was never looked up.
+    # Only the single-colon form is stripped: "2001:db8::" is a valid bare
+    # IPv6 address whose trailing colons belong to it.
+    if text.endswith(":") and ":" not in text[:-1]:
+        text = text[:-1].strip()
+    if not text:
+        return None
     head, sep, tail = text.rpartition(":")
     if sep and head and tail.isdigit() and ":" not in head:
         # Exactly one colon with digits after it is host:port. A digit tail
@@ -360,19 +369,32 @@ def advertised_address_verdict(
     except ValueError:
         literal = None
 
+    try:
+        egress_version = ipaddress.ip_address(egress_ip).version
+    except ValueError:
+        return None
+
     if literal is not None:
         if public_ip(host) is None:
             return (
                 f"This service advertises {host}, a private address the network cannot dial back. "
                 "Set the advertised address to your public DDNS hostname (preferred) or public IP."
             )
+        if literal.version != egress_version:
+            # A v4 literal against a v6 egress reading (or vice versa) says
+            # nothing about staleness — the detection endpoints are dual-stack,
+            # so the two readings can legitimately be different families.
+            # Comparing across them fabricated exactly the false "your address
+            # is stale" this module promises never to produce.
+            return None
         if public_ip(host) != egress_ip:
             return (
                 f"This service advertises {host}, but this machine's current public IP is {egress_ip} — "
                 "the network is dialling an address this machine no longer has (a silent ISP re-provision "
                 "does exactly this). Update the advertised address, and prefer a DDNS hostname so the next "
-                "IP change heals itself. If you deliberately forward this service through a different WAN "
-                "than this machine's default egress, this comparison does not apply."
+                "IP change heals itself. If this machine's IP changed within the last hour, this can also "
+                "be a stale reading that clears itself. If you deliberately forward this service through a "
+                "different WAN than this machine's default egress, this comparison does not apply."
             )
         return None
 
@@ -383,13 +405,29 @@ def advertised_address_verdict(
             f"This service advertises the hostname {host}, which does not resolve at all — "
             "the network cannot even look it up. Check the DNS record (did the DDNS updater stop?)."
         )
-    if egress_ip not in resolved_ips:
-        shown = ", ".join(sorted(resolved_ips)[:3])
+
+    def _version(ip: str) -> int | None:
+        try:
+            return ipaddress.ip_address(ip).version
+        except ValueError:
+            return None
+
+    same_family = {ip for ip in resolved_ips if _version(ip) == egress_version}
+    if not same_family:
+        # The name only has records of the other family — nothing comparable,
+        # so no claim (a v6-only DDNS name against a v4 egress is not stale).
+        return None
+    if egress_ip not in same_family:
+        # Echo only PUBLIC addresses back: resolved IPs originate from a
+        # worker-supplied name, and repeating a private answer would let a
+        # rogue worker read the hub's internal DNS view out of this message.
+        public_resolved = sorted(ip for ip in same_family if public_ip(ip))
+        shown = ", ".join(public_resolved[:3]) or "only non-public addresses"
         return (
             f"This service advertises {host}, which resolves to {shown}, but this machine's current "
             f"public IP is {egress_ip} — the network is dialling an address this machine does not have. "
-            "If the IP just changed, a DDNS updater may simply be lagging; if this persists, fix the "
-            "record. If you deliberately forward this service through a different WAN than this "
-            "machine's default egress, this comparison does not apply."
+            "If the IP just changed, a DDNS updater may simply be lagging and this clears itself; if it "
+            "persists, fix the record. If you deliberately forward this service through a different WAN "
+            "than this machine's default egress, this comparison does not apply."
         )
     return None

--- a/app/main.py
+++ b/app/main.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hmac
+import ipaddress
 import json
 import logging
 import math
 import os
 import re
 import secrets
+import socket
 import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -227,6 +229,13 @@ async def _get_all_worker_containers(workers: list[dict[str, Any]] | None = None
                             # found" for a row the same screen called Running.
                             # The node name is already carried by _node.
                             "deployed_by": c.get("deployed_by") or worker_name,
+                            # The dial-back address the worker read from the ONE
+                            # env var the service's catalog entry declares. None
+                            # when undeclared/unreported — this dict is a key
+                            # allowlist, so without this line the field the
+                            # mismatch check depends on would be silently
+                            # dropped right here.
+                            "advertised_address": c.get("advertised_address"),
                             "_node": worker_name,
                             "_worker_id": w.get("id"),
                             "_has_docker": worker_has_docker,
@@ -2658,6 +2667,57 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
     return result
 
 
+async def _advertised_address_mismatch(matches: list[dict[str, Any]]) -> str | None:
+    """Is the network dialling an address this machine no longer has?
+
+    Compares the advertised_address a worker reported (the ONE env var the
+    service's catalog entry declares, see advertised_address_env in
+    services/_schema.yml) against that worker's detected egress IP. This is
+    the check that catches a stale advertised IP the day the ISP re-provisions
+    it, instead of days later via the provider's offline emails.
+
+    Every failure to gather either side returns None — no claim — because a
+    wrong "your address is stale" sends the operator to fix DNS that is fine.
+    Only a definitive NXDOMAIN counts as a resolution verdict; a timeout or a
+    transient resolver error is indistinguishable from OUR network having a
+    bad moment, which says nothing about the record.
+    """
+    reported = next((c for c in matches if c.get("advertised_address") and c.get("_worker_id") is not None), None)
+    if reported is None:
+        return None
+    row = await database.get_worker(reported["_worker_id"])
+    if row is None:
+        return None
+    egress_ip = egress.egress_of(_decoded_worker(row))
+
+    host = egress.advertised_host(reported["advertised_address"])
+    resolved: set[str] | None = None
+    if host and egress_ip:
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            resolved = await _resolve_advertised_host(host)
+    return egress.advertised_address_verdict(reported["advertised_address"], egress_ip, resolved)
+
+
+async def _resolve_advertised_host(host: str) -> set[str] | None:
+    """Resolve a hostname the way the dialling network would.
+
+    Three-valued by contract: a non-empty set of addresses, an EMPTY set only
+    for a definitive does-not-exist answer (EAI_NONAME/EAI_NODATA), and None
+    for everything transient — timeout, EAI_AGAIN, resolver trouble — because
+    OUR resolver having a bad moment says nothing about the record.
+    """
+    try:
+        infos = await asyncio.wait_for(asyncio.get_running_loop().getaddrinfo(host, None, type=socket.SOCK_STREAM), 3.0)
+        return {addr[4][0] for addr in infos}
+    except socket.gaierror as exc:
+        definitive = {socket.EAI_NONAME, getattr(socket, "EAI_NODATA", socket.EAI_NONAME)}
+        return set() if exc.errno in definitive else None
+    except (TimeoutError, OSError):
+        return None
+
+
 @app.get("/api/services/{slug}/producer-state")
 async def api_producer_state(request: Request, slug: str, worker_id: int | None = None) -> dict[str, Any]:
     """Is this service actually EARNING, as distinct from merely running?
@@ -2708,6 +2768,7 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
     running: bool | None = None
     log_hits: list[dict[str, str]] = []
     traffic: str | None = None
+    address_mismatch: str | None = None
     signals = producer_state.signals_for(service)
     try:
         containers = await _get_all_worker_containers()
@@ -2717,6 +2778,10 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         matches = [c for c in containers if egress.container_slug(c) == slug]
         running = any(str(c.get("status", "")).lower() == "running" for c in matches)
         traffic = _traffic_state(slug, matches)
+        if running:
+            # Inside the same never-500 umbrella: a worker-row or DNS problem
+            # must degrade to "no claim", not break the earnings verdict.
+            address_mismatch = await _advertised_address_mismatch(matches)
         if signals and running:
             wid = worker_id if worker_id is not None else (matches[0].get("_worker_id") if matches else None)
             if wid is not None:
@@ -2734,6 +2799,7 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         log_hits=log_hits,
         traffic=traffic,
         container_running=running,
+        address_mismatch=address_mismatch,
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2713,7 +2713,12 @@ async def _advertised_address_mismatch(matches: list[dict[str, Any]], worker_id:
             if not _HOSTNAME_RE.fullmatch(host):
                 return None
             resolved = await _resolve_advertised_host(host)
-    return egress.advertised_address_verdict(reported["advertised_address"], egress_ip, resolved)
+    reason = egress.advertised_address_verdict(reported["advertised_address"], egress_ip, resolved)
+    # Name the node: on a fleet the bare reason says "this machine" with no
+    # way to tell WHICH machine, which is a finding nobody can act on.
+    if reason and (node := reported.get("_node")):
+        return f"On {node}: {reason}"
+    return reason
 
 
 #: host -> (monotonic stamp, result). One entry per advertised hostname (one
@@ -2723,6 +2728,9 @@ async def _advertised_address_mismatch(matches: list[dict[str, Any]], worker_id:
 #: OS resolver timeout.
 _RESOLVE_CACHE: dict[str, tuple[float, set[str] | None]] = {}
 _RESOLVE_CACHE_TTL = 60.0
+#: The keys are worker-supplied hostnames, so the table must be bounded: a
+#: worker rotating its advertised address must not grow hub memory forever.
+_RESOLVE_CACHE_MAX = 256
 
 
 async def _resolve_advertised_host(host: str) -> set[str] | None:
@@ -2749,7 +2757,14 @@ async def _resolve_advertised_host(host: str) -> set[str] | None:
         result = set() if exc.errno in definitive else None
     except (TimeoutError, OSError, UnicodeError):
         result = None
-    _RESOLVE_CACHE[host] = (time.monotonic(), result)
+    now = time.monotonic()
+    # Purge expired entries on every write, then cap: without eviction each
+    # distinct worker-supplied name would be a permanent key.
+    for stale in [k for k, (stamp, _) in _RESOLVE_CACHE.items() if now - stamp >= _RESOLVE_CACHE_TTL]:
+        del _RESOLVE_CACHE[stale]
+    while len(_RESOLVE_CACHE) >= _RESOLVE_CACHE_MAX:
+        del _RESOLVE_CACHE[min(_RESOLVE_CACHE, key=lambda k: _RESOLVE_CACHE[k][0])]
+    _RESOLVE_CACHE[host] = (now, result)
     return result
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2667,7 +2667,14 @@ async def api_earnings_net(request: Request, days: int = 30) -> dict[str, Any]:
     return result
 
 
-async def _advertised_address_mismatch(matches: list[dict[str, Any]]) -> str | None:
+#: Hostname shape a resolver should ever be asked about. advertised_address is
+#: WORKER-SUPPLIED text: without this gate a rogue worker could drive the hub's
+#: resolver with arbitrary strings (and an IDNA-invalid label does not even
+#: raise the OSError family — see _resolve_advertised_host).
+_HOSTNAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
+
+
+async def _advertised_address_mismatch(matches: list[dict[str, Any]], worker_id: int | None = None) -> str | None:
     """Is the network dialling an address this machine no longer has?
 
     Compares the advertised_address a worker reported (the ONE env var the
@@ -2682,7 +2689,14 @@ async def _advertised_address_mismatch(matches: list[dict[str, Any]]) -> str | N
     transient resolver error is indistinguishable from OUR network having a
     bad moment, which says nothing about the record.
     """
-    reported = next((c for c in matches if c.get("advertised_address") and c.get("_worker_id") is not None), None)
+    # Judge only what is actually RUNNING, and only on the node the caller
+    # asked about: an exited container elsewhere in the fleet carries the env
+    # of its LAST run, and judging that produced a finding about a machine the
+    # page was not even showing.
+    candidates = [c for c in matches if str(c.get("status", "")).lower() == "running"]
+    if worker_id is not None:
+        candidates = [c for c in candidates if c.get("_worker_id") == worker_id]
+    reported = next((c for c in candidates if c.get("advertised_address") and c.get("_worker_id") is not None), None)
     if reported is None:
         return None
     row = await database.get_worker(reported["_worker_id"])
@@ -2696,8 +2710,19 @@ async def _advertised_address_mismatch(matches: list[dict[str, Any]]) -> str | N
         try:
             ipaddress.ip_address(host)
         except ValueError:
+            if not _HOSTNAME_RE.fullmatch(host):
+                return None
             resolved = await _resolve_advertised_host(host)
     return egress.advertised_address_verdict(reported["advertised_address"], egress_ip, resolved)
+
+
+#: host -> (monotonic stamp, result). One entry per advertised hostname (one
+#: service per fleet declares one today), so this stays tiny; the TTL exists so
+#: a blackholed resolver costs one executor thread per window, not one per
+#: request — wait_for abandons the await but the thread blocks on for the full
+#: OS resolver timeout.
+_RESOLVE_CACHE: dict[str, tuple[float, set[str] | None]] = {}
+_RESOLVE_CACHE_TTL = 60.0
 
 
 async def _resolve_advertised_host(host: str) -> set[str] | None:
@@ -2707,15 +2732,25 @@ async def _resolve_advertised_host(host: str) -> set[str] | None:
     for a definitive does-not-exist answer (EAI_NONAME/EAI_NODATA), and None
     for everything transient — timeout, EAI_AGAIN, resolver trouble — because
     OUR resolver having a bad moment says nothing about the record.
+
+    UnicodeError is in the transient clause because getaddrinfo raises it (a
+    ValueError, NOT an OSError) for an IDNA-invalid label — uncaught, it
+    escaped to the route's umbrella handler and silently disabled the log-
+    signal scan that shares the same try block.
     """
+    cached = _RESOLVE_CACHE.get(host)
+    if cached and time.monotonic() - cached[0] < _RESOLVE_CACHE_TTL:
+        return cached[1]
     try:
         infos = await asyncio.wait_for(asyncio.get_running_loop().getaddrinfo(host, None, type=socket.SOCK_STREAM), 3.0)
-        return {addr[4][0] for addr in infos}
+        result: set[str] | None = {addr[4][0] for addr in infos}
     except socket.gaierror as exc:
         definitive = {socket.EAI_NONAME, getattr(socket, "EAI_NODATA", socket.EAI_NONAME)}
-        return set() if exc.errno in definitive else None
-    except (TimeoutError, OSError):
-        return None
+        result = set() if exc.errno in definitive else None
+    except (TimeoutError, OSError, UnicodeError):
+        result = None
+    _RESOLVE_CACHE[host] = (time.monotonic(), result)
+    return result
 
 
 @app.get("/api/services/{slug}/producer-state")
@@ -2779,9 +2814,13 @@ async def api_producer_state(request: Request, slug: str, worker_id: int | None 
         running = any(str(c.get("status", "")).lower() == "running" for c in matches)
         traffic = _traffic_state(slug, matches)
         if running:
-            # Inside the same never-500 umbrella: a worker-row or DNS problem
-            # must degrade to "no claim", not break the earnings verdict.
-            address_mismatch = await _advertised_address_mismatch(matches)
+            # Own guard, not just the outer umbrella: an exception here would
+            # otherwise abandon the whole try block and silently zero the
+            # log-signal scan below — the address check disabling the very
+            # detection (#318) that shares this block. No claim, ever, at the
+            # cost of the rest of the verdict.
+            with contextlib.suppress(Exception):
+                address_mismatch = await _advertised_address_mismatch(matches, worker_id)
         if signals and running:
             wid = worker_id if worker_id is not None else (matches[0].get("_worker_id") if matches else None)
             if wid is not None:

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -591,6 +591,37 @@ def _collect_stats_bulk(containers: list[Any]) -> dict[str, tuple[float, float, 
     return results
 
 
+def _advertised_address(container: Any, slug: str) -> str | None:
+    """The value of the ONE env var this service declares as its dial-back address.
+
+    Only a service whose catalog entry sets ``docker.advertised_address_env``
+    yields anything, and only that single variable is ever read: container env
+    holds credentials, and the heartbeat must never widen into carrying them.
+    The Docker LIST API omits ``Config.Env``, so this costs one inspect call —
+    but only for declaring services (in practice: storj alone), so the status
+    paths stay cheap. None is "nothing to report", covering the undeclared,
+    unset and inspect-failed cases alike — absence is not a claim.
+    """
+    if get_service is None:
+        return None
+    try:
+        service = get_service(slug) or {}
+    except Exception:
+        return None
+    var = (service.get("docker") or {}).get("advertised_address_env")
+    if not var or not isinstance(var, str):
+        return None
+    try:
+        env = (container.client.api.inspect_container(container.id).get("Config") or {}).get("Env") or []
+    except Exception:
+        return None
+    prefix = f"{var}="
+    for entry in env:
+        if isinstance(entry, str) and entry.startswith(prefix):
+            return entry[len(prefix) :] or None
+    return None
+
+
 def get_status() -> list[dict[str, Any]]:
     """Return live status of all known containers (labeled + image-matched).
 
@@ -620,23 +651,26 @@ def get_status() -> list[dict[str, Any]]:
             seen_ids.add(c.id)
             slug = c.labels.get(LABEL_SERVICE, "unknown")
             cpu_pct, mem_mb, net_rx, net_tx = labeled_stats.get(c.id, (0.0, 0.0, None, None))
-            results.append(
-                {
-                    "slug": slug,
-                    "name": c.name,
-                    "status": c.status,
-                    "image": c.image.tags[0] if c.image.tags else str(c.image.short_id),
-                    "cpu_percent": cpu_pct,
-                    "memory_mb": mem_mb,
-                    # Cumulative since container start; None when unavailable.
-                    "net_rx_bytes": net_rx,
-                    "net_tx_bytes": net_tx,
-                    "created": c.attrs.get("Created", ""),
-                    "container_id": c.short_id,
-                    "deployed_by": c.labels.get(LABEL_DEPLOYED_BY, "unknown"),
-                    "category": c.labels.get(LABEL_CATEGORY, ""),
-                }
-            )
+            entry = {
+                "slug": slug,
+                "name": c.name,
+                "status": c.status,
+                "image": c.image.tags[0] if c.image.tags else str(c.image.short_id),
+                "cpu_percent": cpu_pct,
+                "memory_mb": mem_mb,
+                # Cumulative since container start; None when unavailable.
+                "net_rx_bytes": net_rx,
+                "net_tx_bytes": net_tx,
+                "created": c.attrs.get("Created", ""),
+                "container_id": c.short_id,
+                "deployed_by": c.labels.get(LABEL_DEPLOYED_BY, "unknown"),
+                "category": c.labels.get(LABEL_CATEGORY, ""),
+            }
+            # Present only when the service declares a dial-back address var;
+            # the key's absence is "nothing to say", never "checked and fine".
+            if advertised := _advertised_address(c, slug):
+                entry["advertised_address"] = advertised
+            results.append(entry)
         except Exception as exc:
             logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
 
@@ -757,20 +791,22 @@ def get_status_light() -> list[dict[str, Any]]:
         try:
             seen_ids.add(c.id)
             slug = c.labels.get(LABEL_SERVICE, "unknown")
-            results.append(
-                {
-                    "slug": slug,
-                    "name": c.name,
-                    "status": c.status,
-                    "image": c.image.tags[0] if c.image.tags else str(c.image.short_id),
-                    "cpu_percent": 0.0,
-                    "memory_mb": 0.0,
-                    "created": c.attrs.get("Created", ""),
-                    "container_id": c.short_id,
-                    "deployed_by": c.labels.get(LABEL_DEPLOYED_BY, "unknown"),
-                    "category": c.labels.get(LABEL_CATEGORY, ""),
-                }
-            )
+            entry = {
+                "slug": slug,
+                "name": c.name,
+                "status": c.status,
+                "image": c.image.tags[0] if c.image.tags else str(c.image.short_id),
+                "cpu_percent": 0.0,
+                "memory_mb": 0.0,
+                "created": c.attrs.get("Created", ""),
+                "container_id": c.short_id,
+                "deployed_by": c.labels.get(LABEL_DEPLOYED_BY, "unknown"),
+                "category": c.labels.get(LABEL_CATEGORY, ""),
+            }
+            # Same contract as get_status: key present only when declared+set.
+            if advertised := _advertised_address(c, slug):
+                entry["advertised_address"] = advertised
+            results.append(entry)
         except Exception as exc:
             logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -608,9 +608,16 @@ def _advertised_address(container: Any, slug: str) -> str | None:
         service = get_service(slug) or {}
     except Exception:
         return None
-    var = (service.get("docker") or {}).get("advertised_address_env")
+    docker_conf = service.get("docker") or {}
+    var = docker_conf.get("advertised_address_env")
     if not var or not isinstance(var, str):
         return None
+    # Runtime backstop for the CI guard: a catalog edit pointing this at a
+    # secret-flagged var must not start exporting a credential into every
+    # heartbeat just because a test was skipped.
+    for declared in docker_conf.get("env") or []:
+        if isinstance(declared, dict) and declared.get("key") == var and declared.get("secret"):
+            return None
     try:
         env = (container.client.api.inspect_container(container.id).get("Config") or {}).get("Env") or []
     except Exception:
@@ -703,22 +710,26 @@ def get_status() -> list[dict[str, Any]]:
         for c, slug, image_name in matched:
             try:
                 cpu_pct, mem_mb, net_rx, net_tx = matched_stats.get(c.id, (0.0, 0.0, None, None))
-                results.append(
-                    {
-                        "slug": slug,
-                        "name": c.name,
-                        "status": c.status,
-                        "image": image_name or str(c.image.short_id),
-                        "cpu_percent": cpu_pct,
-                        "memory_mb": mem_mb,
-                        "net_rx_bytes": net_rx,
-                        "net_tx_bytes": net_tx,
-                        "created": c.attrs.get("Created", ""),
-                        "container_id": c.short_id,
-                        "deployed_by": "external",
-                        "category": "",
-                    }
-                )
+                entry = {
+                    "slug": slug,
+                    "name": c.name,
+                    "status": c.status,
+                    "image": image_name or str(c.image.short_id),
+                    "cpu_percent": cpu_pct,
+                    "memory_mb": mem_mb,
+                    "net_rx_bytes": net_rx,
+                    "net_tx_bytes": net_tx,
+                    "created": c.attrs.get("Created", ""),
+                    "container_id": c.short_id,
+                    "deployed_by": "external",
+                    "category": "",
+                }
+                # External nodes are the COMMON storj adoption path (the node
+                # predates CashPilot) — leaving them out of the address check
+                # would blind it for exactly the users most likely to need it.
+                if advertised := _advertised_address(c, slug):
+                    entry["advertised_address"] = advertised
+                results.append(entry)
             except Exception as exc:
                 logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
 
@@ -841,20 +852,23 @@ def get_status_light() -> list[dict[str, Any]]:
                 # person who has to manage it.
                 if slug:
                     seen_ids.add(c.id)
-                    results.append(
-                        {
-                            "slug": slug,
-                            "name": c.name,
-                            "status": c.status,
-                            "image": image_name or str(c.image.short_id),
-                            "cpu_percent": 0.0,
-                            "memory_mb": 0.0,
-                            "created": c.attrs.get("Created", ""),
-                            "container_id": c.short_id,
-                            "deployed_by": "external",
-                            "category": "",
-                        }
-                    )
+                    entry = {
+                        "slug": slug,
+                        "name": c.name,
+                        "status": c.status,
+                        "image": image_name or str(c.image.short_id),
+                        "cpu_percent": 0.0,
+                        "memory_mb": 0.0,
+                        "created": c.attrs.get("Created", ""),
+                        "container_id": c.short_id,
+                        "deployed_by": "external",
+                        "category": "",
+                    }
+                    # Same contract as the labeled loops; external storj nodes
+                    # are the common adoption path and must not be blind spots.
+                    if advertised := _advertised_address(c, slug):
+                        entry["advertised_address"] = advertised
+                    results.append(entry)
             except Exception as exc:
                 logger.warning("Skipping corrupted container %s: %s", getattr(c, "short_id", "?"), exc)
 

--- a/app/producer_state.py
+++ b/app/producer_state.py
@@ -88,6 +88,7 @@ def assess(
     log_hits: list[dict[str, str]] | None = None,
     container_running: bool | None = True,
     traffic: str | None = None,
+    address_mismatch: str | None = None,
 ) -> dict[str, Any]:
     """Combine the available signals into one producer state.
 
@@ -125,6 +126,17 @@ def assess(
         state = hit["state"] if hit["state"] in _RANK else FAILING
         candidates.append(state)
         reasons.append(hit["means"])
+
+    # The network dialling an address this machine does not have (a stale
+    # advertised IP after an ISP re-provision) starves a dial-back service of
+    # ALL inbound work while the container looks perfectly healthy — and
+    # earnings can keep ticking from held/storage components, so this must be
+    # able to outrank PRODUCING exactly like a failing log signal does. The
+    # caller computed the reason (egress.advertised_address_verdict); None
+    # means no claim, never "checked and fine".
+    if address_mismatch:
+        candidates.append(FAILING)
+        reasons.append(address_mismatch)
 
     if earned_recently is True:
         candidates.append(PRODUCING)

--- a/services/_schema.yml
+++ b/services/_schema.yml
@@ -64,6 +64,15 @@
 #     Only add a pattern you have actually seen in that service's logs. A guessed regex
 #     that never matches is dead weight; one that matches the wrong line tells the user
 #     something false.
+#   advertised_address_env: ADDRESS  (optional) the env var holding the address
+#     the NETWORK dials this service back at ("host:port" or "host"). The
+#     worker copies that ONE variable's value into heartbeat container entries
+#     as advertised_address — never any other env, which may hold credentials —
+#     so the UI can compare it against the machine's current egress IP and mark
+#     the service failing when the network is dialling an address this machine
+#     no longer has (the classic silent-ISP-re-provision failure). Only declare
+#     it for services that are genuinely dialled back into; for outbound-only
+#     services the comparison would be meaningless.
 #   devices: [] (optional) host devices to map in, e.g. ["/dev/net/tun"]
 #     Only devices on the worker's allow-list may be requested, and only by the
 #     service whose own YAML declares them. A device is a direct line to the

--- a/services/storage/storj.yml
+++ b/services/storage/storj.yml
@@ -69,6 +69,11 @@ docker:
         the node and forfeits the held balance.
   command: "--operator.wallet-features=zksync-era"
   network_mode: ""
+  # Satellites dial the node at exactly this env var's value, so the worker
+  # reports it and the UI cross-checks it against the machine's current
+  # egress IP — the check that catches a stale advertised IP the day it goes
+  # stale instead of days later via provider email.
+  advertised_address_env: ADDRESS
   health_signals:
     # Seen live (Aug 2026): ~40x/hour for days while the container looked
     # perfectly healthy -- the node advertised a stale IP after an ISP

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -728,3 +728,98 @@ class TestTheHeartbeatSurvivesABadCycle:
                 break
         task.cancel()
         assert len(calls) >= 3, "the loop stopped after the first exception"
+
+
+class TestAdvertisedHost:
+    """Parsing the host out of an advertised dial-back address."""
+
+    @pytest.mark.parametrize(
+        ("raw", "host"),
+        [
+            ("84.54.25.89:28967", "84.54.25.89"),
+            ("mynode.ddns.net:28967", "mynode.ddns.net"),
+            ("mynode.ddns.net", "mynode.ddns.net"),
+            ("[2001:db8::1]:28967", "2001:db8::1"),
+            ("2001:db8::1", "2001:db8::1"),
+            ("  host:1  ", "host"),
+        ],
+    )
+    def test_host_is_extracted(self, raw, host):
+        assert egress.advertised_host(raw) == host
+
+    @pytest.mark.parametrize("raw", ["", "   ", None, "[]:28967"])
+    def test_nothing_usable_is_none(self, raw):
+        assert egress.advertised_host(raw) is None
+
+
+class TestAdvertisedAddressVerdict:
+    """The Aug 2026 storj incident, as a decision table.
+
+    The node advertised a stale literal IP after a silent ISP re-provision;
+    satellites dialled a dead address for days while the container looked
+    healthy. The verdict's job is to catch exactly that — and its NO-CLAIM
+    rows matter as much as its findings, because a wrong "your address is
+    stale" sends the operator to fix DNS that is fine.
+    """
+
+    EGRESS = "213.217.28.154"
+
+    def test_the_incident_a_stale_literal_ip_is_a_finding(self):
+        reason = egress.advertised_address_verdict("84.54.25.89:28967", self.EGRESS, None)
+        assert reason and "84.54.25.89" in reason and self.EGRESS in reason
+
+    def test_a_literal_matching_the_egress_is_no_finding(self):
+        assert egress.advertised_address_verdict(f"{self.EGRESS}:28967", self.EGRESS, None) is None
+
+    def test_a_private_literal_is_a_finding_without_any_egress_comparison(self):
+        reason = egress.advertised_address_verdict("192.168.10.100:28967", self.EGRESS, None)
+        assert reason and "private" in reason
+
+    def test_a_hostname_resolving_to_the_egress_is_no_finding(self):
+        assert egress.advertised_address_verdict("node.example.org:28967", self.EGRESS, {self.EGRESS}) is None
+
+    def test_a_hostname_resolving_elsewhere_is_a_finding(self):
+        reason = egress.advertised_address_verdict("node.example.org:28967", self.EGRESS, {"84.54.25.89"})
+        assert reason and "node.example.org" in reason and "84.54.25.89" in reason
+
+    def test_a_name_that_definitively_does_not_resolve_is_a_finding(self):
+        reason = egress.advertised_address_verdict("gone.example.org:28967", self.EGRESS, set())
+        assert reason and "does not resolve" in reason
+
+    # -- the no-claim rows: silence must mean "cannot tell", never "fine" -----
+
+    def test_transient_resolution_failure_is_no_claim(self):
+        assert egress.advertised_address_verdict("node.example.org:28967", self.EGRESS, None) is None
+
+    def test_undetected_egress_is_no_claim_even_for_a_wrong_literal(self):
+        # Negative control: the strongest possible finding input must still be
+        # silent when the machine's own egress is unknown.
+        assert egress.advertised_address_verdict("84.54.25.89:28967", None, None) is None
+
+    def test_no_advertised_address_is_no_claim(self):
+        assert egress.advertised_address_verdict(None, self.EGRESS, {"1.2.3.4"}) is None
+        assert egress.advertised_address_verdict("", self.EGRESS, {"1.2.3.4"}) is None
+
+
+class TestAdvertisedAddressCatalog:
+    """The schema key is only useful if it names an env var that exists."""
+
+    def test_storj_declares_its_dial_back_env(self):
+        from app.catalog import load_services
+
+        storj = next(s for s in load_services() if s.get("slug") == "storj")
+        assert (storj.get("docker") or {}).get("advertised_address_env") == "ADDRESS"
+
+    def test_every_declared_address_env_exists_in_that_services_env_list(self):
+        # A typo here would make the worker look up an env var that is never
+        # set, silently reporting nothing — the same failure mode this whole
+        # feature exists to end.
+        from app.catalog import load_services
+
+        for svc in load_services():
+            docker = svc.get("docker") or {}
+            var = docker.get("advertised_address_env")
+            if not var:
+                continue
+            keys = {e.get("key") for e in (docker.get("env") or [])}
+            assert var in keys, f"{svc.get('slug')}: advertised_address_env={var!r} names no declared env var"

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -823,3 +823,61 @@ class TestAdvertisedAddressCatalog:
                 continue
             keys = {e.get("key") for e in (docker.get("env") or [])}
             assert var in keys, f"{svc.get('slug')}: advertised_address_env={var!r} names no declared env var"
+
+
+class TestAdvertisedAddressVerdictFamilies:
+    """Cross-family comparisons must be silence, not fabricated staleness.
+
+    The egress detection endpoints are dual-stack, so a v6 egress reading
+    against a v4 advertised address is a legitimate state of the world —
+    comparing across families produced a confident wrong finding.
+    """
+
+    V6_EGRESS = "2001:db8::1234"
+
+    def test_a_v4_literal_against_a_v6_egress_is_no_claim(self):
+        assert egress.advertised_address_verdict("84.54.25.89:28967", self.V6_EGRESS, None) is None
+
+    def test_a_v6_only_name_against_a_v4_egress_is_no_claim(self):
+        assert egress.advertised_address_verdict("node.example.org:28967", "213.217.28.154", {"2001:db8::9"}) is None
+
+    def test_mixed_records_compare_within_the_egress_family(self):
+        # The v6 record is noise; the v4 one matches the v4 egress: no finding.
+        resolved = {"213.217.28.154", "2001:db8::9"}
+        assert egress.advertised_address_verdict("node.example.org:28967", "213.217.28.154", resolved) is None
+        # And a v4 mismatch still fires even with a v6 record alongside.
+        assert egress.advertised_address_verdict(
+            "node.example.org:28967", "213.217.28.154", {"84.54.25.89", "2001:db8::9"}
+        )
+
+    def test_private_resolved_addresses_are_not_echoed_back(self):
+        # resolved IPs originate from a worker-supplied name; repeating a
+        # private answer would leak the hub's internal DNS view.
+        reason = egress.advertised_address_verdict("intra.example.org:28967", "213.217.28.154", {"192.168.10.100"})
+        assert reason and "192.168.10.100" not in reason and "non-public" in reason
+
+
+class TestAdvertisedHostTrailingColon:
+    def test_a_dangling_colon_is_a_typo_not_part_of_the_host(self):
+        # It used to fall through whole and earn a confident "does not
+        # resolve at all" about a name that was never looked up.
+        assert egress.advertised_host("node.example.org:") == "node.example.org"
+
+    def test_a_bare_v6_keeps_its_trailing_colons(self):
+        assert egress.advertised_host("2001:db8::") == "2001:db8::"
+
+
+class TestAdvertisedAddressNeverNamesASecret:
+    def test_no_declared_address_env_is_secret_flagged(self):
+        # The worker exports the declared var's VALUE into heartbeats; a
+        # secret-flagged var here would ship a credential to the hub in clear.
+        from app.catalog import load_services
+
+        for svc in load_services():
+            docker = svc.get("docker") or {}
+            var = docker.get("advertised_address_env")
+            if not var:
+                continue
+            declared = next((e for e in docker.get("env") or [] if e.get("key") == var), None)
+            assert declared is not None
+            assert not declared.get("secret"), f"{svc.get('slug')}: advertised_address_env names a SECRET env var"

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -465,3 +465,46 @@ class TestStatusCarriesAdvertisedAddress:
         # Absent, not None: the key's absence is "nothing to say".
         entries = self._entries(self._labeled("honeygain", ["EMAIL=a@b.c"]), {"docker": {}})
         assert "advertised_address" not in entries[0]
+
+
+class TestAdvertisedAddressSecretBackstop:
+    def test_a_secret_flagged_var_is_refused_even_when_declared(self):
+        # Runtime backstop: a catalog edit pointing advertised_address_env at
+        # a credential must not export it into every heartbeat.
+        c = MagicMock()
+        c.id = "cid"
+        c.client.api.inspect_container.return_value = {"Config": {"Env": ["TOKEN=supersecret"]}}
+        service = {
+            "docker": {
+                "advertised_address_env": "TOKEN",
+                "env": [{"key": "TOKEN", "secret": True}],
+            }
+        }
+        with patch.object(orchestrator, "get_service", return_value=service):
+            assert orchestrator._advertised_address(c, "shady") is None
+        c.client.api.inspect_container.assert_not_called()
+
+
+class TestExternalContainersCarryAdvertisedAddress:
+    def test_an_image_matched_external_node_is_not_a_blind_spot(self):
+        # Running a storagenode BEFORE installing CashPilot is the common storj
+        # adoption path; the address check must cover those containers too.
+        c = MagicMock()
+        c.id = "ext1"
+        c.short_id = "ext1"
+        c.name = "storagenode"
+        c.status = "running"
+        c.labels = {}
+        c.image.tags = ["storjlabs/storagenode:latest"]
+        c.attrs = {"Created": "2026-08-10"}
+        c.client.api.inspect_container.return_value = {"Config": {"Env": ["ADDRESS=node.example.org:28967"]}}
+        client = MagicMock()
+        client.containers.list.side_effect = [[], [c]]  # no labeled, one external
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            patch.object(orchestrator, "_build_image_slug_map", return_value={"storjlabs/storagenode": "storj"}),
+            patch.object(orchestrator, "get_service", return_value={"docker": {"advertised_address_env": "ADDRESS"}}),
+        ):
+            entries = orchestrator.get_status_light()
+        assert entries and entries[0]["deployed_by"] == "external"
+        assert entries[0]["advertised_address"] == "node.example.org:28967"

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -383,3 +383,85 @@ class TestGetStatusLight:
         ):
             results = orchestrator.get_status_light()
         assert len(results) == 1
+
+
+class TestAdvertisedAddressExtraction:
+    """The worker reads ONE declared env var into the heartbeat — never more.
+
+    Container env holds credentials (wallets, API keys), so the security
+    property under test is as important as the feature: only the variable the
+    catalog declares may ever leave the container inspect.
+    """
+
+    def _container(self, env):
+        c = MagicMock()
+        c.id = "cid123"
+        c.client.api.inspect_container.return_value = {"Config": {"Env": env}}
+        return c
+
+    def test_the_declared_var_is_extracted(self):
+        with patch.object(orchestrator, "get_service", return_value={"docker": {"advertised_address_env": "ADDRESS"}}):
+            value = orchestrator._advertised_address(
+                self._container(["WALLET=0xdeadbeef", "ADDRESS=storj.example.org:28967"]), "storj"
+            )
+        assert value == "storj.example.org:28967"
+
+    def test_an_undeclared_service_never_even_inspects(self):
+        c = self._container(["ADDRESS=whatever:1"])
+        with patch.object(orchestrator, "get_service", return_value={"docker": {}}):
+            assert orchestrator._advertised_address(c, "honeygain") is None
+        c.client.api.inspect_container.assert_not_called()
+
+    def test_an_unset_declared_var_is_none_not_empty(self):
+        with patch.object(orchestrator, "get_service", return_value={"docker": {"advertised_address_env": "ADDRESS"}}):
+            assert orchestrator._advertised_address(self._container(["WALLET=0xdeadbeef"]), "storj") is None
+
+    def test_an_inspect_failure_is_none_not_a_crash(self):
+        c = self._container([])
+        c.client.api.inspect_container.side_effect = RuntimeError("daemon hiccup")
+        with patch.object(orchestrator, "get_service", return_value={"docker": {"advertised_address_env": "ADDRESS"}}):
+            assert orchestrator._advertised_address(c, "storj") is None
+
+    def test_an_unknown_service_is_none(self):
+        with patch.object(orchestrator, "get_service", return_value=None):
+            assert orchestrator._advertised_address(self._container(["ADDRESS=x:1"]), "ghost") is None
+
+
+class TestStatusCarriesAdvertisedAddress:
+    """get_status_light forwards the field — and omits it when undeclared."""
+
+    def _labeled(self, slug, env):
+        c = MagicMock()
+        c.id = f"id-{slug}"
+        c.short_id = f"id-{slug}"[:10]
+        c.name = f"cashpilot-{slug}"
+        c.status = "running"
+        c.labels = {"cashpilot.managed": "true", "cashpilot.service": slug}
+        c.image.tags = ["img:1"]
+        c.attrs = {"Created": "2026-08-10"}
+        c.client.api.inspect_container.return_value = {"Config": {"Env": env}}
+        return c
+
+    def _entries(self, container, service):
+        client = MagicMock()
+        client.containers.list.return_value = [container]
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            patch.object(orchestrator, "_build_image_slug_map", return_value={}),
+            patch.object(orchestrator, "get_service", return_value=service),
+        ):
+            return orchestrator.get_status_light()
+
+    def test_a_declaring_service_reports_its_address(self):
+        entries = self._entries(
+            self._labeled("storj", ["ADDRESS=node.example.org:28967", "WALLET=0xdeadbeef"]),
+            {"docker": {"advertised_address_env": "ADDRESS"}},
+        )
+        assert entries[0]["advertised_address"] == "node.example.org:28967"
+        # The security property: nothing else from the env may ride along.
+        assert "0xdeadbeef" not in str(entries[0])
+
+    def test_an_undeclared_service_has_no_key_at_all(self):
+        # Absent, not None: the key's absence is "nothing to say".
+        entries = self._entries(self._labeled("honeygain", ["EMAIL=a@b.c"]), {"docker": {}})
+        assert "advertised_address" not in entries[0]

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -521,8 +521,12 @@ class TestResolveAdvertisedHost:
         from app import main
 
         async def go():
+            # A fixed host with an explicit cache clear: keying on id() looked
+            # unique but CPython reuses ids, so two tests could share a cache
+            # entry inside the TTL and read each other's result.
+            main._RESOLVE_CACHE.clear()
             with patch.object(main.asyncio, "wait_for", AsyncMock(side_effect=side_effect)):
-                return await main._resolve_advertised_host(f"host-{id(side_effect)}.example.org")
+                return await main._resolve_advertised_host("host.example.org")
 
         return asyncio.run(go())
 
@@ -584,3 +588,58 @@ class TestAdvertisedMismatchFiltering:
     def test_a_garbage_hostname_is_rejected_before_any_resolution(self):
         weird = [{"slug": "storj", "status": "running", "advertised_address": "not a hostname!:1", "_worker_id": 1}]
         assert self._run(weird) is None
+
+
+class TestResolveCacheBounds:
+    def test_expired_entries_are_purged_and_the_table_is_capped(self):
+        # The keys are worker-supplied hostnames: without eviction each
+        # distinct name would be a permanent key in hub memory.
+        import asyncio
+        import time as _time
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        async def go():
+            main._RESOLVE_CACHE.clear()
+            stale_stamp = _time.monotonic() - main._RESOLVE_CACHE_TTL - 1
+            main._RESOLVE_CACHE["old.example.org"] = (stale_stamp, {"1.2.3.4"})
+            for i in range(main._RESOLVE_CACHE_MAX):
+                main._RESOLVE_CACHE[f"h{i}.example.org"] = (_time.monotonic(), None)
+            with patch.object(main.asyncio, "wait_for", AsyncMock(side_effect=TimeoutError())):
+                await main._resolve_advertised_host("fresh.example.org")
+            assert "old.example.org" not in main._RESOLVE_CACHE, "expired entry survived the write"
+            assert len(main._RESOLVE_CACHE) <= main._RESOLVE_CACHE_MAX, "the cap did not hold"
+            assert "fresh.example.org" in main._RESOLVE_CACHE
+            main._RESOLVE_CACHE.clear()
+
+        asyncio.run(go())
+
+
+class TestMismatchNamesTheNode:
+    def test_the_reason_says_which_machine(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        row = {"id": 1, "system_info": '{"egress_ip": "213.217.28.154"}', "containers": "[]"}
+        entry = [
+            {
+                "slug": "storj",
+                "status": "running",
+                "advertised_address": "84.54.25.89:28967",
+                "_worker_id": 1,
+                "_node": "watchtower",
+            }
+        ]
+
+        async def go():
+            with (
+                patch.object(main.database, "get_worker", AsyncMock(return_value=row)),
+                patch.object(main, "_resolve_advertised_host", AsyncMock(return_value=None)),
+            ):
+                return await main._advertised_address_mismatch(entry)
+
+        reason = asyncio.run(go())
+        assert reason and reason.startswith("On watchtower:"), "a fleet finding must name its node"

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -466,14 +466,23 @@ class TestAdvertisedMismatchHelper:
         return asyncio.run(go())
 
     def test_a_stale_literal_yields_the_reason(self):
-        reason = self._run([{"slug": "storj", "advertised_address": "84.54.25.89:28967", "_worker_id": 1}])
+        reason = self._run(
+            [{"slug": "storj", "status": "running", "advertised_address": "84.54.25.89:28967", "_worker_id": 1}]
+        )
         assert reason and "84.54.25.89" in reason
 
     def test_a_matching_literal_is_silent(self):
-        assert self._run([{"slug": "storj", "advertised_address": "213.217.28.154:28967", "_worker_id": 1}]) is None
+        assert (
+            self._run(
+                [{"slug": "storj", "status": "running", "advertised_address": "213.217.28.154:28967", "_worker_id": 1}]
+            )
+            is None
+        )
 
     def test_a_hostname_is_judged_through_the_resolver(self):
-        entry = [{"slug": "storj", "advertised_address": "node.example.org:28967", "_worker_id": 1}]
+        entry = [
+            {"slug": "storj", "status": "running", "advertised_address": "node.example.org:28967", "_worker_id": 1}
+        ]
         assert self._run(entry, resolved={"213.217.28.154"}) is None
         assert self._run(entry, resolved={"84.54.25.89"})
 
@@ -483,12 +492,95 @@ class TestAdvertisedMismatchHelper:
         assert self._run([{"slug": "storj", "status": "running", "_worker_id": 1}], expect_db_call=False) is None
 
     def test_a_missing_worker_row_is_no_claim(self):
-        entry = [{"slug": "storj", "advertised_address": "84.54.25.89:1", "_worker_id": 9}]
+        entry = [{"slug": "storj", "status": "running", "advertised_address": "84.54.25.89:1", "_worker_id": 9}]
         assert self._run(entry, worker_row=None) is None
 
     def test_a_worker_with_undetected_egress_is_no_claim(self):
         row = {"id": 1, "system_info": "{}", "containers": "[]"}
         assert (
-            self._run([{"slug": "storj", "advertised_address": "84.54.25.89:1", "_worker_id": 1}], worker_row=row)
+            self._run(
+                [{"slug": "storj", "status": "running", "advertised_address": "84.54.25.89:1", "_worker_id": 1}],
+                worker_row=row,
+            )
             is None
         )
+
+
+class TestResolveAdvertisedHost:
+    """The three-valued resolver contract, exercised on the real function.
+
+    Every earlier test replaced this wholesale, which is how a UnicodeError
+    (ValueError, not OSError) escaped it and silently disabled the log-signal
+    scan sharing the route's try block.
+    """
+
+    def _resolve(self, side_effect):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        async def go():
+            with patch.object(main.asyncio, "wait_for", AsyncMock(side_effect=side_effect)):
+                return await main._resolve_advertised_host(f"host-{id(side_effect)}.example.org")
+
+        return asyncio.run(go())
+
+    def test_a_definitive_nxdomain_is_an_empty_set(self):
+        import socket
+
+        assert self._resolve(socket.gaierror(socket.EAI_NONAME, "no name")) == set()
+
+    def test_a_transient_resolver_error_is_none(self):
+        import socket
+
+        assert self._resolve(socket.gaierror(socket.EAI_AGAIN, "try again")) is None
+
+    def test_a_timeout_is_none(self):
+        assert self._resolve(TimeoutError()) is None
+
+    def test_an_idna_invalid_label_is_none_not_an_escape(self):
+        # UnicodeError is a ValueError: uncaught it left this function
+        # entirely and took the log-signal scan down with it.
+        assert self._resolve(UnicodeError("label too long")) is None
+
+
+class TestAdvertisedMismatchFiltering:
+    """Only running containers, and only the node the caller asked about."""
+
+    WORKER_ROW = {"id": 1, "system_info": '{"egress_ip": "213.217.28.154"}', "containers": "[]"}
+
+    def _run(self, containers, worker_id=None):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        async def go():
+            with (
+                patch.object(main.database, "get_worker", AsyncMock(return_value=self.WORKER_ROW)),
+                patch.object(main, "_resolve_advertised_host", AsyncMock(return_value=None)),
+            ):
+                return await main._advertised_address_mismatch(containers, worker_id)
+
+        return asyncio.run(go())
+
+    def test_an_exited_container_is_never_judged(self):
+        # Its env is from the LAST run — a stale ADDRESS there is history,
+        # not a finding about the machine.
+        exited = [{"slug": "storj", "status": "exited", "advertised_address": "84.54.25.89:1", "_worker_id": 1}]
+        assert self._run(exited) is None
+
+    def test_only_the_requested_worker_is_judged(self):
+        both = [
+            {"slug": "storj", "status": "running", "advertised_address": "84.54.25.89:1", "_worker_id": 1},
+            {"slug": "storj", "status": "running", "advertised_address": "213.217.28.154:1", "_worker_id": 2},
+        ]
+        # Worker 2's address matches the (mocked) egress: asking about worker 2
+        # must not surface worker 1's stale address.
+        assert self._run(both, worker_id=2) is None
+        assert self._run(both, worker_id=1)
+
+    def test_a_garbage_hostname_is_rejected_before_any_resolution(self):
+        weird = [{"slug": "storj", "status": "running", "advertised_address": "not a hostname!:1", "_worker_id": 1}]
+        assert self._run(weird) is None

--- a/tests/test_producer_state.py
+++ b/tests/test_producer_state.py
@@ -416,3 +416,79 @@ class TestStorjDialBackSignal:
             "INFO bandwidth Persisting bandwidth usage cache to db\n"
         )
         assert ps.match_log_signals(healthy, self._signals()) == []
+
+
+class TestAddressMismatch:
+    """A stale advertised address must be able to outrank everything good."""
+
+    def test_a_mismatch_reads_failing_and_carries_the_reason(self):
+        out = ps.assess(slug="s", has_collector=False, earned_recently=None, address_mismatch="stale address")
+        assert out["state"] == ps.FAILING
+        assert "stale address" in out["reasons"]
+
+    def test_a_mismatch_beats_moving_earnings(self):
+        # Storage/held components keep ticking while inbound work is dead, so
+        # PRODUCING must not mask an unreachable node.
+        out = ps.assess(slug="s", has_collector=True, earned_recently=True, address_mismatch="stale")
+        assert out["state"] == ps.FAILING
+
+    def test_none_is_no_claim(self):
+        # Negative control: absent mismatch must leave the verdict untouched.
+        out = ps.assess(slug="s", has_collector=True, earned_recently=True, address_mismatch=None)
+        assert out["state"] == ps.PRODUCING
+
+
+class TestAdvertisedMismatchHelper:
+    """The hub-side wiring: worker row -> egress IP -> verdict."""
+
+    WORKER_ROW = {"id": 1, "system_info": '{"egress_ip": "213.217.28.154"}', "containers": "[]"}
+
+    _DEFAULT = object()
+
+    def _run(self, containers, worker_row=_DEFAULT, resolved=None, expect_db_call=True):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from app import main
+
+        get_worker = AsyncMock(return_value=self.WORKER_ROW if worker_row is self._DEFAULT else worker_row)
+
+        async def go():
+            with (
+                patch.object(main.database, "get_worker", get_worker),
+                patch.object(main, "_resolve_advertised_host", AsyncMock(return_value=resolved)),
+            ):
+                result = await main._advertised_address_mismatch(containers)
+            if not expect_db_call:
+                get_worker.assert_not_awaited()
+            return result
+
+        return asyncio.run(go())
+
+    def test_a_stale_literal_yields_the_reason(self):
+        reason = self._run([{"slug": "storj", "advertised_address": "84.54.25.89:28967", "_worker_id": 1}])
+        assert reason and "84.54.25.89" in reason
+
+    def test_a_matching_literal_is_silent(self):
+        assert self._run([{"slug": "storj", "advertised_address": "213.217.28.154:28967", "_worker_id": 1}]) is None
+
+    def test_a_hostname_is_judged_through_the_resolver(self):
+        entry = [{"slug": "storj", "advertised_address": "node.example.org:28967", "_worker_id": 1}]
+        assert self._run(entry, resolved={"213.217.28.154"}) is None
+        assert self._run(entry, resolved={"84.54.25.89"})
+
+    def test_no_advertised_address_never_touches_the_database(self):
+        # Negative control for every pre-existing route test: containers that
+        # do not carry the field must exit before any worker lookup.
+        assert self._run([{"slug": "storj", "status": "running", "_worker_id": 1}], expect_db_call=False) is None
+
+    def test_a_missing_worker_row_is_no_claim(self):
+        entry = [{"slug": "storj", "advertised_address": "84.54.25.89:1", "_worker_id": 9}]
+        assert self._run(entry, worker_row=None) is None
+
+    def test_a_worker_with_undetected_egress_is_no_claim(self):
+        row = {"id": 1, "system_info": "{}", "containers": "[]"}
+        assert (
+            self._run([{"slug": "storj", "advertised_address": "84.54.25.89:1", "_worker_id": 1}], worker_row=row)
+            is None
+        )


### PR DESCRIPTION
## Why

Fix 2 of the storj dial-back incident review (follows #318). The incident: a silent ISP re-provision left the node advertising a dead literal IP — satellites dialled it for days while the container looked healthy. #318 added the log-pattern alarm; this PR adds the check that catches the mismatch **the day it happens**, from data the fleet already collects.

## What

- **Schema**: `docker.advertised_address_env` — the ONE env var holding the address the network dials the service back at. storj declares `ADDRESS`.
- **Worker**: copies that single variable's value into heartbeat container entries as `advertised_address` — never any other env (env holds credentials); one inspect call per declaring container, absent key when undeclared/unset.
- **Hub** (`producer-state`): compares it against that worker's detected egress IP. Findings (FAILING, outranking PRODUCING since storage/held income keeps ticking while inbound is dead): stale public literal, private literal, hostname resolving away from the egress, definitive NXDOMAIN. **No claim** (silent): undetected egress, transient DNS trouble, unreported address — a wrong "your address is stale" sends the operator to fix DNS that is fine. The reason text names its assumption so a deliberate second-WAN forward can be read and dismissed.

## Testing

- Decision-table tests over `advertised_address_verdict` covering findings **and** every no-claim row (the strongest finding input must stay silent when egress is undetected).
- Hub helper tested with an injectable resolver; a container without the field must exit before any DB lookup (control protecting all pre-existing route tests).
- Worker-side: the declared var and ONLY the declared var leaves the container inspect (wallet value asserted absent from the entry); undeclared services carry no key at all.
- Catalog guard: every declared `advertised_address_env` names a real env var in that service's own env list.
- Full suite: 4570 passed, 6 skipped, coverage 95.49%; ruff check + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advertised dial-back address reporting for supported services.
  * Added validation to detect private, unreachable, stale, or mismatched advertised addresses.
  * Added service configuration support for declaring the address environment variable.
  * Added address mismatch details to service status and health results.

* **Bug Fixes**
  * Improved handling of IPv4, IPv6, hostnames, malformed addresses, and temporary DNS failures.
  * Prevented private resolved addresses from appearing in diagnostic messages.
  * Ensured address-check failures do not hide other service status signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->