### PR TITLE
feat(collector): storj warns when satellites cannot reach the node (CashPilot-1gmy)

### DIFF
--- a/app/collectors/storj.py
+++ b/app/collectors/storj.py
@@ -37,9 +37,17 @@ def _parse_node_time(raw: Any) -> datetime | None:
     The node emits RFC 3339 with nanosecond fractions and either Z or a local
     offset; fromisoformat handles all observed forms. A naive result is read
     as UTC rather than discarded — Go only omits the offset for UTC.
+
+    A bare DATE is refused: fromisoformat reads "2026-08-10" as midnight,
+    which would fabricate a stale-looking timestamp out of a value that never
+    claimed a time. Go's time.Time marshalling always emits a time component,
+    so anything without one is not a node timestamp.
     """
+    text = str(raw or "")
+    if "T" not in text:
+        return None
     try:
-        parsed = datetime.fromisoformat(str(raw or ""))
+        parsed = datetime.fromisoformat(text)
     except ValueError:
         return None
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)

--- a/app/collectors/storj.py
+++ b/app/collectors/storj.py
@@ -7,6 +7,8 @@ No authentication required — the API is only accessible on localhost.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import httpx
 
@@ -16,6 +18,31 @@ from app.collectors.base import BaseCollector, EarningsResult
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_URL = "http://localhost:14002"
+
+#: A zero-value Go time.Time — the node has NEVER been successfully pinged.
+#: The Aug 2026 incident node carried this for four months while its dashboard
+#: looked healthy: satellites were dialling a stale advertised IP the whole time.
+_NEVER_PINGED_PREFIX = "0001-01-01"
+
+#: Satellites ping the node on every contact cycle (well under an hour in
+#: practice — a freshly fixed node was pinged within two minutes). Three hours
+#: keeps maintenance pauses and satellite-side slowness from crying wolf while
+#: still catching a real reachability loss the same day it starts.
+_PINGED_STALE_AFTER = timedelta(hours=3)
+
+
+def _parse_node_time(raw: Any) -> datetime | None:
+    """A Go-marshalled timestamp as an aware datetime, or None (no claim).
+
+    The node emits RFC 3339 with nanosecond fractions and either Z or a local
+    offset; fromisoformat handles all observed forms. A naive result is read
+    as UTC rather than discarded — Go only omits the offset for UTC.
+    """
+    try:
+        parsed = datetime.fromisoformat(str(raw or ""))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
 
 
 class StorjCollector(BaseCollector):
@@ -76,6 +103,10 @@ class StorjCollector(BaseCollector):
                 platform=self.platform,
                 balance=round(balance, 4),
                 currency="USD",
+                # The balance can keep ticking (held amount, storage income)
+                # while satellites cannot reach the node at all, so a healthy
+                # collection is exactly when a reachability caveat is needed.
+                warning=await self._reachability_warning(client),
             )
         except httpx.ConnectError:
             return EarningsResult(
@@ -95,3 +126,55 @@ class StorjCollector(BaseCollector):
                 balance=0.0,
                 error=str(exc),
             )
+
+    async def _reachability_warning(self, client: httpx.AsyncClient) -> str | None:
+        """Can satellites actually reach this node? None is 'nothing to report'.
+
+        The dashboard's /api/sno/ states it directly: ``lastPinged`` is the
+        last time any satellite successfully dialled the node back, and
+        ``quicStatus`` whether UDP 28967 got through. A node can be green in
+        every other way — container healthy, balance moving — while both of
+        these say the network cannot reach it (the Aug 2026 stale-ADDRESS
+        incident ran ~40 failed dial-backs an hour for days, invisible).
+
+        Every failure of this PROBE returns None: reachability is a bonus
+        reading on top of a successful collection, and inventing a verdict
+        from a probe that itself failed would be the same false confidence
+        this exists to remove.
+        """
+        try:
+            resp = await client.get(f"{self.api_url}/api/sno/")
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+
+        notes: list[str] = []
+        raw_pinged = data.get("lastPinged")
+        pinged_at = _parse_node_time(raw_pinged)
+        if str(raw_pinged or "").startswith(_NEVER_PINGED_PREFIX):
+            notes.append(
+                "No satellite has EVER successfully reached this node — it is being "
+                "counted offline. Check that the advertised ADDRESS matches your current "
+                "public IP (prefer a DDNS hostname) and that port 28967 TCP+UDP is forwarded."
+            )
+        elif pinged_at is not None and datetime.now(UTC) - pinged_at > _PINGED_STALE_AFTER:
+            hours = (datetime.now(UTC) - pinged_at).total_seconds() / 3600
+            notes.append(
+                f"No satellite has reached this node for {hours:.0f}h (last ping "
+                f"{pinged_at.isoformat(timespec='seconds')}) — it is being counted offline. "
+                "Check the advertised ADDRESS and that port 28967 TCP+UDP is forwarded."
+            )
+        # An absent or unparseable lastPinged is deliberately silent: this is a
+        # bonus probe, and "cannot tell" must never read as "unreachable".
+
+        # Only the one value we have SEEN mean broken. "Refreshing" appears
+        # briefly at startup and warning on anything != OK would cry wolf.
+        if data.get("quicStatus") == "Misconfigured":
+            notes.append(
+                "QUIC is misconfigured: UDP on port 28967 is not reaching the node. "
+                "TCP transfers still work, but forward UDP 28967 too for full performance."
+            )
+        return " ".join(notes) or None

--- a/app/collectors/storj.py
+++ b/app/collectors/storj.py
@@ -143,10 +143,18 @@ class StorjCollector(BaseCollector):
         this exists to remove.
         """
         try:
-            resp = await client.get(f"{self.api_url}/api/sno/")
+            # A shorter deadline than the collection's own 15s: a stalling
+            # dashboard must not be able to double the cost of the reading
+            # this probe merely decorates.
+            resp = await client.get(f"{self.api_url}/api/sno/", timeout=5)
             resp.raise_for_status()
             data = resp.json()
-        except Exception:
+        except Exception as exc:
+            # Debug, not warning: silence is the right product behaviour, but
+            # with no line at all a probe that never fires (wrong path, shape
+            # change) is indistinguishable from a healthy node — the same
+            # invisibility class this feature exists to end.
+            logger.debug("Storj reachability probe unavailable: %s", exc)
             return None
         if not isinstance(data, dict):
             return None
@@ -154,7 +162,17 @@ class StorjCollector(BaseCollector):
         notes: list[str] = []
         raw_pinged = data.get("lastPinged")
         pinged_at = _parse_node_time(raw_pinged)
-        if str(raw_pinged or "").startswith(_NEVER_PINGED_PREFIX):
+        # A node started seconds ago legitimately carries the zero-value
+        # lastPinged — satellites have not had a chance yet. Warning then
+        # would make the user's FIRST reading of a healthy new node an
+        # unreachability alert, teaching them to ignore the one notice that
+        # matters. An absent/unparseable startedAt reads as not-young, so the
+        # behaviour degrades to the warning, never to silence.
+        started_at = _parse_node_time(data.get("startedAt"))
+        node_is_young = started_at is not None and datetime.now(UTC) - started_at < timedelta(minutes=15)
+        if node_is_young:
+            logger.debug("Storj node started %s — too young to judge dial-backs", started_at)
+        elif str(raw_pinged or "").startswith(_NEVER_PINGED_PREFIX):
             notes.append(
                 "No satellite has EVER successfully reached this node — it is being "
                 "counted offline. Check that the advertised ADDRESS matches your current "

--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -736,3 +736,14 @@ class TestStorjYoungNodeGrace:
     def test_an_absent_started_at_fails_toward_the_warning(self):
         result = self._collect({"lastPinged": "0001-01-01T00:00:00Z", "quicStatus": "OK"})
         assert result.warning and "EVER" in result.warning
+
+
+class TestStorjDateOnlyTimestamp:
+    def test_a_bare_date_is_no_claim_not_midnight(self):
+        # fromisoformat reads "2026-08-10" as midnight — treating that as a
+        # real ping time would fabricate an hours-stale timestamp from a value
+        # that never claimed a time. Go always emits a time component, so a
+        # date-only value is not a node timestamp at all.
+        from app.collectors.storj import _parse_node_time
+
+        assert _parse_node_time("2026-08-10") is None

--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -692,3 +692,47 @@ class TestStorjNodeTimeParsing:
         assert _parse_node_time("not-a-time") is None
         assert _parse_node_time(None) is None
         assert _parse_node_time(12345) is None
+
+
+class TestStorjYoungNodeGrace:
+    """A node started minutes ago must not greet its user with an alert.
+
+    The zero-value lastPinged is legitimate until satellites have had a
+    chance; and an ABSENT startedAt degrades to the warning (current
+    behaviour), never to silence — failing toward the alert, not away.
+    """
+
+    def _collect(self, payload):
+        import asyncio
+
+        from app.collectors.storj import StorjCollector
+
+        earnings = _mock_response(200, {"estimatedPayout": 250})
+        probe = _mock_response(200, payload)
+        client = _make_async_client()
+        client.get.side_effect = [earnings, probe]
+        with patch("app.collectors.storj.httpx.AsyncClient", return_value=client):
+            return asyncio.run(StorjCollector().collect())
+
+    @staticmethod
+    def _ago(**kwargs):
+        from datetime import UTC, datetime, timedelta
+
+        return (datetime.now(UTC) - timedelta(**kwargs)).isoformat()
+
+    def test_a_five_minute_old_node_gets_grace(self):
+        result = self._collect(
+            {"lastPinged": "0001-01-01T00:00:00Z", "quicStatus": "OK", "startedAt": self._ago(minutes=5)}
+        )
+        assert result.warning is None
+
+    def test_a_two_hour_old_node_gets_no_grace(self):
+        # Negative control: the grace window must not swallow the real alert.
+        result = self._collect(
+            {"lastPinged": "0001-01-01T00:00:00Z", "quicStatus": "OK", "startedAt": self._ago(hours=2)}
+        )
+        assert result.warning and "EVER" in result.warning
+
+    def test_an_absent_started_at_fails_toward_the_warning(self):
+        result = self._collect({"lastPinged": "0001-01-01T00:00:00Z", "quicStatus": "OK"})
+        assert result.warning and "EVER" in result.warning

--- a/tests/test_collectors_deep.py
+++ b/tests/test_collectors_deep.py
@@ -592,3 +592,103 @@ class TestAnyoneProtocolDeep:
         assert result.error is None
         assert result.balance == 1.0
         assert result.currency == "ANYONE"
+
+
+# ---------------------------------------------------------------------------
+# Storj — reachability warning (the Aug 2026 stale-ADDRESS incident)
+# ---------------------------------------------------------------------------
+
+
+class TestStorjReachability:
+    """A successful collection must still say when satellites cannot reach the node.
+
+    The balance keeps ticking from held/storage components while inbound work
+    is dead, so the warning rides on a HEALTHY reading — and the probe failing
+    must produce silence, never a verdict.
+    """
+
+    def _collect(self, sno_payload=None, probe_fails=False):
+        import asyncio
+        from datetime import UTC, datetime
+
+        from app.collectors.storj import StorjCollector
+
+        earnings = _mock_response(200, {"estimatedPayout": 250})
+        if probe_fails:
+            probe = MagicMock()
+            probe.raise_for_status.side_effect = RuntimeError("probe down")
+        else:
+            payload = sno_payload if sno_payload is not None else {}
+            probe = _mock_response(200, payload)
+        client = _make_async_client()
+        client.get.side_effect = [earnings, probe]
+
+        with patch("app.collectors.storj.httpx.AsyncClient", return_value=client):
+            result = asyncio.run(StorjCollector().collect())
+        assert result.error is None and result.balance == 2.50, "the earnings reading itself must be untouched"
+        self._now = datetime.now(UTC)
+        return result
+
+    @staticmethod
+    def _ago(**kwargs):
+        from datetime import UTC, datetime, timedelta
+
+        return (datetime.now(UTC) - timedelta(**kwargs)).isoformat()
+
+    def test_a_recently_pinged_node_carries_no_warning(self):
+        result = self._collect({"lastPinged": self._ago(minutes=10), "quicStatus": "OK"})
+        assert result.warning is None
+
+    def test_a_never_pinged_node_warns(self):
+        # The incident node carried the zero-value for four months, invisible.
+        result = self._collect({"lastPinged": "0001-01-01T00:00:00Z", "quicStatus": "OK"})
+        assert result.warning and "EVER" in result.warning and "ADDRESS" in result.warning
+
+    def test_a_stale_ping_warns_with_the_age(self):
+        result = self._collect({"lastPinged": self._ago(hours=7), "quicStatus": "OK"})
+        assert result.warning and "counted offline" in result.warning
+
+    def test_misconfigured_quic_warns(self):
+        result = self._collect({"lastPinged": self._ago(minutes=5), "quicStatus": "Misconfigured"})
+        assert result.warning and "QUIC" in result.warning
+
+    def test_stale_ping_and_bad_quic_both_appear(self):
+        result = self._collect({"lastPinged": self._ago(hours=7), "quicStatus": "Misconfigured"})
+        assert result.warning and "counted offline" in result.warning and "QUIC" in result.warning
+
+    def test_refreshing_quic_is_not_a_warning(self):
+        # Negative control: only the one value SEEN to mean broken may fire —
+        # "Refreshing" appears briefly at every startup.
+        result = self._collect({"lastPinged": self._ago(minutes=5), "quicStatus": "Refreshing"})
+        assert result.warning is None
+
+    def test_an_absent_last_pinged_is_no_claim(self):
+        # Negative control: a payload without the field must stay silent.
+        result = self._collect({"quicStatus": "OK"})
+        assert result.warning is None
+
+    def test_a_failing_probe_is_silence_not_a_verdict(self):
+        # Negative control: the probe itself failing must not invent anything.
+        result = self._collect(probe_fails=True)
+        assert result.warning is None
+
+
+class TestStorjNodeTimeParsing:
+    def test_go_nanosecond_and_offset_forms_parse(self):
+        from app.collectors.storj import _parse_node_time
+
+        assert _parse_node_time("2026-08-10T11:51:24.45559978Z") is not None
+        assert _parse_node_time("2026-08-10T13:50:14.25180728+02:00") is not None
+
+    def test_a_naive_timestamp_is_read_as_utc(self):
+        from app.collectors.storj import _parse_node_time
+
+        parsed = _parse_node_time("2026-08-10T11:51:24")
+        assert parsed is not None and parsed.tzinfo is not None
+
+    def test_garbage_is_none_not_a_crash(self):
+        from app.collectors.storj import _parse_node_time
+
+        assert _parse_node_time("not-a-time") is None
+        assert _parse_node_time(None) is None
+        assert _parse_node_time(12345) is None


### PR DESCRIPTION
## Why

Fix 3 of the storj dial-back incident review (follows #318, #320). The incident node's dashboard API had been saying "no satellite has ever reached me" (`lastPinged` zero-value, `quicStatus: Misconfigured`) for four months — nothing read it. The balance keeps ticking from held/storage components while inbound work is dead, so container health, earnings movement, and the dashboard all stayed green.

## What

After each **successful** earnings collection, the storj collector probes the node's `/api/sno/` and attaches a warning to the reading when:
- no satellite has EVER reached the node (Go zero-time `lastPinged`),
- the last successful dial-back is older than 3 hours (satellites ping well under hourly; the fixed incident node was re-pinged within two minutes),
- `quicStatus` is `Misconfigured` — the one value observed to mean broken; `Refreshing` is a startup transient and warning on it would cry wolf.

A failing probe produces **silence, never a verdict** — reachability is a bonus reading on top of a successful collection. The warning rides `EarningsResult.warning` into the existing `kind=notice` alert pipeline, so it reaches the notification bell with zero UI changes.

## Testing

8 reachability cases including 4 negative controls (recent ping, `Refreshing`, absent field, failing probe — all must stay silent), Go timestamp parsing (nanosecond fractions, `Z`/offset forms, naive-as-UTC), and a guard on every case that the earnings figure itself is untouched. Full suite: 4544 passed, 6 skipped, coverage 95.61%; ruff check + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Storj node reachability monitoring alongside payout collection.
  - Displays warnings when no satellite has reached the node, the last successful ping is more than three hours old, or QUIC is misconfigured.
  - Payout results remain successful while reachability warnings are reported separately.
- **Improvements**
  - Added support for varied node timestamp formats and startup grace periods.
  - Temporary probe failures and incomplete data no longer generate unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->