### PR TITLE
fix(worker): report unhealthy when the worker cannot reach the UI

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -73,7 +73,11 @@ ENTRYPOINT ["/entrypoint.sh"]
 # for days, so `docker ps` read "healthy" right through a 42-hour outage while
 # the fleet page showed the worker offline. /api/health returns 503 only after a
 # sustained run of missed heartbeats, so a UI restart does not flap the state.
+# http.client, NOT urllib.request: urlopen honors http_proxy/HTTPS_PROXY (which
+# Docker injects fleet-wide when the host has a proxies config) and has no
+# localhost exemption, so the "loopback" probe would be answered by the proxy —
+# unhealthy forever, or worse, healthy on the strength of a different host.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD ["python", "-c", "import sys,urllib.request\ntry:\n    urllib.request.urlopen('http://127.0.0.1:8081/api/health', timeout=3)\nexcept Exception:\n    sys.exit(1)"]
+    CMD ["python", "-c", "import sys,http.client\ntry:\n    c = http.client.HTTPConnection('127.0.0.1', 8081, timeout=3)\n    c.request('GET', '/api/health')\n    sys.exit(0 if c.getresponse().status == 200 else 1)\nexcept Exception:\n    sys.exit(1)"]
 
 CMD ["python", "-m", "uvicorn", "app.worker_api:app", "--host", "0.0.0.0", "--port", "8081", "--no-access-log"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -68,7 +68,12 @@ VOLUME /data
 EXPOSE 8081
 
 ENTRYPOINT ["/entrypoint.sh"]
+# Ask the app whether it can still REPORT IN, not merely whether this port is
+# open. A TCP connect succeeds on a worker that has been unable to reach the UI
+# for days, so `docker ps` read "healthy" right through a 42-hour outage while
+# the fleet page showed the worker offline. /api/health returns 503 only after a
+# sustained run of missed heartbeats, so a UI restart does not flap the state.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD ["python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8081), timeout=3).close()"]
+    CMD ["python", "-c", "import sys,urllib.request\ntry:\n    urllib.request.urlopen('http://127.0.0.1:8081/api/health', timeout=3)\nexcept Exception:\n    sys.exit(1)"]
 
 CMD ["python", "-m", "uvicorn", "app.worker_api:app", "--host", "0.0.0.0", "--port", "8081", "--no-access-log"]

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -30,6 +30,7 @@ from datetime import UTC, datetime
 from html import escape as _esc
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -80,10 +81,34 @@ _AUTH_FAILURE_DISCARD_AFTER = 10
 # unresolvable. This is what /api/health reports on, because from the operator's
 # side the only thing that matters is "is this worker still reporting in".
 _consecutive_heartbeat_failures = 0
-# ~5 minutes at the 60s interval. Long enough that a UI restart or a brief
-# network blip does not flip the container to unhealthy, short enough that a
-# genuinely disconnected worker is visible in `docker ps` the same hour.
-_HEARTBEAT_FAILURES_UNHEALTHY_AFTER = 5
+# Monotonic time of the last heartbeat the UI actually accepted. The counter
+# above only moves when a cycle RETURNS; a payload helper that blocks forever
+# (statvfs against a wedged /data mount, a wedged Docker socket) freezes the
+# loop with the counter at zero, which is the 42-hour false-healthy all over
+# again. Staleness of this stamp catches raise, hang and dead-task alike.
+# Initialized to process start so a freshly booted worker gets the same grace
+# window before it is expected to have reported in.
+_last_heartbeat_ok = time.monotonic()
+# The endpoint DEGRADES once 12 consecutive sends have missed (~11 min after
+# the outage starts — the first failure lands at t≈0) or the last accepted
+# heartbeat is _HEARTBEAT_STALE_AFTER (16 min) old; `docker ps` flips to
+# unhealthy up to 3 failed checks (~90s) later — the counter path is visible
+# the same quarter-hour, the hang path within 20 minutes. Long enough that a
+# UI restart or a brief blip does not flap the container. It MUST stay
+# above _AUTH_FAILURE_DISCARD_AFTER: this repo documents an autoheal sidecar
+# that restarts unhealthy containers, a restart resets the in-memory auth
+# ladder while the stale key file survives on disk — so an unhealthy threshold
+# below the discard threshold would restart-loop a locked-out worker at N
+# failures forever and the discard-and-re-enrol self-heal could never run.
+_HEARTBEAT_FAILURES_UNHEALTHY_AFTER = 12
+# The staleness backstop gets its own, LONGER window. The discard ladder is
+# counted in CYCLES and a cycle costs 60s plus payload time (container stats
+# stretch it with fleet size; nvidia-smi alone may burn its 10s timeout), so a
+# wall-clock window equal to 12 nominal cycles can expire BEFORE failure #10
+# lands on a slow host — tripping unhealthy (and any restart-on-unhealthy
+# supervisor) during the worker's own self-heal. Four extra nominal cycles
+# tolerate ~36s of per-cycle overhead before that ordering could invert.
+_HEARTBEAT_STALE_AFTER = (_HEARTBEAT_FAILURES_UNHEALTHY_AFTER + 4) * HEARTBEAT_INTERVAL
 # The name-resolution hint is logged ONCE per outage, not every cycle. A warning
 # repeated every 60 seconds for 42 hours is precisely how the last one was missed.
 _link_hint_logged = False
@@ -505,6 +530,38 @@ async def _detect_egress_ip() -> str | None:
     return None
 
 
+def _ui_host() -> str:
+    """Hostname of UI_URL, safe to log.
+
+    CASHPILOT_UI_URL can carry userinfo (a UI behind reverse-proxy basic auth is
+    `https://user:pass@host`), and string-splitting leaked it: `token@host` kept
+    the whole token, `user:pass@host` printed the username as the "host". Parse
+    properly and log only the hostname.
+    """
+    raw = UI_URL if "://" in UI_URL else f"//{UI_URL}"
+    try:
+        host = urlsplit(raw).hostname
+    except ValueError:
+        host = None
+    return host or "<unparseable CASHPILOT_UI_URL>"
+
+
+def _redact_userinfo(text: str) -> str:
+    """Strip URL credentials (user:pass@ / token@) from a URL or a message.
+
+    Applied to log text that can embed UI_URL: httpx's HTTPStatusError message
+    interpolates str(request.url) UNREDACTED, so a credentialed CASHPILOT_UI_URL
+    put the password in the per-cycle "Heartbeat failed" warning.
+
+    The userinfo class deliberately allows '@' so the greedy match runs to the
+    LAST '@' before the path — a password containing an unencoded '@' must not
+    half-survive. Scheme matching is case-insensitive ('HTTPS://user:pass@h'
+    is a working httpx config).
+    """
+    text = re.sub(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s'\"]*@", r"\1", text)
+    return re.sub(r"^[^/\s]*@", "", text, count=1)
+
+
 def _log_link_failure_hint(exc: BaseException) -> None:
     """Explain a heartbeat that never reached the UI, once per outage.
 
@@ -534,12 +591,15 @@ def _log_link_failure_hint(exc: BaseException) -> None:
         if isinstance(cur, socket.gaierror):
             is_resolution_failure = True
             break
-        cur = cur.__cause__ or cur.__context__
+        # Honor `raise X from None`: a suppressed context was deliberately
+        # disowned, and following it anyway would blame DNS for an exception
+        # that merely HAPPENED during a resolution failure's cleanup.
+        cur = cur.__cause__ if cur.__cause__ is not None or cur.__suppress_context__ else cur.__context__
 
     if not is_resolution_failure:
         return
 
-    host = UI_URL.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0] or UI_URL
+    host = _ui_host()
     logger.error(
         "Cannot resolve %r from inside this container, so no heartbeat can reach the UI. "
         "If that is a Compose service name, this worker and the UI must share a Docker "
@@ -557,7 +617,7 @@ def _log_link_failure_hint(exc: BaseException) -> None:
 async def _send_heartbeat() -> None:
     """Send a single heartbeat to the UI."""
     global _ui_connected, _last_heartbeat, _last_error, _consecutive_auth_failures
-    global _consecutive_heartbeat_failures, _link_hint_logged
+    global _consecutive_heartbeat_failures, _link_hint_logged, _last_heartbeat_ok
 
     containers = []
     try:
@@ -599,28 +659,42 @@ async def _send_heartbeat() -> None:
                 headers={"Authorization": f"Bearer {_active_key()}"},
             )
             resp.raise_for_status()
-            # Enrollment: the UI returns our own per-worker key exactly once.
-            issued = None
-            with contextlib.suppress(Exception):
-                issued = resp.json().get("worker_key")
-            if issued and issued != _worker_key:
-                if _save_worker_key(issued):
-                    logger.info("Enrolled: received and persisted this worker's own fleet key")
-                else:
-                    logger.error("Received per-worker key but could not persist it — staying on shared key")
+            # The heartbeat LANDED — record the success before any enrollment
+            # bookkeeping. This state measures "did the UI hear from us", and a
+            # bug in the bookkeeping below (a UI version skew handing back a
+            # malformed worker_key, say) must not count a delivered heartbeat
+            # as a connection failure and degrade a perfectly reporting worker.
             _ui_connected = True
             _last_heartbeat = datetime.now(UTC).strftime("%H:%M:%S UTC")
+            _last_heartbeat_ok = time.monotonic()
             _last_error = ""
             _consecutive_auth_failures = 0
             _consecutive_heartbeat_failures = 0
             _link_hint_logged = False
-            logger.debug("Heartbeat sent to %s", UI_URL)
+            logger.debug("Heartbeat sent to %s", _ui_host())
+            try:
+                # Enrollment: the UI returns our own per-worker key exactly once.
+                issued = None
+                with contextlib.suppress(Exception):
+                    issued = resp.json().get("worker_key")
+                if issued and issued != _worker_key:
+                    if _save_worker_key(issued):
+                        logger.info("Enrolled: received and persisted this worker's own fleet key")
+                    else:
+                        logger.error("Received per-worker key but could not persist it — staying on shared key")
+            except Exception as exc:  # noqa: BLE001 - bookkeeping must not report as an outage
+                logger.error("Enrollment bookkeeping failed (heartbeat itself landed): %s", _redact_userinfo(str(exc)))
     except httpx.HTTPStatusError as exc:
         _ui_connected = False
         _consecutive_heartbeat_failures += 1
+        # A reply — any reply — proves the UI's name resolves, so a resolution
+        # outage is over and the hint must re-arm. Resetting only on full
+        # success left the flag stuck True through a post-outage 401 spell,
+        # silencing the hint for the NEXT resolution outage.
+        _link_hint_logged = False
         status = exc.response.status_code
         _last_error = f"authentication rejected ({status})" if status in (401, 403) else "connection failed"
-        logger.warning("Heartbeat failed: %s", exc)
+        logger.warning("Heartbeat failed: %s", _redact_userinfo(str(exc)))
         if status == 401:
             # Counted whether or not we hold our own key. The condition used to
             # be `and _worker_key`, which skipped the alarm in exactly the case
@@ -677,7 +751,7 @@ async def _send_heartbeat() -> None:
         # A network failure is not an auth rejection, so it breaks the run too.
         _consecutive_auth_failures = 0
         _consecutive_heartbeat_failures += 1
-        logger.warning("Heartbeat failed: %s", exc)
+        logger.warning("Heartbeat failed: %s", _redact_userinfo(str(exc)))
         _log_link_failure_hint(exc)
 
 
@@ -693,12 +767,21 @@ async def _heartbeat_loop() -> None:
     offline until someone restarts the container — while the service containers
     keep earning and nothing surfaces the problem.
     """
+    global _ui_connected, _last_error, _consecutive_heartbeat_failures
     while True:
         try:
             await _send_heartbeat()
         except asyncio.CancelledError:
             raise
         except Exception:
+            # A cycle that died before the POST is still a heartbeat that did
+            # not land. Without this accounting a worker whose payload
+            # construction fails every time never degrades /api/health — 200
+            # "ok" forever while it never reports in, which is exactly the
+            # invisible state this endpoint exists to expose.
+            _ui_connected = False
+            _consecutive_heartbeat_failures += 1
+            _last_error = "internal error preparing the heartbeat"
             logger.exception("Heartbeat cycle failed — continuing")
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -731,7 +814,7 @@ async def lifespan(app: FastAPI):
 
     if UI_URL:
         _heartbeat_task = asyncio.create_task(_heartbeat_loop())
-        logger.info("Heartbeat enabled -> %s (every %ds)", UI_URL, HEARTBEAT_INTERVAL)
+        logger.info("Heartbeat enabled -> %s (every %ds)", _redact_userinfo(UI_URL), HEARTBEAT_INTERVAL)
         if not API_KEY:
             logger.warning("CASHPILOT_API_KEY not set — heartbeats sent without auth")
     else:
@@ -1428,7 +1511,7 @@ async def api_runtimes(request: Request) -> dict[str, Any]:
 
 
 @app.get("/api/health")
-async def api_health(response: Response) -> dict[str, str]:
+async def api_health(response: Response) -> dict[str, Any]:
     """Health check endpoint (no auth required).
 
     Reports whether this worker can still REPORT IN, not merely whether its own
@@ -1439,18 +1522,35 @@ async def api_health(response: Response) -> dict[str, str]:
     the two. A check that cannot fail for the failure you actually have is not a
     check.
 
-    Degraded only after a sustained run of misses, so a UI restart or a brief
-    network blip does not flap the container. Deliberately NOT degraded when no
-    UI_URL is configured: a worker with nowhere to report is doing exactly what
-    it was told to.
+    Two triggers, two windows: a sustained run of counted misses (12 cycles),
+    OR a last-success stamp older than the separate, longer _HEARTBEAT_STALE_AFTER
+    wall-clock window — they are deliberately NOT the same number, because the
+    auth-discard ladder is cycle-counted and a wall clock equal to 12 nominal
+    cycles would pre-empt it on a slow host (see the constants).
+    The stamp is what catches a cycle that never RETURNS —
+    a payload helper blocking on a wedged /data mount or Docker socket freezes
+    the loop with the counter at zero, and only staleness can see that. It also
+    covers a dead heartbeat task outright. Degraded only after a full window,
+    so a UI restart or a brief blip does not flap the container. Deliberately
+    NOT degraded when no UI_URL is configured: a worker with nowhere to report
+    is doing exactly what it was told to.
+
+    The annotation is dict[str, Any] on purpose: FastAPI validates the response
+    against it AFTER the work is done, and a stricter type turns a future
+    non-str field into a 500 exactly when the endpoint has news (the api_deploy
+    lesson). Every value is still deliberately built as a str.
     """
-    body = {"status": "ok", "worker": WORKER_NAME}
-    if UI_URL and _consecutive_heartbeat_failures >= _HEARTBEAT_FAILURES_UNHEALTHY_AFTER:
+    body: dict[str, Any] = {"status": "ok", "worker": WORKER_NAME}
+    success_age = time.monotonic() - _last_heartbeat_ok
+    if UI_URL and (
+        _consecutive_heartbeat_failures >= _HEARTBEAT_FAILURES_UNHEALTHY_AFTER or success_age > _HEARTBEAT_STALE_AFTER
+    ):
         response.status_code = 503
         body["status"] = "degraded"
         body["reason"] = "not reporting to the UI"
         body["last_heartbeat"] = _last_heartbeat
         body["consecutive_failures"] = str(_consecutive_heartbeat_failures)
+        body["last_success_age"] = f"{int(success_age)}s"
         if _last_error:
             body["error"] = _last_error
     return body

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
@@ -75,6 +75,18 @@ _AUTH_FAILURE_ALARM_AFTER = 3
 # Well above the alarm: the operator is told first, and a key is only discarded
 # after the rejection has clearly persisted rather than on a flaky link.
 _AUTH_FAILURE_DISCARD_AFTER = 10
+
+# Consecutive heartbeats that did not land, for ANY reason — refused, timed out,
+# unresolvable. This is what /api/health reports on, because from the operator's
+# side the only thing that matters is "is this worker still reporting in".
+_consecutive_heartbeat_failures = 0
+# ~5 minutes at the 60s interval. Long enough that a UI restart or a brief
+# network blip does not flip the container to unhealthy, short enough that a
+# genuinely disconnected worker is visible in `docker ps` the same hour.
+_HEARTBEAT_FAILURES_UNHEALTHY_AFTER = 5
+# The name-resolution hint is logged ONCE per outage, not every cycle. A warning
+# repeated every 60 seconds for 42 hours is precisely how the last one was missed.
+_link_hint_logged = False
 
 # Per-worker fleet key. On first contact the UI enrolls this worker and hands back
 # a key unique to us, which we persist here (in our own private /data, never the
@@ -493,9 +505,59 @@ async def _detect_egress_ip() -> str | None:
     return None
 
 
+def _log_link_failure_hint(exc: BaseException) -> None:
+    """Explain a heartbeat that never reached the UI, once per outage.
+
+    A worker that cannot resolve CASHPILOT_UI_URL logs the same opaque line
+    every 60 seconds — `Heartbeat failed: [Errno -3] Try again` — which says
+    nothing about the cause and is trivially scrolled past. In production this
+    ran for 42 hours on two hosts before anyone looked, while the containers
+    kept earning and the UI simply showed the workers as offline.
+
+    The usual cause is not DNS being broken: it is that the worker is not on the
+    same Docker network as the UI. Compose service names only resolve inside a
+    shared user-defined network, so a container that was started detached (an
+    unclean shutdown, `docker start` on a container whose project network was
+    since recreated) fails to resolve a name that is otherwise perfectly valid.
+    """
+    global _link_hint_logged
+    if _link_hint_logged:
+        return
+
+    # The resolution failure is usually wrapped (httpx.ConnectError -> gaierror),
+    # so inspect the whole chain rather than just the surface exception.
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    is_resolution_failure = False
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, socket.gaierror):
+            is_resolution_failure = True
+            break
+        cur = cur.__cause__ or cur.__context__
+
+    if not is_resolution_failure:
+        return
+
+    host = UI_URL.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0] or UI_URL
+    logger.error(
+        "Cannot resolve %r from inside this container, so no heartbeat can reach the UI. "
+        "If that is a Compose service name, this worker and the UI must share a Docker "
+        "network — check `docker inspect %s --format '{{json .NetworkSettings.Networks}}'`: "
+        "an empty result means this container is attached to NO network, which `docker start` "
+        "can leave behind after an unclean shutdown. `docker compose up -d` reattaches it. "
+        "If the UI is on another host, use an address this container can actually resolve. "
+        "Logging this once; the per-cycle warning continues.",
+        host,
+        WORKER_NAME,
+    )
+    _link_hint_logged = True
+
+
 async def _send_heartbeat() -> None:
     """Send a single heartbeat to the UI."""
     global _ui_connected, _last_heartbeat, _last_error, _consecutive_auth_failures
+    global _consecutive_heartbeat_failures, _link_hint_logged
 
     containers = []
     try:
@@ -550,9 +612,12 @@ async def _send_heartbeat() -> None:
             _last_heartbeat = datetime.now(UTC).strftime("%H:%M:%S UTC")
             _last_error = ""
             _consecutive_auth_failures = 0
+            _consecutive_heartbeat_failures = 0
+            _link_hint_logged = False
             logger.debug("Heartbeat sent to %s", UI_URL)
     except httpx.HTTPStatusError as exc:
         _ui_connected = False
+        _consecutive_heartbeat_failures += 1
         status = exc.response.status_code
         _last_error = f"authentication rejected ({status})" if status in (401, 403) else "connection failed"
         logger.warning("Heartbeat failed: %s", exc)
@@ -611,7 +676,9 @@ async def _send_heartbeat() -> None:
         _last_error = "connection failed"
         # A network failure is not an auth rejection, so it breaks the run too.
         _consecutive_auth_failures = 0
+        _consecutive_heartbeat_failures += 1
         logger.warning("Heartbeat failed: %s", exc)
+        _log_link_failure_hint(exc)
 
 
 async def _heartbeat_loop() -> None:
@@ -1361,6 +1428,29 @@ async def api_runtimes(request: Request) -> dict[str, Any]:
 
 
 @app.get("/api/health")
-async def api_health() -> dict[str, str]:
-    """Health check endpoint (no auth required)."""
-    return {"status": "ok", "worker": WORKER_NAME}
+async def api_health(response: Response) -> dict[str, str]:
+    """Health check endpoint (no auth required).
+
+    Reports whether this worker can still REPORT IN, not merely whether its own
+    process is listening. The container healthcheck used to be a TCP connect to
+    this port, which is true of a worker that has been unable to reach the UI
+    for days — so `docker ps` showed "healthy" throughout a 42-hour outage on
+    two hosts while the fleet page showed both as offline and nobody reconciled
+    the two. A check that cannot fail for the failure you actually have is not a
+    check.
+
+    Degraded only after a sustained run of misses, so a UI restart or a brief
+    network blip does not flap the container. Deliberately NOT degraded when no
+    UI_URL is configured: a worker with nowhere to report is doing exactly what
+    it was told to.
+    """
+    body = {"status": "ok", "worker": WORKER_NAME}
+    if UI_URL and _consecutive_heartbeat_failures >= _HEARTBEAT_FAILURES_UNHEALTHY_AFTER:
+        response.status_code = 503
+        body["status"] = "degraded"
+        body["reason"] = "not reporting to the UI"
+        body["last_heartbeat"] = _last_heartbeat
+        body["consecutive_failures"] = str(_consecutive_heartbeat_failures)
+        if _last_error:
+            body["error"] = _last_error
+    return body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,19 @@ def _reset_process_wide_caches():
 
         orchestrator._status_cache = []
         orchestrator._status_cache_time = 0.0
+    with contextlib.suppress(Exception):
+        # test_worker_keys drives _send_heartbeat through 401/ConnectError paths
+        # and leaves the heartbeat-failure counter nonzero; with CASHPILOT_UI_URL
+        # exported (any dev pointed at a real fleet) that turns /api/health tests
+        # in OTHER files into 503s.
+        from app import worker_api
+
+        worker_api._consecutive_heartbeat_failures = 0
+        worker_api._link_hint_logged = False
+        # A stale stamp reads as "not reporting in": without this reset, any
+        # pytest process older than the staleness window would 503 every
+        # /api/health test that patches UI_URL.
+        worker_api._last_heartbeat_ok = worker_api.time.monotonic()
     yield
 
 

--- a/tests/test_worker_heartbeat_health.py
+++ b/tests/test_worker_heartbeat_health.py
@@ -1,0 +1,171 @@
+"""The worker must be able to report that it cannot report.
+
+A worker whose heartbeats stopped landing kept passing its container
+healthcheck, because that check was a TCP connect to its own port -- true of a
+process that is listening and completely disconnected. Two hosts ran like that
+for 42 hours: `docker ps` said healthy, the fleet page said offline, and nothing
+reconciled the two.
+
+These tests pin the two behaviours that close that gap: /api/health degrades
+after a sustained run of missed heartbeats, and a name-resolution failure is
+explained once with the cause that actually produces it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+try:
+    from fastapi.testclient import TestClient  # noqa: E402
+except ImportError:  # pragma: no cover - exercised only without fastapi
+    pytest.skip("fastapi not installed", allow_module_level=True)
+
+from app import worker_api  # noqa: E402
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app):
+    yield
+
+
+def _client():
+    worker_api.app.router.lifespan_context = _noop_lifespan
+    return TestClient(worker_api.app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_heartbeat_state():
+    """Module-level counters leak between tests otherwise."""
+    before = (
+        worker_api._consecutive_heartbeat_failures,
+        worker_api._link_hint_logged,
+        worker_api._last_heartbeat,
+        worker_api._last_error,
+    )
+    yield
+    (
+        worker_api._consecutive_heartbeat_failures,
+        worker_api._link_hint_logged,
+        worker_api._last_heartbeat,
+        worker_api._last_error,
+    ) = before
+
+
+class TestHealthReflectsHeartbeat:
+    def test_healthy_shape_is_unchanged(self):
+        """The healthy response must stay byte-identical to the old one.
+
+        Anything already parsing this endpoint keeps working; only the degraded
+        path adds fields.
+        """
+        worker_api._consecutive_heartbeat_failures = 0
+        resp = _client().get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok", "worker": worker_api.WORKER_NAME}
+
+    def test_still_ok_below_the_threshold(self):
+        """A UI restart or a blip must not flap the container to unhealthy."""
+        worker_api._consecutive_heartbeat_failures = worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER - 1
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_degrades_after_sustained_failures(self):
+        worker_api._consecutive_heartbeat_failures = worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER
+        worker_api._last_heartbeat = "never"
+        worker_api._last_error = "connection failed"
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["last_heartbeat"] == "never"
+        assert body["error"] == "connection failed"
+        assert body["consecutive_failures"] == str(worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER)
+
+    def test_no_ui_configured_is_not_degraded(self):
+        """A worker with nowhere to report is doing what it was told.
+
+        Without this guard every standalone worker would report unhealthy
+        forever, which trains operators to ignore the signal.
+        """
+        worker_api._consecutive_heartbeat_failures = 99
+        with patch.object(worker_api, "UI_URL", ""):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+
+class TestLinkFailureHint:
+    def test_explains_a_resolution_failure_once(self, caplog):
+        worker_api._link_hint_logged = False
+        wrapped = ConnectionError("connect failed")
+        wrapped.__cause__ = socket.gaierror(-3, "Try again")
+
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(wrapped)
+            first = len([r for r in caplog.records if "Cannot resolve" in r.getMessage()])
+            # A second failure in the same outage must stay quiet: this used to
+            # be logged every 60s for 42 hours, which is how it was ignored.
+            worker_api._log_link_failure_hint(wrapped)
+            second = len([r for r in caplog.records if "Cannot resolve" in r.getMessage()])
+
+        assert first == 1
+        assert second == 1
+        msg = next(r.getMessage() for r in caplog.records if "Cannot resolve" in r.getMessage())
+        assert "cashpilot-ui" in msg
+        assert "NetworkSettings.Networks" in msg
+
+    def test_silent_for_failures_that_are_not_resolution(self, caplog):
+        """A refused connection or a timeout has a different cause and fix."""
+        worker_api._link_hint_logged = False
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(TimeoutError("timed out"))
+
+        assert not [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
+        assert worker_api._link_hint_logged is False
+
+    def test_finds_the_gaierror_deep_in_the_chain(self, caplog):
+        """httpx wraps the resolution error, so the surface type is not gaierror."""
+        worker_api._link_hint_logged = False
+        inner = socket.gaierror(-3, "Try again")
+        middle = OSError("transport failed")
+        middle.__cause__ = inner
+        outer = ConnectionError("all connection attempts failed")
+        outer.__cause__ = middle
+
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(outer)
+
+        assert [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
+
+    def test_survives_a_self_referential_exception_chain(self):
+        """A cycle in __cause__/__context__ must not hang the heartbeat loop."""
+        worker_api._link_hint_logged = False
+        a = ConnectionError("a")
+        b = ConnectionError("b")
+        a.__cause__ = b
+        b.__cause__ = a
+
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            worker_api._log_link_failure_hint(a)  # must return, not spin
+
+        assert worker_api._link_hint_logged is False

--- a/tests/test_worker_heartbeat_health.py
+++ b/tests/test_worker_heartbeat_health.py
@@ -13,14 +13,19 @@ explained once with the cause that actually produces it.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import os
 import socket
+import threading
+import time
 from contextlib import asynccontextmanager
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
 
+import httpx  # noqa: E402
 import pytest  # noqa: E402
 
 try:
@@ -49,6 +54,7 @@ def _reset_heartbeat_state():
         worker_api._link_hint_logged,
         worker_api._last_heartbeat,
         worker_api._last_error,
+        worker_api._last_heartbeat_ok,
     )
     yield
     (
@@ -56,6 +62,7 @@ def _reset_heartbeat_state():
         worker_api._link_hint_logged,
         worker_api._last_heartbeat,
         worker_api._last_error,
+        worker_api._last_heartbeat_ok,
     ) = before
 
 
@@ -99,10 +106,40 @@ class TestHealthReflectsHeartbeat:
         forever, which trains operators to ignore the signal.
         """
         worker_api._consecutive_heartbeat_failures = 99
+        worker_api._last_heartbeat_ok = 0.0  # maximally stale, still ok
         with patch.object(worker_api, "UI_URL", ""):
             resp = _client().get("/api/health")
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
+
+    def test_a_hung_cycle_degrades_via_staleness(self):
+        """A cycle that never RETURNS must still become visible.
+
+        A payload helper blocking forever (statvfs on a wedged /data mount, a
+        wedged Docker socket) freezes the loop: no exception, no next cycle, so
+        the failure counter stays at ZERO. The frozen last-success stamp is the
+        only signal that survives a hang — this is the 42-hour false-healthy
+        with a different mechanism.
+        """
+        worker_api._consecutive_heartbeat_failures = 0  # the hang's signature
+        worker_api._last_heartbeat_ok = time.monotonic() - (worker_api._HEARTBEAT_STALE_AFTER + 1)
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["consecutive_failures"] == "0"
+        assert body["last_success_age"].endswith("s")
+
+    def test_a_fresh_success_stamp_is_healthy(self):
+        # Negative control for staleness: fresh stamp + zero failures = ok,
+        # which is also the boot state (the stamp starts at process start).
+        worker_api._consecutive_heartbeat_failures = 0
+        worker_api._last_heartbeat_ok = time.monotonic()
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok", "worker": worker_api.WORKER_NAME}
 
 
 class TestLinkFailureHint:
@@ -140,6 +177,52 @@ class TestLinkFailureHint:
         assert not [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
         assert worker_api._link_hint_logged is False
 
+    def test_finds_the_gaierror_via_implicit_context(self, caplog):
+        """An exception raised DURING gaierror handling chains via __context__,
+        not __cause__ — the walk must follow both."""
+        worker_api._link_hint_logged = False
+        try:
+            try:
+                raise socket.gaierror(-3, "Try again")
+            except socket.gaierror:
+                raise ConnectionError("failed during resolution cleanup")  # noqa: B904 - implicit context IS the test
+        except ConnectionError as e:
+            exc = e
+
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(exc)
+
+        assert [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
+
+    def test_a_suppressed_context_is_not_blamed_on_dns(self, caplog):
+        """`raise X from None` disowns the context on purpose.
+
+        Negative control for the implicit-context test above: same shape, but
+        the author said this exception is NOT caused by the resolution failure
+        it interrupted — blaming DNS would send the operator down the wrong
+        runbook.
+        """
+        worker_api._link_hint_logged = False
+        try:
+            try:
+                raise socket.gaierror(-3, "Try again")
+            except socket.gaierror:
+                raise ConnectionError("independent failure") from None
+        except ConnectionError as e:
+            exc = e
+
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(exc)
+
+        assert not [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
+        assert worker_api._link_hint_logged is False
+
     def test_finds_the_gaierror_deep_in_the_chain(self, caplog):
         """httpx wraps the resolution error, so the surface type is not gaierror."""
         worker_api._link_hint_logged = False
@@ -158,14 +241,323 @@ class TestLinkFailureHint:
         assert [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
 
     def test_survives_a_self_referential_exception_chain(self):
-        """A cycle in __cause__/__context__ must not hang the heartbeat loop."""
+        """A cycle in __cause__/__context__ must not hang the heartbeat loop.
+
+        Run in a watched thread so that if the cycle guard is ever removed this
+        test FAILS in five seconds instead of hanging the whole run — a test
+        that can only hang is a check that cannot fail.
+        """
         worker_api._link_hint_logged = False
         a = ConnectionError("a")
         b = ConnectionError("b")
         a.__cause__ = b
         b.__cause__ = a
 
-        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
-            worker_api._log_link_failure_hint(a)  # must return, not spin
+        done = threading.Event()
 
+        def _call():
+            with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+                worker_api._log_link_failure_hint(a)
+            done.set()
+
+        t = threading.Thread(target=_call, daemon=True)
+        t.start()
+        t.join(5)
+
+        assert done.is_set(), "the exception-chain walk did not terminate"
         assert worker_api._link_hint_logged is False
+
+
+def _drive_heartbeat(outcome, json_body=None, extra_patches=()):
+    """Run _send_heartbeat once through a mocked transport.
+
+    outcome: int = HTTP status of the reply; BaseException = raised by post;
+    None = generic network failure.
+    """
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    if outcome is None:
+        client.post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    elif isinstance(outcome, BaseException):
+        client.post = AsyncMock(side_effect=outcome)
+    else:
+        request = httpx.Request("POST", "http://ui:8080/api/workers/heartbeat")
+        response = httpx.Response(outcome, request=request, json=json_body or {})
+        client.post = AsyncMock(return_value=response)
+    with (
+        patch.object(worker_api, "_worker_key", "own"),
+        patch.object(worker_api, "UI_URL", "http://ui:8080"),
+        patch("app.worker_api.orchestrator.get_status", return_value=[]),
+        patch("app.worker_api.orchestrator.docker_available", return_value=True),
+        patch("app.worker_api.httpx.AsyncClient", return_value=client),
+        contextlib.ExitStack() as stack,
+    ):
+        for p in extra_patches:
+            stack.enter_context(p)
+        asyncio.run(worker_api._send_heartbeat())
+    return worker_api._consecutive_heartbeat_failures
+
+
+class TestCounterWiring:
+    """The counter must move on REAL heartbeat outcomes, not only when a test
+    sets it by hand — deleting the increments must fail these tests."""
+
+    def test_failures_count_and_a_success_resets(self):
+        worker_api._consecutive_heartbeat_failures = 0
+        assert _drive_heartbeat(None) == 1  # network failure path
+        assert _drive_heartbeat(500) == 2  # HTTP status failure path
+        worker_api._link_hint_logged = True  # as if an outage logged the hint
+        assert _drive_heartbeat(200) == 0  # success resets the run...
+        assert worker_api._link_hint_logged is False  # ...and re-arms the hint
+
+    def test_a_success_advances_the_staleness_stamp(self):
+        worker_api._last_heartbeat_ok = 1.0  # ancient
+        _drive_heartbeat(200)
+        assert time.monotonic() - worker_api._last_heartbeat_ok < 60
+
+    def test_enrollment_explosion_does_not_count_a_landed_heartbeat(self, caplog):
+        """The counter measures "did the UI hear from us", nothing else.
+
+        A UI version skew handing back a malformed worker_key used to raise out
+        of the success block into the generic handler, permanently degrading a
+        worker whose every heartbeat LANDED — and calling it "connection
+        failed" on top.
+        """
+        worker_api._consecutive_heartbeat_failures = 3
+        with caplog.at_level(logging.ERROR, logger=worker_api.logger.name):
+            count = _drive_heartbeat(
+                200,
+                json_body={"worker_key": 12345},
+                extra_patches=(
+                    patch.object(worker_api, "_save_worker_key", side_effect=TypeError("data must be str")),
+                ),
+            )
+        assert count == 0  # the landed 200 reset the run
+        assert worker_api._ui_connected is True
+        assert any("Enrollment bookkeeping failed" in r.getMessage() for r in caplog.records)
+
+    def test_the_hint_is_wired_to_the_failure_path(self, caplog):
+        """A resolution failure must produce the hint through the REAL call
+        site, not only when the helper is invoked directly."""
+        worker_api._consecutive_heartbeat_failures = 0
+        worker_api._link_hint_logged = False
+        err = httpx.ConnectError("resolve failed")
+        err.__cause__ = socket.gaierror(-3, "Try again")
+        with caplog.at_level(logging.ERROR, logger=worker_api.logger.name):
+            count = _drive_heartbeat(err)
+
+        assert count == 1
+        assert any("Cannot resolve" in r.getMessage() for r in caplog.records)
+
+    def test_a_reply_rearms_the_hint_for_the_next_outage(self, caplog):
+        """Any HTTP reply proves the name resolves, so the outage is over.
+
+        Resetting the flag only on full success left it stuck True through a
+        post-outage 401 spell — and the NEXT resolution outage then logged
+        nothing, which is the original 42-hour blind spot all over again.
+        """
+
+        def _resolution_error():
+            err = httpx.ConnectError("resolve failed")
+            err.__cause__ = socket.gaierror(-3, "Try again")
+            return err
+
+        worker_api._link_hint_logged = False
+        with caplog.at_level(logging.ERROR, logger=worker_api.logger.name):
+            _drive_heartbeat(_resolution_error())  # outage 1 → hint
+            _drive_heartbeat(401)  # name resolves again, auth broken
+            assert worker_api._link_hint_logged is False  # re-armed by the reply
+            _drive_heartbeat(_resolution_error())  # outage 2 → hint AGAIN
+
+        hints = [r for r in caplog.records if "Cannot resolve" in r.getMessage()]
+        assert len(hints) == 2
+
+
+class TestThresholdContract:
+    def test_unhealthy_fires_only_after_the_key_self_heal_could(self):
+        """The unhealthy threshold must sit ABOVE the key-discard ladder.
+
+        This repo documents an autoheal sidecar that restarts unhealthy
+        containers. A restart resets the in-memory auth-failure ladder while
+        the stale key file survives on disk — so if "unhealthy" fired before
+        the discard-and-re-enrol step, a locked-out worker would be restart-
+        looped at N failures forever and the self-heal could never run.
+        """
+        assert worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER > worker_api._AUTH_FAILURE_DISCARD_AFTER
+
+    def test_a_real_outage_is_visible_within_a_quarter_hour(self):
+        # The operational point of the endpoint: docker ps must tell the truth
+        # the same quarter-hour, not eventually.
+        assert worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER * worker_api.HEARTBEAT_INTERVAL <= 900
+        # The hang path is the rare one and may take a little longer, but it
+        # must still surface within 20 minutes.
+        assert worker_api._HEARTBEAT_STALE_AFTER <= 1200
+
+    def test_the_staleness_window_also_clears_the_ladder(self):
+        """The wall-clock backstop must not pre-empt the cycle-counted ladder.
+
+        The discard ladder is counted in CYCLES, each costing HEARTBEAT_INTERVAL
+        plus payload time (stats stretch with fleet size; nvidia-smi may burn a
+        10s timeout). If the staleness window were merely threshold x interval,
+        ~15s of per-cycle overhead would flip the container unhealthy BEFORE
+        failure #10 — restart-looping a locked-out worker through the exact
+        hole the 12>10 ordering exists to close. 30s headroom per discard-cycle
+        is the tolerance this pins.
+        """
+        ladder_wall_time = worker_api._AUTH_FAILURE_DISCARD_AFTER * (worker_api.HEARTBEAT_INTERVAL + 30)
+        assert ladder_wall_time < worker_api._HEARTBEAT_STALE_AFTER
+
+
+class TestLogsNeverCarryCredentials:
+    """CASHPILOT_UI_URL can embed userinfo (a UI behind reverse-proxy basic
+    auth is `https://user:pass@host`), and log lines must never repeat it."""
+
+    def _resolution_failure(self):
+        exc = ConnectionError("connect failed")
+        exc.__cause__ = socket.gaierror(-3, "Try again")
+        return exc
+
+    def test_hint_logs_the_host_not_the_token(self, caplog):
+        worker_api._link_hint_logged = False
+        with (
+            patch.object(worker_api, "UI_URL", "http://secret-token@cashpilot-ui:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(self._resolution_failure())
+
+        msg = next(r.getMessage() for r in caplog.records if "Cannot resolve" in r.getMessage())
+        assert "'cashpilot-ui'" in msg
+        assert "secret-token" not in caplog.text
+
+    def test_hint_logs_the_host_not_the_username(self, caplog):
+        # user:pass form: the old string-split printed the USERNAME as the host.
+        worker_api._link_hint_logged = False
+        with (
+            patch.object(worker_api, "UI_URL", "http://user:hunter2@ui.internal:8080"),
+            caplog.at_level(logging.ERROR, logger=worker_api.logger.name),
+        ):
+            worker_api._log_link_failure_hint(self._resolution_failure())
+
+        msg = next(r.getMessage() for r in caplog.records if "Cannot resolve" in r.getMessage())
+        assert "'ui.internal'" in msg
+        assert "hunter2" not in caplog.text
+        assert "'user'" not in msg
+
+    def test_ui_host_on_a_plain_url_is_unchanged(self):
+        # Negative control: no userinfo, nothing to strip.
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            assert worker_api._ui_host() == "cashpilot-ui"
+
+    def test_redact_userinfo(self):
+        assert worker_api._redact_userinfo("https://user:pass@host:8080/x") == "https://host:8080/x"
+        assert worker_api._redact_userinfo("http://token@cashpilot-ui:8080") == "http://cashpilot-ui:8080"
+        # Negative control: a URL without credentials passes through untouched.
+        assert worker_api._redact_userinfo("http://cashpilot-ui:8080") == "http://cashpilot-ui:8080"
+
+    def test_redact_userinfo_uppercase_scheme(self):
+        # httpx accepts and normalizes 'HTTPS://', so this is a working config
+        # — and the startup log redacts the RAW env value.
+        assert worker_api._redact_userinfo("HTTPS://user:hunter2@ui.internal:8080") == "HTTPS://ui.internal:8080"
+
+    def test_redact_userinfo_password_containing_at(self):
+        # An unencoded '@' inside the password must not half-survive: the match
+        # runs to the LAST '@' before the path.
+        assert worker_api._redact_userinfo("https://user:p@ss@host/x") == "https://host/x"
+        # Same property on the schemeless form (the startup-log input): this is
+        # the second regex, which no scheme-carrying case can exercise.
+        assert worker_api._redact_userinfo("user:p@ss@host:8080") == "host:8080"
+
+    def test_redact_userinfo_inside_a_message(self):
+        # httpx's HTTPStatusError message embeds str(request.url) UNREDACTED,
+        # so the per-cycle warning must be scrubbed before logging.
+        msg = "Client error '401 Unauthorized' for url 'https://user:hunter2@ui.internal/api/workers/heartbeat'"
+        out = worker_api._redact_userinfo(msg)
+        assert "hunter2" not in out
+        assert "https://ui.internal/api/workers/heartbeat" in out
+        # Negative control: a message whose URL has no userinfo is untouched.
+        plain = "Client error '401 Unauthorized' for url 'https://ui.internal/x'"
+        assert worker_api._redact_userinfo(plain) == plain
+
+    def test_failed_heartbeat_warning_never_logs_the_password(self, caplog):
+        import httpx
+
+        req = httpx.Request("POST", "https://user:hunter2@ui.internal/api/workers/heartbeat")
+
+        class _RaisingClient:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, *a, **k):
+                httpx.Response(401, request=req).raise_for_status()
+
+        async def _noop_status():
+            return []
+
+        with (
+            patch.object(worker_api, "UI_URL", "https://user:hunter2@ui.internal"),
+            patch.object(worker_api.httpx, "AsyncClient", _RaisingClient),
+            patch.object(worker_api.orchestrator, "get_status", return_value=[]),
+            caplog.at_level(logging.WARNING, logger=worker_api.logger.name),
+        ):
+            asyncio.run(worker_api._send_heartbeat())
+
+        warning = next(r.getMessage() for r in caplog.records if "Heartbeat failed" in r.getMessage())
+        assert "401" in warning
+        assert "hunter2" not in caplog.text
+
+
+class TestPayloadFailuresStillCount:
+    def test_a_payload_construction_failure_still_degrades_health(self):
+        """An exception BEFORE the POST is still a heartbeat that did not land.
+
+        Payload construction runs outside _send_heartbeat's own try, so it
+        escapes to the loop. Without loop-level accounting a worker whose
+        egress probe (or any payload dependency) fails every cycle would keep
+        answering 200 "ok" forever while never reporting in — the exact
+        invisible state /api/health exists to expose.
+        """
+        worker_api._consecutive_heartbeat_failures = 0
+        worker_api._last_error = ""
+
+        async def _boom():
+            raise RuntimeError("egress probe exploded")
+
+        async def _run():
+            task = asyncio.create_task(worker_api._heartbeat_loop())
+            try:
+                deadline = time.monotonic() + 10
+                while (
+                    worker_api._consecutive_heartbeat_failures < worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER
+                    and time.monotonic() < deadline
+                ):
+                    await asyncio.sleep(0.01)
+            finally:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        with (
+            patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"),
+            patch.object(worker_api, "HEARTBEAT_INTERVAL", 0),
+            patch.object(worker_api, "_detect_egress_ip", _boom),
+            patch.object(worker_api.orchestrator, "get_status", return_value=[]),
+            patch.object(worker_api.orchestrator, "docker_available", return_value=False),
+        ):
+            asyncio.run(_run())
+
+        assert worker_api._consecutive_heartbeat_failures >= worker_api._HEARTBEAT_FAILURES_UNHEALTHY_AFTER
+        assert worker_api._last_error == "internal error preparing the heartbeat"
+
+        with patch.object(worker_api, "UI_URL", "http://cashpilot-ui:8080"):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["error"] == "internal error preparing the heartbeat"


### PR DESCRIPTION
## Why

Two workers in a production fleet were unable to reach the UI for **42 hours**. Throughout, `docker ps` reported them `Up (healthy)` while the fleet page showed them offline — and nothing reconciled the two views, so nobody noticed until someone went looking for an unrelated reason.

Both causes are things any user can hit:

1. **The healthcheck could not fail for this failure.** It was a TCP connect to the worker's own port, which succeeds on a worker that is listening and completely disconnected.
2. **The log said nothing useful.** A worker that cannot resolve `CASHPILOT_UI_URL` emitted a bare `Heartbeat failed: [Errno -3] Try again` every 60 seconds. The real cause is usually *not* broken DNS — it is that the container is attached to **no Docker network**, so a Compose service name cannot resolve. `docker start` can leave a container detached after an unclean shutdown (power cut, host crash), and `docker compose up -d` fixes it — but nothing in the logs points there.

## What

- `/api/health` returns **503 + `status: degraded`** after a sustained run of missed heartbeats (5 ≈ 5 min), including `last_heartbeat`, `consecutive_failures` and the last error.
- `Dockerfile.worker` healthcheck now asks `/api/health` instead of opening a socket, so `docker ps` and any container monitoring surface it.
- A **name-resolution failure is explained once per outage** with the docker-network cause and the `docker inspect … NetworkSettings.Networks` command that confirms it (an empty result is the bug). Logged once, not per cycle — the per-60s warning is exactly what got scrolled past for 42 hours.

Deliberate constraints:
- **The healthy response is byte-identical to before** (`{"status": "ok", "worker": …}`), so anything already parsing it keeps working. Only the degraded path adds fields.
- **A worker with no `CASHPILOT_UI_URL` is never degraded** — it has nowhere to report by design, and marking it unhealthy forever would train operators to ignore the signal.
- Degradation needs a *sustained* run, so a UI restart or a brief blip does not flap the container.
- The exception chain walk is cycle-safe (`httpx` wraps the `gaierror`, so the surface type is not the cause).

## Testing

- `uv run pytest tests/` — **4643 passed, 6 skipped**
- New `tests/test_worker_heartbeat_health.py`: healthy shape unchanged, below-threshold stays ok, degrades after sustained failures, no-UI-configured never degrades, hint logged exactly once, silent for non-resolution errors, finds a `gaierror` nested deep in the chain, and survives a self-referential exception chain
- `ruff check` + `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worker health reporting for heartbeat status, recent errors, failure counts, and stale heartbeats.
  * Health status degrades after sustained heartbeat failures and returns to healthy after successful recovery.
  * Added actionable Docker network and DNS troubleshooting diagnostics with sensitive credentials protected.

* **Bug Fixes**
  * Docker health checks now validate the worker’s HTTP health endpoint instead of only checking port connectivity.
  * Heartbeat preparation and enrollment failures are now reflected in health reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->