### PR TITLE
feat(alerts): a worker going offline now notifies, not just logs

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1890,6 +1890,28 @@ async def set_worker_status(worker_id: int, status: str) -> None:
         await db.close()
 
 
+async def mark_worker_offline_if_unchanged(worker_id: int, expected_heartbeat: str) -> bool:
+    """Mark a worker offline only if no heartbeat landed since the sweep read it.
+
+    The stale-worker sweep reads the row, decides, then writes — and a recovery
+    heartbeat can land in that gap. An unconditional write would flip a worker
+    that JUST came back to offline and alert on it, exactly at its moment of
+    recovery. Conditioning on the heartbeat value the sweep based its decision
+    on makes the decide-and-write atomic: if anything moved, the update matches
+    nothing and the sweep simply reconsiders in two minutes.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "UPDATE workers SET status = 'offline' WHERE id = ? AND last_heartbeat = ? AND status = 'online'",
+            (worker_id, expected_heartbeat),
+        )
+        await db.commit()
+        return cursor.rowcount == 1
+    finally:
+        await db.close()
+
+
 async def delete_worker(worker_id: int) -> None:
     db = await _get_db()
     try:

--- a/app/database.py
+++ b/app/database.py
@@ -1855,6 +1855,22 @@ async def get_worker(worker_id: int) -> dict[str, Any] | None:
         await db.close()
 
 
+async def get_worker_status_and_name(client_id: str) -> tuple[str, str] | None:
+    """The (status, display name) a worker had BEFORE its next upsert.
+
+    The heartbeat route needs the pre-upsert state to detect an
+    offline -> online recovery — upsert_worker unconditionally writes
+    'online', so after it runs the transition is no longer observable.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute("SELECT status, name FROM workers WHERE client_id = ?", (client_id,))
+        row = await cursor.fetchone()
+        return (row["status"], row["name"]) if row else None
+    finally:
+        await db.close()
+
+
 async def list_workers() -> list[dict[str, Any]]:
     db = await _get_db()
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -472,6 +472,37 @@ async def _collect_bounded(collector) -> Any:
             )
 
 
+async def _offline_worker_alerts() -> list[dict[str, str]]:
+    """Bell entries for every worker currently marked offline.
+
+    Derived from the workers table on each rebuild rather than carried in
+    memory: the collection loop replaces _collector_alerts wholesale every
+    hour, and an entry that lived only in the list would be dropped there —
+    silently un-reporting a machine that is still down. Recovery needs no
+    bookkeeping either: the next heartbeat flips the row back to online and
+    the entry stops being derived.
+    """
+    try:
+        workers = await database.list_workers()
+    except Exception as exc:  # noqa: BLE001 - the bell must not take down collection
+        logger.warning("Could not derive offline-worker alerts: %s", exc)
+        return []
+    entries: list[dict[str, str]] = []
+    for w in workers:
+        if w.get("status") == "offline" and w.get("last_heartbeat"):
+            entries.append(
+                {
+                    "kind": "worker",
+                    "platform": w["name"],
+                    "error": (
+                        f"Offline since {w['last_heartbeat']} UTC. Its containers keep running "
+                        "and earning, but CashPilot cannot see or manage them until it reconnects."
+                    ),
+                }
+            )
+    return entries
+
+
 async def _flatline_check() -> list[dict[str, str]]:
     """Alert on services that are running but whose balance has stopped moving.
 
@@ -548,7 +579,12 @@ async def _warm_collector_alerts() -> None:
         # flatline belongs here for the same reason payout does: it is recorded,
         # and without this it is dropped on the way to the bell, so a restart
         # silently clears a warning about a service that is still not earning.
-        if alert["kind"] not in ("collector", "payout", "flatline"):
+        # worker likewise: an offline machine must survive a UI restart. And
+        # notice: #326 made notices durable and deduped, but a restart dropped
+        # them from the bell while their 24h push-dedupe survived — so a
+        # recovery inside the gap skipped clear_alerts and the stale row
+        # swallowed the next genuine warning.
+        if alert["kind"] not in ("collector", "payout", "flatline", "worker", "notice"):
             continue
         key = f"{alert['kind']}:{alert['subject']}"
         if key in seen:
@@ -757,6 +793,9 @@ async def _run_collection() -> None:
             # user would ever see it was the one place it never went. The bell
             # said "All collectors healthy".
             alerts.extend(await _flatline_check())
+            # Offline workers re-derived every rebuild, or the hourly wholesale
+            # replacement of this list would silently un-report a dead machine.
+            alerts.extend(await _offline_worker_alerts())
             _collector_alerts = alerts
         except Exception as exc:
             logger.error("Collection run failed: %s", exc)
@@ -832,6 +871,26 @@ async def _check_stale_workers() -> None:
             if w["status"] == "online" and last < cutoff:
                 await database.set_worker_status(w["id"], "offline")
                 logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], last_hb)
+                # The 42-hour incident, UI side: this transition used to be the
+                # log line above and nothing else — the UI KNEW and told nobody.
+                # Same alert/push/recovery pattern as a failing collector.
+                msg = (
+                    f"No heartbeat for over {STALE_WORKER_SECONDS // 60} minutes. Its containers "
+                    "keep running and earning, but CashPilot cannot see or manage them until it reconnects."
+                )
+                if await database.record_alert("worker", w["name"], msg):
+                    _spawn(
+                        notify.send(
+                            f"CashPilot: worker '{w['name']}' went offline",
+                            msg,
+                            kind="worker",
+                            subject=w["name"],
+                        )
+                    )
+                # Into the bell NOW (this job runs every 2 min); the hourly
+                # collection rebuild re-derives it from the workers table.
+                if not any(a.get("kind") == "worker" and a.get("platform") == w["name"] for a in _collector_alerts):
+                    _collector_alerts.append({"kind": "worker", "platform": w["name"], "error": msg})
             elif w["status"] == "offline" and last < purge_cutoff and not w.get("api_key_enc"):
                 await database.delete_worker(w["id"])
                 logger.info("Purged stale unenrolled worker '%s' (offline since %s)", w["name"], last_hb)
@@ -4229,6 +4288,16 @@ async def api_worker_heartbeat(request: Request, body: WorkerHeartbeat) -> dict[
     if not cid:
         raise HTTPException(status_code=400, detail="Worker name or client_id required")
     state = await _authenticate_worker_heartbeat(request, cid)
+    # Pre-upsert state: upsert_worker unconditionally writes 'online', so the
+    # offline -> online recovery is only observable here, before it runs.
+    # Best-effort on purpose: this read failing must never reject a heartbeat
+    # (the upsert below is the loud path if the DB is really broken); the cost
+    # is one missed immediate alert-clear, which the 24h cooldown self-heals.
+    previous = None
+    try:
+        previous = await database.get_worker_status_and_name(cid)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not read pre-heartbeat worker state for %s: %s", cid, exc)
     worker_id = await database.upsert_worker(
         client_id=cid,
         name=body.name,
@@ -4238,6 +4307,19 @@ async def api_worker_heartbeat(request: Request, body: WorkerHeartbeat) -> dict[
         system_info=json.dumps(body.system_info),
     )
     metrics.record_heartbeat(body.name)
+    if previous is not None and previous[0] == "offline":
+        # Recovered — drop the stored alert so the NEXT outage notifies again
+        # instead of being deduped inside the cooldown window, and prune the
+        # bell entry now rather than at the next hourly rebuild. The alert was
+        # recorded under the STORED display name, which name-protection can
+        # keep different from what this heartbeat carries.
+        prev_name = previous[1]
+        await database.clear_alerts("worker", prev_name)
+        global _collector_alerts
+        _collector_alerts = [
+            a for a in _collector_alerts if not (a.get("kind") == "worker" and a.get("platform") == prev_name)
+        ]
+        logger.info("Worker '%s' is back online", prev_name)
     resp: dict[str, Any] = {"status": "ok", "worker_id": worker_id}
     if state == "enroll":
         # First contact: mint this worker's own key and hand it back once. Stored

--- a/app/main.py
+++ b/app/main.py
@@ -494,6 +494,10 @@ async def _offline_worker_alerts() -> list[dict[str, str]]:
                 {
                     "kind": "worker",
                     "platform": w["name"],
+                    # Identity travels beside the display name: recovery and
+                    # dedupe match on client_id, because two hosts can share a
+                    # hostname and hostnames churn across recreates.
+                    "client_id": w.get("client_id") or w["name"],
                     "error": (
                         f"Offline since {w['last_heartbeat']} UTC. Its containers keep running "
                         "and earning, but CashPilot cannot see or manage them until it reconnects."
@@ -594,6 +598,17 @@ async def _warm_collector_alerts() -> None:
         if alert.get("category"):
             entry["category"] = alert["category"]
         restored.append(entry)
+    # Worker alerts are stored under client_id (the identity); the bell shows
+    # people a NAME. Resolve display names in one pass, keeping the client_id
+    # beside it for recovery matching. A worker deleted since the alert was
+    # stored keeps the raw id — still actionable, never wrong.
+    worker_entries = [e for e in restored if e["kind"] == "worker"]
+    if worker_entries:
+        with contextlib.suppress(Exception):
+            names = {w.get("client_id"): w["name"] for w in await database.list_workers()}
+            for e in worker_entries:
+                e["client_id"] = e["platform"]
+                e["platform"] = names.get(e["platform"], e["platform"])
     _collector_alerts = restored
     # A restart must not make the bell claim nothing has ever been checked. Any
     # stored alert, or any earnings row, is proof that a collection ran.
@@ -862,40 +877,80 @@ async def _check_stale_workers() -> None:
     now = datetime.now(UTC)
     cutoff = now - timedelta(seconds=STALE_WORKER_SECONDS)
     purge_cutoff = now - timedelta(hours=1)
+    global _collector_alerts
     for w in workers:
         try:
             last_hb = w.get("last_heartbeat")
             if not last_hb:
                 continue
+            cid = w.get("client_id") or w["name"]
             last = datetime.fromisoformat(last_hb).replace(tzinfo=UTC)
             if w["status"] == "online" and last < cutoff:
-                await database.set_worker_status(w["id"], "offline")
+                # Conditional on the heartbeat the decision was based on: a
+                # recovery heartbeat landing between this sweep's read and its
+                # write must win, or the worker would be alerted offline at its
+                # exact moment of coming back.
+                if not await database.mark_worker_offline_if_unchanged(w["id"], last_hb):
+                    continue
                 logger.info("Worker '%s' marked offline (last heartbeat: %s)", w["name"], last_hb)
                 # The 42-hour incident, UI side: this transition used to be the
                 # log line above and nothing else — the UI KNEW and told nobody.
                 # Same alert/push/recovery pattern as a failing collector.
-                msg = (
-                    f"No heartbeat for over {STALE_WORKER_SECONDS // 60} minutes. Its containers "
-                    "keep running and earning, but CashPilot cannot see or manage them until it reconnects."
-                )
-                if await database.record_alert("worker", w["name"], msg):
-                    _spawn(
-                        notify.send(
-                            f"CashPilot: worker '{w['name']}' went offline",
-                            msg,
-                            kind="worker",
-                            subject=w["name"],
-                        )
-                    )
-                # Into the bell NOW (this job runs every 2 min); the hourly
-                # collection rebuild re-derives it from the workers table.
-                if not any(a.get("kind") == "worker" and a.get("platform") == w["name"] for a in _collector_alerts):
-                    _collector_alerts.append({"kind": "worker", "platform": w["name"], "error": msg})
-            elif w["status"] == "offline" and last < purge_cutoff and not w.get("api_key_enc"):
-                await database.delete_worker(w["id"])
-                logger.info("Purged stale unenrolled worker '%s' (offline since %s)", w["name"], last_hb)
+                await _raise_worker_offline_alert(w)
+            elif w["status"] == "offline":
+                if last < purge_cutoff and not w.get("api_key_enc"):
+                    await database.delete_worker(w["id"])
+                    logger.info("Purged stale unenrolled worker '%s' (offline since %s)", w["name"], last_hb)
+                else:
+                    # Still offline: re-attempt the durable alert. record_alert
+                    # dedupes inside its window, so this is a no-op two minutes
+                    # after a SUCCESSFUL insert — but an insert or push that
+                    # FAILED at transition time (DB blip, notifier down) gets
+                    # retried instead of being lost to the already-offline
+                    # state, which used to make the miss permanent.
+                    await _raise_worker_offline_alert(w)
+            elif w["status"] == "online" and any(
+                a.get("kind") == "worker" and a.get("client_id") == cid for a in _collector_alerts
+            ):
+                # Reconciliation: an online worker with a lingering worker
+                # alert means a recovery clear failed or was missed (the
+                # heartbeat route treats that clear as best-effort so a DB
+                # hiccup can never fail a heartbeat). Finish the job here.
+                await database.clear_alerts("worker", cid)
+                _collector_alerts = [
+                    a for a in _collector_alerts if not (a.get("kind") == "worker" and a.get("client_id") == cid)
+                ]
+                logger.info("Cleared lingering offline alert for recovered worker '%s'", w["name"])
         except Exception as exc:
             logger.warning("Stale worker check error for worker '%s': %s", w.get("name", w.get("id")), exc)
+
+
+async def _raise_worker_offline_alert(w: dict[str, Any]) -> None:
+    """Record + push + bell an offline worker, keyed by client_id.
+
+    client_id is the identity, per this codebase's own rule: workers.name is
+    the container hostname, cosmetic, mutable across recreates, and shareable
+    by two hosts — keying alerts on it would let one worker suppress or clear
+    another's. The display name travels in the message and title only.
+    """
+    cid = w.get("client_id") or w["name"]
+    msg = (
+        f"Worker '{w['name']}': no heartbeat for over {STALE_WORKER_SECONDS // 60} minutes. Its "
+        "containers keep running and earning, but CashPilot cannot see or manage them until it reconnects."
+    )
+    if await database.record_alert("worker", cid, msg):
+        _spawn(
+            notify.send(
+                f"CashPilot: worker '{w['name']}' went offline",
+                msg,
+                kind="worker",
+                subject=cid,
+            )
+        )
+    # Into the bell NOW (the sweep runs every 2 min); the hourly collection
+    # rebuild re-derives it from the workers table.
+    if not any(a.get("kind") == "worker" and a.get("client_id") == cid for a in _collector_alerts):
+        _collector_alerts.append({"kind": "worker", "platform": w["name"], "client_id": cid, "error": msg})
 
 
 FLEET_API_KEY = fleet_key.resolve_fleet_key()
@@ -4310,16 +4365,20 @@ async def api_worker_heartbeat(request: Request, body: WorkerHeartbeat) -> dict[
     if previous is not None and previous[0] == "offline":
         # Recovered — drop the stored alert so the NEXT outage notifies again
         # instead of being deduped inside the cooldown window, and prune the
-        # bell entry now rather than at the next hourly rebuild. The alert was
-        # recorded under the STORED display name, which name-protection can
-        # keep different from what this heartbeat carries.
-        prev_name = previous[1]
-        await database.clear_alerts("worker", prev_name)
-        global _collector_alerts
-        _collector_alerts = [
-            a for a in _collector_alerts if not (a.get("kind") == "worker" and a.get("platform") == prev_name)
-        ]
-        logger.info("Worker '%s' is back online", prev_name)
+        # bell entry now rather than at the next hourly rebuild. Keyed by
+        # client_id (the identity), never the cosmetic display name. Best
+        # effort on purpose: a DB hiccup here must never fail a HEARTBEAT —
+        # the stale-worker sweep reconciles any clear this misses.
+        try:
+            await database.clear_alerts("worker", cid)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not clear the offline alert for recovered worker %s (sweep will): %s", cid, exc)
+        else:
+            global _collector_alerts
+            _collector_alerts = [
+                a for a in _collector_alerts if not (a.get("kind") == "worker" and a.get("client_id") == cid)
+            ]
+        logger.info("Worker '%s' is back online", previous[1])
     resp: dict[str, Any] = {"status": "ok", "worker_id": worker_id}
     if state == "enroll":
         # First contact: mint this worker's own key and hand it back once. Stored

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1906,13 +1906,16 @@ class TestPeriodicTasks:
         from app.main import _check_stale_workers
 
         old_time = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
-        workers = [{"id": 1, "name": "w1", "status": "online", "last_heartbeat": old_time}]
+        workers = [{"id": 1, "client_id": "w1-cid", "name": "w1", "status": "online", "last_heartbeat": old_time}]
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
-            patch("app.main.database.set_worker_status", new_callable=AsyncMock) as mock_set,
+            patch(
+                "app.main.database.mark_worker_offline_if_unchanged", new_callable=AsyncMock, return_value=True
+            ) as mock_mark,
+            patch("app.main.database.record_alert", new_callable=AsyncMock, return_value=False),
         ):
             asyncio.run(_check_stale_workers())
-            mock_set.assert_called_once_with(1, "offline")
+            mock_mark.assert_called_once_with(1, old_time)
 
     def test_check_stale_workers_error(self):
         from app.main import _check_stale_workers

--- a/tests/test_worker_offline_alerts.py
+++ b/tests/test_worker_offline_alerts.py
@@ -1,0 +1,211 @@
+"""A worker going offline must be an alert, not a log line.
+
+The 42-hour incident, UI side: two workers stopped heartbeating, the UI marked
+them offline in its own database within 3 minutes — and told nobody. The fleet
+page was the only witness, and nobody was looking at it. These tests pin the
+full lifecycle: transition -> alert row + push + bell, dedupe inside the
+cooldown, persistence across a UI restart, and recovery clearing all of it.
+"""
+
+import asyncio
+import os
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+try:
+    from app.main import (  # noqa: E402
+        _check_stale_workers,
+        _offline_worker_alerts,
+        _warm_collector_alerts,
+        api_worker_heartbeat,
+    )
+except ImportError:
+    pytest.skip(
+        "Requires full app dependencies (fastapi, httpx, etc.) — runs in CI",
+        allow_module_level=True,
+    )
+
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+from app import main  # noqa: E402
+
+
+def _request():
+    req = MagicMock()
+    req.headers = {"Authorization": "Bearer test-fleet-key"}
+    return req
+
+
+def _worker_row(**over):
+    row = {
+        "id": 1,
+        "client_id": "srv-1",
+        "name": "watchtower",
+        "url": "",
+        "status": "online",
+        "containers": "[]",
+        "apps": "[]",
+        "system_info": '{"docker_available": true}',
+        "last_heartbeat": "2026-04-04T12:00:00",
+        "registered_at": "2026-04-01T00:00:00",
+        "api_key_enc": None,
+    }
+    row.update(over)
+    return row
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_bell():
+    before = main._collector_alerts
+    main._collector_alerts = []
+    yield
+    main._collector_alerts = before
+
+
+class TestOfflineTransition:
+    def _sweep(self, *, record_returns, rows=None):
+        """Run _check_stale_workers over one stale online worker."""
+        sends = []
+
+        async def _capture_send(title, message, **kw):
+            sends.append((title, kw.get("kind"), kw.get("subject")))
+            return 1
+
+        record = AsyncMock(return_value=record_returns)
+        with (
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=rows or [_worker_row()]),
+            patch("app.main.database.set_worker_status", new_callable=AsyncMock) as set_status,
+            patch("app.main.database.record_alert", record),
+            patch("app.main.notify.send", _capture_send),
+        ):
+            _run(_check_stale_workers())
+        return record, set_status, sends
+
+    def test_going_offline_records_pushes_and_bells(self):
+        record, set_status, sends = self._sweep(record_returns=True)
+        set_status.assert_awaited_once_with(1, "offline")
+        assert record.await_args.args[0] == "worker"
+        assert record.await_args.args[1] == "watchtower"
+        assert len(sends) == 1
+        assert sends[0][1] == "worker" and sends[0][2] == "watchtower"
+        assert any(a["kind"] == "worker" and a["platform"] == "watchtower" for a in main._collector_alerts)
+
+    def test_cooldown_dedupes_the_push_but_not_the_bell(self):
+        # record_alert False = still inside the cooldown window: no second
+        # push, and no duplicate bell entry either.
+        main._collector_alerts = [{"kind": "worker", "platform": "watchtower", "error": "x"}]
+        record, _, sends = self._sweep(record_returns=False)
+        assert record.await_count == 1
+        assert sends == []
+        assert len([a for a in main._collector_alerts if a["kind"] == "worker"]) == 1
+
+    def test_a_fresh_worker_is_left_alone(self):
+        # Negative control: recent heartbeat -> no transition, no alert.
+        from datetime import UTC, datetime
+
+        fresh = _worker_row(last_heartbeat=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"))
+        record, set_status, sends = self._sweep(record_returns=True, rows=[fresh])
+        set_status.assert_not_awaited()
+        record.assert_not_awaited()
+        assert sends == []
+        assert main._collector_alerts == []
+
+
+class TestBellRebuildDerivesOfflineWorkers:
+    def test_offline_workers_are_derived_each_rebuild(self):
+        rows = [
+            _worker_row(status="offline"),
+            _worker_row(id=2, client_id="srv-2", name="geiserback", status="online"),
+        ]
+        with patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=rows):
+            entries = _run(_offline_worker_alerts())
+        assert [e["platform"] for e in entries] == ["watchtower"]
+        assert entries[0]["kind"] == "worker"
+
+    def test_no_offline_workers_is_empty(self):
+        # Negative control — an all-online fleet derives nothing.
+        with patch(
+            "app.main.database.list_workers",
+            new_callable=AsyncMock,
+            return_value=[_worker_row(status="online")],
+        ):
+            assert _run(_offline_worker_alerts()) == []
+
+    def test_a_db_error_degrades_to_empty_not_a_crash(self):
+        with patch("app.main.database.list_workers", new_callable=AsyncMock, side_effect=RuntimeError("db gone")):
+            assert _run(_offline_worker_alerts()) == []
+
+
+class TestWarmRestoresWorkerAlerts:
+    def test_worker_and_notice_kinds_survive_a_restart(self):
+        stored = [
+            {"kind": "worker", "subject": "watchtower", "message": "offline", "category": None},
+            # A notice dropped here used to skip clear_alerts on recovery
+            # inside the warm gap, so its stale row swallowed the next warning.
+            {"kind": "notice", "subject": "storj", "message": "unreachable", "category": None},
+            {"kind": "bogus", "subject": "x", "message": "y", "category": None},
+        ]
+        with patch("app.main.database.list_alerts", new_callable=AsyncMock, return_value=stored):
+            _run(_warm_collector_alerts())
+        kinds = [a["kind"] for a in main._collector_alerts]
+        assert "worker" in kinds
+        assert "notice" in kinds
+        assert "bogus" not in kinds  # negative control: unknown kinds still dropped
+
+
+class TestRecoveryClears:
+    def _heartbeat(self, previous):
+        cleared = []
+
+        async def _capture_clear(kind, subject):
+            cleared.append((kind, subject))
+
+        with (
+            patch("app.main._authenticate_worker_heartbeat", new_callable=AsyncMock, return_value=False),
+            patch("app.main.database.get_worker_status_and_name", new_callable=AsyncMock, return_value=previous),
+            patch("app.main.database.upsert_worker", new_callable=AsyncMock, return_value=1),
+            patch("app.main.database.clear_alerts", _capture_clear),
+            patch("app.main._earnings_for_worker", new_callable=AsyncMock, return_value=None),
+        ):
+            _run(
+                api_worker_heartbeat(
+                    _request(),
+                    SimpleNamespace(
+                        name="watchtower",
+                        url="",
+                        client_id="srv-1",
+                        containers=[],
+                        apps=[],
+                        system_info={},
+                    ),
+                )
+            )
+        return cleared
+
+    def test_recovery_clears_the_alert_and_the_bell(self):
+        main._collector_alerts = [
+            {"kind": "worker", "platform": "watchtower", "error": "offline"},
+            {"kind": "collector", "platform": "honeygain", "error": "kept"},
+        ]
+        cleared = self._heartbeat(previous=("offline", "watchtower"))
+        assert cleared == [("worker", "watchtower")]
+        kinds = [(a["kind"], a["platform"]) for a in main._collector_alerts]
+        assert ("worker", "watchtower") not in kinds
+        assert ("collector", "honeygain") in kinds  # untouched
+
+    def test_an_online_worker_heartbeat_clears_nothing(self):
+        # Negative control: no transition, no clearing.
+        main._collector_alerts = [{"kind": "worker", "platform": "watchtower", "error": "offline"}]
+        cleared = self._heartbeat(previous=("online", "watchtower"))
+        assert cleared == []
+        assert len(main._collector_alerts) == 1
+
+    def test_a_new_worker_heartbeat_clears_nothing(self):
+        assert self._heartbeat(previous=None) == []

--- a/tests/test_worker_offline_alerts.py
+++ b/tests/test_worker_offline_alerts.py
@@ -5,6 +5,13 @@ them offline in its own database within 3 minutes — and told nobody. The fleet
 page was the only witness, and nobody was looking at it. These tests pin the
 full lifecycle: transition -> alert row + push + bell, dedupe inside the
 cooldown, persistence across a UI restart, and recovery clearing all of it.
+
+Identity is client_id throughout: workers.name is the container hostname —
+cosmetic, mutable across recreates, shareable by two hosts — so keying alerts
+on it would let one worker suppress or clear another's. The transition write is
+conditional on the heartbeat it was decided from, so a recovery landing in the
+sweep's read-write gap wins instead of being alerted offline at its exact
+moment of coming back.
 """
 
 import asyncio
@@ -34,15 +41,17 @@ from app import main  # noqa: E402
 
 
 def _request():
+    # The key comes from the environment (set or defaulted above) — never a
+    # second copy of the literal, so a CI-provided key keeps these green.
     req = MagicMock()
-    req.headers = {"Authorization": "Bearer test-fleet-key"}
+    req.headers = {"Authorization": f"Bearer {os.environ['CASHPILOT_API_KEY']}"}
     return req
 
 
 def _worker_row(**over):
     row = {
         "id": 1,
-        "client_id": "srv-1",
+        "client_id": "cid-watchtower",
         "name": "watchtower",
         "url": "",
         "status": "online",
@@ -70,8 +79,8 @@ def _isolate_bell():
 
 
 class TestOfflineTransition:
-    def _sweep(self, *, record_returns, rows=None):
-        """Run _check_stale_workers over one stale online worker."""
+    def _sweep(self, *, record_returns=True, rows=None, transition_wins=True):
+        """Run _check_stale_workers over the given worker rows."""
         sends = []
 
         async def _capture_send(title, message, **kw):
@@ -79,31 +88,44 @@ class TestOfflineTransition:
             return 1
 
         record = AsyncMock(return_value=record_returns)
+        mark = AsyncMock(return_value=transition_wins)
+        clear = AsyncMock()
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=rows or [_worker_row()]),
-            patch("app.main.database.set_worker_status", new_callable=AsyncMock) as set_status,
+            patch("app.main.database.mark_worker_offline_if_unchanged", mark),
+            patch("app.main.database.delete_worker", new_callable=AsyncMock) as delete,
             patch("app.main.database.record_alert", record),
+            patch("app.main.database.clear_alerts", clear),
             patch("app.main.notify.send", _capture_send),
         ):
             _run(_check_stale_workers())
-        return record, set_status, sends
+        return SimpleNamespace(record=record, mark=mark, clear=clear, delete=delete, sends=sends)
 
     def test_going_offline_records_pushes_and_bells(self):
-        record, set_status, sends = self._sweep(record_returns=True)
-        set_status.assert_awaited_once_with(1, "offline")
-        assert record.await_args.args[0] == "worker"
-        assert record.await_args.args[1] == "watchtower"
-        assert len(sends) == 1
-        assert sends[0][1] == "worker" and sends[0][2] == "watchtower"
-        assert any(a["kind"] == "worker" and a["platform"] == "watchtower" for a in main._collector_alerts)
+        r = self._sweep()
+        r.mark.assert_awaited_once_with(1, "2026-04-04T12:00:00")
+        assert r.record.await_args.args[0] == "worker"
+        assert r.record.await_args.args[1] == "cid-watchtower"  # identity, not the name
+        assert "watchtower" in r.record.await_args.args[2]  # the name travels in the message
+        assert r.sends == [("CashPilot: worker 'watchtower' went offline", "worker", "cid-watchtower")]
+        entry = next(a for a in main._collector_alerts if a["kind"] == "worker")
+        assert entry["platform"] == "watchtower"
+        assert entry["client_id"] == "cid-watchtower"
+
+    def test_a_recovery_racing_the_sweep_wins(self):
+        """The conditional write loses when a heartbeat landed in the gap —
+        and then NOTHING may fire: no alert, no push, no bell entry."""
+        r = self._sweep(transition_wins=False)
+        r.record.assert_not_awaited()
+        assert r.sends == []
+        assert main._collector_alerts == []
 
     def test_cooldown_dedupes_the_push_but_not_the_bell(self):
-        # record_alert False = still inside the cooldown window: no second
-        # push, and no duplicate bell entry either.
-        main._collector_alerts = [{"kind": "worker", "platform": "watchtower", "error": "x"}]
-        record, _, sends = self._sweep(record_returns=False)
-        assert record.await_count == 1
-        assert sends == []
+        main._collector_alerts = [
+            {"kind": "worker", "platform": "watchtower", "client_id": "cid-watchtower", "error": "x"}
+        ]
+        r = self._sweep(record_returns=False)
+        assert r.sends == []
         assert len([a for a in main._collector_alerts if a["kind"] == "worker"]) == 1
 
     def test_a_fresh_worker_is_left_alone(self):
@@ -111,10 +133,32 @@ class TestOfflineTransition:
         from datetime import UTC, datetime
 
         fresh = _worker_row(last_heartbeat=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"))
-        record, set_status, sends = self._sweep(record_returns=True, rows=[fresh])
-        set_status.assert_not_awaited()
-        record.assert_not_awaited()
-        assert sends == []
+        r = self._sweep(rows=[fresh])
+        r.mark.assert_not_awaited()
+        r.record.assert_not_awaited()
+        assert main._collector_alerts == []
+
+    def test_a_still_offline_worker_retries_the_durable_alert(self):
+        """A record_alert or push that failed at transition time must not be
+        lost to the already-offline state — the sweep re-attempts, and the
+        record_alert cooldown makes the successful case a cheap no-op."""
+        # Enrolled (api_key_enc set): never purge-eligible, however long offline.
+        offline = _worker_row(status="offline", api_key_enc="enc")
+        r = self._sweep(rows=[offline])
+        assert r.record.await_args.args[:2] == ("worker", "cid-watchtower")
+        r.delete.assert_not_awaited()
+
+    def test_an_online_worker_with_a_lingering_alert_is_reconciled(self):
+        """A recovery clear the heartbeat route missed (it is best-effort so a
+        DB hiccup can never fail a heartbeat) is finished by the sweep."""
+        from datetime import UTC, datetime
+
+        fresh = _worker_row(last_heartbeat=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"))
+        main._collector_alerts = [
+            {"kind": "worker", "platform": "watchtower", "client_id": "cid-watchtower", "error": "x"}
+        ]
+        r = self._sweep(rows=[fresh])
+        r.clear.assert_awaited_once_with("worker", "cid-watchtower")
         assert main._collector_alerts == []
 
 
@@ -122,11 +166,11 @@ class TestBellRebuildDerivesOfflineWorkers:
     def test_offline_workers_are_derived_each_rebuild(self):
         rows = [
             _worker_row(status="offline"),
-            _worker_row(id=2, client_id="srv-2", name="geiserback", status="online"),
+            _worker_row(id=2, client_id="cid-geiserback", name="geiserback", status="online"),
         ]
         with patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=rows):
             entries = _run(_offline_worker_alerts())
-        assert [e["platform"] for e in entries] == ["watchtower"]
+        assert [(e["platform"], e["client_id"]) for e in entries] == [("watchtower", "cid-watchtower")]
         assert entries[0]["kind"] == "worker"
 
     def test_no_offline_workers_is_empty(self):
@@ -146,25 +190,43 @@ class TestBellRebuildDerivesOfflineWorkers:
 class TestWarmRestoresWorkerAlerts:
     def test_worker_and_notice_kinds_survive_a_restart(self):
         stored = [
-            {"kind": "worker", "subject": "watchtower", "message": "offline", "category": None},
-            # A notice dropped here used to skip clear_alerts on recovery
-            # inside the warm gap, so its stale row swallowed the next warning.
+            # Worker alerts are stored under client_id; the warm pass resolves
+            # the display name and keeps the id beside it.
+            {"kind": "worker", "subject": "cid-watchtower", "message": "offline", "category": None},
             {"kind": "notice", "subject": "storj", "message": "unreachable", "category": None},
             {"kind": "bogus", "subject": "x", "message": "y", "category": None},
         ]
-        with patch("app.main.database.list_alerts", new_callable=AsyncMock, return_value=stored):
+        with (
+            patch("app.main.database.list_alerts", new_callable=AsyncMock, return_value=stored),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[_worker_row()]),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+        ):
             _run(_warm_collector_alerts())
-        kinds = [a["kind"] for a in main._collector_alerts]
-        assert "worker" in kinds
-        assert "notice" in kinds
-        assert "bogus" not in kinds  # negative control: unknown kinds still dropped
+        by_kind = {a["kind"]: a for a in main._collector_alerts}
+        assert by_kind["worker"]["platform"] == "watchtower"  # resolved for display
+        assert by_kind["worker"]["client_id"] == "cid-watchtower"  # identity kept
+        assert "notice" in by_kind
+        assert "bogus" not in by_kind  # negative control: unknown kinds still dropped
+
+    def test_a_deleted_workers_alert_keeps_the_raw_id(self):
+        stored = [{"kind": "worker", "subject": "cid-gone", "message": "offline", "category": None}]
+        with (
+            patch("app.main.database.list_alerts", new_callable=AsyncMock, return_value=stored),
+            patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[]),
+            patch("app.main.database.get_earnings_summary", new_callable=AsyncMock, return_value=[]),
+        ):
+            _run(_warm_collector_alerts())
+        entry = next(a for a in main._collector_alerts if a["kind"] == "worker")
+        assert entry["platform"] == "cid-gone"  # still actionable, never wrong
 
 
 class TestRecoveryClears:
-    def _heartbeat(self, previous):
+    def _heartbeat(self, previous, *, clear_raises=False):
         cleared = []
 
         async def _capture_clear(kind, subject):
+            if clear_raises:
+                raise RuntimeError("db locked")
             cleared.append((kind, subject))
 
         with (
@@ -174,38 +236,53 @@ class TestRecoveryClears:
             patch("app.main.database.clear_alerts", _capture_clear),
             patch("app.main._earnings_for_worker", new_callable=AsyncMock, return_value=None),
         ):
-            _run(
+            result = _run(
                 api_worker_heartbeat(
                     _request(),
                     SimpleNamespace(
                         name="watchtower",
                         url="",
-                        client_id="srv-1",
+                        client_id="cid-watchtower",
                         containers=[],
                         apps=[],
                         system_info={},
                     ),
                 )
             )
-        return cleared
+        return cleared, result
 
-    def test_recovery_clears_the_alert_and_the_bell(self):
+    def test_recovery_clears_the_alert_and_the_bell_by_identity(self):
         main._collector_alerts = [
-            {"kind": "worker", "platform": "watchtower", "error": "offline"},
+            {"kind": "worker", "platform": "watchtower", "client_id": "cid-watchtower", "error": "offline"},
             {"kind": "collector", "platform": "honeygain", "error": "kept"},
         ]
-        cleared = self._heartbeat(previous=("offline", "watchtower"))
-        assert cleared == [("worker", "watchtower")]
-        kinds = [(a["kind"], a["platform"]) for a in main._collector_alerts]
-        assert ("worker", "watchtower") not in kinds
-        assert ("collector", "honeygain") in kinds  # untouched
+        cleared, _ = self._heartbeat(previous=("offline", "watchtower"))
+        assert cleared == [("worker", "cid-watchtower")]
+        kinds = [(a["kind"], a.get("client_id")) for a in main._collector_alerts]
+        assert ("worker", "cid-watchtower") not in kinds
+        assert ("collector", None) in kinds  # untouched
+
+    def test_a_failed_clear_never_fails_the_heartbeat(self):
+        """Heartbeats are the fleet's lifeline: the clear is best-effort, the
+        bell entry stays (memory and disk must not diverge), and the sweep's
+        reconciliation finishes the job."""
+        main._collector_alerts = [
+            {"kind": "worker", "platform": "watchtower", "client_id": "cid-watchtower", "error": "offline"}
+        ]
+        cleared, result = self._heartbeat(previous=("offline", "watchtower"), clear_raises=True)
+        assert result["status"] == "ok"  # the heartbeat itself succeeded
+        assert cleared == []
+        assert len(main._collector_alerts) == 1  # NOT pruned while the row survives
 
     def test_an_online_worker_heartbeat_clears_nothing(self):
         # Negative control: no transition, no clearing.
-        main._collector_alerts = [{"kind": "worker", "platform": "watchtower", "error": "offline"}]
-        cleared = self._heartbeat(previous=("online", "watchtower"))
+        main._collector_alerts = [
+            {"kind": "worker", "platform": "watchtower", "client_id": "cid-watchtower", "error": "offline"}
+        ]
+        cleared, _ = self._heartbeat(previous=("online", "watchtower"))
         assert cleared == []
         assert len(main._collector_alerts) == 1
 
     def test_a_new_worker_heartbeat_clears_nothing(self):
-        assert self._heartbeat(previous=None) == []
+        cleared, _ = self._heartbeat(previous=None)
+        assert cleared == []

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -339,7 +339,8 @@ class TestStaleWorkerPurge:
         mock_delete = AsyncMock()
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
-            patch("app.main.database.set_worker_status", new_callable=AsyncMock),
+            patch("app.main.database.mark_worker_offline_if_unchanged", new_callable=AsyncMock, return_value=True),
+            patch("app.main.database.record_alert", new_callable=AsyncMock, return_value=False),
             patch("app.main.database.delete_worker", mock_delete),
         ):
             _run(_check_stale_workers())
@@ -362,7 +363,8 @@ class TestStaleWorkerPurge:
         mock_delete = AsyncMock()
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=workers),
-            patch("app.main.database.set_worker_status", new_callable=AsyncMock),
+            patch("app.main.database.mark_worker_offline_if_unchanged", new_callable=AsyncMock, return_value=True),
+            patch("app.main.database.record_alert", new_callable=AsyncMock, return_value=False),
             patch("app.main.database.delete_worker", mock_delete),
         ):
             _run(_check_stale_workers())
@@ -385,14 +387,17 @@ class TestStaleWorkerPurge:
         in the same batch from being processed (per-worker error boundary)."""
         bad = _worker_row(id=4, name="bad", status="online", last_heartbeat="not-a-real-timestamp")
         good = _worker_row(id=3, name="good", status="online", last_heartbeat="2020-01-01T00:00:00")
-        mock_set_status = AsyncMock()
+        mock_mark = AsyncMock(return_value=True)
         with (
             patch("app.main.database.list_workers", new_callable=AsyncMock, return_value=[bad, good]),
-            patch("app.main.database.set_worker_status", mock_set_status),
+            patch("app.main.database.mark_worker_offline_if_unchanged", mock_mark),
+            patch("app.main.database.record_alert", new_callable=AsyncMock, return_value=False),
             patch("app.main.database.delete_worker", new_callable=AsyncMock),
         ):
             _run(_check_stale_workers())
-        mock_set_status.assert_called_once_with(3, "offline")
+        # The offline mark is conditional on the heartbeat the decision came
+        # from — the sweep hands over exactly what it read.
+        mock_mark.assert_called_once_with(3, "2020-01-01T00:00:00")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The 42-hour incident had two halves. #330 fixed the worker's half — its own container now goes unhealthy. This is the UI's half: **the UI knew within 3 minutes and told nobody.** `_check_stale_workers` wrote `offline` to the database and emitted one INFO log line. No alert row, no push, not even a bell entry. The fleet page was the only witness, and the incident lasted 42 hours precisely because nobody was looking at it.

Two independent review lenses converged on this as the top remaining gap in the audit that followed #330.

## What

- **online → offline**: records a durable `worker` alert and pushes out-of-band, with the same once-per-window dedupe collector failures get.
- **The bell shows every currently offline worker.** Entries are re-derived from the workers table on each hourly rebuild — the collection loop replaces the in-memory list wholesale, so an entry that lived only in memory would have been silently dropped while the machine was still down. Immediate visibility comes from the 2-minute sweep; durability across UI restarts from the warm filter.
- **Recovery clears everything**: the next heartbeat from an offline worker clears the stored alert (so the *next* outage notifies again instead of being deduped) and prunes the bell without waiting for the hourly rebuild. Cleared under the *stored* display name, which name-protection can keep different from what the heartbeat carries.
- **Bonus, same line**: `notice` entries now also survive a UI restart. #326 made them durable, but the warm filter dropped them — so a recovery inside the gap skipped `clear_alerts` and the stale row swallowed the next genuine warning inside the cooldown window.
- The pre-heartbeat state read is best-effort by design: it failing must never reject a heartbeat. The upsert one line below is the loud path.

## Testing

- 10 new tests in `tests/test_worker_offline_alerts.py`: transition records/pushes/bells, cooldown dedupes the push but not the bell, fresh workers untouched (negative control), rebuild derives offline workers (+ empty and DB-error controls), warm restores `worker` and `notice` while still dropping unknown kinds, recovery clears alert + bell without touching other entries, online/new heartbeats clear nothing.
- Mutation-verified: disabling the transition alert path turns the test red.
- Full suite **4674 passed**, coverage **95.64%**; ruff + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alerts when monitored workers go offline, including bell updates and push notifications.
  * Restored worker and notice alerts after application restarts.
  * Automatically removes a worker’s alert when service recovers.
  * Prevented duplicate offline alerts during cooldown periods.

* **Bug Fixes**
  * Improved alert handling when stored data is unavailable or database errors occur.

* **Tests**
  * Added coverage for offline transitions, recovery, persistence, deduplication, and alert restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->