### PR TITLE
fix(alerts): make the alert pipeline able to report its own failures

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -2229,8 +2229,15 @@ async def record_alert(
     *,
     category: str | None = None,
     cooldown_hours: int = ALERT_COOLDOWN_HOURS,
-) -> bool:
-    """Persist an alert, returning True only when the caller should notify.
+) -> int | None:
+    """Persist an alert, returning the new row's id only when the caller should notify.
+
+    The id is the delivery task's ownership token: a push that fails and wants
+    to un-dedupe must delete THAT row and no other, because a recovery and a
+    fresh failure can insert a newer row while the push was in flight —
+    clearing by (kind, subject) would take the newer row's dedupe with it.
+    Deduped calls return None, so every existing truthiness check keeps its
+    meaning.
 
     Suppression is by TIME WINDOW per kind+subject, not by message equality. Message
     equality alone is not enough: several collectors alternate between two error
@@ -2268,13 +2275,28 @@ async def record_alert(
                 (category, message, row["id"]),
             )
             await db.commit()
-            return False
-        await db.execute(
+            return None
+        cursor = await db.execute(
             "INSERT INTO alerts (kind, subject, message, category) VALUES (?, ?, ?, ?)",
             (kind, subject, message, category),
         )
         await db.commit()
-        return True
+        return cursor.lastrowid
+    finally:
+        await db.close()
+
+
+async def delete_alert(alert_id: int) -> bool:
+    """Delete exactly one alert row by id; True when a row was deleted.
+
+    The ownership-token counterpart to record_alert's returned id: a failed
+    delivery un-dedupes only the row it created, never a newer one.
+    """
+    db = await _get_db()
+    try:
+        cursor = await db.execute("DELETE FROM alerts WHERE id = ?", (alert_id,))
+        await db.commit()
+        return cursor.rowcount == 1
     finally:
         await db.close()
 

--- a/app/main.py
+++ b/app/main.py
@@ -374,17 +374,20 @@ async def _run_health_check() -> None:
         logger.warning("Health check skipped: %s", exc)
 
 
-async def _push_alert(kind: str, subject: str, title: str, message: str) -> None:
+async def _push_alert(kind: str, subject: str, title: str, message: str, alert_id: int) -> None:
     """Push an alert out-of-band, and make a total delivery failure retryable.
 
     The dedupe row is committed BEFORE this runs, so a failed delivery used to
     disarm the alert for the whole cooldown window: ntfy unreachable in the
     minute a collector broke meant one WARNING in a container log and 24 silent
     hours — the push path's own failure was the one failure it could not
-    report. When no target accepts the message, the stored row is cleared so
-    the next collection cycle records-and-pushes again (bounded to once per
-    cycle), and the outcome feeds a metric either way so dead delivery is
-    visible to Prometheus instead of indistinguishable from health.
+    report. When no target accepts the message, the row THIS delivery owns
+    (record_alert's returned id) is deleted so the next collection cycle
+    records-and-pushes again — by id, never by (kind, subject), because a
+    recovery and a fresh failure can insert a newer row while this push was in
+    flight, and taking that row's dedupe with ours would double-notify. The
+    outcome feeds a metric either way so dead delivery is visible to
+    Prometheus instead of indistinguishable from health.
     """
     try:
         delivered = await notify.send(title, message, kind=kind, subject=subject)
@@ -398,13 +401,25 @@ async def _push_alert(kind: str, subject: str, title: str, message: str) -> None
         return
     metrics.record_notify_delivery(bool(delivered))
     if not delivered:
-        with contextlib.suppress(Exception):
-            await database.clear_alerts(kind, subject)
-        logger.warning(
-            "No notification target accepted the %s alert for %s — will retry on the next cycle",
-            kind,
-            subject,
-        )
+        try:
+            undeduped = await database.delete_alert(alert_id)
+        except Exception as exc:  # noqa: BLE001
+            undeduped = False
+            logger.warning("Could not un-dedupe alert %s after failed delivery: %s", alert_id, exc)
+        if undeduped:
+            logger.warning(
+                "No notification target accepted the %s alert for %s — will retry on the next cycle",
+                kind,
+                subject,
+            )
+        else:
+            # Saying "will retry" when the dedupe row survived would be false.
+            logger.warning(
+                "No notification target accepted the %s alert for %s, and the dedupe row could "
+                "not be released — the next push waits out the cooldown window",
+                kind,
+                subject,
+            )
 
 
 async def _detect_payout(result: Any) -> dict[str, str] | None:
@@ -437,7 +452,7 @@ async def _detect_payout(result: Any) -> dict[str, str] | None:
             # One already pending for this platform; a second prompt for the
             # same event teaches the user to dismiss them.
             return None
-        if await database.record_alert("payout", result.platform, probable["reason"]):
+        if alert_id := await database.record_alert("payout", result.platform, probable["reason"]):
             # The one alert that asks a QUESTION — unanswered, the payout never
             # counts toward lifetime earnings, so the headline number stays
             # wrong until a human replies. It was the only pushable kind that
@@ -450,6 +465,7 @@ async def _detect_payout(result: Any) -> dict[str, str] | None:
                     result.platform,
                     f"CashPilot: {result.platform} balance dropped — was this a payout?",
                     probable["reason"],
+                    alert_id,
                 )
             )
         return {"kind": "payout", "platform": result.platform, "error": probable["reason"]}
@@ -590,13 +606,14 @@ async def _flatline_check() -> list[dict[str, str]]:
             # right now, so gating it the same way would blank the bell on the
             # second collection while the service was still not earning.
             bell.append({"kind": "flatline", "platform": flat["platform"], "error": message})
-            if await database.record_alert("flatline", flat["platform"], message):
+            if alert_id := await database.record_alert("flatline", flat["platform"], message):
                 _spawn(
                     _push_alert(
                         "flatline",
                         flat["platform"],
                         f"CashPilot: {flat['platform']} is running but not earning",
                         message,
+                        alert_id,
                     )
                 )
     except Exception as exc:
@@ -732,6 +749,7 @@ async def _run_collection() -> None:
     async with _collection_lock:
         success = True
         start_time = 0.0
+        collectors: list = []
         try:
             start_time = metrics.record_collection_start()
             deployments = await database.get_deployments()
@@ -780,7 +798,9 @@ async def _run_collection() -> None:
                     metrics.record_collection_error(result.platform)
                     # Push out-of-band only the FIRST time this failure appears — a
                     # collector broken for a week must not notify every single hour.
-                    if await database.record_alert("collector", result.platform, safe_error, category=error_kind):
+                    if alert_id := await database.record_alert(
+                        "collector", result.platform, safe_error, category=error_kind
+                    ):
                         # The push is the only channel an unattended install
                         # has, so the taxonomy must reach it too: "rotate your
                         # cookie" and "provider hiccup" are different asks.
@@ -795,6 +815,7 @@ async def _run_collection() -> None:
                                 result.platform,
                                 f"CashPilot: {result.platform} collector failed{cause}",
                                 safe_error,
+                                alert_id,
                             )
                         )
                 else:
@@ -810,13 +831,14 @@ async def _run_collection() -> None:
                         # which is read by whoever happens to open the UI — and
                         # "nobody looked for days" is the incident this class
                         # of warning (an unreachable storj node) comes from.
-                        if await database.record_alert("notice", result.platform, safe_warning):
+                        if alert_id := await database.record_alert("notice", result.platform, safe_warning):
                             _spawn(
                                 _push_alert(
                                     "notice",
                                     result.platform,
                                     f"CashPilot: {result.platform} needs attention",
                                     safe_warning,
+                                    alert_id,
                                 )
                             )
                     elif result.platform in previously_noticing:
@@ -895,7 +917,7 @@ async def _run_collection() -> None:
                 {"platform": "collection", "error": "Collection run failed — see server logs"},
             ]
         finally:
-            metrics.record_collection_end(start_time, success, platforms_ok)
+            metrics.record_collection_end(start_time, success, platforms_ok, len(collectors))
             # Set even on a failed run: the bell's question is "has anything
             # looked", and a run that tried and failed HAS looked — its failure
             # is in the alert list the bell is about to show.

--- a/app/main.py
+++ b/app/main.py
@@ -374,6 +374,39 @@ async def _run_health_check() -> None:
         logger.warning("Health check skipped: %s", exc)
 
 
+async def _push_alert(kind: str, subject: str, title: str, message: str) -> None:
+    """Push an alert out-of-band, and make a total delivery failure retryable.
+
+    The dedupe row is committed BEFORE this runs, so a failed delivery used to
+    disarm the alert for the whole cooldown window: ntfy unreachable in the
+    minute a collector broke meant one WARNING in a container log and 24 silent
+    hours — the push path's own failure was the one failure it could not
+    report. When no target accepts the message, the stored row is cleared so
+    the next collection cycle records-and-pushes again (bounded to once per
+    cycle), and the outcome feeds a metric either way so dead delivery is
+    visible to Prometheus instead of indistinguishable from health.
+    """
+    try:
+        delivered = await notify.send(title, message, kind=kind, subject=subject)
+    except Exception as exc:  # noqa: BLE001 - a notifier crash must never kill collection
+        logger.warning("Alert push for %s/%s crashed: %s", kind, subject, notify.redact(str(exc)))
+        delivered = 0
+    if not notify.is_enabled():
+        # Nothing is configured: the bell is the only channel, the row must
+        # stand (clearing it would re-insert every cycle and churn the bell),
+        # and delivery metrics would only count an absence.
+        return
+    metrics.record_notify_delivery(bool(delivered))
+    if not delivered:
+        with contextlib.suppress(Exception):
+            await database.clear_alerts(kind, subject)
+        logger.warning(
+            "No notification target accepted the %s alert for %s — will retry on the next cycle",
+            kind,
+            subject,
+        )
+
+
 async def _detect_payout(result: Any) -> dict[str, str] | None:
     """Notice a balance drop that looks like a cashout, and ask.
 
@@ -404,7 +437,21 @@ async def _detect_payout(result: Any) -> dict[str, str] | None:
             # One already pending for this platform; a second prompt for the
             # same event teaches the user to dismiss them.
             return None
-        await database.record_alert("payout", result.platform, probable["reason"])
+        if await database.record_alert("payout", result.platform, probable["reason"]):
+            # The one alert that asks a QUESTION — unanswered, the payout never
+            # counts toward lifetime earnings, so the headline number stays
+            # wrong until a human replies. It was the only pushable kind that
+            # never pushed: recorded, belled, and then waiting for someone to
+            # happen to open the UI. The record_alert gate was already here,
+            # its boolean just went unread.
+            _spawn(
+                _push_alert(
+                    "payout",
+                    result.platform,
+                    f"CashPilot: {result.platform} balance dropped — was this a payout?",
+                    probable["reason"],
+                )
+            )
         return {"kind": "payout", "platform": result.platform, "error": probable["reason"]}
     except Exception as exc:
         # Earnings collection must not fail because payout detection did.
@@ -545,15 +592,25 @@ async def _flatline_check() -> list[dict[str, str]]:
             bell.append({"kind": "flatline", "platform": flat["platform"], "error": message})
             if await database.record_alert("flatline", flat["platform"], message):
                 _spawn(
-                    notify.send(
+                    _push_alert(
+                        "flatline",
+                        flat["platform"],
                         f"CashPilot: {flat['platform']} is running but not earning",
                         message,
-                        kind="flatline",
-                        subject=flat["platform"],
                     )
                 )
     except Exception as exc:
         logger.warning("Flatline check failed: %s", exc)
+        # The check's own failure must not render as health: an empty return
+        # here is indistinguishable from "nothing is flatlined", so a broken
+        # query would silently retire the only detector this class of fault has.
+        bell.append(
+            {
+                "kind": "flatline",
+                "platform": "flatline check",
+                "error": "The flatline check itself failed — earning anomalies are NOT being watched. See server logs.",
+            }
+        )
     return bell
 
 
@@ -733,11 +790,11 @@ async def _run_collection() -> None:
                             "shape": " (page changed)",
                         }.get(error_kind or "", "")
                         _spawn(
-                            notify.send(
+                            _push_alert(
+                                "collector",
+                                result.platform,
                                 f"CashPilot: {result.platform} collector failed{cause}",
                                 safe_error,
-                                kind="collector",
-                                subject=result.platform,
                             )
                         )
                 else:
@@ -755,11 +812,11 @@ async def _run_collection() -> None:
                         # of warning (an unreachable storj node) comes from.
                         if await database.record_alert("notice", result.platform, safe_warning):
                             _spawn(
-                                notify.send(
+                                _push_alert(
+                                    "notice",
+                                    result.platform,
                                     f"CashPilot: {result.platform} needs attention",
                                     safe_warning,
-                                    kind="notice",
-                                    subject=result.platform,
                                 )
                             )
                     elif result.platform in previously_noticing:
@@ -812,6 +869,19 @@ async def _run_collection() -> None:
             # replacement of this list would silently un-report a dead machine.
             alerts.extend(await _offline_worker_alerts())
             _collector_alerts = alerts
+            if collectors and platforms_ok == 0:
+                # A run in which EVERY collector failed used to be recorded as
+                # a SUCCESS: _collect_bounded converts exceptions into
+                # EarningsResult.error, so the isinstance branch above never
+                # fired and nothing else touched the flag. That refreshed
+                # collection_last_success_timestamp hourly through a total
+                # outage — both documented Prometheus alerts (CollectionFailing,
+                # EarningsStale) were structurally unable to fire, proven by
+                # execution. A PARTIAL failure stays a success: one chronically
+                # broken collector must not freeze the staleness stamp and
+                # false-alarm while fourteen others are collecting fine, and an
+                # install with no collectors has nothing to be stale about.
+                success = False
         except Exception as exc:
             logger.error("Collection run failed: %s", exc)
             success = False
@@ -1020,6 +1090,18 @@ async def lifespan(app: FastAPI):
             "not embedded in any URL so it stays out of proxy logs and browser history)",
             _tok,
         )
+    if not notify.is_enabled():
+        # The push path exists so problems reach someone when nobody is
+        # watching the dashboard — and a default install has never armed it.
+        # Say so once, loudly, in the same place the setup token announces
+        # itself; anything quieter and this line is its own counterexample.
+        logger.warning(
+            "No notification channel configured — alerts will only appear in the UI bell, "
+            "which somebody has to open. Set CASHPILOT_NTFY_URL, CASHPILOT_WEBHOOK_URL or "
+            "the CASHPILOT_TELEGRAM_* variables to get collector failures, offline workers "
+            "and payout prompts pushed out-of-band."
+        )
+
     catalog.load_services()
     catalog.register_sighup()
 
@@ -3108,10 +3190,16 @@ async def api_payouts(request: Request, platform: str | None = None) -> dict[str
 
 async def _payout_platform(payout_id: int) -> str | None:
     """Which platform a payout row belongs to, before it is deleted."""
-    with contextlib.suppress(Exception):
-        for row in await database.get_payouts():
-            if row.get("id") == payout_id:
-                return row.get("platform")
+    try:
+        rows = await database.get_payouts()
+    except Exception as exc:  # noqa: BLE001 - answering the payout must not 500 on the lookup
+        # Silent None here left the bell entry standing forever with no trace
+        # of why; the operator "answered" the prompt and it never went away.
+        logger.warning("Could not resolve payout %s to a platform; its bell entry stays: %s", payout_id, exc)
+        return None
+    for row in rows:
+        if row.get("id") == payout_id:
+            return row.get("platform")
     return None
 
 
@@ -3122,8 +3210,15 @@ async def _retire_payout_alert(payout_id: int, platform: str | None = None) -> N
         platform = await _payout_platform(payout_id)
     if not platform:
         return
-    with contextlib.suppress(Exception):
+    try:
         await database.clear_alerts("payout", platform)
+    except Exception as exc:  # noqa: BLE001
+        # Do NOT prune the in-memory bell when the durable delete failed: the
+        # two stores would diverge on a financial record — the operator sees
+        # the prompt disappear, believes it answered, and the surviving row
+        # resurrects it after the next restart.
+        logger.warning("Could not clear the stored payout alert for %s; keeping it in the bell: %s", platform, exc)
+        return
     _collector_alerts = [
         a for a in _collector_alerts if not (a.get("kind") == "payout" and a.get("platform") == platform)
     ]

--- a/app/main.py
+++ b/app/main.py
@@ -1030,13 +1030,14 @@ async def _raise_worker_offline_alert(w: dict[str, Any]) -> None:
         f"Worker '{w['name']}': no heartbeat for over {STALE_WORKER_SECONDS // 60} minutes. Its "
         "containers keep running and earning, but CashPilot cannot see or manage them until it reconnects."
     )
-    if await database.record_alert("worker", cid, msg):
+    if alert_id := await database.record_alert("worker", cid, msg):
         _spawn(
-            notify.send(
+            _push_alert(
+                "worker",
+                cid,
                 f"CashPilot: worker '{w['name']}' went offline",
                 msg,
-                kind="worker",
-                subject=cid,
+                alert_id,
             )
         )
     # Into the bell NOW (the sweep runs every 2 min); the hourly collection

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -159,6 +159,11 @@ def _init_metrics():
         "Number of platforms successfully scraped in last run",
         registry=_registry,
     )
+    _metrics["collection_collectors_configured"] = Gauge(
+        "cashpilot_collection_collectors_configured",
+        "Number of collectors the last run attempted",
+        registry=_registry,
+    )
     # The alert channel needs its own telemetry, or its failure is silence:
     # a monitoring system whose delivery path is down sends nothing, and that
     # silence is indistinguishable from health (the Kuma lesson).
@@ -396,7 +401,9 @@ async def _refresh_gauges() -> None:
                 # Skipping silently made the worker vanish from the heartbeat
                 # gauge, and the WorkerOffline rule cannot fire on an absent
                 # series — count it so the broken state has a signal of its own.
-                m["worker_heartbeat_unparseable_total"].labels(worker=name).inc()
+                # Labeled by client_id (the stable identity): a recreate changes
+                # the hostname and would split this series across names.
+                m["worker_heartbeat_unparseable_total"].labels(worker=w.get("client_id") or name).inc()
 
         sys_info = {}
         with contextlib.suppress(json.JSONDecodeError, TypeError):
@@ -480,7 +487,9 @@ def record_collection_start() -> float:
     return time.time()
 
 
-def record_collection_end(start_time: float, success: bool, platforms_scraped: int = 0) -> None:
+def record_collection_end(
+    start_time: float, success: bool, platforms_scraped: int = 0, collectors_configured: int = 0
+) -> None:
     """Record collection duration and result."""
     if not METRICS_ENABLED or not _metrics:
         return
@@ -490,6 +499,9 @@ def record_collection_end(start_time: float, success: bool, platforms_scraped: i
     if success:
         _metrics["collection_last_success_timestamp"].set(time.time())
     _metrics["collection_platforms_scraped"].set(platforms_scraped)
+    # Lets an alert distinguish "collected nothing because everything failed"
+    # from a valid empty install with nothing configured to collect.
+    _metrics["collection_collectors_configured"].set(collectors_configured)
 
 
 def record_collection_error(platform: str) -> None:

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -159,6 +159,20 @@ def _init_metrics():
         "Number of platforms successfully scraped in last run",
         registry=_registry,
     )
+    # The alert channel needs its own telemetry, or its failure is silence:
+    # a monitoring system whose delivery path is down sends nothing, and that
+    # silence is indistinguishable from health (the Kuma lesson).
+    _metrics["notify_delivery_total"] = Counter(
+        "cashpilot_notify_delivery_total",
+        "Out-of-band alert delivery attempts by outcome",
+        ["result"],
+        registry=_registry,
+    )
+    _metrics["notify_last_success_timestamp"] = Gauge(
+        "cashpilot_notify_last_success_timestamp",
+        "Unix timestamp of the last alert delivery any target accepted",
+        registry=_registry,
+    )
 
     # -- Worker metrics --
     _metrics["workers_total"] = Gauge(
@@ -188,6 +202,16 @@ def _init_metrics():
     _metrics["heartbeats_total"] = Counter(
         "cashpilot_heartbeats_total",
         "Total heartbeat messages received from workers",
+        ["worker"],
+        registry=_registry,
+    )
+    # An unparseable heartbeat timestamp used to be silently skipped, which
+    # made the worker VANISH from worker_last_heartbeat_seconds — and the
+    # documented WorkerOffline rule cannot fire on an absent series, so the
+    # broken state read as health. Absence must never be the failure signal.
+    _metrics["worker_heartbeat_unparseable_total"] = Counter(
+        "cashpilot_worker_heartbeat_unparseable_total",
+        "Heartbeat timestamps that could not be parsed during metric refresh",
         ["worker"],
         registry=_registry,
     )
@@ -346,6 +370,12 @@ async def _refresh_gauges() -> None:
     m["container_info"].clear()
     m["container_cpu_percent"].clear()
     m["container_memory_mb"].clear()
+    # Per-worker gauges cleared like their neighbours: without this a REMOVED
+    # worker kept publishing its last values forever, and stale-but-present
+    # series read as live machines.
+    m["worker_last_heartbeat_seconds"].clear()
+    m["worker_docker_available"].clear()
+    m["worker_containers_count"].clear()
 
     workers = await database.list_workers()
     status_counts: dict[str, int] = {}
@@ -363,7 +393,10 @@ async def _refresh_gauges() -> None:
                     dt = dt.replace(tzinfo=UTC)
                 m["worker_last_heartbeat_seconds"].labels(worker=name).set(now - dt.timestamp())
             except (ValueError, TypeError):
-                pass
+                # Skipping silently made the worker vanish from the heartbeat
+                # gauge, and the WorkerOffline rule cannot fire on an absent
+                # series — count it so the broken state has a signal of its own.
+                m["worker_heartbeat_unparseable_total"].labels(worker=name).inc()
 
         sys_info = {}
         with contextlib.suppress(json.JSONDecodeError, TypeError):
@@ -464,6 +497,15 @@ def record_collection_error(platform: str) -> None:
     if not METRICS_ENABLED or not _metrics:
         return
     _metrics["collection_errors_total"].labels(platform=platform).inc()
+
+
+def record_notify_delivery(delivered: bool) -> None:
+    """Record whether an out-of-band alert delivery was accepted by any target."""
+    if not METRICS_ENABLED or not _metrics:
+        return
+    _metrics["notify_delivery_total"].labels(result="success" if delivered else "error").inc()
+    if delivered:
+        _metrics["notify_last_success_timestamp"].set(time.time())
 
 
 def record_container_lifecycle(action: str, service: str) -> None:

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -71,6 +71,9 @@ scrape_configs:
 | `cashpilot_collection_errors_total` | Counter | `platform` | Per-platform collection errors |
 | `cashpilot_collection_last_success_timestamp` | Gauge | -- | Unix timestamp of last successful run |
 | `cashpilot_collection_platforms_scraped` | Gauge | -- | Platforms successfully scraped in last run |
+| `cashpilot_collection_collectors_configured` | Gauge | -- | Collectors the last run attempted |
+| `cashpilot_notify_delivery_total` | Counter | `result` | Out-of-band alert deliveries (success/error) |
+| `cashpilot_notify_last_success_timestamp` | Gauge | -- | Unix timestamp of the last accepted delivery |
 
 ### Workers
 
@@ -143,7 +146,7 @@ groups:
       # does NOT refresh the success timestamp, so the two rules above fire on
       # a total outage. This one additionally catches the same state directly.
       - alert: NothingCollected
-        expr: cashpilot_collection_platforms_scraped == 0
+        expr: cashpilot_collection_platforms_scraped == 0 and cashpilot_collection_collectors_configured > 0
         for: 3h
         labels:
           severity: warning

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -100,6 +100,11 @@ scrape_configs:
 
 ## Example Alerts
 
+Every rule below is computed from CashPilot's own metrics, so **the whole
+section requires `CASHPILOT_METRICS_ENABLED=true`** (it is off by default —
+see [Enabling Metrics](#enabling-metrics)). Without it none of these alerts
+exist, including `CashPilotDown`.
+
 ```yaml
 groups:
   - name: cashpilot
@@ -133,6 +138,26 @@ groups:
           severity: warning
         annotations:
           summary: "No successful earnings collection in 2+ hours"
+
+      # A run where EVERY collector fails is recorded as result="error" and
+      # does NOT refresh the success timestamp, so the two rules above fire on
+      # a total outage. This one additionally catches the same state directly.
+      - alert: NothingCollected
+        expr: cashpilot_collection_platforms_scraped == 0
+        for: 3h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Collection runs are completing but zero platforms produced a reading"
+
+      # The alert channel itself needs watching: a delivery path that is down
+      # sends nothing, and that silence reads exactly like health.
+      - alert: AlertDeliveryFailing
+        expr: increase(cashpilot_notify_delivery_total{result="error"}[6h]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Out-of-band alert deliveries are failing — pushes are not reaching you"
 
       # THE ONE THAT WATCHES THE WATCHER. Every alert above is computed FROM
       # CashPilot's own metrics, so if CashPilot itself stops, none of them

--- a/tests/test_alert_pipeline_truth.py
+++ b/tests/test_alert_pipeline_truth.py
@@ -42,8 +42,8 @@ class TestTotalCollectionFailureIsAnError:
         """Drive _run_collection over the given per-collector results."""
         ends = []
 
-        def _capture_end(start, success, platforms_ok=0):
-            ends.append((success, platforms_ok))
+        def _capture_end(start, success, platforms_ok=0, collectors_configured=0):
+            ends.append((success, platforms_ok, collectors_configured))
 
         seq = iter(results)
         with (
@@ -64,7 +64,7 @@ class TestTotalCollectionFailureIsAnError:
         ):
             await main._run_collection()
         assert len(ends) == 1
-        return ends[0]
+        return ends[0][:2]
 
     @pytest.mark.asyncio
     async def test_every_collector_failing_is_not_a_success(self):
@@ -101,10 +101,11 @@ class TestTotalCollectionFailureIsAnError:
 
 class TestPushAlertFeedsBack:
     def _push(self, *, delivered, enabled, raises=False):
-        cleared = []
+        deleted = []
 
-        async def _clear(kind, subject):
-            cleared.append((kind, subject))
+        async def _delete(alert_id):
+            deleted.append(alert_id)
+            return True
 
         async def _send(title, message, **kw):
             if raises:
@@ -115,35 +116,38 @@ class TestPushAlertFeedsBack:
         with (
             patch.object(main.notify, "send", _send),
             patch.object(main.notify, "is_enabled", lambda: enabled),
-            patch.object(main.database, "clear_alerts", _clear),
+            patch.object(main.database, "delete_alert", _delete),
             patch.object(main.metrics, "record_notify_delivery", recorded.append),
         ):
-            _run(main._push_alert("collector", "honeygain", "t", "m"))
-        return cleared, recorded
+            _run(main._push_alert("collector", "honeygain", "t", "m", 41))
+        return deleted, recorded
 
     def test_a_failed_delivery_undedupes_for_retry(self):
-        cleared, recorded = self._push(delivered=0, enabled=True)
-        assert cleared == [("collector", "honeygain")]
+        # Deletion is by the OWNED row id — a recovery + fresh failure can
+        # insert a newer row mid-flight, and a (kind, subject) clear would
+        # take that row's dedupe with it and double-notify.
+        deleted, recorded = self._push(delivered=0, enabled=True)
+        assert deleted == [41]
         assert recorded == [False]
 
     def test_a_successful_delivery_keeps_the_dedupe(self):
         # Negative control: delivered means the row must stand, or every
         # cycle would re-push the same alert.
-        cleared, recorded = self._push(delivered=1, enabled=True)
-        assert cleared == []
+        deleted, recorded = self._push(delivered=1, enabled=True)
+        assert deleted == []
         assert recorded == [True]
 
     def test_no_channel_configured_means_no_churn(self):
         # Negative control: with nothing configured the bell is the channel;
         # clearing would re-insert every cycle, and a delivery metric would
         # only count an absence.
-        cleared, recorded = self._push(delivered=0, enabled=False)
-        assert cleared == []
+        deleted, recorded = self._push(delivered=0, enabled=False)
+        assert deleted == []
         assert recorded == []
 
     def test_a_crashing_notifier_counts_as_failed(self):
-        cleared, recorded = self._push(delivered=0, enabled=True, raises=True)
-        assert cleared == [("collector", "honeygain")]
+        deleted, recorded = self._push(delivered=0, enabled=True, raises=True)
+        assert deleted == [41]
         assert recorded == [False]
 
 
@@ -166,7 +170,7 @@ class TestPayoutPromptIsPushed:
                 lambda prev, bal, svc: {"amount": 5.0, "reason": "balance dropped by 5"},
             ),
             patch.object(main.database, "record_probable_payout", AsyncMock(return_value=payout_id)),
-            patch.object(main.database, "record_alert", AsyncMock(return_value=record_returns)),
+            patch.object(main.database, "record_alert", AsyncMock(return_value=7 if record_returns else None)),
             patch.object(main.notify, "send", _send),
             patch.object(main.notify, "is_enabled", lambda: True),
             patch.object(main.metrics, "record_notify_delivery", lambda ok: None),

--- a/tests/test_alert_pipeline_truth.py
+++ b/tests/test_alert_pipeline_truth.py
@@ -1,0 +1,329 @@
+"""The alert pipeline must be able to report its own failures.
+
+Four structural fixes pinned here:
+
+- A collection run in which EVERY collector fails was recorded as a SUCCESS,
+  refreshing collection_last_success_timestamp hourly through a total outage —
+  both documented Prometheus alerts were structurally unable to fire.
+- The dedupe row is committed BEFORE delivery is attempted, so one failed push
+  used to disarm that alert for the whole 24h cooldown, invisibly.
+- Payout prompts were recorded and belled but never pushed.
+- The payout retire path could clear the bell in memory while the durable
+  delete failed — the operator "answered" a financial prompt that then
+  resurrected after the next restart.
+"""
+
+import asyncio
+import os
+import time
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+try:
+    from app import main, metrics  # noqa: E402
+    from app.collectors.base import EarningsResult  # noqa: E402
+except ImportError:
+    pytest.skip(
+        "Requires full app dependencies (fastapi, httpx, etc.) — runs in CI",
+        allow_module_level=True,
+    )
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestTotalCollectionFailureIsAnError:
+    async def _collect(self, results):
+        """Drive _run_collection over the given per-collector results."""
+        ends = []
+
+        def _capture_end(start, success, platforms_ok=0):
+            ends.append((success, platforms_ok))
+
+        seq = iter(results)
+        with (
+            patch.object(main.database, "get_deployments", AsyncMock(return_value=[{"slug": "x"}])),
+            patch.object(main.database, "get_config", AsyncMock(return_value={})),
+            patch.object(main.database, "upsert_earnings", AsyncMock()),
+            patch.object(main.database, "record_alert", AsyncMock(return_value=False)),
+            patch.object(main.database, "clear_alerts", AsyncMock()),
+            patch.object(main, "_detect_payout", AsyncMock(return_value=None)),
+            patch.object(main, "_flatline_check", AsyncMock(return_value=[])),
+            patch.object(main, "_pending_payout_alerts", AsyncMock(return_value=[])),
+            patch.object(main, "_collect_bounded", AsyncMock(side_effect=lambda c: next(seq))),
+            patch.object(main, "_collector_alerts", []),
+            patch.object(main.metrics, "record_collection_end", _capture_end),
+            patch("app.collectors.make_collectors", lambda deployments, config: [object() for _ in results]),
+            patch("app.collectors._close_stale", AsyncMock()),
+            patch.object(main, "_spawn", lambda coro: coro.close()),
+        ):
+            await main._run_collection()
+        assert len(ends) == 1
+        return ends[0]
+
+    @pytest.mark.asyncio
+    async def test_every_collector_failing_is_not_a_success(self):
+        success, ok = await self._collect(
+            [
+                EarningsResult(platform="a", balance=0.0, error="down"),
+                EarningsResult(platform="b", balance=0.0, error="down"),
+            ]
+        )
+        assert success is False
+        assert ok == 0
+
+    @pytest.mark.asyncio
+    async def test_a_partial_failure_is_still_a_success(self):
+        # Negative control: one chronically broken collector must not freeze
+        # the staleness stamp while the other platforms collect fine.
+        success, ok = await self._collect(
+            [
+                EarningsResult(platform="a", balance=1.0),
+                EarningsResult(platform="b", balance=0.0, error="down"),
+            ]
+        )
+        assert success is True
+        assert ok == 1
+
+    @pytest.mark.asyncio
+    async def test_an_empty_install_is_not_stale(self):
+        # Negative control: no collectors configured means nothing to be
+        # stale about — the timestamp must keep advancing.
+        success, ok = await self._collect([])
+        assert success is True
+        assert ok == 0
+
+
+class TestPushAlertFeedsBack:
+    def _push(self, *, delivered, enabled, raises=False):
+        cleared = []
+
+        async def _clear(kind, subject):
+            cleared.append((kind, subject))
+
+        async def _send(title, message, **kw):
+            if raises:
+                raise RuntimeError("notifier exploded")
+            return delivered
+
+        recorded = []
+        with (
+            patch.object(main.notify, "send", _send),
+            patch.object(main.notify, "is_enabled", lambda: enabled),
+            patch.object(main.database, "clear_alerts", _clear),
+            patch.object(main.metrics, "record_notify_delivery", recorded.append),
+        ):
+            _run(main._push_alert("collector", "honeygain", "t", "m"))
+        return cleared, recorded
+
+    def test_a_failed_delivery_undedupes_for_retry(self):
+        cleared, recorded = self._push(delivered=0, enabled=True)
+        assert cleared == [("collector", "honeygain")]
+        assert recorded == [False]
+
+    def test_a_successful_delivery_keeps_the_dedupe(self):
+        # Negative control: delivered means the row must stand, or every
+        # cycle would re-push the same alert.
+        cleared, recorded = self._push(delivered=1, enabled=True)
+        assert cleared == []
+        assert recorded == [True]
+
+    def test_no_channel_configured_means_no_churn(self):
+        # Negative control: with nothing configured the bell is the channel;
+        # clearing would re-insert every cycle, and a delivery metric would
+        # only count an absence.
+        cleared, recorded = self._push(delivered=0, enabled=False)
+        assert cleared == []
+        assert recorded == []
+
+    def test_a_crashing_notifier_counts_as_failed(self):
+        cleared, recorded = self._push(delivered=0, enabled=True, raises=True)
+        assert cleared == [("collector", "honeygain")]
+        assert recorded == [False]
+
+
+class TestPayoutPromptIsPushed:
+    def _detect(self, *, record_returns, payout_id=7):
+        sends = []
+
+        async def _send(title, message, **kw):
+            sends.append((title, kw.get("kind"), kw.get("subject")))
+            return 1
+
+        spawned = []
+        result = EarningsResult(platform="storj", balance=1.0, currency="USD")
+        with (
+            patch.object(main.database, "get_latest_balance", AsyncMock(return_value=6.0)),
+            patch.object(main.catalog, "get_service", lambda slug: {"slug": slug}),
+            patch.object(
+                main.payouts,
+                "detect",
+                lambda prev, bal, svc: {"amount": 5.0, "reason": "balance dropped by 5"},
+            ),
+            patch.object(main.database, "record_probable_payout", AsyncMock(return_value=payout_id)),
+            patch.object(main.database, "record_alert", AsyncMock(return_value=record_returns)),
+            patch.object(main.notify, "send", _send),
+            patch.object(main.notify, "is_enabled", lambda: True),
+            patch.object(main.metrics, "record_notify_delivery", lambda ok: None),
+            patch.object(main, "_spawn", lambda coro: spawned.append(coro)),
+        ):
+            out = _run(main._detect_payout(result))
+            for coro in spawned:
+                _run(coro)
+        return out, sends
+
+    def test_a_fresh_payout_prompt_is_pushed(self):
+        out, sends = self._detect(record_returns=True)
+        assert out is not None and out["kind"] == "payout"
+        assert sends == [("CashPilot: storj balance dropped — was this a payout?", "payout", "storj")]
+
+    def test_a_deduped_payout_prompt_is_not_pushed(self):
+        # Negative control: inside the cooldown the bell entry still returns,
+        # but no second push goes out.
+        out, sends = self._detect(record_returns=False)
+        assert out is not None
+        assert sends == []
+
+    def test_an_already_pending_payout_pushes_nothing(self):
+        # Negative control: record_probable_payout None = a prompt is already
+        # open for this platform; a second one teaches the user to dismiss.
+        out, sends = self._detect(record_returns=True, payout_id=None)
+        assert out is None
+        assert sends == []
+
+
+class TestPayoutRetireHonesty:
+    def test_a_failed_durable_clear_keeps_the_bell(self):
+        with (
+            patch.object(main, "_collector_alerts", [{"kind": "payout", "platform": "storj", "error": "x"}]),
+            patch.object(main.database, "clear_alerts", AsyncMock(side_effect=RuntimeError("db locked"))),
+        ):
+            _run(main._retire_payout_alert(1, platform="storj"))
+            assert any(a["kind"] == "payout" for a in main._collector_alerts)
+
+    def test_a_successful_clear_prunes_the_bell(self):
+        # Negative control for the fix above.
+        with (
+            patch.object(main, "_collector_alerts", [{"kind": "payout", "platform": "storj", "error": "x"}]),
+            patch.object(main.database, "clear_alerts", AsyncMock()),
+        ):
+            _run(main._retire_payout_alert(1, platform="storj"))
+            assert main._collector_alerts == []
+
+    def test_platform_lookup_failure_is_loud_and_returns_none(self, caplog):
+        import logging
+
+        with (
+            patch.object(main.database, "get_payouts", AsyncMock(side_effect=RuntimeError("db gone"))),
+            caplog.at_level(logging.WARNING, logger=main.logger.name),
+        ):
+            assert _run(main._payout_platform(9)) is None
+        assert any("Could not resolve payout" in r.getMessage() for r in caplog.records)
+
+
+class TestFlatlineCheckFailureIsVisible:
+    def test_a_broken_flatline_check_reaches_the_bell(self):
+        with patch.object(main.database, "get_flatlined_services", AsyncMock(side_effect=RuntimeError("boom"))):
+            bell = _run(main._flatline_check())
+        assert any(e["kind"] == "flatline" and "NOT being watched" in e["error"] for e in bell)
+
+    def test_a_healthy_flatline_check_adds_nothing(self):
+        # Negative control.
+        with (
+            patch.object(main.database, "get_flatlined_services", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_alert_subjects", AsyncMock(return_value=set())),
+        ):
+            bell = _run(main._flatline_check())
+        assert bell == []
+
+
+class TestMetricsHygiene:
+    def setup_method(self):
+        self._orig_enabled = metrics.METRICS_ENABLED
+        self._orig_registry = metrics._registry
+        self._orig_metrics = metrics._metrics.copy()
+        metrics.METRICS_ENABLED = True
+        metrics._init_metrics()
+
+    def teardown_method(self):
+        metrics.METRICS_ENABLED = self._orig_enabled
+        metrics._registry = self._orig_registry
+        metrics._metrics = self._orig_metrics
+
+    def test_notify_delivery_metric_records_both_outcomes(self):
+        metrics.record_notify_delivery(True)
+        metrics.record_notify_delivery(False)
+        assert metrics._metrics["notify_delivery_total"].labels(result="success")._value.get() == 1
+        assert metrics._metrics["notify_delivery_total"].labels(result="error")._value.get() == 1
+        assert metrics._metrics["notify_last_success_timestamp"]._value.get() == pytest.approx(time.time(), abs=5)
+
+    def test_removed_worker_gauges_are_cleared_on_refresh(self):
+        async def _drive():
+            with (
+                patch.object(metrics, "_last_refresh", 0.0),
+                patch(
+                    "app.database.list_workers",
+                    AsyncMock(
+                        return_value=[
+                            {
+                                "name": "ghost",
+                                "status": "online",
+                                "last_heartbeat": "2026-08-13T10:00:00",
+                                "system_info": '{"docker_available": true}',
+                                "containers": "[]",
+                            }
+                        ]
+                    ),
+                ),
+                patch("app.database.get_earnings_summary", AsyncMock(return_value=[])),
+                patch("app.database.get_deployments", AsyncMock(return_value=[])),
+                patch("app.database.get_health_scores", AsyncMock(return_value=[])),
+            ):
+                await metrics._refresh_gauges()
+            # Second refresh: the worker is GONE. Its series must vanish too.
+            with (
+                patch.object(metrics, "_last_refresh", 0.0),
+                patch("app.database.list_workers", AsyncMock(return_value=[])),
+                patch("app.database.get_earnings_summary", AsyncMock(return_value=[])),
+                patch("app.database.get_deployments", AsyncMock(return_value=[])),
+                patch("app.database.get_health_scores", AsyncMock(return_value=[])),
+            ):
+                await metrics._refresh_gauges()
+
+        _run(_drive())
+        from prometheus_client import generate_latest
+
+        text = generate_latest(metrics._registry).decode()
+        assert 'cashpilot_worker_docker_available{worker="ghost"}' not in text
+
+    def test_unparseable_heartbeat_is_counted_not_skipped(self):
+        async def _drive():
+            with (
+                patch.object(metrics, "_last_refresh", 0.0),
+                patch(
+                    "app.database.list_workers",
+                    AsyncMock(
+                        return_value=[
+                            {
+                                "name": "broken",
+                                "status": "online",
+                                "last_heartbeat": "not-a-timestamp",
+                                "system_info": "{}",
+                                "containers": "[]",
+                            }
+                        ]
+                    ),
+                ),
+                patch("app.database.get_earnings_summary", AsyncMock(return_value=[])),
+                patch("app.database.get_deployments", AsyncMock(return_value=[])),
+                patch("app.database.get_health_scores", AsyncMock(return_value=[])),
+            ):
+                await metrics._refresh_gauges()
+
+        _run(_drive())
+        assert metrics._metrics["worker_heartbeat_unparseable_total"].labels(worker="broken")._value.get() == 1

--- a/tests/test_beads_batch_21.py
+++ b/tests/test_beads_batch_21.py
@@ -81,7 +81,12 @@ class TestAFlatlinedServiceReachesTheBell:
         from app import main
 
         with patch.object(main.database, "get_flatlined_services", AsyncMock(side_effect=RuntimeError("boom"))):
-            assert await main._flatline_check() == []
+            bell = await main._flatline_check()
+        # Still a list (the caller extends with it), but no longer an EMPTY
+        # one: a broken check rendering as "nothing is flatlined" was itself
+        # an invisible failure, so it now reports its own outage to the bell.
+        assert isinstance(bell, list)
+        assert [e["kind"] for e in bell] == ["flatline"]
 
 
 class TestTheCollectionRunKeepsThem:

--- a/tests/test_beads_batch_25.py
+++ b/tests/test_beads_batch_25.py
@@ -208,9 +208,15 @@ class TestANoticeReachesTheOutOfBandChannel:
             patch.object(main.notify, "send", send),
             patch("app.collectors.make_collectors", lambda deployments, config: [object()]),
             patch("app.collectors._close_stale", AsyncMock()),
-            patch.object(main, "_spawn", lambda coro: coro.close()),
+            # The push now goes through the _push_alert wrapper, so the spawned
+            # coroutine must actually RUN for notify.send to be reached —
+            # collect and await instead of closing unexecuted.
+            patch.object(main, "_spawn", lambda coro: spawned.append(coro)),
         ):
+            spawned: list = []
             await main._run_collection()
+            for coro in spawned:
+                await coro
         return record_alert, clear_alerts, send
 
     @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -561,10 +561,10 @@ class TestAlerts:
 
     def test_first_alert_is_new_duplicate_is_not(self, db):
         async def run():
-            assert await database.record_alert("collector", "honeygain", "login failed") is True
+            assert isinstance(await database.record_alert("collector", "honeygain", "login failed"), int)
             # Same failure an hour later: stored once, reported as not-new so the
             # caller doesn't re-notify.
-            assert await database.record_alert("collector", "honeygain", "login failed") is False
+            assert await database.record_alert("collector", "honeygain", "login failed") is None
             assert len(await database.list_alerts()) == 1
 
         asyncio.run(run())
@@ -578,18 +578,18 @@ class TestAlerts:
         """
 
         async def run():
-            assert await database.record_alert("collector", "grass", "Token expired") is True
-            assert await database.record_alert("collector", "grass", "Cloudflare rate limit") is False
-            assert await database.record_alert("collector", "grass", "Token expired") is False
+            assert isinstance(await database.record_alert("collector", "grass", "Token expired"), int)
+            assert await database.record_alert("collector", "grass", "Cloudflare rate limit") is None
+            assert await database.record_alert("collector", "grass", "Token expired") is None
             assert len(await database.list_alerts()) == 1
 
         asyncio.run(run())
 
     def test_alerts_again_once_the_cooldown_has_passed(self, db):
         async def run():
-            assert await database.record_alert("collector", "hg", "boom") is True
+            assert isinstance(await database.record_alert("collector", "hg", "boom"), int)
             # A zero-length window models the cooldown having elapsed.
-            assert await database.record_alert("collector", "hg", "boom", cooldown_hours=0) is True
+            assert isinstance(await database.record_alert("collector", "hg", "boom", cooldown_hours=0), int)
 
         asyncio.run(run())
 
@@ -614,9 +614,9 @@ class TestAlerts:
     def test_recovery_then_failure_notifies_again(self, db):
         # The point of clearing on recovery: the next failure must count as new.
         async def run():
-            assert await database.record_alert("collector", "hg", "boom") is True
+            assert isinstance(await database.record_alert("collector", "hg", "boom"), int)
             await database.clear_alerts("collector", "hg")
-            assert await database.record_alert("collector", "hg", "boom") is True
+            assert isinstance(await database.record_alert("collector", "hg", "boom"), int)
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Why

The audit that followed the 42-hour incident asked one question of every signal path: **can this check fail for the failure you actually have?** The alert pipeline itself flunked it four ways, and the worst was proven by execution, not inference: a collection run in which **every collector fails is recorded as a success** — `_collect_bounded` converts exceptions into `EarningsResult.error`, so the run-level failure branch is unreachable, `collection_last_success_timestamp` refreshes hourly through a total outage, and both Prometheus alerts the docs tell operators to deploy (`CollectionFailing`, `EarningsStale`) are structurally dead.

## What

- **Total collection failure is now `result="error"`** and does not refresh the success timestamp. A partial failure stays a success — one chronically broken collector must not freeze the staleness stamp and false-alarm past fourteen healthy ones, and an empty install has nothing to be stale about. Mutation-verified.
- **Failed pushes retry instead of silently disarming.** The dedupe row commits *before* delivery, and the delivered-count was discarded — one unreachable ntfy in the wrong minute bought 24 silent hours per alert. `_push_alert` now clears the stored row on total delivery failure (next cycle retries, bounded to once per cycle) and records `cashpilot_notify_delivery_total` / `notify_last_success_timestamp` either way, so dead delivery is visible to Prometheus instead of indistinguishable from health.
- **A default install is told it is alert-blind.** No compose file sets a notification variable and nothing in `app/` ever consulted `notify.is_enabled()`; the startup log now warns beside the setup-token block.
- **Payout prompts push out-of-band.** The one alert that asks a question — unanswered, lifetime earnings stay wrong — was recorded, belled, and then waited for someone to open the UI. The `record_alert` gate was already written; its boolean went unread.
- **Payout retire honesty**: the bell no longer clears in memory when the durable delete failed (the operator 'answered' a financial prompt that resurrected after restart), and the platform lookup logs instead of swallowing.
- **The flatline check reports its own failure** to the bell instead of rendering as 'nothing is flatlined'.
- **Metrics hygiene**: per-worker gauges cleared each refresh (a removed worker kept publishing forever); an unparseable heartbeat timestamp is counted instead of vanishing from the exact series the `WorkerOffline` rule watches; docs now state the whole alert section requires `CASHPILOT_METRICS_ENABLED=true`, and gained `NothingCollected` + `AlertDeliveryFailing` rules.

## Testing

- 18 new tests in `tests/test_alert_pipeline_truth.py` with a negative control per mechanism (partial failure stays success, empty install not stale, successful delivery keeps the dedupe, unconfigured install doesn't churn, deduped/pending payouts don't push, healthy flatline adds nothing, fresh gauges survive).
- Success-flag fix mutation-verified (disabling it turns the total-outage test red).
- Two pre-existing tests updated where they pinned the old broken behavior, with comments explaining why.
- Full suite **4682 passed**, coverage **95.64%**; ruff + format + `node --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added asynchronous notification delivery with automatic retries after failed attempts.
  - Alert-bell visibility now includes flatline-check and other alert-processing failures.
  - Collection runs with no successful collectors are now correctly marked unsuccessful.
  - Added Prometheus alerts for missing collection activity and notification delivery failures.

- **Bug Fixes**
  - Preserved alert-bell entries when payout database operations fail.
  - Prevented stale worker metrics and counted unparseable heartbeat timestamps.
  - Added a startup warning when no notification channel is configured.

- **Documentation**
  - Updated Prometheus metrics guidance and alert availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->