### PR TITLE
fix(worker): a worker that cannot see Docker now says so

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -44,24 +44,55 @@ _status_cache: list[dict[str, Any]] = []
 _status_cache_time: float = 0.0
 
 
+def _mark_docker_unavailable(reason: str, exc: BaseException) -> None:
+    """Flip the availability memo to False, saying so LOUDLY on the transition.
+
+    Docker going away mid-life used to be a logger.debug — invisible at the
+    default INFO level — so a worker silently degraded to monitor-only, every
+    deploy 503'd, and `docker logs` contained no reason at all. The transition
+    is the loud moment; a persisting outage stays quiet (the caller's per-call
+    debug covers it) so a dead daemon does not warn once per probe forever.
+    Only True -> False warns: None -> False is startup discovering a
+    monitor-only worker, which lifespan already announces.
+    """
+    global _docker_available
+    if _docker_available is True:
+        logger.warning(
+            "Docker became unreachable (%s): %s — degrading to monitor-only until it returns",
+            reason,
+            exc,
+        )
+    _docker_available = False
+
+
+def _mark_docker_available() -> None:
+    """Flip the availability memo to True, announcing a recovery."""
+    global _docker_available
+    if _docker_available is False:
+        logger.warning("Docker is reachable again — container management restored")
+    _docker_available = True
+
+
 def docker_available() -> bool:
     """Check whether the Docker socket is accessible.
 
     Only the positive result is memoized. A negative/unknown result is
-    re-probed on every call so a transient daemon blip self-heals.
+    re-probed on every call so a transient daemon blip self-heals. The memo is
+    invalidated by any code path that catches a live Docker failure (see
+    _mark_docker_unavailable), so a daemon that dies AFTER a successful probe
+    is re-discovered rather than reported available forever.
     """
-    global _docker_available
     if _docker_available:
         return True
     try:
         client = docker.from_env()
         client.ping()
         client.close()
-        _docker_available = True
+        _mark_docker_available()
     except Exception as exc:
         logger.debug("Docker ping failed: %s", exc)
-        _docker_available = False
-    return _docker_available
+        _mark_docker_unavailable("ping failed", exc)
+    return bool(_docker_available)
 
 
 def _get_client() -> docker.DockerClient:
@@ -69,10 +100,10 @@ def _get_client() -> docker.DockerClient:
     try:
         client = docker.from_env()
         client.ping()
+        _mark_docker_available()
         return client
     except DockerException as exc:
-        global _docker_available
-        _docker_available = False
+        _mark_docker_unavailable("client connect failed", exc)
         raise RuntimeError(
             "Docker socket not available. Mount /var/run/docker.sock to "
             "enable container management, or use CashPilot in monitor-only "
@@ -653,10 +684,21 @@ def get_status() -> list[dict[str, Any]]:
         return []
 
     # Labeled containers (CashPilot-managed)
-    labeled = client.containers.list(
-        all=True,
-        filters={"label": f"{LABEL_MANAGED}=true"},
-    )
+    try:
+        labeled = client.containers.list(
+            all=True,
+            filters={"label": f"{LABEL_MANAGED}=true"},
+        )
+    except Exception as exc:
+        # "Ping works, list fails" (daemon 500, read timeout, containerd
+        # hiccup) used to escape this function entirely: the heartbeat then
+        # shipped containers=[] WITH docker_available=true — a worker that
+        # looks online and deliberately empty, while the UI writes a durable
+        # check_down for every deployment it can no longer see. Flag the
+        # outage so the SAME heartbeat reports blind, and the UI's guard
+        # skips the false downtime.
+        _mark_docker_unavailable("container listing failed", exc)
+        return []
     seen_ids: set[str] = set()
 
     results: list[dict[str, Any]] = []

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -7,6 +7,7 @@ inspection for cashpilot-managed containers via the Docker SDK.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import time
@@ -84,14 +85,19 @@ def docker_available() -> bool:
     """
     if _docker_available:
         return True
+    client = None
     try:
         client = docker.from_env()
         client.ping()
-        client.close()
         _mark_docker_available()
     except Exception as exc:
         logger.debug("Docker ping failed: %s", exc)
         _mark_docker_unavailable("ping failed", exc)
+    finally:
+        # A ping that RAISED used to leak the half-built client and its pool.
+        if client is not None:
+            with contextlib.suppress(Exception):
+                client.close()
     return bool(_docker_available)
 
 
@@ -197,19 +203,32 @@ def _read_pids_limit() -> int:
 _PIDS_LIMIT = _read_pids_limit()
 
 
-def available_runtimes() -> set[str]:
-    """Runtimes the local Docker daemon actually reports.
+def available_runtimes() -> set[str] | None:
+    """Runtimes the local Docker daemon actually reports, or None if unaskable.
 
     The allowlist is derived from the daemon rather than hardcoded, because a
     runtime CashPilot has heard of but the host has not installed would fail at
     container-create time with a Docker error the user cannot act on. Asking the
     daemon means the only runtimes offered are ones that exist here.
+
+    None, not an empty set, when the daemon cannot be asked: "no runtimes
+    installed here" is a caller mistake (400), "daemon unreachable" is an
+    outage (503), and collapsing them told the operator to fix the wrong
+    thing. The probe uses its OWN short-timeout client — the shared client
+    keeps the SDK's long default because deploys legitimately take minutes,
+    but a validation probe hanging 60s per call could pile onto the executor.
     """
+    client = None
     try:
-        info = _get_client().info()
-    except Exception:
-        logger.warning("Could not read Docker runtimes; treating none as available")
-        return set()
+        client = docker.from_env(timeout=5)
+        info = client.info()
+    except Exception as exc:
+        logger.warning("Could not read Docker runtimes (daemon unreachable?): %s", exc)
+        return None
+    finally:
+        if client is not None:
+            with contextlib.suppress(Exception):
+                client.close()
     runtimes = info.get("Runtimes")
     return set(runtimes) if isinstance(runtimes, dict) else set()
 
@@ -737,8 +756,11 @@ def get_status() -> list[dict[str, Any]]:
         try:
             all_containers = client.containers.list(all=True)
         except Exception as exc:
-            logger.warning("Failed to list all containers: %s", exc)
-            all_containers = []
+            # Same rule as the labeled list: a partial result with the flag
+            # still true would show EXTERNAL deployments as down instead of
+            # Docker-blind — the exact lie this change removes.
+            _mark_docker_unavailable("container listing failed", exc)
+            return []
         # Resolve which externally-deployed containers we actually care about
         # BEFORE fetching stats, so nothing is paid for a container we skip.
         matched: list[tuple[Any, str, str]] = []
@@ -841,10 +863,16 @@ def get_status_light() -> list[dict[str, Any]]:
         return []
 
     # First: labeled containers (CashPilot-managed)
-    labeled = client.containers.list(
-        all=True,
-        filters={"label": f"{LABEL_MANAGED}=true"},
-    )
+    try:
+        labeled = client.containers.list(
+            all=True,
+            filters={"label": f"{LABEL_MANAGED}=true"},
+        )
+    except Exception as exc:
+        # Mirror of get_status: "ping works, list fails" must flag the outage,
+        # not serve an empty-but-healthy answer.
+        _mark_docker_unavailable("container listing failed", exc)
+        return []
     seen_ids: set[str] = set()
 
     results: list[dict[str, Any]] = []
@@ -877,8 +905,11 @@ def get_status_light() -> list[dict[str, Any]]:
         try:
             all_containers = client.containers.list(all=True)
         except Exception as exc:
-            logger.warning("Failed to list all containers: %s", exc)
-            all_containers = []
+            # Same rule as the labeled list: a partial result with the flag
+            # still true would show EXTERNAL deployments as down instead of
+            # Docker-blind — the exact lie this change removes.
+            _mark_docker_unavailable("container listing failed", exc)
+            return []
         for c in all_containers:
             try:
                 if c.id in seen_ids:

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -1169,6 +1169,15 @@ def _validate_runtime(runtime: str | None) -> None:
     if not runtime:
         return
     available = orchestrator.available_runtimes()
+    if available is None:
+        # An unreachable daemon is an OUTAGE, not a caller mistake: answering
+        # 400 here told the operator their runtime choice was wrong when the
+        # actual fix was the daemon. The deploy would fail against the dead
+        # daemon anyway — refuse honestly first.
+        raise HTTPException(
+            status_code=503,
+            detail=f"Cannot verify the {runtime!r} runtime — the Docker daemon is not answering.",
+        )
     if runtime not in available:
         raise HTTPException(
             status_code=400,
@@ -1504,7 +1513,12 @@ async def api_runtimes(request: Request) -> dict[str, Any]:
     throughput on a workload that is pure network I/O.
     """
     _verify_api_key(request)
-    available = sorted(await asyncio.to_thread(orchestrator.available_runtimes))
+    runtimes = await asyncio.to_thread(orchestrator.available_runtimes)
+    if runtimes is None:
+        # Same split as _validate_runtime: unreachable daemon is an outage,
+        # and an empty list here would read as "no runtimes installed".
+        raise HTTPException(status_code=503, detail="The Docker daemon is not answering.")
+    available = sorted(runtimes)
     return {
         "available": available,
         "default": None,

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -1272,7 +1272,13 @@ async def api_list_containers(request: Request) -> list[dict[str, Any]]:
 async def api_deploy_container(request: Request, slug: str, spec: DeploySpec) -> dict[str, str]:
     """Deploy a container from spec sent by UI."""
     _verify_api_key(request)
-    _validate_deploy_spec(spec, slug=slug)
+    # Threaded like every other Docker touch in this file: _validate_runtime
+    # inside does a live daemon round-trip (available_runtimes has no cache and
+    # no timeout), and unthreaded it blocked the WHOLE event loop on a wedged
+    # daemon — including /api/health, so the container flipped unhealthy
+    # because an unrelated route was stuck. HTTPException propagates through
+    # to_thread unchanged, so the 400/403 behaviour is identical.
+    await asyncio.to_thread(_validate_deploy_spec, spec, slug)
     try:
         container_id = await asyncio.to_thread(
             orchestrator.deploy_raw,

--- a/tests/test_docker_honesty.py
+++ b/tests/test_docker_honesty.py
@@ -1,0 +1,154 @@
+"""A worker that cannot see Docker must say so — loudly, and in-band.
+
+Three fixes pinned here:
+
+- Docker dying mid-life was a logger.debug, invisible at the default INFO
+  level: the worker silently degraded to monitor-only and `docker logs` held
+  no reason at all. The True -> False transition now warns once.
+- "Ping works, list fails" escaped get_status, so the heartbeat shipped
+  containers=[] WITH docker_available=true — an online-looking worker the UI
+  then punished with a durable check_down for every deployment it could no
+  longer see. The enumeration failure now flags the outage so the same
+  heartbeat reports blind.
+- The deploy route called available_runtimes() unthreaded — a live daemon
+  round-trip with no cache and no timeout on the event loop, starving
+  /api/health on a wedged daemon.
+"""
+
+import logging
+import os
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+try:
+    from app import orchestrator  # noqa: E402
+except ImportError:
+    pytest.skip(
+        "Requires full app dependencies — runs in CI",
+        allow_module_level=True,
+    )
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_docker_memo():
+    before = orchestrator._docker_available
+    orchestrator._docker_available = None
+    yield
+    orchestrator._docker_available = before
+
+
+class TestMidLifeDockerLossIsLoud:
+    def test_true_to_false_warns_once(self, caplog):
+        orchestrator._docker_available = True
+        with caplog.at_level(logging.WARNING, logger=orchestrator.logger.name):
+            orchestrator._mark_docker_unavailable("test", RuntimeError("daemon gone"))
+            orchestrator._mark_docker_unavailable("test", RuntimeError("still gone"))
+        warns = [r for r in caplog.records if "became unreachable" in r.getMessage()]
+        assert len(warns) == 1
+        assert orchestrator._docker_available is False
+
+    def test_startup_discovery_stays_quiet(self, caplog):
+        # Negative control: None -> False is a monitor-only worker booting,
+        # which lifespan already announces — no mid-life warning.
+        orchestrator._docker_available = None
+        with caplog.at_level(logging.WARNING, logger=orchestrator.logger.name):
+            orchestrator._mark_docker_unavailable("test", RuntimeError("no socket"))
+        assert not [r for r in caplog.records if "became unreachable" in r.getMessage()]
+        assert orchestrator._docker_available is False
+
+    def test_recovery_is_announced(self, caplog):
+        orchestrator._docker_available = False
+        with caplog.at_level(logging.WARNING, logger=orchestrator.logger.name):
+            orchestrator._mark_docker_available()
+        assert [r for r in caplog.records if "reachable again" in r.getMessage()]
+        assert orchestrator._docker_available is True
+
+    def test_first_success_is_silent(self, caplog):
+        # Negative control: None -> True at startup is not a "recovery".
+        orchestrator._docker_available = None
+        with caplog.at_level(logging.WARNING, logger=orchestrator.logger.name):
+            orchestrator._mark_docker_available()
+        assert not [r for r in caplog.records if "reachable again" in r.getMessage()]
+
+
+class TestListFailureFlagsTheOutage:
+    def test_enumeration_failure_returns_empty_and_flags_blind(self):
+        client = MagicMock()
+        client.ping.return_value = True
+        client.containers.list.side_effect = RuntimeError("daemon 500")
+        orchestrator._docker_available = True
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            assert orchestrator.get_status() == []
+        # The same heartbeat that ships containers=[] must now also report
+        # docker_available=False — that is what keeps the UI from writing a
+        # durable check_down for every deployment it can no longer see.
+        assert orchestrator._docker_available is False
+
+    def test_a_healthy_list_keeps_the_flag(self):
+        # Negative control.
+        client = MagicMock()
+        client.containers.list.return_value = []
+        orchestrator._docker_available = True
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.get_status()
+        assert orchestrator._docker_available is True
+
+
+class TestDeployValidationIsThreaded:
+    def test_deploy_route_threads_the_validation(self):
+        """The validation must run via to_thread, not on the event loop.
+
+        Pinned by behavior, measured DURING the call: a probe task ticking
+        every 10ms is started first, then the deploy route (whose validation
+        blocks for 0.4s) is awaited, and the ticks accumulated strictly while
+        it ran are compared. Unthreaded, the loop freezes and the probe scores
+        ~0 in that window; threaded it keeps ticking. (An earlier version of
+        this test measured the probe's own later window, which an unthreaded
+        block simply finished before — a check that could not fail.)
+        """
+        import asyncio
+        import contextlib
+        import time as _time
+
+        from app import worker_api
+
+        measured = {}
+
+        def _slow_validate(spec, slug=None):
+            _time.sleep(0.4)
+
+        async def _drive():
+            with (
+                patch.object(worker_api, "_verify_api_key", lambda request: None),
+                patch.object(worker_api, "_validate_deploy_spec", _slow_validate),
+                patch.object(
+                    worker_api.orchestrator,
+                    "deploy_raw",
+                    lambda **kw: (_ for _ in ()).throw(RuntimeError("stop here")),
+                ),
+            ):
+                ticks = {"n": 0}
+                stop = asyncio.Event()
+
+                async def _probe():
+                    while not stop.is_set():
+                        ticks["n"] += 1
+                        await asyncio.sleep(0.01)
+
+                probe_task = asyncio.create_task(_probe())
+                await asyncio.sleep(0.05)  # the probe is demonstrably ticking
+                before = ticks["n"]
+                with contextlib.suppress(Exception):
+                    await worker_api.api_deploy_container(MagicMock(), "storj", worker_api.DeploySpec(image="x"))
+                measured["during"] = ticks["n"] - before
+                stop.set()
+                await probe_task
+
+        asyncio.run(_drive())
+        # Unthreaded, the 0.4s sleep freezes the loop: ~0-2 ticks. Threaded,
+        # the probe keeps its ~10ms cadence: ~30+.
+        assert measured["during"] > 10

--- a/tests/test_optional_runtime.py
+++ b/tests/test_optional_runtime.py
@@ -96,18 +96,35 @@ class TestReadingTheDaemon:
     def test_it_returns_what_docker_reports(self):
         client = MagicMock()
         client.info.return_value = {"Runtimes": {"runc": {}, "runsc": {}}}
-        with patch.object(orchestrator, "_get_client", return_value=client):
+        with patch.object(orchestrator.docker, "from_env", return_value=client) as from_env:
             assert orchestrator.available_runtimes() == {"runc", "runsc"}
+        # The probe uses its own short-timeout client, not the shared one whose
+        # long default exists for image pulls.
+        assert from_env.call_args.kwargs.get("timeout") == 5
+        client.close.assert_called_once()
 
     def test_a_daemon_that_cannot_be_reached_reports_none_rather_than_raising(self):
-        with patch.object(orchestrator, "_get_client", side_effect=RuntimeError("no docker")):
-            assert orchestrator.available_runtimes() == set()
+        # None, not set(): "no runtimes installed" is a 400-class caller
+        # mistake, "daemon unreachable" is a 503-class outage — collapsing
+        # them told the operator to fix the wrong thing.
+        with patch.object(orchestrator.docker, "from_env", side_effect=RuntimeError("no docker")):
+            assert orchestrator.available_runtimes() is None
 
-    def test_a_malformed_info_response_reports_none(self):
+    def test_a_malformed_info_response_reports_empty_not_outage(self):
+        # A daemon that ANSWERS with a shape we cannot read is not an outage:
+        # empty set, so the caller 400s rather than 503s.
         client = MagicMock()
         client.info.return_value = {"Runtimes": "runc"}
-        with patch.object(orchestrator, "_get_client", return_value=client):
+        with patch.object(orchestrator.docker, "from_env", return_value=client):
             assert orchestrator.available_runtimes() == set()
+
+    def test_an_unreachable_daemon_is_a_503_not_a_400(self):
+        with (
+            patch.object(orchestrator, "available_runtimes", return_value=None),
+            pytest.raises(HTTPException) as exc,
+        ):
+            worker_api._validate_runtime("runsc")
+        assert exc.value.status_code == 503
 
 
 class TestTheSpecStillRefusesEverythingElse:

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -288,19 +288,30 @@ class TestGetStatus:
         assert results[0]["slug"] == "storj"
         assert results[0]["deployed_by"] == "external"
 
-    def test_all_containers_listing_failure_still_returns_labeled(self):
+    def test_all_containers_listing_failure_flags_blind_not_partial(self):
+        """A half-answer is a lie with the flag still true.
+
+        This used to return the labeled results and swallow the external-list
+        failure — so external deployments read as DOWN while the worker looked
+        healthy. Now any listing failure returns [] and flips the availability
+        memo, and the same heartbeat reports docker_available=false.
+        """
         labeled = _mock_container(name="cashpilot-honeygain", status="running", slug="honeygain")
         labeled.stats.return_value = _zero_stats()
         client = MagicMock()
         client.containers.list.side_effect = [[labeled], Exception("docker daemon hiccup")]
         image_map = {"some/image:latest": "svc"}
-        with (
-            patch.object(orchestrator, "_get_client", return_value=client),
-            patch.object(orchestrator, "_build_image_slug_map", return_value=image_map),
-        ):
-            results = orchestrator.get_status()
-        assert len(results) == 1
-        assert results[0]["slug"] == "honeygain"
+        orchestrator._docker_available = True
+        try:
+            with (
+                patch.object(orchestrator, "_get_client", return_value=client),
+                patch.object(orchestrator, "_build_image_slug_map", return_value=image_map),
+            ):
+                results = orchestrator.get_status()
+            assert results == []
+            assert orchestrator._docker_available is False
+        finally:
+            orchestrator._docker_available = None
 
 
 # ---------------------------------------------------------------------------
@@ -372,17 +383,23 @@ class TestGetStatusLight:
             results = orchestrator.get_status_light()
         assert len(results) == 1
 
-    def test_all_containers_listing_failure_handled(self):
+    def test_all_containers_listing_failure_flags_blind_not_partial(self):
+        # Mirror of get_status: no half-answers with the flag still true.
         labeled = _mock_container(name="cashpilot-honeygain", status="running", slug="honeygain")
         client = MagicMock()
         client.containers.list.side_effect = [[labeled], Exception("boom")]
         image_map = {"x": "y"}
-        with (
-            patch.object(orchestrator, "_get_client", return_value=client),
-            patch.object(orchestrator, "_build_image_slug_map", return_value=image_map),
-        ):
-            results = orchestrator.get_status_light()
-        assert len(results) == 1
+        orchestrator._docker_available = True
+        try:
+            with (
+                patch.object(orchestrator, "_get_client", return_value=client),
+                patch.object(orchestrator, "_build_image_slug_map", return_value=image_map),
+            ):
+                results = orchestrator.get_status_light()
+            assert results == []
+            assert orchestrator._docker_available is False
+        finally:
+            orchestrator._docker_available = None
 
 
 class TestAdvertisedAddressExtraction:


### PR DESCRIPTION
## Why

Part of the invisible-failure audit that followed the 42-hour incident. A worker whose Docker daemon dies keeps running — and today it does so **silently**: the failed ping is a `logger.debug` nobody can see at the default INFO level, the availability memo can keep answering `true` against a daemon that only half-works, and one route can block the whole event loop on that daemon and take `/api/health` down with it.

## What

- **Mid-life Docker loss warns once, recovery is announced.** `True→False` is the loud moment; a persisting outage stays quiet, and startup discovery of a deliberately monitor-only worker stays quiet too (lifespan already announces the mode).
- **"Ping works, list fails" no longer lies.** That failure used to escape `get_status`, so the heartbeat shipped `containers=[]` with `docker_available=true` — an online-looking, deliberately-empty worker, while the UI wrote a durable `check_down` every 5 minutes for each deployment it could no longer see (the exact false-downtime regression the health-check guard exists to prevent, reintroduced through a flag that could lie). The enumeration failure now flips the memo so the *same* heartbeat reports blind.
- **The deploy route can no longer starve the loop.** `_validate_deploy_spec` runs via `to_thread` like every sibling Docker touch — its runtime validation does a live daemon round-trip with no cache and no timeout (fresh client + ping + info per call), and unthreaded it blocked everything including `/api/health`, flipping the container unhealthy because an unrelated route was stuck. Only reachable when a spec explicitly names a runtime (the UI never does), which is why this is the smallest of the three.

## Testing

- 7 tests with negative controls: transition warns once / startup quiet / recovery announced / first success silent; enumeration failure returns empty **and** flags blind vs healthy list keeps the flag; the threading test measures event-loop ticks **during** the validation call.
- The threading test is mutation-verified — and its first version measured a later window and could not fail; the committed docstring records that lesson.
- Full suite **4671 passed**, coverage **95.75%**; ruff + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker availability reporting when connections fail, recover, or become unavailable.
  * Worker status now correctly reports Docker outages when managed container information cannot be retrieved.
  * Deployment validation no longer blocks other worker operations while checking runtime availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->