### PR TITLE
feat(health): the UI can now report that it cannot do its job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,14 @@ VOLUME /data
 EXPOSE 8080
 
 ENTRYPOINT ["/entrypoint.sh"]
+# Ask the app whether it can still DO ITS JOB, not merely whether the port
+# answers: a TCP connect is completed by the kernel's listen backlog while
+# uvicorn is wedged, the scheduler is dead or the database is unreadable —
+# every internal failure rendered as "healthy". /api/health answers 503 for
+# those. http.client, NOT urllib.request: urlopen honors http_proxy (which
+# Docker injects fleet-wide when the host has a proxies config) with no
+# localhost exemption, so the "loopback" probe would be answered by the proxy.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD ["python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8080), timeout=3).close()"]
+    CMD ["python", "-c", "import sys,http.client\ntry:\n    c = http.client.HTTPConnection('127.0.0.1', 8080, timeout=3)\n    c.request('GET', '/api/health')\n    sys.exit(0 if c.getresponse().status == 200 else 1)\nexcept Exception:\n    sys.exit(1)"]
 
 CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--no-access-log"]

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ from typing import Any
 import httpx
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_MISSED
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -77,6 +77,13 @@ _collector_alerts: list[dict[str, str]] = []
 # collectors healthy" (CashPilot-tb5). Restored on startup from durable state so
 # a restart does not reset the claim to "never ran" while data exists.
 _collection_has_run: bool = False
+# Monotonic time the collection machinery last COMPLETED a run (success or
+# failure — this measures aliveness, not outcome; the success timestamp is a
+# metric). Initialized to process start so boot gets a grace window, exactly
+# like the worker's heartbeat stamp. A dead scheduler, a wedged collection
+# lock, or a blocked event loop all freeze this — and they used to freeze
+# every other signal green with them.
+_last_collection_finished: float = time.monotonic()
 _collection_lock = asyncio.Lock()
 _collection_semaphore = asyncio.Semaphore(8)
 
@@ -775,8 +782,14 @@ async def _run_collection() -> None:
             # Set even on a failed run: the bell's question is "has anything
             # looked", and a run that tried and failed HAS looked — its failure
             # is in the alert list the bell is about to show.
-            global _collection_has_run
+            global _collection_has_run, _last_collection_finished
             _collection_has_run = True
+            # "The machinery ran", success or not — /api/health and the bell
+            # measure staleness of THIS stamp. A run that wedges on the
+            # collection lock returns early above and never reaches here, so
+            # the age keeps growing through exactly the failure the skip line
+            # used to disguise as routine.
+            _last_collection_finished = time.monotonic()
 
 
 # ---------------------------------------------------------------------------
@@ -3361,6 +3374,47 @@ async def api_update_status(request: Request) -> dict[str, Any]:
     return update_check.state()
 
 
+# How stale the collection stamp may grow before it is a problem: 2.5x the
+# interval tolerates one slow run and one missed slot before declaring the
+# machinery dead — the same flap-resistance reasoning as the worker's window.
+_COLLECTION_STALE_FACTOR = 2.5
+
+
+@app.get("/api/health")
+async def api_health(response: Response) -> dict[str, Any]:
+    """Health of the UI process itself (no auth — the Docker healthcheck asks).
+
+    Reports whether this process can still DO ITS JOB, not merely whether the
+    port answers. The container healthcheck used to be a TCP connect, which the
+    kernel's listen backlog completes for a wedged uvicorn, a dead scheduler or
+    an unwritable database — every internal failure rendered as "healthy". A
+    check that cannot fail for the failure you actually have is not a check.
+
+    Three concrete questions, each a distinct operational failure an operator
+    can act on: is the scheduler running, has the collection machinery
+    completed a run recently (a wedged collection lock freezes this stamp —
+    the skip line used to disguise that as routine), and can the database be
+    read. Values are deliberately generic state names, no secrets.
+    """
+    problems: list[str] = []
+    if not scheduler.running:
+        problems.append("scheduler stopped")
+    stale_after = _COLLECTION_STALE_FACTOR * COLLECT_INTERVAL_MIN * 60
+    age = time.monotonic() - _last_collection_finished
+    if age > stale_after:
+        problems.append(f"no collection completed in {int(age // 60)} minutes")
+    try:
+        await database.get_config()
+    except Exception:  # noqa: BLE001 - the reason goes to the body, not a 500
+        problems.append("database unreadable")
+    body: dict[str, Any] = {"status": "ok"}
+    if problems:
+        response.status_code = 503
+        body["status"] = "degraded"
+        body["problems"] = problems
+    return body
+
+
 @app.get("/api/collector-alerts")
 async def api_collector_alerts(request: Request) -> dict[str, Any]:
     """Collector errors from the last run, and whether a run has happened.
@@ -3391,7 +3445,18 @@ async def api_collector_alerts(request: Request) -> dict[str, Any]:
         if alert.get("category"):
             entry["category"] = alert["category"]
         sanitized.append(entry)
-    return {"alerts": sanitized, "collected": _collection_has_run}
+    # The staleness flag is what keeps "All collectors healthy" honest: the
+    # collected latch below is permanent once set, so after a scheduler death
+    # the bell would affirm health forever on the strength of a collection
+    # that stopped happening. Decided server-side so the frontend never has
+    # to know the interval.
+    age = int(time.monotonic() - _last_collection_finished)
+    return {
+        "alerts": sanitized,
+        "collected": _collection_has_run,
+        "last_run_age_seconds": age,
+        "collection_stale": age > _COLLECTION_STALE_FACTOR * COLLECT_INTERVAL_MIN * 60,
+    }
 
 
 @app.get("/api/exchange-rates")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3327,6 +3327,15 @@ const CP = (() => {
         // rejects everywhere else. The bell's failure path already gets this
         // right ("Alerts unavailable"), which made the never-ran case the
         // outlier (CashPilot-tb5).
+        // "Healthy" additionally requires the collection machinery to be
+        // ALIVE: the collected latch is permanent, so after a scheduler death
+        // the bell would otherwise affirm health forever on the strength of a
+        // collection that stopped happening. The server decides staleness.
+        if (payload.collected && payload.collection_stale) {
+          const mins = Math.floor((payload.last_run_age_seconds || 0) / 60);
+          list.innerHTML = `<div class="notify-empty">No collection in ${mins} minutes — status unknown. Check the server.</div>`;
+          return;
+        }
         list.innerHTML = payload.collected
           ? '<div class="notify-empty">All collectors healthy</div>'
           : '<div class="notify-empty">No collection has run yet — nothing has been checked.</div>';

--- a/tests/test_every_route_rejects_anonymous.py
+++ b/tests/test_every_route_rejects_anonymous.py
@@ -30,6 +30,7 @@ import pytest
 # The routes that are meant to be reachable with no credentials, and why. A new
 # entry here is a deliberate decision to expose something publicly.
 PUBLIC = {
+    ("GET", "/api/health"): "the Docker healthcheck asks it; fixed state names, no data",
     ("GET", "/login"): "the login form itself",
     ("POST", "/login"): "authenticates; rejects bad credentials on its own",
     ("GET", "/logout"): "clears the session — safe to hit anonymously",

--- a/tests/test_ui_health_endpoint.py
+++ b/tests/test_ui_health_endpoint.py
@@ -1,0 +1,158 @@
+"""The UI must be able to report that it cannot do its job.
+
+The container healthcheck was a TCP connect — completed by the kernel's listen
+backlog while uvicorn is wedged, the scheduler is dead or the database is
+unreadable. Meanwhile the bell's "All collectors healthy" is rendered from a
+latch that can never go false once set, so a dead scheduler left every signal
+affirmatively green with week-old numbers underneath.
+
+/api/health (unauthenticated — the Docker healthcheck asks it) answers three
+concrete questions: scheduler running, collection machinery recently completed
+a run, database readable. The bell additionally goes "status unknown" when the
+collection stamp goes stale.
+"""
+
+import asyncio
+import os
+import time
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest  # noqa: E402
+
+try:
+    from fastapi.testclient import TestClient  # noqa: E402
+
+    from app import main  # noqa: E402
+except ImportError:
+    pytest.skip(
+        "Requires full app dependencies — runs in CI",
+        allow_module_level=True,
+    )
+
+from contextlib import asynccontextmanager  # noqa: E402
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app):
+    yield
+
+
+def _client():
+    main.app.router.lifespan_context = _noop_lifespan
+    return TestClient(main.app, raise_server_exceptions=False)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_stamp():
+    before = main._last_collection_finished
+    main._last_collection_finished = time.monotonic()
+    yield
+    main._last_collection_finished = before
+
+
+def _stale_age():
+    return main._COLLECTION_STALE_FACTOR * main.COLLECT_INTERVAL_MIN * 60 + 1
+
+
+class TestUiHealth:
+    def _get(self):
+        with patch.object(main.database, "get_config", AsyncMock(return_value={})):
+            return _client().get("/api/health")
+
+    def test_healthy_and_unauthenticated(self):
+        # No Authorization header, no session — the Docker healthcheck has
+        # neither. Scheduler "running" is patched because tests never start it.
+        with patch.object(type(main.scheduler), "running", property(lambda self: True)):
+            resp = self._get()
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_a_dead_scheduler_degrades(self):
+        with patch.object(type(main.scheduler), "running", property(lambda self: False)):
+            resp = self._get()
+        assert resp.status_code == 503
+        assert "scheduler stopped" in resp.json()["problems"]
+
+    def test_a_stale_collection_stamp_degrades(self):
+        """A wedged collection lock freezes the stamp: every subsequent run
+        skip-returns before the finally, and the age grows through exactly
+        the failure the skip line used to disguise as routine."""
+        main._last_collection_finished = time.monotonic() - _stale_age()
+        with patch.object(type(main.scheduler), "running", property(lambda self: True)):
+            resp = self._get()
+        assert resp.status_code == 503
+        assert any("no collection completed" in p for p in resp.json()["problems"])
+
+    def test_an_unreadable_database_degrades(self):
+        with (
+            patch.object(type(main.scheduler), "running", property(lambda self: True)),
+            patch.object(main.database, "get_config", AsyncMock(side_effect=RuntimeError("locked"))),
+        ):
+            resp = _client().get("/api/health")
+        assert resp.status_code == 503
+        assert "database unreadable" in resp.json()["problems"]
+
+    def test_problems_never_carry_exception_text(self):
+        # The endpoint is unauthenticated; the reason strings are fixed
+        # operational states, never str(exc).
+        secret = "password-in-a-connection-error"
+        with (
+            patch.object(type(main.scheduler), "running", property(lambda self: True)),
+            patch.object(main.database, "get_config", AsyncMock(side_effect=RuntimeError(secret))),
+        ):
+            resp = _client().get("/api/health")
+        assert secret not in resp.text
+
+
+class TestCollectionStampAdvances:
+    @pytest.mark.asyncio
+    async def test_a_completed_run_advances_the_stamp(self):
+        main._last_collection_finished = 1.0  # ancient
+        with (
+            patch.object(main.database, "get_deployments", AsyncMock(return_value=[])),
+            patch.object(main.database, "get_config", AsyncMock(return_value={})),
+            patch.object(main, "_detect_payout", AsyncMock(return_value=None)),
+            patch.object(main, "_flatline_check", AsyncMock(return_value=[])),
+            patch.object(main, "_pending_payout_alerts", AsyncMock(return_value=[])),
+            patch.object(main, "_collector_alerts", []),
+            patch("app.collectors.make_collectors", lambda deployments, config: []),
+            patch("app.collectors._close_stale", AsyncMock()),
+        ):
+            await main._run_collection()
+        assert time.monotonic() - main._last_collection_finished < 60
+
+    @pytest.mark.asyncio
+    async def test_a_lock_skip_does_not_advance_the_stamp(self):
+        # Negative control: a skipped run is not a completed run — the stamp
+        # freezing during a wedge is the entire detection mechanism.
+        main._last_collection_finished = 1.0
+        async with main._collection_lock:
+            await main._run_collection()  # lock held -> skip path
+        assert main._last_collection_finished == 1.0
+
+
+class TestBellStalenessContract:
+    def _payload(self):
+        with (
+            patch.object(main, "_require_auth_api", lambda request: None),
+            patch.object(main, "_collector_alerts", []),
+            patch.object(main, "_collection_has_run", True),
+        ):
+            return _client().get("/api/collector-alerts").json()
+
+    def test_fresh_collection_is_not_stale(self):
+        main._last_collection_finished = time.monotonic()
+        payload = self._payload()
+        assert payload["collection_stale"] is False
+        assert payload["last_run_age_seconds"] < 60
+
+    def test_a_frozen_stamp_reads_stale(self):
+        main._last_collection_finished = time.monotonic() - _stale_age()
+        payload = self._payload()
+        assert payload["collection_stale"] is True


### PR DESCRIPTION
## Why

The UI half of the healthcheck audit. Its container healthcheck was a **TCP connect** — completed by the kernel's listen backlog while uvicorn is wedged, the scheduler is dead or the database is unreadable — and `docs/guides/prometheus-metrics.md` claimed both images verify "the app inside is actually answering", which after #330 was only true of the worker. Separately, the bell's **"All collectors healthy" renders from a latch that can never go false** once set: after a scheduler death, every signal stays affirmatively green — green worker dots (a frozen status column), a healthy bell, week-old balances that look identical to fresh ones — indefinitely.

## What

- **`GET /api/health`** (unauthenticated — the Docker healthcheck has no credentials; registered in the anonymous-rejection test's `PUBLIC` list with its reason). Answers three concrete operational questions and 503s with fixed state names: `scheduler stopped`, `no collection completed in N minutes` (2.5× the interval — one slow run plus one missed slot of flap resistance), `database unreadable`. Exception text never reaches the unauthenticated body, and there is a test pinning that.
- **The staleness stamp measures completion, not success** — stamped in the collection `finally`. A wedged collection lock freezes it, because the skip path returns *before* the finally: the wedge that `"Collection already in progress, skipping"` used to disguise as routine is now exactly what this detects.
- **Dockerfile healthcheck** asks the endpoint via `http.client` with an explicit 200 check (`urlopen` honors `http_proxy` with no localhost exemption — the worker-side lesson from #330's review). Verified to parse intact in a real Docker build.
- **The bell stops lying**: when the server-computed `collection_stale` flag is set it renders "No collection in N minutes — status unknown" instead of affirming health from the permanent latch.

## Testing

- 9 new tests with negative controls: healthy + unauthenticated exact shape, each degradation cause, no-secrets-in-body, completed run advances the stamp vs **lock-skip does not**, fresh vs frozen staleness contract.
- Full suite **4673 passed**, coverage **96.56%**; ruff + format + `node --check` clean; the anonymous-rejection sweep (87 routes) passes with the one documented exemption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an unauthenticated health endpoint reporting scheduler, collection, and database status.
  - Health checks now return clear degraded status details when services are unavailable.
  - Collector alerts now show collection age and identify stale results.

- **Bug Fixes**
  - The interface no longer reports all collectors as healthy when results are outdated.
  - Container health monitoring now verifies a successful HTTP health response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->