### PR TITLE
fix(catalog): tell the truth about Presearch, PassiveApp and Bytelixir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,7 @@ Working collectors (15 total, in `app/collectors/__init__.py` `COLLECTOR_MAP`):
 | Category | Active | Broken | Dead | Shady | Total |
 |----------|--------|--------|------|-------|-------|
 | Bandwidth | 14 | 2 | 4 | 0 | 22 |
-| DePIN | 8 | 4 | 0 | 2 | 20 |
+| DePIN | 7 | 4 | 1 | 2 | 20 |
 | Compute | 4 | 1 | 0 | 0 | 6 |
 | Storage | 1 | 0 | 0 | 0 | 1 |
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Services CashPilot can deploy and manage automatically via Docker.
 | [IPRoyal Pawns](https://pawns.app?r=19266874) | [Guide](docs/guides/iproyal.md) | ✅ | ❌ | ? \*\*\* | 1 | PayPal, Crypto, Bank Transfer |
 | [MystNodes](https://mystnodes.co/?referral_code=do7v7YOoBBpbOstKQovX2pUvZYKia4ZhH3QIdNtE) | [Guide](docs/guides/mysterium.md) | ❌ | ✅ | ? \*\*\* | Unlimited | Crypto |
 | [PacketStream](https://packetstream.io/?psr=7xgZ) | [Guide](docs/guides/packetstream.md) | ✅ | ❌ | ? \*\*\* | ? \*\*\* | PayPal |
-| [Presearch](https://presearch.com/signup?rid=4872322) | [Guide](docs/guides/presearch.md) | ❌ | ✅ | ? \*\*\* | ? \*\*\* | Crypto |
 | [ProxyBase](https://peer.proxybase.org?referral=nXzS3c6iTO) | [Guide](docs/guides/proxybase.md) | ❌ | ✅ | ? \*\*\* | ? \*\*\* | Crypto |
 | [ProxyBase Markets](https://proxybase.xyz?referral=nXzS3c6iTO) | [Guide](docs/guides/proxybase-xyz.md) | ❌ | ✅ | ? \*\*\* | ? \*\*\* | Crypto (USDC) |
 | [ProxyLite](https://proxylite.ru/?r=KMUPRZIZ) | [Guide](docs/guides/proxylite.md) | ❌ | ✅ | ? \*\*\* | ? \*\*\* | Crypto, PayPal |
@@ -358,6 +357,7 @@ Services that were evaluated but are no longer listed in the catalog due to bein
 
 | Service | Status | Reason | Last checked |
 |---------|--------|--------|:------------:|
+| Presearch | Dead | Company shut down July 24-28, 2026; node program and backend decommissioned | Aug 2026 |
 | SpeedShare | Dead | Project confirmed dead in Discord | Mar 2026 |
 | Peer2Profit | Dead | Domain unreachable | Mar 2026 |
 | PacketShare | Dead | Signup process broken, no progress | Mar 2026 |

--- a/app/compose_generator.py
+++ b/app/compose_generator.py
@@ -25,6 +25,7 @@ from app.constants import (
     LABEL_MANAGED,
     LABEL_SERVICE,
     LABEL_VERSION,
+    UNDEPLOYABLE_STATUSES,
 )
 
 
@@ -152,6 +153,11 @@ def generate_compose_single(
     svc = get_service(slug)
     if not svc:
         raise ValueError(f"Unknown service: {slug}")
+    if svc.get("status") in UNDEPLOYABLE_STATUSES:
+        # A compose file for a dead service is a runnable artifact pointing at
+        # something that cannot earn — the export must refuse like the deploy
+        # route does, not hand the user a working-looking YAML.
+        raise ValueError(f"Service {slug} is no longer available ({svc.get('status')})")
 
     compose_svc = _service_to_compose(svc, env_vars, hostname)
     if not compose_svc:
@@ -178,6 +184,8 @@ def generate_compose_multi(
     for slug in slugs:
         svc = get_service(slug)
         if not svc:
+            continue
+        if svc.get("status") in UNDEPLOYABLE_STATUSES:
             continue
         compose_svc = _service_to_compose(svc, env_map.get(slug), hostname)
         if compose_svc:

--- a/app/constants.py
+++ b/app/constants.py
@@ -6,3 +6,9 @@ LABEL_VERSION = "cashpilot.version"
 LABEL_CATEGORY = "cashpilot.category"
 LABEL_DEPLOYED_BY = "cashpilot.deployed-by"
 CONTAINER_PREFIX = "cashpilot-"
+
+# Catalog statuses that must never be deployed or exported: the service is
+# gone, broken, or dropped, and producing a runnable artifact for it points
+# users at something that cannot earn. One definition, shared by the deploy
+# routes and the compose exporter, so the rule cannot half-change.
+UNDEPLOYABLE_STATUSES = frozenset({"broken", "dead", "dropped"})

--- a/app/main.py
+++ b/app/main.py
@@ -1433,7 +1433,7 @@ def _collector_needs_setup(slug: str, config: dict[str, str]) -> bool:
 # can't drift apart again — previously the listing hid all three but deploy only
 # refused "dead", so a direct link or a stale page could still deploy a broken or
 # dropped service and then silently earn nothing.
-_UNDEPLOYABLE_STATUSES = frozenset({"broken", "dead", "dropped"})
+from app.constants import UNDEPLOYABLE_STATUSES as _UNDEPLOYABLE_STATUSES  # noqa: E402 - single source, see constants
 
 
 def _split_image(ref: str) -> tuple[str, str, str]:

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -57,7 +57,7 @@ Setup and configuration for every service CashPilot supports.
 | [Nodepay](nodepay.md) | Residential IP | App only | — | active |
 | [Nodle](nodle.md) | — | App only | — | active |
 | [PassiveApp](passiveapp.md) | Residential IP | App only | $5 | active |
-| [Presearch](presearch.md) | — | Docker | — | active |
+| [Presearch](presearch.md) | — | Docker | — | dead |
 | [Sentinel dVPN](sentinel-dvpn.md) | 10 Mbps | App only | — | active |
 | [Teneo Protocol](teneo.md) | Residential IP | App only | — | active |
 | [Theta Edge Node](theta-edge.md) | — | App only | — | active |

--- a/docs/guides/bytelixir.md
+++ b/docs/guides/bytelixir.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Bytelixir lets you earn passive income by sharing unused internet bandwidth. Supports Windows and Android only — the official FAQ states no Linux or Docker client is planned, iOS is unsupported, and macOS is not offered. Earnings range $2-50/month depending on location. Web dashboard at dash.bytelixir.com for tracking. No Docker image available.
+Bytelixir lets you earn passive income by sharing unused internet bandwidth. Supports Windows and Android only — the official FAQ states no Linux or Docker client is planned, iOS is unsupported, and macOS is not offered. Earnings depend heavily on location. Web dashboard at dash.bytelixir.com for tracking. No Docker image available.
 
 ## Earning Estimates
 
@@ -17,7 +17,7 @@ Bytelixir lets you earn passive income by sharing unused internet bandwidth. Sup
 | Payout frequency | On request |
 | Payment methods | Crypto |
 
-> Earnings vary by location ($2-50/month). No Docker image, and the official FAQ says none is planned. Windows desktop app or Android app required.
+> Earnings vary heavily by location. No Docker image, and the official FAQ says none is planned. Windows desktop app or Android app required.
 
 ## Requirements
 
@@ -35,18 +35,16 @@ Bytelixir lets you earn passive income by sharing unused internet bandwidth. Sup
 
 Sign up at [Bytelixir](https://bytelixir.com/r/OYEIRE0VSZBZ).
 
-### 2. Get your credentials
+### 2. Install the app
 
-After signing up, locate the credentials needed for Docker deployment. These are typically your email/password or an API token found in the dashboard.
+Download the Windows or Android app from the **Download** section of your dashboard at
+[dash.bytelixir.com](https://dash.bytelixir.com) — those are the only supported platforms,
+and the official FAQ states no Linux or Docker client is planned.
 
-### 3. Deploy with CashPilot
+### 3. Track earnings in CashPilot
 
-In the CashPilot web UI, find **Bytelixir** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
-
-## Docker Configuration
-
-- **Image:** ``
-
-### Environment Variables
-
-No environment variables required.
+There is no container to deploy; CashPilot tracks Bytelixir's earnings through your
+dashboard session. In the catalog entry, paste the session cookie values exactly as the
+credential fields describe (log in at dash.bytelixir.com, then F12 → Application →
+Cookies). Sessions with "Remember Me" last days to weeks; refresh the cookie when the
+collector reports it expired.

--- a/docs/guides/bytelixir.md
+++ b/docs/guides/bytelixir.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Bytelixir lets you earn passive income by sharing unused internet bandwidth. Supports Windows, macOS, Linux, and Android. Earnings range $2-50/month depending on location. Web dashboard at dash.bytelixir.com for tracking. No Docker image available.
+Bytelixir lets you earn passive income by sharing unused internet bandwidth. Supports Windows and Android only — the official FAQ states no Linux or Docker client is planned, iOS is unsupported, and macOS is not offered. Earnings range $2-50/month depending on location. Web dashboard at dash.bytelixir.com for tracking. No Docker image available.
 
 ## Earning Estimates
 
@@ -17,7 +17,7 @@ Bytelixir lets you earn passive income by sharing unused internet bandwidth. Sup
 | Payout frequency | On request |
 | Payment methods | Crypto |
 
-> Earnings vary by location ($2-50/month). No Docker image. Desktop app or Android app required.
+> Earnings vary by location ($2-50/month). No Docker image, and the official FAQ says none is planned. Windows desktop app or Android app required.
 
 ## Requirements
 
@@ -27,7 +27,7 @@ Bytelixir lets you earn passive income by sharing unused internet bandwidth. Sup
 | Minimum bandwidth | None |
 | GPU required | No |
 | Minimum storage | None |
-| Supported platforms | Windows, Macos, Linux, Android |
+| Supported platforms | Windows, Android |
 
 ## Setup Instructions
 

--- a/docs/guides/passiveapp.md
+++ b/docs/guides/passiveapp.md
@@ -1,6 +1,6 @@
 # PassiveApp
 
-> **Category:** DePIN | **Status:** Dead
+> **Category:** DePIN | **Status:** Active
 > **Website:** [https://passiveapp.com](https://passiveapp.com)
 
 ## Description
@@ -35,18 +35,14 @@ PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards by s
 
 Sign up at [PassiveApp](https://passiveapp.com/i/bqpC4M).
 
-### 2. Get your credentials
+### 2. Install the Windows app
 
-After signing up, locate the credentials needed for Docker deployment. These are typically your email/password or an API token found in the dashboard.
+Download the Windows desktop app from the vendor's download page and log in. That is the
+only released client — Android, iOS and Linux are vendor-announced "coming soon" and have
+never shipped.
 
-### 3. Deploy with CashPilot
+### 3. What CashPilot can and cannot do here
 
-In the CashPilot web UI, find **PassiveApp** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
-
-## Docker Configuration
-
-- **Image:** ``
-
-### Environment Variables
-
-No environment variables required.
+There is no Docker image and no public API, so CashPilot can neither deploy nor track
+PassiveApp automatically. It is listed for completeness; earnings tracking is manual via
+the vendor dashboard.

--- a/docs/guides/passiveapp.md
+++ b/docs/guides/passiveapp.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards by sharing unused bandwidth and computing resources. Relatively new service with limited Docker support through community images.
+PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards by sharing unused bandwidth and computing resources. Windows only in practice: Android, iOS and Linux have been vendor-announced "coming soon" since early 2025 and have never shipped; no macOS version exists. No Docker image.
 
 ## Earning Estimates
 
@@ -17,7 +17,7 @@ PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards by s
 | Payout frequency | On request |
 | Payment methods | Crypto, Paypal |
 
-> **Dead as of March 2026.** App does not exist on Android Play Store. Website still up but no working app available on any platform. Do not attempt to deploy.
+> **Windows only.** The Windows desktop app (v1.0.x) downloads and works. The vendor's own download page has listed Android, iOS and Linux as "coming soon" unchanged since at least February 2025 — none has ever shipped — and no macOS version exists. The site's marketing copy claiming broader platform support contradicts its own download page. (An earlier note here declared the service dead; the Windows app is downloadable and the service is live.)
 
 ## Requirements
 
@@ -27,7 +27,7 @@ PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards by s
 | Minimum bandwidth | None |
 | GPU required | No |
 | Minimum storage | None |
-| Supported platforms | Windows, Linux, Android, Ios |
+| Supported platforms | Windows |
 
 ## Setup Instructions
 

--- a/docs/guides/presearch.md
+++ b/docs/guides/presearch.md
@@ -2,7 +2,7 @@
 
 > **Category:** DePIN | **Status:** Dead
 > **Website:** [https://presearch.com](https://presearch.com)
-
+>
 > **Presearch shut down permanently in July 2026.** The company announced the closure on July 24, 2026 (effective July 28, 2026): the search platform and the node program are gone, backend infrastructure was decommissioned, and node operators were told to unstake and withdraw their PRE before the deadline. The `presearch/node` Docker image received its last update on July 21, 2026 and running it earns nothing. This page is kept for reference only — do not deploy.
 
 ## Description
@@ -31,27 +31,9 @@ Presearch was a decentralized search engine where node operators ran Docker cont
 | Minimum storage | None |
 | Supported platforms | Docker, Linux |
 
-## Setup Instructions
+## Historical reference
 
-### 1. Create an account
-
-Sign up at [Presearch](https://presearch.com/signup?rid=4872322).
-
-### 2. Get your credentials
-
-After signing up, locate the credentials needed for Docker deployment. These are typically your email/password or an API token found in the dashboard.
-
-### 3. Deploy with CashPilot
-
-In the CashPilot web UI, find **Presearch** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
-
-## Docker Configuration
-
-- **Image:** `presearch/node`
-- **Platforms:** linux/amd64, linux/arm64
-
-### Environment Variables
-
-| Variable | Label | Required | Secret | Description |
-|----------|-------|:--------:|:------:|-------------|
-| `REGISTRATION_CODE` | Registration Code | Yes | Yes | Your Presearch node registration code from the dashboard |
+The node ran as the `presearch/node` Docker image (linux/amd64 + linux/arm64) with a single
+`REGISTRATION_CODE` secret from the node dashboard, and required a 4,000 PRE stake. None of
+this works anymore: registration, the dashboard and the node backend were all decommissioned
+in the July 2026 shutdown, so there is nothing to sign up for and nothing to deploy.

--- a/docs/guides/presearch.md
+++ b/docs/guides/presearch.md
@@ -1,11 +1,13 @@
 # Presearch
 
-> **Category:** DePIN | **Status:** Active
+> **Category:** DePIN | **Status:** Dead
 > **Website:** [https://presearch.com](https://presearch.com)
+
+> **Presearch shut down permanently in July 2026.** The company announced the closure on July 24, 2026 (effective July 28, 2026): the search platform and the node program are gone, backend infrastructure was decommissioned, and node operators were told to unstake and withdraw their PRE before the deadline. The `presearch/node` Docker image received its last update on July 21, 2026 and running it earns nothing. This page is kept for reference only — do not deploy.
 
 ## Description
 
-Presearch is a decentralized search engine where node operators run Docker containers to process search queries and earn PRE tokens. Requires staking a minimum of 4,000 PRE tokens to earn rewards. Prioritizes fast internet and low latency nodes.
+Presearch was a decentralized search engine where node operators ran Docker containers to process search queries and earned PRE tokens. It required staking a minimum of 4,000 PRE tokens to earn rewards.
 
 ## Earning Estimates
 

--- a/services/bandwidth/bytelixir.yml
+++ b/services/bandwidth/bytelixir.yml
@@ -7,9 +7,9 @@ description: >
   Bytelixir lets you earn passive income by sharing unused internet bandwidth.
   Supports Windows and Android only — the official FAQ states no Linux or
   Docker client is planned, iOS is unsupported, and macOS is not offered.
-  Earnings range $2-50/month depending on location. Web dashboard at
-  dash.bytelixir.com for tracking. No Docker image available.
-short_description: Bandwidth sharing - $2-50/month, Windows + Android only
+  Earnings depend heavily on location. Web dashboard at dash.bytelixir.com
+  for tracking. No Docker image available.
+short_description: Bandwidth sharing - Windows + Android only
 
 referral:
   signup_url: "https://bytelixir.com/r/OYEIRE0VSZBZ"

--- a/services/bandwidth/bytelixir.yml
+++ b/services/bandwidth/bytelixir.yml
@@ -5,10 +5,11 @@ status: active
 website: https://bytelixir.com
 description: >
   Bytelixir lets you earn passive income by sharing unused internet bandwidth.
-  Supports Windows, macOS, Linux, and Android. Earnings range $2-50/month
-  depending on location. Web dashboard at dash.bytelixir.com for tracking.
-  No Docker image available.
-short_description: Bandwidth sharing - $2-50/month, desktop + Android
+  Supports Windows and Android only — the official FAQ states no Linux or
+  Docker client is planned, iOS is unsupported, and macOS is not offered.
+  Earnings range $2-50/month depending on location. Web dashboard at
+  dash.bytelixir.com for tracking. No Docker image available.
+short_description: Bandwidth sharing - $2-50/month, Windows + Android only
 
 referral:
   signup_url: "https://bytelixir.com/r/OYEIRE0VSZBZ"
@@ -63,7 +64,7 @@ cashout:
   min_amount: 5.0
   currency: USD
 
-platforms: [windows, macos, linux, android]
+platforms: [windows, android]
 
 collector:
   type: manual

--- a/services/depin/passiveapp.yml
+++ b/services/depin/passiveapp.yml
@@ -5,9 +5,12 @@ status: active
 website: https://passiveapp.com
 description: >
   PassiveApp is a DePIN platform that lets you earn crypto and PayPal rewards
-  by sharing unused bandwidth and computing resources. Relatively new service
-  with limited Docker support through community images.
-short_description: DePIN bandwidth/compute - crypto and PayPal payouts
+  by sharing unused bandwidth and computing resources. Windows only in
+  practice: the vendor's own download page has listed Android, iOS and Linux
+  as "coming soon" unchanged since at least February 2025, and no macOS
+  version exists — despite marketing copy on the same site claiming broader
+  support. No Docker image.
+short_description: DePIN bandwidth/compute - Windows only, crypto and PayPal payouts
 
 referral:
   signup_url: "https://passiveapp.com/i/bqpC4M"
@@ -39,7 +42,7 @@ earnings:
   monthly_high: 4
   currency: USD
   per: "device"
-  notes: "Relatively new. No official Docker image available yet."
+  notes: "Windows desktop app only (v1.0.x); Android/iOS/Linux are vendor-announced 'coming soon' since early 2025 and have never shipped. No official Docker image."
 
 cashout:
   method: redirect
@@ -47,7 +50,7 @@ cashout:
   min_amount: 5.0
   currency: USD
 
-platforms: [windows, linux, android, ios]
+platforms: [windows]
 
 collector:
   type: manual

--- a/services/depin/presearch.yml
+++ b/services/depin/presearch.yml
@@ -1,14 +1,17 @@
 name: Presearch
 slug: presearch
 category: depin
-status: active
+status: dead
 website: https://presearch.com
 description: >
-  Presearch is a decentralized search engine where node operators run Docker
-  containers to process search queries and earn PRE tokens. Requires staking
-  a minimum of 4,000 PRE tokens to earn rewards. Prioritizes fast internet
-  and low latency nodes.
-short_description: Decentralized search engine - Docker nodes, PRE token rewards
+  Presearch was a decentralized search engine where node operators ran Docker
+  containers to process search queries and earn PRE tokens. The company
+  announced its permanent shutdown on July 24, 2026 (effective July 28, 2026):
+  the search platform and the node program are gone, backend infrastructure
+  was decommissioned, and operators were told to withdraw their staked PRE
+  before the deadline. The PRE token contract still trades residually on
+  DEXes, but no node can earn anything anymore.
+short_description: Decentralized search engine - SHUT DOWN July 2026
 
 referral:
   signup_url: "https://presearch.com/signup?rid=4872322"

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -189,6 +189,46 @@ class TestGenerateComposeAll:
         assert "cashpilot-b" in output
 
 
+class TestDeadServicesAreNotExported:
+    """A compose file is a runnable artifact: exporting one for a dead service
+    points the user at something that cannot earn (Presearch shut down July
+    2026 and its entry stays in the catalog as status: dead)."""
+
+    def _dead(self):
+        svc = _mock_service(slug="presearch", name="Presearch", image="presearch/node")
+        svc["status"] = "dead"
+        return svc
+
+    def test_single_export_of_a_dead_service_refuses(self):
+        with (
+            patch("app.compose_generator.get_service", return_value=self._dead()),
+            pytest.raises(ValueError, match="no longer available"),
+        ):
+            compose_generator.generate_compose_single("presearch")
+
+    def test_multi_export_skips_dead_services(self):
+        live = _mock_service(slug="honeygain", name="Honeygain")
+
+        def mock_get(slug):
+            return {"presearch": self._dead(), "honeygain": live}.get(slug)
+
+        with patch("app.compose_generator.get_service", side_effect=mock_get):
+            output = compose_generator.generate_compose_multi(["presearch", "honeygain"])
+        assert "cashpilot-honeygain" in output  # negative control: live stays
+        assert "presearch" not in output
+
+    def test_the_real_dead_presearch_is_not_in_export_all(self):
+        # Against the real catalog: the entry exists with an image, and must
+        # still not be exported.
+        from app.catalog import load_services
+
+        presearch = next(s for s in load_services() if s.get("slug") == "presearch")
+        assert presearch["status"] == "dead"
+        assert presearch["docker"]["image"]  # the trap: image present, status dead
+        out = compose_generator.generate_compose_all()
+        assert "presearch" not in out
+
+
 class TestEscapeInterpolation:
     def test_basic_escape(self):
         assert compose_generator._escape_interpolation("${FOO}") == "$${FOO}"


### PR DESCRIPTION
## Why

@kissofkill opened three reports — #337, #338, #339 — and after verifying every claim against primary sources, **all three are correct**, and two of them were understatements:

- **Presearch is gone** (#337): the company announced its permanent shutdown on July 24, 2026, effective July 28 — from its own X account and newsletter, with node operators explicitly addressed and backend infrastructure decommissioned. The `presearch/node` image's last push was July 21, then silence; their blog now returns 410. The residual PRE token trading on DEXes is a permissionless contract, not a sign of life.
- **PassiveApp is Windows-only in practice** (#338): the vendor's own download page tags Android, iOS and Linux "coming soon" — unchanged in every Wayback snapshot since February 2025 — and no macOS build exists. Our catalog had copied the site's marketing prose, which contradicts its own download buttons. Our guide separately carried a premature "dead" note; the Windows app (v1.0.15) is live and downloadable, so that's corrected in the other direction too.
- **Bytelixir has no Linux support** (#339): the official FAQ says Windows and Android only, and answers the Linux/Docker question with "no client is planned." We also wrongly listed macOS, which the vendor offers nowhere.

## What

- `presearch.yml` → `status: dead` with the shutdown facts; removed from the README deployable table; recorded under Discontinued / Broken Services; guide carries a do-not-deploy banner. (Dead entries stay in the catalog per house convention — they render hidden and undeployable via `_UNDEPLOYABLE_STATUSES`.)
- `passiveapp.yml` → `platforms: [windows]`; description/notes state the verified coming-soon history; guide's wrong dead-note replaced with the verified state.
- `bytelixir.yml` → `platforms: [windows, android]`; description/notes carry the FAQ's no-Linux-planned fact; guide matched.
- Guides index regenerated (`scripts/sync_docs_nav.py`); README service tables and CLAUDE.md category counts updated.
- Referral links on the two living services click-verified as resolving to working signup flows.

## Testing

Full suite **4714 passed**, coverage **95.61%**; ruff + format clean; `node --check`, currency check, fleet staleness check, and the docs-nav generator check all green.

Fixes #337
Fixes #338
Fixes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated service-status listings to mark Presearch as discontinued following its shutdown.
  - Clarified that Presearch nodes no longer earn rewards and that remaining token activity is residual.
  - Updated Bytelixir support details: Windows and Android are supported; other platforms are unavailable.
  - Updated PassiveApp guidance to reflect current Windows-only availability and earning status.
  - Adjusted active and discontinued service counts accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->