### PR TITLE
fix(catalog): bitping, proxybase and urnetwork could never authenticate

### DIFF
--- a/app/compose_generator.py
+++ b/app/compose_generator.py
@@ -38,6 +38,16 @@ def _escape_interpolation(value: str) -> str:
     return re.sub(r"(?<!\$)\$\{", "$${", value)
 
 
+def _escape_value(value: str) -> str:
+    """Escape every $ in a substituted value so Compose keeps it literal.
+
+    Compose interpolates $VAR and ${VAR} in unquoted and double-quoted YAML
+    values, so a credential like ``tok$word`` written into the file verbatim
+    silently CHANGES when the exported file runs. $$ is the spec's literal form.
+    """
+    return value.replace("$", "$$")
+
+
 def _substitute_env(value: str, env: dict[str, str]) -> str:
     """Fill ${KEY} placeholders from the emitted environment map.
 
@@ -48,9 +58,11 @@ def _substitute_env(value: str, env: dict[str, str]) -> str:
     client with the literal eight characters "${EMAIL}" as its credentials: a file
     that could never authenticate, silently. Placeholders with no corresponding
     entry (proxyrack's ${UUID}) are left for _escape_interpolation, preserving the
-    old template behavior for values CashPilot does not hold.
+    old template behavior for values CashPilot does not hold. Inserted values are
+    $-escaped so a credential containing a dollar sign survives Compose's own
+    interpolation pass.
     """
-    return re.sub(r"\$\{(\w+)\}", lambda m: env.get(m.group(1), m.group(0)), value)
+    return re.sub(r"\$\{(\w+)\}", lambda m: _escape_value(env[m.group(1)]) if m.group(1) in env else m.group(0), value)
 
 
 def _is_named_volume(volume_str: str) -> str | None:
@@ -117,7 +129,12 @@ def _service_to_compose(
         elif var.get("required"):
             env[key] = f"<{var.get('label', key)}>"
     if env:
-        compose_svc["environment"] = env
+        # $-escaped at emission: Compose interpolates inside environment values
+        # too, so a stored password containing $ would otherwise change (or
+        # error) when the exported file runs. The raw map stays unescaped — it
+        # is also the substitution source for command/volumes, which escape at
+        # their own emission point.
+        compose_svc["environment"] = {key: _escape_value(value) for key, value in env.items()}
 
     # Ports
     ports = docker_conf.get("ports", [])

--- a/app/compose_generator.py
+++ b/app/compose_generator.py
@@ -38,6 +38,21 @@ def _escape_interpolation(value: str) -> str:
     return re.sub(r"(?<!\$)\$\{", "$${", value)
 
 
+def _substitute_env(value: str, env: dict[str, str]) -> str:
+    """Fill ${KEY} placeholders from the emitted environment map.
+
+    The catalog uses ${KEY} in `command` and volume host paths to mean "the value
+    of this service's KEY variable" — and the worker deploy path substitutes them
+    (app/main.py api_deploy). The exporter used to only ESCAPE them instead, so an
+    exported honeygain/iproyal/traffmonetizer/packetstream/proxybase file ran the
+    client with the literal eight characters "${EMAIL}" as its credentials: a file
+    that could never authenticate, silently. Placeholders with no corresponding
+    entry (proxyrack's ${UUID}) are left for _escape_interpolation, preserving the
+    old template behavior for values CashPilot does not hold.
+    """
+    return re.sub(r"\$\{(\w+)\}", lambda m: env.get(m.group(1), m.group(0)), value)
+
+
 def _is_named_volume(volume_str: str) -> str | None:
     """Return the volume name if the mapping uses a named volume, else None.
 
@@ -109,10 +124,10 @@ def _service_to_compose(
     if ports:
         compose_svc["ports"] = [str(p) for p in ports]
 
-    # Volumes — escape ${VAR} interpolation in host paths
+    # Volumes — fill ${VAR} host paths from known values, escape whatever remains
     volumes = docker_conf.get("volumes", [])
     if volumes:
-        compose_svc["volumes"] = [_escape_interpolation(str(v)) for v in volumes]
+        compose_svc["volumes"] = [_escape_interpolation(_substitute_env(str(v), env)) for v in volumes]
 
     # Network mode
     network_mode = docker_conf.get("network_mode")
@@ -124,10 +139,10 @@ def _service_to_compose(
     if cap_add:
         compose_svc["cap_add"] = cap_add
 
-    # Command — escape ${VAR} interpolation
+    # Command — fill ${VAR} credentials from known values, escape whatever remains
     command = docker_conf.get("command")
     if command:
-        compose_svc["command"] = _escape_interpolation(command)
+        compose_svc["command"] = _escape_interpolation(_substitute_env(command, env))
 
     # Durable resource limits. Compose accepts these as top-level service keys
     # under the same names the catalog uses; dropping them exported a container

--- a/docs/guides/bitping.md
+++ b/docs/guides/bitping.md
@@ -43,7 +43,7 @@ The node uses your normal account login: the same email and password you use at 
 
 In the CashPilot web UI, find **Bitping** in the service catalog and click **Deploy**. Enter your email and password; the node logs itself in on first start and stores its session in the `bitping-data` volume.
 
-> **Deployed Bitping before and it never earned anything?** CashPilot releases between 2026-03-28 and 1.35.x deployed the container with **no credentials at all** (the catalog had lost the two variables), so the node sat waiting for a login forever. Upgrade CashPilot, then **Deploy** Bitping again from the catalog with your email and password.
+> **Deployed Bitping before and it never earned anything?** CashPilot releases **v0.2.32 through v1.35.1** deployed the container with **no credentials at all** (the catalog had lost the two variables), so the node sat waiting for a login forever. Upgrade CashPilot, then **Deploy** Bitping again from the catalog with your email and password.
 
 ## Docker Configuration
 

--- a/docs/guides/bitping.md
+++ b/docs/guides/bitping.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Bitping is a decentralized network monitoring platform that pays you for running a node. Your node performs website monitoring, latency testing, and network quality checks for Bitping's customers. Works on both residential and VPS connections. The Docker image requires interactive initial setup to authenticate, then persists credentials in a volume mount.
+Bitping is a decentralized network monitoring platform that pays you for running a node. Your node performs website monitoring, latency testing, and network quality checks for Bitping's customers. Works on both residential and VPS connections. The Docker image logs in with the `BITPING_EMAIL` and `BITPING_PASSWORD` environment variables on first start, then persists the session in a volume mount so restarts do not re-authenticate.
 
 ## Earning Estimates
 
@@ -37,11 +37,13 @@ Sign up at [Bitping](https://app.bitping.com).
 
 ### 2. Get your credentials
 
-After signing up, locate the credentials needed for Docker deployment. These are typically your email/password or an API token found in the dashboard.
+The node uses your normal account login: the same email and password you use at [app.bitping.com](https://app.bitping.com). No separate API token is needed.
 
 ### 3. Deploy with CashPilot
 
-In the CashPilot web UI, find **Bitping** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
+In the CashPilot web UI, find **Bitping** in the service catalog and click **Deploy**. Enter your email and password; the node logs itself in on first start and stores its session in the `bitping-data` volume.
+
+> **Deployed Bitping before and it never earned anything?** CashPilot releases between 2026-03-28 and 1.35.x deployed the container with **no credentials at all** (the catalog had lost the two variables), so the node sat waiting for a login forever. Upgrade CashPilot, then **Deploy** Bitping again from the catalog with your email and password.
 
 ## Docker Configuration
 

--- a/docs/guides/proxybase.md
+++ b/docs/guides/proxybase.md
@@ -42,7 +42,7 @@ After signing up and verifying your email, open your [dashboard](https://peer.pr
 
 ### 3. Deploy with CashPilot
 
-In the CashPilot web UI, find **ProxyBase** in the service catalog and click **Deploy**. Enter your Access Token and a device name, and CashPilot will handle the rest.
+In the CashPilot web UI, find **ProxyBase** in the service catalog and click **Deploy**. Enter your Access Token and a device name (no spaces), and CashPilot will handle the rest.
 
 > **Upgrading from an older CashPilot?** ProxyBase moved to a new client image and replaced its credentials: the old `USER_ID`/`DEVICE_NAME` values are retired and cannot be reused. Generate a fresh **Access Token** in your [dashboard](https://peer.proxybase.org/dashboard), then re-deploy ProxyBase from the catalog with it (plus a Device Name) — existing containers built on the old image have stopped earning.
 
@@ -66,6 +66,8 @@ If ProxyBase was deployed before the migration to the new client, the container 
 
 Fix: **Remove** the ProxyBase service, then **Deploy** it again from the catalog and paste a fresh **Access Token** from [your dashboard](https://peer.proxybase.org/dashboard). The redeploy pulls the current `ghcr.io/proxybaseorg/peer-cli` image.
 
-### Container exits immediately after deploy
+### Container loops on `Missing ID and NAME`
 
-The client exits with `Missing ID and NAME` when it starts without credentials. CashPilot's deploy form requires both fields, so this normally can't happen — but if you deployed with an exported compose file, make sure the `ID` and `NAME` environment variables are filled in.
+The peer client accepts its credentials **only as command-line arguments**. Its error text also offers "environment variables ID and NAME", but no published image actually reads them — a container started with only the environment variables loops on `Missing ID and NAME` forever while showing as "running".
+
+CashPilot releases from 2026-07-17 through 1.35.x deployed exactly that shape, so **every fresh ProxyBase deploy in that window hit this** (issue #343). Current CashPilot passes the token and device name as arguments. Fix: upgrade CashPilot, then **Deploy** ProxyBase again from the catalog. If you used an exported compose file from an affected release, re-export it — old exports carried literal `${ID}` placeholders in the command.

--- a/docs/guides/urnetwork.md
+++ b/docs/guides/urnetwork.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-URnetwork is a decentralized VPN and bandwidth-sharing network. You earn by providing bandwidth as a community provider. Uses JWT-based authentication. Official Docker image from Bring Your Own (bringyour). Supports both direct mode (with tun device) and proxy mode (SOCKS5).
+URnetwork is a decentralized VPN and bandwidth-sharing network. You earn by providing bandwidth as a community provider. The provider container authenticates itself with your account email and password (the binary's `auth-provide` subcommand), stores the session JWT in the `urnetwork-data` volume, and starts providing — no manual token extraction involved.
 
 ## Earning Estimates
 
@@ -37,19 +37,24 @@ Sign up at [URnetwork](https://ur.io/?referral_code=1Q3G19).
 
 ### 2. Get your credentials
 
-After signing up, locate the credentials needed for Docker deployment. These are typically your email/password or an API token found in the dashboard.
+The provider logs in with your normal URnetwork account: the email and password you use at [ur.io](https://ur.io). If you created the account with Google or Apple sign-in, set a password on it first — the headless provider has no browser to run an SSO flow in.
 
 ### 3. Deploy with CashPilot
 
-In the CashPilot web UI, find **URnetwork** in the service catalog and click **Deploy**. Enter the required credentials and CashPilot will handle the rest.
+In the CashPilot web UI, find **URnetwork** in the service catalog and click **Deploy**. Enter your email and password; the provider authenticates on first start (`Jwt written to /root/.urnetwork/jwt` in its log), keeps the session in the `urnetwork-data` volume, and starts providing.
+
+Your provider stats and earnings live at [app.ur.network/stats](https://app.ur.network/stats). Link a wallet in the URnetwork app — an unlinked wallet forfeits payouts after 30 days.
+
+> **Deployed URnetwork before and it never earned anything?** CashPilot releases before this fix asked for a `UR_AUTH_TOKEN` variable that the provider binary has never read — the container simply ran unauthenticated (issue #344). Upgrade CashPilot, then **Deploy** URnetwork again from the catalog with your email and password.
 
 ## Docker Configuration
 
-- **Image:** `bringyour/community-provider`
+- **Image:** `bringyour/community-provider:g4-latest` (the release channel the [provider docs](https://docs.ur.io/provider) name as most stable)
 - **Platforms:** linux/amd64, linux/arm64
 
 ### Environment Variables
 
 | Variable | Label | Required | Secret | Description |
 |----------|-------|:--------:|:------:|-------------|
-| `UR_AUTH_TOKEN` | Auth Token | Yes | Yes | Your URnetwork authentication token from the dashboard |
+| `UR_USER_AUTH` | Email | Yes | No | Your URnetwork account email (ur.io login) |
+| `UR_PASSWORD` | Password | Yes | Yes | Your URnetwork account password (no spaces); used by `auth-provide`, session persists in the volume |

--- a/services/bandwidth/bitping.yml
+++ b/services/bandwidth/bitping.yml
@@ -7,8 +7,10 @@ description: >
   Bitping is a decentralized network monitoring platform that pays you for running
   a node. Your node performs website monitoring, latency testing, and network
   quality checks for Bitping's customers. Works on both residential and VPS
-  connections. The Docker image requires interactive initial setup to authenticate,
-  then persists credentials in a volume mount.
+  connections. The Docker image logs in with the BITPING_EMAIL and BITPING_PASSWORD
+  environment variables on first start ("Attempting login with environment
+  variables" in its own log), then persists the session in the volume mount so
+  restarts do not re-authenticate.
 short_description: Bandwidth sharing - decentralized network monitoring, works on VPS
 
 referral:
@@ -20,7 +22,22 @@ docker:
   resources:
     mem_limit: "192m"
     oom_score_adj: 200
-  env: []
+  # These two were dropped in the 2026-03-28 catalog rewrite while the image kept
+  # supporting them, which left every deploy since with NO credentials at all: the
+  # container sat at "No active session" forever and earned nothing (issue #341).
+  # Verified live 2026-08-19 on bitpingd 26.8.17-1: with both set, the daemon logs
+  # "Attempting login with environment variables" and writes a session to disk.
+  env:
+    - key: BITPING_EMAIL
+      label: "Email"
+      required: true
+      secret: false
+      description: "Your Bitping account email (same login as <a href='https://app.bitping.com' target='_blank'>app.bitping.com</a>)"
+    - key: BITPING_PASSWORD
+      label: "Password"
+      required: true
+      secret: true
+      description: "Your Bitping account password. Used once to create the node session, which then persists in the data volume."
   ports: []
   volumes:
     - "bitping-data:/root/.bitping"
@@ -37,9 +54,9 @@ docker:
   # Scoped per-slug, so it grants nothing to any other service.
   cap_add: [NET_RAW]
   notes: >
-    Initial authentication is interactive via the container's web UI.
-    Credentials are then persisted in the /root/.bitping volume mount.
-    No environment variables are needed.
+    Authentication is fully non-interactive: the daemon reads BITPING_EMAIL and
+    BITPING_PASSWORD at startup and stores the resulting session in the
+    /root/.bitping volume mount.
 
 requirements:
   residential_ip: false

--- a/services/bandwidth/proxybase.yml
+++ b/services/bandwidth/proxybase.yml
@@ -15,6 +15,8 @@ referral:
   code: "nXzS3c6iTO"
 
 docker:
+  # Index digest of tag v2.0.3 (their v2.0.x tags re-package the same client, which
+  # still reports itself as 1.0.4 — verified against ghcr 2026-08-19).
   image: "ghcr.io/proxybaseorg/peer-cli@sha256:b78dda3969019eb9e0d3ba0aeba0929148337898b00d99cf780f4d8c99b31b0e"
   platforms: [linux/amd64, linux/arm64, linux/arm/v7]
   resources:
@@ -30,11 +32,17 @@ docker:
       label: "Device Name"
       required: true
       secret: false
-      description: "Any name to identify this device in your ProxyBase dashboard"
+      description: "Any name (no spaces) to identify this device in your ProxyBase dashboard"
       default: "cashpilot-{hostname}"
   ports: []
   volumes: []
-  command: ""
+  # The peer client reads its credentials ONLY as positional arguments. Its own
+  # error text offers "environment variables ID and NAME" as an alternative, but
+  # no published image honors them — verified live 2026-08-19 on both the pinned
+  # digest and tag v2.0.3: env-only containers loop on "Missing ID and NAME"
+  # while argument-style containers connect (issue #343). The ${VAR} placeholders
+  # are filled from the form values at deploy time.
+  command: "${ID} ${NAME}"
   network_mode: ""
 
 requirements:

--- a/services/bandwidth/urnetwork.yml
+++ b/services/bandwidth/urnetwork.yml
@@ -5,31 +5,47 @@ status: active
 website: https://ur.io
 description: >
   URnetwork is a decentralized VPN and bandwidth-sharing network. You earn by
-  providing bandwidth as a community provider. Uses JWT-based authentication.
-  Official Docker image from Bring Your Own (bringyour). Supports both direct
-  mode (with tun device) and proxy mode (SOCKS5).
-short_description: Decentralized VPN/bandwidth - JWT auth, direct or proxy mode
+  providing bandwidth as a community provider. The provider binary authenticates
+  itself with your account email and password (its auth-provide subcommand) and
+  stores the resulting session JWT in the data volume. Official Docker image
+  from BringYour, Inc.
+short_description: Decentralized VPN/bandwidth - email+password auth, JWT session in volume
 
 referral:
   signup_url: "https://ur.io/?referral_code=1Q3G19"
   code: "1Q3G19"
 
 docker:
-  image: bringyour/community-provider
+  # g4-latest is the channel the provider docs (docs.ur.io/provider) name as the
+  # most stable release line.
+  image: bringyour/community-provider:g4-latest
   platforms: [linux/amd64, linux/arm64]
   resources:
     mem_limit: "128m"
     oom_score_adj: 300
+  # The old UR_AUTH_TOKEN env var never existed in the provider: the binary reads
+  # no environment variables at all (its --help is the contract), so every deploy
+  # of that spec started an unauthenticated container (issue #344). auth-provide
+  # logs in with the account credentials, writes the session JWT into the volume
+  # ("Jwt written to /root/.urnetwork/jwt" — verified live 2026-08-19) and starts
+  # providing in one step. On restart it keeps the existing JWT (the overwrite
+  # prompt defaults to No without a TTY) and keeps providing; a fresh client_id
+  # per process start is normal provider behavior on every auth path.
   env:
-    - key: UR_AUTH_TOKEN
-      label: "Auth Token"
+    - key: UR_USER_AUTH
+      label: "Email"
+      required: true
+      secret: false
+      description: "Your URnetwork account email (the login you use at <a href=\"https://ur.io\" target=\"_blank\">ur.io</a>). Accounts created via Google/Apple sign-in need a password set first."
+    - key: UR_PASSWORD
+      label: "Password"
       required: true
       secret: true
-      description: "Log in at <a href=\"https://app.urnetwork.com\">app.urnetwork.com</a>, press F12 → Application → Local Storage → click <code>https://app.urnetwork.com</code> → copy the <code>auth_token</code> value (a JWT starting with eyJ)"
+      description: "Your URnetwork account password (no spaces). Used by the provider's auth-provide login; the session then persists in the data volume."
   ports: []
   volumes:
     - "urnetwork-data:/root/.urnetwork"
-  command: "provide"
+  command: "auth-provide --user_auth=${UR_USER_AUTH} --password=${UR_PASSWORD}"
   network_mode: ""
 
 requirements:
@@ -53,7 +69,9 @@ earnings:
 
 cashout:
   method: redirect
-  dashboard_url: "https://urnetwork.com/dashboard"
+  # urnetwork.com is dead (v6-only DNS remnants, no HTTP answer — issue #344);
+  # the live provider stats page is on the ur.network app domain.
+  dashboard_url: "https://app.ur.network/stats"
   min_amount: 5.0
   currency: USD
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -409,6 +409,36 @@ class TestCommandAndVolumeSubstitution:
         assert parsed["services"]["cashpilot-proxybase"]["command"] == "tok123 mydev"
         assert "${ID}" not in output
 
+    def test_a_credential_containing_a_dollar_survives_compose_interpolation(self):
+        # Compose interpolates $VAR inside unquoted/double-quoted YAML values,
+        # so a password like tok$word emitted verbatim silently CHANGES when the
+        # exported file runs. $$ is the spec's literal form — assert on it.
+        svc = _mock_service(
+            env=[{"key": "ID", "required": True, "label": "Access Token"}],
+            command="${ID} fixed",
+        )
+        result = compose_generator._service_to_compose(svc, env_vars={"ID": "tok$word"})
+        assert result["command"] == "tok$$word fixed"
+        assert result["environment"]["ID"] == "tok$$word"
+
+    def test_dollar_escape_applies_to_volume_paths_too(self):
+        svc = _mock_service(
+            env=[{"key": "IDENTITY_DIR", "required": True, "label": "Identity Directory"}],
+            volumes=["${IDENTITY_DIR}:/app/identity"],
+        )
+        result = compose_generator._service_to_compose(svc, env_vars={"IDENTITY_DIR": "/mnt/$data"})
+        assert result["volumes"] == ["/mnt/$$data:/app/identity"]
+
+    def test_a_value_that_itself_looks_like_a_placeholder_is_not_reinterpolated(self):
+        # The value escapes BEFORE the general escape pass, so its ${ arrives
+        # already $-prefixed and the pass leaves it alone: one escape, not two.
+        svc = _mock_service(
+            env=[{"key": "ID", "required": True, "label": "Access Token"}],
+            command="${ID}",
+        )
+        result = compose_generator._service_to_compose(svc, env_vars={"ID": "we${ird}"})
+        assert result["command"] == "we$${ird}"
+
     def test_the_real_honeygain_export_carries_credentials(self):
         from app.catalog import load_services
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -347,3 +347,82 @@ class TestResourceLimitsSurviveExport:
         assert svc["mem_limit"] == "2g"
         assert svc["oom_score_adj"] == -100
         assert svc["cpu_shares"] == 4096
+
+
+class TestCommandAndVolumeSubstitution:
+    """The exporter must FILL ${KEY} placeholders the way the worker deploy does.
+
+    Before this existed, the exporter only ESCAPED them, so an exported file for
+    every argument-auth service (honeygain, iproyal, traffmonetizer, packetshare,
+    proxybase) ran the client with the literal string "${EMAIL}" as its
+    credential — a compose file that could never authenticate (issue #343).
+    """
+
+    def test_command_placeholders_are_filled_from_supplied_values(self):
+        svc = _mock_service(
+            env=[
+                {"key": "ID", "required": True, "label": "Access Token"},
+                {"key": "NAME", "default": "dev-{hostname}"},
+            ],
+            command="${ID} ${NAME}",
+        )
+        result = compose_generator._service_to_compose(svc, env_vars={"ID": "tok123", "NAME": "mydev"})
+        assert result["command"] == "tok123 mydev"
+
+    def test_command_placeholders_fall_back_to_defaults_and_labels(self):
+        svc = _mock_service(
+            env=[
+                {"key": "ID", "required": True, "label": "Access Token"},
+                {"key": "NAME", "default": "dev-{hostname}"},
+            ],
+            command="${ID} ${NAME}",
+        )
+        result = compose_generator._service_to_compose(svc, hostname="pi4")
+        assert result["command"] == "<Access Token> dev-pi4"
+
+    def test_unknown_placeholder_is_still_escaped_for_compose(self):
+        # proxyrack's default carries ${UUID}, which is no catalog env key —
+        # values CashPilot does not hold keep the escape-as-template behavior.
+        svc = _mock_service(command="start ${NOT_A_CATALOG_KEY}")
+        result = compose_generator._service_to_compose(svc)
+        assert result["command"] == "start $${NOT_A_CATALOG_KEY}"
+
+    def test_volume_host_paths_are_filled_from_supplied_values(self):
+        svc = _mock_service(
+            env=[{"key": "IDENTITY_DIR", "required": True, "label": "Identity Directory"}],
+            volumes=["${IDENTITY_DIR}:/app/identity"],
+        )
+        result = compose_generator._service_to_compose(svc, env_vars={"IDENTITY_DIR": "/mnt/id"})
+        assert result["volumes"] == ["/mnt/id:/app/identity"]
+
+    def test_the_real_proxybase_export_authenticates_not_placeholders(self):
+        # End to end through the YAML renderer against the real catalog entry:
+        # the peer client reads ONLY positional arguments (its env-var hint is
+        # false — verified live against the pinned digest and tag v2.0.3), so
+        # the exported command must carry the actual values.
+        from app.catalog import load_services
+
+        proxybase = next(s for s in load_services() if s.get("slug") == "proxybase")
+        with patch("app.compose_generator.get_service", return_value=proxybase):
+            output = compose_generator.generate_compose_single("proxybase", env_vars={"ID": "tok123", "NAME": "mydev"})
+        parsed = yaml.safe_load("\n".join(line for line in output.split("\n") if not line.startswith("#")))
+        assert parsed["services"]["cashpilot-proxybase"]["command"] == "tok123 mydev"
+        assert "${ID}" not in output
+
+    def test_the_real_honeygain_export_carries_credentials(self):
+        from app.catalog import load_services
+
+        honeygain = next(s for s in load_services() if s.get("slug") == "honeygain")
+        with patch("app.compose_generator.get_service", return_value=honeygain):
+            output = compose_generator.generate_compose_single(
+                "honeygain",
+                env_vars={
+                    "HONEYGAIN_EMAIL": "a@b.c",
+                    "HONEYGAIN_PASSWORD": "pw",
+                    "HONEYGAIN_DEVICE_NAME": "dev1",
+                },
+            )
+        parsed = yaml.safe_load("\n".join(line for line in output.split("\n") if not line.startswith("#")))
+        cmd = parsed["services"]["cashpilot-honeygain"]["command"]
+        assert "-email a@b.c" in cmd
+        assert "${HONEYGAIN_EMAIL}" not in cmd

--- a/tests/test_main_deploy_routes.py
+++ b/tests/test_main_deploy_routes.py
@@ -395,6 +395,107 @@ class TestApiDeploy:
                 "cpu_shares": 4096,
             }
 
+    def test_deploy_proxybase_real_catalog_passes_credentials_as_arguments(self, client, deploy_capture):
+        """Guard for issue #343: the peer client reads ONLY positional arguments.
+
+        Its own error text offers "environment variables ID and NAME", but no
+        published image honors them (verified live against the pinned digest
+        and tag v2.0.3): an env-only container loops on "Missing ID and NAME"
+        while showing as running. The catalog command must therefore reach the
+        worker spec with both values substituted — if a catalog rewrite drops
+        the command line again (the 2026-07-17 fix shipped without it), this
+        goes red.
+        """
+        captured, capture = deploy_capture
+
+        from app import catalog
+
+        catalog.load_services()
+
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_worker_deploy", side_effect=capture),
+            patch("app.main.database.save_deployment", new_callable=AsyncMock),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
+        ):
+            resp = client.post(
+                "/api/deploy/proxybase",
+                json={"env": {"ID": "tok123", "NAME": "mydev"}},
+            )
+            assert resp.status_code == 200, resp.text
+            assert captured["spec"]["command"] == "tok123 mydev"
+
+    def test_deploy_bitping_real_catalog_requires_credentials(self, client, deploy_capture):
+        """Guard for issue #341: bitping must not deploy credential-less.
+
+        The 2026-03-28 catalog rewrite dropped BITPING_EMAIL/BITPING_PASSWORD
+        while the guide and the image kept supporting them, so every deploy
+        for months shipped a node that sat at "No active session" earning
+        nothing. With the env block restored, an empty deploy is rejected up
+        front; if the block is ever dropped again, the empty deploy succeeds
+        and this goes red.
+        """
+        captured, capture = deploy_capture
+
+        from app import catalog
+
+        catalog.load_services()
+
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_worker_deploy", side_effect=capture),
+            patch("app.main.database.save_deployment", new_callable=AsyncMock),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
+        ):
+            resp = client.post("/api/deploy/bitping", json={"env": {}})
+            assert resp.status_code == 400
+            assert "Email" in resp.json()["detail"]
+            assert "Password" in resp.json()["detail"]
+
+            resp = client.post(
+                "/api/deploy/bitping",
+                json={"env": {"BITPING_EMAIL": "a@b.c", "BITPING_PASSWORD": "pw"}},
+            )
+            assert resp.status_code == 200, resp.text
+            assert captured["spec"]["env"]["BITPING_EMAIL"] == "a@b.c"
+            assert captured["spec"]["env"]["BITPING_PASSWORD"] == "pw"
+
+    def test_deploy_urnetwork_real_catalog_authenticates_via_auth_provide(self, client, deploy_capture):
+        """Guard for issue #344: the provider binary reads NO environment variables.
+
+        The retired UR_AUTH_TOKEN spec deployed containers that simply ran
+        unauthenticated. The working contract (the binary's own --help, verified
+        live) is the auth-provide subcommand with the account credentials as
+        arguments — so the substituted command must reach the worker spec, and a
+        credential-less deploy must be rejected up front.
+        """
+        captured, capture = deploy_capture
+
+        from app import catalog
+
+        catalog.load_services()
+
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_worker_deploy", side_effect=capture),
+            patch("app.main.database.save_deployment", new_callable=AsyncMock),
+            patch("app.main.database.record_health_event", new_callable=AsyncMock),
+        ):
+            resp = client.post("/api/deploy/urnetwork", json={"env": {}})
+            assert resp.status_code == 400
+            assert "Email" in resp.json()["detail"]
+            assert "Password" in resp.json()["detail"]
+
+            resp = client.post(
+                "/api/deploy/urnetwork",
+                json={"env": {"UR_USER_AUTH": "a@b.c", "UR_PASSWORD": "pw"}},
+            )
+            assert resp.status_code == 200, resp.text
+            assert captured["spec"]["command"] == "auth-provide --user_auth=a@b.c --password=pw"
+
 
 # ---------------------------------------------------------------------------
 # Stop / Restart / Start / Remove (service management routes)


### PR DESCRIPTION
kissofkill deployed three services from the catalog on a Pi and none of them worked — bitping never logged in (#341), proxybase looped on `Missing ID and NAME` while showing as running (#343), and urnetwork's dashboard link led to a dead site while the container ran unauthenticated (#344). All three claims are real, and in every case the catalog described an auth mechanism the provider's container does not actually have.

**bitping** — the `BITPING_EMAIL`/`BITPING_PASSWORD` env block was dropped in the 2026-03-28 catalog rewrite while the image and the guide kept supporting it, so every deploy since March shipped a node with no credentials that sat at "No active session" forever. Restored, and the description now tells the truth (there is no "interactive web UI" setup). Verified live on `bitpingd 26.8.17-1`: "Attempting login with environment variables" → "Wrote new session to disk", session persists in the volume.

**proxybase** — the peer client reads credentials **only as positional arguments**. Its own error text offers "environment variables ID and NAME", but no published image honors them — verified against both the pinned digest and tag v2.0.3 (which is the same manifest; the binary self-reports 1.0.4). The env-only spec from the 2026-07-17 migration therefore broke every fresh deploy while the fleet containers from that incident's hand-testing kept working. The spec now passes `${ID} ${NAME}` as the command; verified authenticating end to end with a real token.

**urnetwork** — `UR_AUTH_TOKEN` never existed: the provider binary reads no environment variables at all (its `--help` is the contract), so the old spec deployed unauthenticated containers, and the localStorage-token instructions pointed users at the wrong kind of token. The spec now uses the binary's `auth-provide` subcommand with the account email and password; the session JWT lands in the data volume (verified live: "Jwt written to /root/.urnetwork/jwt", then providing; restart keeps the JWT and keeps providing). `cashout.dashboard_url` moves from the dead `urnetwork.com/dashboard` to the live stats page `app.ur.network/stats`, and the image pins `g4-latest`, the channel the provider docs name as most stable.

**Found on the way, same class:** the compose exporter only *escaped* `${VAR}` placeholders, so exported files for every argument-auth service (honeygain, iproyal, traffmonetizer, packetstream, and now proxybase) carried the literal placeholder string as the credential — a compose file that could never authenticate. The exporter now substitutes known values the way the worker deploy does, then escapes whatever remains (unknown placeholders like proxyrack's `${UUID}` keep the template behavior).

Every spec change was validated through the real UI → worker → docker path on a fresh 1.35.0 install with real credentials. The new regression tests are mutation-verified — each goes red when its mechanism is removed (proxybase command dropped, bitping env dropped, urnetwork command reverted, exporter substitution removed).

Fixes #341
Fixes #343
Fixes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic environment-variable substitution in deployment commands and volume paths.
  - Updated Bitping, ProxyBase, and URnetwork deployments with streamlined credential handling and startup configuration.
  - Added persistent authentication sessions for Bitping and URnetwork.
  - Updated URnetwork to use email/password authentication and a stable provider image.

- **Documentation**
  - Clarified setup, credential, persistence, device naming, troubleshooting, upgrade, and redeployment guidance.
  - Documented affected CashPilot releases and required configuration updates.

- **Bug Fixes**
  - Improved credential validation and forwarding for supported deployments.
  - Preserved unknown Compose placeholders for Docker’s literal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->