### PR TITLE
feat(settings): update CashPilot from the dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2207,7 +2207,16 @@ def _safe_worker_detail(resp: Any) -> dict[str, Any] | None:
     error = detail.get("error") if isinstance(detail, dict) else None
     # error comes from a remote worker body; a list/dict would make the `not in`
     # test raise TypeError and turn a 409 into a 500. Require a string.
-    if not isinstance(error, str) or error not in _FORWARDABLE_WORKER_ERRORS:
+    if not isinstance(error, str):
+        return None
+    # The self-update refusal is the second forwardable shape: a fixed,
+    # worker-authored instruction string ("not compose-managed, run these
+    # commands instead"). Without this, the sanitizer replaced it with the
+    # generic "Worker request failed" and the promised manual instructions
+    # never reached the operator.
+    if error == "self_update_unavailable":
+        return {"error": error, "message": str(detail.get("message") or "")}
+    if error not in _FORWARDABLE_WORKER_ERRORS:
         return None
     blocked = detail.get("blocked")
     if not isinstance(blocked, list):

--- a/app/main.py
+++ b/app/main.py
@@ -3887,6 +3887,53 @@ async def api_set_preferences(
 # ---------------------------------------------------------------------------
 
 
+# --- Self-update surface (issue #342) ------------------------------------
+#
+# The daily release check (app/update_check.py, CashPilot-w0ss) already knows
+# the newest published release; these routes add what an operator can DO about
+# it. `behind` from update_check.state() is deliberately series-based; the
+# update button's semantic is different — it installs the newest PATCH of the
+# series the compose file pins — so patch_available is computed separately.
+
+
+@app.get("/api/update-info")
+async def api_update_info(request: Request, worker_id: int | None = None) -> dict[str, Any]:
+    """Everything the settings card needs: versions + what an update would do."""
+    _require_owner(request)
+    wid = await _resolve_worker_id(worker_id)
+    info = await _proxy_to_worker(wid, "GET", "/api/update/info")
+    check = update_check.state()
+    current = version.current()
+    latest = check.get("latest")
+    same_series = version.series(latest) is not None and version.series(latest) == version.series(current)
+    info.update(
+        {
+            "current": current,
+            "current_display": version.display(),
+            "latest": latest,
+            "known": check.get("known", False),
+            "behind": check.get("behind", False),
+            # True only when the documented `compose pull` would actually land a
+            # newer image on a series-pinned install.
+            "patch_available": same_series and version.is_newer(latest, current),
+        }
+    )
+    return info
+
+
+@app.post("/api/update")
+async def api_update(request: Request, worker_id: int | None = None) -> dict[str, Any]:
+    """Run the documented update on the selected worker's install.
+
+    The worker refuses with instructions (409) when the install is not
+    compose-managed; that detail passes through to the caller verbatim. The
+    long timeout covers the helper-image pull on a slow line.
+    """
+    _require_owner(request)
+    wid = await _resolve_worker_id(worker_id)
+    return await _proxy_to_worker(wid, "POST", "/api/update/self", timeout=120)
+
+
 @app.get("/api/env-info")
 async def api_env_info(request: Request) -> list[dict[str, Any]]:
     _require_owner(request)

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -565,6 +565,142 @@ def start_service(slug: str) -> None:
     logger.info("Started container %s", container.name)
 
 
+# ---------------------------------------------------------------------------
+# Self-update (issue #342)
+#
+# The documented install pins a MAJOR.MINOR image series with pull_policy:
+# always, and docker-compose.yml itself names `docker compose pull && docker
+# compose up -d` as the update path. The update button runs exactly that — from
+# a transient helper container, because the worker cannot recreate itself from
+# inside the process being recreated.
+#
+# Nothing here is caller-controlled: the compose project location comes from
+# the labels Compose put on the worker's OWN container, the helper image is
+# pinned, and the command is fixed. An install that pins an exact tag (GitOps
+# fleets) gets a no-op pull by construction; an install not managed by Compose
+# is refused with instructions instead of guessing.
+# ---------------------------------------------------------------------------
+
+#: Pinned helper image (ships the compose plugin — verified v2.33.0). Never :latest.
+UPDATER_IMAGE = "docker:27.5.1-cli"
+#: Fixed helper name: doubles as the only-one-update-at-a-time lock.
+UPDATER_NAME = "cashpilot-updater"
+_UPDATER_COMMAND = "docker compose pull && docker compose up -d"
+
+
+class SelfUpdateUnavailable(RuntimeError):
+    """This install cannot be updated by the helper; the message says what to do."""
+
+
+def _self_container(client: docker.DockerClient):
+    """The worker's own container, or None outside Docker.
+
+    The container hostname defaults to the short container id (the documented
+    compose file sets container_name, not hostname), so gethostname() resolves
+    directly; the documented container name is the fallback for installs that
+    do set a hostname.
+    """
+    import socket as _socket
+
+    for candidate in (_socket.gethostname(), "cashpilot-worker"):
+        try:
+            return client.containers.get(candidate)
+        except (NotFound, APIError):
+            continue
+    return None
+
+
+def _compose_project(container: Any) -> dict[str, str]:
+    labels = (container.attrs.get("Config", {}) or {}).get("Labels") or {}
+    return {
+        "working_dir": labels.get("com.docker.compose.project.working_dir") or "",
+        "config_files": labels.get("com.docker.compose.project.config_files") or "",
+        "project": labels.get("com.docker.compose.project") or "",
+    }
+
+
+def self_update_info() -> dict[str, Any]:
+    """What an update here would actually do — facts, no side effects."""
+    client = _get_client()
+    me = _self_container(client)
+    info: dict[str, Any] = {
+        "compose_managed": False,
+        "working_dir": "",
+        "project": "",
+        "worker_image": "",
+        "ui_image": "",
+        "updater_running": False,
+    }
+    if me is not None:
+        project = _compose_project(me)
+        info["compose_managed"] = bool(project["working_dir"])
+        info["working_dir"] = project["working_dir"]
+        info["project"] = project["project"]
+        info["worker_image"] = (me.attrs.get("Config", {}) or {}).get("Image") or ""
+    with contextlib.suppress(NotFound, APIError):
+        ui = client.containers.get("cashpilot-ui")
+        info["ui_image"] = (ui.attrs.get("Config", {}) or {}).get("Image") or ""
+    with contextlib.suppress(NotFound, APIError):
+        updater = client.containers.get(UPDATER_NAME)
+        info["updater_running"] = updater.status == "running"
+    return info
+
+
+def spawn_self_update() -> dict[str, Any]:
+    """Start the one-shot updater helper and return its identity.
+
+    Raises SelfUpdateUnavailable when this install has no compose project to
+    update (not deployed via Compose, or the worker cannot see itself), and
+    when an update is already running.
+    """
+    client = _get_client()
+    me = _self_container(client)
+    if me is None:
+        raise SelfUpdateUnavailable(
+            "The worker cannot identify its own container, so it cannot locate "
+            "your compose project. Update manually: docker compose pull && docker compose up -d"
+        )
+    project = _compose_project(me)
+    if not project["working_dir"]:
+        raise SelfUpdateUnavailable(
+            "This install is not managed by Docker Compose (no compose labels on "
+            "the worker container). Update manually with the commands you used to "
+            "install — for docker run, pull the new image and recreate the "
+            "cashpilot-ui and cashpilot-worker containers."
+        )
+
+    try:
+        existing = client.containers.get(UPDATER_NAME)
+        if existing.status == "running":
+            raise SelfUpdateUnavailable("An update is already running.")
+        # A leftover from an interrupted run — clear it so the fixed name is free.
+        existing.remove(force=True)
+    except NotFound:
+        pass
+
+    environment: dict[str, str] = {}
+    if project["config_files"]:
+        # Compose separates label paths with commas; COMPOSE_FILE uses colons.
+        environment["COMPOSE_FILE"] = project["config_files"].replace(",", ":")
+
+    updater = client.containers.run(
+        UPDATER_IMAGE,
+        name=UPDATER_NAME,
+        command=["sh", "-c", _UPDATER_COMMAND],
+        working_dir=project["working_dir"],
+        volumes={
+            "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
+            project["working_dir"]: {"bind": project["working_dir"], "mode": "rw"},
+        },
+        environment=environment,
+        labels={"cashpilot.updater": "true"},
+        detach=True,
+        remove=True,
+    )
+    logger.info("Self-update started: helper %s in %s", updater.id[:12], project["working_dir"])
+    return {"updater_id": updater.id[:12], "working_dir": project["working_dir"]}
+
+
 def _collect_stats(c) -> tuple[float, float, int | None, int | None]:
     """Collect CPU%, memory and cumulative network counters for one container.
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -585,7 +585,34 @@ def start_service(slug: str) -> None:
 UPDATER_IMAGE = "docker:27.5.1-cli"
 #: Fixed helper name: doubles as the only-one-update-at-a-time lock.
 UPDATER_NAME = "cashpilot-updater"
-_UPDATER_COMMAND = "docker compose pull && docker compose up -d"
+
+
+def _updater_script(services: list[str]) -> str:
+    """The helper's fixed script, scoped to the named compose services.
+
+    Two guards precede the documented pull/up:
+    - `docker compose config` must succeed — a file the resolver rejects must
+      never drive a recreation.
+    - Unset ``${VAR}`` substitutions abort. The helper does not inherit the
+      shell environment the operator originally deployed with, so a variable
+      that resolved to a bind path then would resolve to EMPTY now — recreating
+      onto broken mounts. (The documented compose file only uses ``:-`` defaults
+      and is immune; this protects customized files.)
+
+    And the pull/up is scoped to the CashPilot services by name — a user's
+    compose project may hold other services, and recreating those is exactly
+    the bulk-redeploy the catalog rules forbid.
+    """
+    import shlex as _shlex
+
+    scoped = " ".join(_shlex.quote(s) for s in services)
+    return (
+        "if ! w=$(docker compose config 2>&1 >/dev/null); then "
+        'echo "refusing to update: docker compose rejected the configuration:"; echo "$w"; exit 1; fi; '
+        'if [ -n "$w" ] && echo "$w" | grep -qi "is not set"; then '
+        'echo "refusing to update: the compose file references variables that are not set here:"; echo "$w"; exit 1; fi; '
+        f"docker compose pull {scoped} && docker compose up -d --no-deps {scoped}"
+    )
 
 
 class SelfUpdateUnavailable(RuntimeError):
@@ -669,36 +696,73 @@ def spawn_self_update() -> dict[str, Any]:
             "cashpilot-ui and cashpilot-worker containers."
         )
 
-    try:
-        existing = client.containers.get(UPDATER_NAME)
-        if existing.status == "running":
-            raise SelfUpdateUnavailable("An update is already running.")
-        # A leftover from an interrupted run — clear it so the fixed name is free.
-        existing.remove(force=True)
-    except NotFound:
-        pass
+    # The update is scoped to the CashPilot services BY NAME, both derived from
+    # container labels — never `up -d` on the whole project, which would
+    # recreate any unrelated services the operator keeps in the same file.
+    me_labels = (me.attrs.get("Config", {}) or {}).get("Labels") or {}
+    services: list[str] = []
+    my_service = me_labels.get("com.docker.compose.service")
+    if my_service:
+        services.append(my_service)
+    with contextlib.suppress(NotFound, APIError):
+        ui = client.containers.get("cashpilot-ui")
+        ui_labels = (ui.attrs.get("Config", {}) or {}).get("Labels") or {}
+        if ui_labels.get("com.docker.compose.project") == project["project"]:
+            ui_service = ui_labels.get("com.docker.compose.service")
+            if ui_service and ui_service not in services:
+                services.append(ui_service)
+    if not services:
+        raise SelfUpdateUnavailable(
+            "The worker container carries a compose project but no service name "
+            "label, so the update cannot be scoped safely. Update manually: "
+            "docker compose pull && docker compose up -d"
+        )
 
     environment: dict[str, str] = {}
     if project["config_files"]:
         # Compose separates label paths with commas; COMPOSE_FILE uses colons.
         environment["COMPOSE_FILE"] = project["config_files"].replace(",", ":")
 
-    updater = client.containers.run(
-        UPDATER_IMAGE,
-        name=UPDATER_NAME,
-        command=["sh", "-c", _UPDATER_COMMAND],
-        working_dir=project["working_dir"],
-        volumes={
-            "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
-            project["working_dir"]: {"bind": project["working_dir"], "mode": "rw"},
-        },
-        environment=environment,
-        labels={"cashpilot.updater": "true"},
-        detach=True,
-        remove=True,
+    try:
+        try:
+            existing = client.containers.get(UPDATER_NAME)
+            if existing.status == "running":
+                raise SelfUpdateUnavailable("An update is already running.")
+            # A leftover from an interrupted run — clear it so the fixed name is free.
+            existing.remove(force=True)
+        except NotFound:
+            pass
+
+        updater = client.containers.run(
+            UPDATER_IMAGE,
+            name=UPDATER_NAME,
+            command=["sh", "-c", _updater_script(services)],
+            working_dir=project["working_dir"],
+            volumes={
+                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
+                project["working_dir"]: {"bind": project["working_dir"], "mode": "rw"},
+            },
+            environment=environment,
+            labels={"cashpilot.updater": "true"},
+            detach=True,
+            remove=True,
+        )
+    except APIError as exc:
+        # Two updates racing: the loser's containers.run hits a 409 name
+        # conflict on the fixed helper name — that is the already-running
+        # answer, not an outage. Anything else from the daemon is.
+        if getattr(exc, "status_code", None) == 409:
+            raise SelfUpdateUnavailable("An update is already running (the helper name is in use).") from exc
+        logger.warning("Self-update helper failed to start: %s", exc)
+        raise RuntimeError("Docker refused to start the update helper.") from exc
+
+    logger.info(
+        "Self-update started: helper %s updating %s in %s",
+        updater.id[:12],
+        ", ".join(services),
+        project["working_dir"],
     )
-    logger.info("Self-update started: helper %s in %s", updater.id[:12], project["working_dir"])
-    return {"updater_id": updater.id[:12], "working_dir": project["working_dir"]}
+    return {"updater_id": updater.id[:12], "working_dir": project["working_dir"], "services": services}
 
 
 def _collect_stats(c) -> tuple[float, float, int | None, int | None]:

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -23,8 +23,11 @@ const CP = (() => {
       const res = await fetch(path, config);
       const data = await res.json().catch(() => null);
       if (!res.ok) {
-        const msg = (data && data.detail) || `Error ${res.status}`;
-        throw new Error(msg);
+        // detail can be a structured refusal ({error, message, ...}); surface
+        // its message instead of the useless "[object Object]".
+        let detail = data && data.detail;
+        if (detail && typeof detail === 'object') detail = detail.message || JSON.stringify(detail);
+        throw new Error(detail || `Error ${res.status}`);
       }
       return data;
     } catch (err) {
@@ -2839,6 +2842,9 @@ const CP = (() => {
 
   async function loadSettings() {
     populateCurrencyDropdown();
+    // Independent of /api/config on purpose: a failed config load must not
+    // leave the update card stuck on "Loading..." — it has its own error path.
+    loadUpdateCard();
     try {
       const [config, envInfo, collectorsMeta] = await Promise.all([
         api('/api/config'),
@@ -2848,7 +2854,6 @@ const CP = (() => {
       renderEnvVars(envInfo, config);
       renderCollectors(collectorsMeta, config);
       loadCredentialHealth();
-      loadUpdateCard();
     } catch (err) {
       // Say what happened. /api/env-info and /api/collectors/meta each carry
       // their own .catch, so the only call that can reject is /api/config —
@@ -2882,12 +2887,23 @@ const CP = (() => {
 
   // --- About & Updates (issue #342) ---------------------------------------
 
+  // The worker whose install the card inspects/updates. Multi-worker fleets
+  // get a selector; _resolve_worker_id would otherwise 400 the whole card.
+  let updateCardWorkerId = null;
+
   async function loadUpdateCard() {
     const container = document.getElementById('update-card-container');
     if (!container) return;
     try {
-      const info = await api('/api/update-info');
-      renderUpdateCard(info);
+      const workers = await api('/api/workers').catch(() => []);
+      const online = (workers || []).filter(w => w.status === 'online');
+      if (!online.length) {
+        container.innerHTML = `<p style="color:var(--text-muted);font-size:0.85rem;">No worker is online, so the install cannot be inspected or updated right now.</p>`;
+        return;
+      }
+      if (!online.some(w => w.id === updateCardWorkerId)) updateCardWorkerId = online[0].id;
+      const info = await api(`/api/update-info?worker_id=${updateCardWorkerId}`);
+      renderUpdateCard(info, online);
     } catch (err) {
       // The card must render something honest even with the worker down — the
       // rest of the settings page is still usable.
@@ -2896,7 +2912,12 @@ const CP = (() => {
     }
   }
 
-  function renderUpdateCard(info) {
+  function selectUpdateWorker(sel) {
+    updateCardWorkerId = parseInt(sel.value, 10);
+    loadUpdateCard();
+  }
+
+  function renderUpdateCard(info, onlineWorkers) {
     const container = document.getElementById('update-card-container');
     if (!container) return;
     const current = info.current_display || info.current || 'dev';
@@ -2906,7 +2927,18 @@ const CP = (() => {
         <div style="font-weight:600;font-size:0.9rem;color:var(--text-primary);">${escapeHtml(label)}</div>
         <div style="font-size:0.9rem;color:var(--text-secondary);font-family:monospace;">${escapeHtml(value)}</div>
       </div>`;
-    let html = line('Running', current);
+    let html = '';
+    if ((onlineWorkers || []).length > 1) {
+      const options = onlineWorkers.map(w =>
+        `<option value="${escapeHtml(String(w.id))}" ${w.id === updateCardWorkerId ? 'selected' : ''}>${escapeHtml(w.name || `worker ${w.id}`)}</option>`
+      ).join('');
+      html += `
+      <div style="display:grid;grid-template-columns:220px 1fr;gap:12px;padding:8px 0;border-bottom:1px solid var(--border-color);">
+        <div style="font-weight:600;font-size:0.9rem;color:var(--text-primary);">Server</div>
+        <div><select id="update-worker-select" class="form-input" style="max-width:280px;">${options}</select></div>
+      </div>`;
+    }
+    html += line('Running', current);
     if (info.worker_image) html += line('Worker image', info.worker_image);
     if (info.ui_image) html += line('Dashboard image', info.ui_image);
     html += line('Latest release', latest || 'unknown — check disabled, not yet run, or GitHub unreachable');
@@ -2938,6 +2970,8 @@ const CP = (() => {
       <div class="form-hint" style="margin-top:8px;">${escapeHtml(note)}</div>`;
     }
     container.innerHTML = html + action;
+    const sel = container.querySelector('#update-worker-select');
+    if (sel) sel.addEventListener('change', e => selectUpdateWorker(e.target));
   }
 
   async function runSelfUpdate() {
@@ -2945,7 +2979,9 @@ const CP = (() => {
     const status = document.getElementById('update-run-status');
     if (status) status.textContent = 'Starting update…';
     try {
-      await api('/api/update', { method: 'POST' });
+      // Same worker the card inspected — info and action must not diverge.
+      const q = updateCardWorkerId != null ? `?worker_id=${updateCardWorkerId}` : '';
+      await api(`/api/update${q}`, { method: 'POST' });
       if (status) status.textContent = 'Update started — the dashboard will restart. Reload this page in a minute.';
     } catch (err) {
       // A 409 carries the worker's honest refusal (e.g. not compose-managed,

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2848,6 +2848,7 @@ const CP = (() => {
       renderEnvVars(envInfo, config);
       renderCollectors(collectorsMeta, config);
       loadCredentialHealth();
+      loadUpdateCard();
     } catch (err) {
       // Say what happened. /api/env-info and /api/collectors/meta each carry
       // their own .catch, so the only call that can reject is /api/config —
@@ -2877,6 +2878,80 @@ const CP = (() => {
       const el = document.getElementById(id);
       if (el) el.innerHTML = `<p style="color:var(--error);font-size:0.85rem;">${escapeHtml(message)}</p>`;
     });
+  }
+
+  // --- About & Updates (issue #342) ---------------------------------------
+
+  async function loadUpdateCard() {
+    const container = document.getElementById('update-card-container');
+    if (!container) return;
+    try {
+      const info = await api('/api/update-info');
+      renderUpdateCard(info);
+    } catch (err) {
+      // The card must render something honest even with the worker down — the
+      // rest of the settings page is still usable.
+      const detail = (err && err.message) ? `: ${err.message}` : '';
+      container.innerHTML = `<p style="color:var(--text-muted);font-size:0.85rem;">${escapeHtml(`Could not read update state${detail}. The local worker may be unreachable.`)}</p>`;
+    }
+  }
+
+  function renderUpdateCard(info) {
+    const container = document.getElementById('update-card-container');
+    if (!container) return;
+    const current = info.current_display || info.current || 'dev';
+    const latest = (info.known && info.latest) ? `v${String(info.latest).replace(/^v/, '')}` : null;
+    const line = (label, value) => `
+      <div style="display:grid;grid-template-columns:220px 1fr;gap:12px;padding:8px 0;border-bottom:1px solid var(--border-color);">
+        <div style="font-weight:600;font-size:0.9rem;color:var(--text-primary);">${escapeHtml(label)}</div>
+        <div style="font-size:0.9rem;color:var(--text-secondary);font-family:monospace;">${escapeHtml(value)}</div>
+      </div>`;
+    let html = line('Running', current);
+    if (info.worker_image) html += line('Worker image', info.worker_image);
+    if (info.ui_image) html += line('Dashboard image', info.ui_image);
+    html += line('Latest release', latest || 'unknown — check disabled, not yet run, or GitHub unreachable');
+
+    let action;
+    if (info.updater_running) {
+      action = `<p style="font-size:0.85rem;color:var(--text-secondary);margin-top:12px;">An update is already running — the dashboard may restart at any moment. Reload this page in a minute.</p>`;
+    } else if (!info.compose_managed) {
+      action = `<p style="font-size:0.85rem;color:var(--text-muted);margin-top:12px;">This install is not managed by Docker Compose, so CashPilot cannot update itself. Update manually: pull the new images, then recreate the <code>cashpilot-ui</code> and <code>cashpilot-worker</code> containers the way you created them.</p>`;
+    } else {
+      let label; let note;
+      if (info.patch_available) {
+        label = `Update to ${latest}`;
+        note = 'Installs the newest patch of your pinned series and recreates the CashPilot containers.';
+      } else if (info.behind) {
+        label = 'Pull newest patches';
+        note = `A newer series (${latest}) exists — moving to it means editing the image tags in your compose file. This button installs the newest patch of the series you currently pin.`;
+      } else {
+        label = 'Re-pull images';
+        note = latest
+          ? 'You are on the newest known release. The button re-runs the documented pull anyway.'
+          : 'The newest release is unknown; the button still runs the documented pull for your pinned series.';
+      }
+      action = `
+      <div style="display:flex;gap:12px;align-items:center;margin-top:14px;">
+        <button class="btn btn-primary" data-action="runSelfUpdate">${escapeHtml(label)}</button>
+        <span id="update-run-status" style="font-size:0.85rem;color:var(--text-muted);"></span>
+      </div>
+      <div class="form-hint" style="margin-top:8px;">${escapeHtml(note)}</div>`;
+    }
+    container.innerHTML = html + action;
+  }
+
+  async function runSelfUpdate() {
+    if (!confirm('Update CashPilot now? This pulls the newest images of your pinned series and recreates the CashPilot containers — the dashboard will briefly go away.')) return;
+    const status = document.getElementById('update-run-status');
+    if (status) status.textContent = 'Starting update…';
+    try {
+      await api('/api/update', { method: 'POST' });
+      if (status) status.textContent = 'Update started — the dashboard will restart. Reload this page in a minute.';
+    } catch (err) {
+      // A 409 carries the worker's honest refusal (e.g. not compose-managed,
+      // or an update already running) — show it verbatim, it IS the answer.
+      if (status) status.textContent = (err && err.message) ? err.message : 'Update failed to start.';
+    }
   }
 
   function renderEnvVars(envInfo, config) {
@@ -3657,6 +3732,7 @@ const CP = (() => {
     loadDeployRisk,
     confirmPayout,
     rejectPayout,
+    runSelfUpdate,
     // Exposed for fleet.html, which rendered running costs with a bare
     // Number(v).toFixed(2) — no unit at all, on figures that mixed USD earnings
     // with a tariff in the user's own currency. The API is canonical USD now,

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -7,6 +7,21 @@
 {% block content %}
 <h2 class="section-title" style="margin-bottom: 24px;">Settings</h2>
 
+<!-- About & Updates (issue #342) -->
+<div class="card settings-section">
+  <h3 class="settings-section-title">About &amp; Updates</h3>
+  <p class="settings-section-desc">
+    CashPilot checks GitHub for the latest release. <strong>Update</strong> runs the
+    documented <code>docker compose pull &amp;&amp; docker compose up -d</code> for you,
+    from a one-shot helper container &mdash; it installs the newest patch of the image
+    series your compose file pins. Moving to a newer series still means editing the
+    image tags. Installs not managed by Compose get the manual commands instead.
+  </p>
+  <div id="update-card-container">
+    <p style="color: var(--text-muted); font-size: 0.85rem;">Loading...</p>
+  </div>
+</div>
+
 <!-- Environment Variables -->
 <div class="card settings-section">
   <h3 class="settings-section-title">Environment Variables</h3>

--- a/app/version.py
+++ b/app/version.py
@@ -59,7 +59,9 @@ def series(value: str | None) -> str | None:
     Patch releases inside a series are meant to interoperate; a difference in
     major or minor is the one worth telling somebody about.
     """
-    text = (value or "").strip().lstrip("v")
+    # removeprefix, not lstrip: lstrip("v") strips EVERY leading v, so the
+    # malformed tag vv1.36.0 would read as a valid release.
+    text = (value or "").strip().removeprefix("v")
     if not is_release(text):
         return None
     parts = text.split(".")
@@ -75,7 +77,8 @@ def release_tuple(value: str | None) -> tuple[int, ...] | None:
     like ``dev``, ``latest`` or ``1.36.0-rc1`` yields None, because comparing
     against a non-release is how an update check invents an update.
     """
-    text = (value or "").strip().lstrip("v")
+    # At most ONE leading v — see series().
+    text = (value or "").strip().removeprefix("v")
     if not is_release(text):
         return None
     parts = text.split(".")

--- a/app/version.py
+++ b/app/version.py
@@ -68,6 +68,36 @@ def series(value: str | None) -> str | None:
     return f"{parts[0]}.{parts[1]}"
 
 
+def release_tuple(value: str | None) -> tuple[int, ...] | None:
+    """The numeric parts of a release string, or None for anything else.
+
+    Strictly all-digit dotted parts after an optional leading ``v``: a value
+    like ``dev``, ``latest`` or ``1.36.0-rc1`` yields None, because comparing
+    against a non-release is how an update check invents an update.
+    """
+    text = (value or "").strip().lstrip("v")
+    if not is_release(text):
+        return None
+    parts = text.split(".")
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    return tuple(int(p) for p in parts)
+
+
+def is_newer(candidate: str | None, current_value: str | None) -> bool:
+    """Whether ``candidate`` is a strictly newer release than ``current_value``.
+
+    False whenever either side is not a clean release — a ``dev`` build never
+    sees an "update available" claim it cannot act on, and a malformed tag from
+    the release feed never counts as newer than anything.
+    """
+    a, b = release_tuple(candidate), release_tuple(current_value)
+    if a is None or b is None:
+        return False
+    length = max(len(a), len(b))
+    return a + (0,) * (length - len(a)) > b + (0,) * (length - len(b))
+
+
 def skewed(ui: str | None, worker: str | None) -> bool:
     """True only when both sides are known releases AND their series differ.
 

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -1530,6 +1530,38 @@ async def api_runtimes(request: Request) -> dict[str, Any]:
     }
 
 
+@app.get("/api/update/info")
+async def api_update_info(request: Request) -> dict[str, Any]:
+    """Whether this install can update itself, and what it runs (issue #342)."""
+    _verify_api_key(request)
+    try:
+        return await asyncio.to_thread(orchestrator.self_update_info)
+    except RuntimeError as exc:
+        # No Docker socket — same outage split as everywhere else on this API.
+        raise HTTPException(status_code=503, detail=str(exc))
+
+
+@app.post("/api/update/self")
+async def api_update_self(request: Request) -> dict[str, Any]:
+    """Run the documented update (`docker compose pull && up -d`) via a one-shot
+    helper container.
+
+    Deliberately parameterless: the compose project location comes from the
+    labels on this worker's own container, the helper image is pinned, and the
+    command is fixed — the caller controls nothing that reaches Docker. The
+    caller still has to hold the per-worker key, and whoever holds that already
+    commands this worker's Docker socket through the deploy API.
+    """
+    _verify_api_key(request)
+    try:
+        result = await asyncio.to_thread(orchestrator.spawn_self_update)
+    except orchestrator.SelfUpdateUnavailable as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+    return {"status": "updating", **result}
+
+
 @app.get("/api/health")
 async def api_health(response: Response) -> dict[str, Any]:
     """Health check endpoint (no auth required).

--- a/app/worker_api.py
+++ b/app/worker_api.py
@@ -1556,7 +1556,10 @@ async def api_update_self(request: Request) -> dict[str, Any]:
     try:
         result = await asyncio.to_thread(orchestrator.spawn_self_update)
     except orchestrator.SelfUpdateUnavailable as exc:
-        raise HTTPException(status_code=409, detail=str(exc))
+        # Structured, so the UI's worker-detail sanitizer can forward the
+        # instructions verbatim — a bare string detail gets replaced with a
+        # generic message and the operator never sees what to do instead.
+        raise HTTPException(status_code=409, detail={"error": "self_update_unavailable", "message": str(exc)})
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc))
     return {"status": "updating", **result}

--- a/tests/test_update_feature.py
+++ b/tests/test_update_feature.py
@@ -1,0 +1,369 @@
+"""The update surface (issue #342): version comparison, the worker's self-update
+endpoints, and the UI routes that drive them.
+
+The worker side is the security-sensitive half: the endpoint is deliberately
+parameterless and everything that reaches Docker (helper image, command, binds)
+is either a pinned constant or derived from the worker's OWN container labels.
+The spawn-kwargs test pins that property — if a caller-controlled value ever
+reaches the helper, it fails.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("CASHPILOT_API_KEY", "test-fleet-key")
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app import orchestrator, version, worker_api
+from app.main import app as ui_app
+
+
+@asynccontextmanager
+async def _noop_lifespan(a):
+    yield
+
+
+def _worker_client():
+    worker_api.app.router.lifespan_context = _noop_lifespan
+    return TestClient(worker_api.app, raise_server_exceptions=False)
+
+
+def _worker_auth():
+    return {"Authorization": f"Bearer {worker_api.API_KEY}"}
+
+
+def _ui_client():
+    ui_app.router.lifespan_context = _noop_lifespan
+    return TestClient(ui_app, raise_server_exceptions=False)
+
+
+def _auth_owner():
+    return patch("app.main.auth.get_current_user", return_value={"uid": 1, "u": "admin", "r": "owner"})
+
+
+# ---------------------------------------------------------------------------
+# version.release_tuple / version.is_newer
+# ---------------------------------------------------------------------------
+
+
+class TestVersionComparison:
+    def test_release_tuple_parses_clean_releases(self):
+        assert version.release_tuple("1.35.2") == (1, 35, 2)
+        assert version.release_tuple("v1.36.0") == (1, 36, 0)
+
+    def test_release_tuple_refuses_non_releases(self):
+        # A non-release compared as a version is how an update check invents an
+        # update — every one of these must land on None.
+        for value in (None, "", "dev", "latest", "1.36.0-rc1", "not-a-release"):
+            assert version.release_tuple(value) is None, value
+
+    def test_is_newer_true_for_newer_patch_and_series(self):
+        assert version.is_newer("1.35.2", "1.35.0")
+        assert version.is_newer("1.36.0", "1.35.9")
+
+    def test_is_newer_false_for_equal_and_older(self):
+        assert not version.is_newer("1.35.2", "1.35.2")
+        assert not version.is_newer("1.34.9", "1.35.0")
+
+    def test_is_newer_handles_tenth_release_numerically(self):
+        # String comparison gets 1.9 vs 1.10 backwards — the exact trap
+        # update_check._tuple documents.
+        assert version.is_newer("1.10.0", "1.9.9")
+
+    def test_is_newer_false_when_either_side_is_not_a_release(self):
+        assert not version.is_newer("1.36.0", "dev")
+        assert not version.is_newer("dev", "1.35.0")
+        assert not version.is_newer(None, "1.35.0")
+
+    def test_is_newer_pads_shorter_tuples(self):
+        assert version.is_newer("1.36", "1.35.9")
+        assert not version.is_newer("1.35", "1.35.0")
+
+
+# ---------------------------------------------------------------------------
+# orchestrator.self_update_info / spawn_self_update — fake docker client
+# ---------------------------------------------------------------------------
+
+
+def _fake_container(labels=None, image="drumsergio/cashpilot-worker:1.35", status="running"):
+    c = MagicMock()
+    c.attrs = {"Config": {"Labels": labels or {}, "Image": image}}
+    c.status = status
+    c.id = "f" * 64
+    return c
+
+
+_COMPOSE_LABELS = {
+    "com.docker.compose.project.working_dir": "/srv/cashpilot",
+    "com.docker.compose.project.config_files": "/srv/cashpilot/docker-compose.yml,/srv/cashpilot/override.yml",
+    "com.docker.compose.project": "cashpilot",
+}
+
+
+def _fake_docker(me=None, ui=None, updater=None):
+    """A docker client whose containers.get resolves the three names involved."""
+    from docker.errors import NotFound
+
+    client = MagicMock()
+
+    def get(name):
+        if me is not None and name in ("cashpilot-worker", os.uname().nodename if hasattr(os, "uname") else "host"):
+            return me
+        if me is not None and name not in ("cashpilot-ui", orchestrator.UPDATER_NAME):
+            # gethostname() candidate — resolve to the worker container too.
+            return me
+        if name == "cashpilot-ui":
+            if ui is None:
+                raise NotFound("no ui")
+            return ui
+        if name == orchestrator.UPDATER_NAME:
+            if updater is None:
+                raise NotFound("no updater")
+            return updater
+        raise NotFound(name)
+
+    client.containers.get.side_effect = get
+    return client
+
+
+class TestSelfUpdateInfo:
+    def test_compose_managed_install_reports_its_project(self):
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        ui = _fake_container(image="drumsergio/cashpilot:1.35")
+        with patch.object(orchestrator, "_get_client", return_value=_fake_docker(me=me, ui=ui)):
+            info = orchestrator.self_update_info()
+        assert info["compose_managed"] is True
+        assert info["working_dir"] == "/srv/cashpilot"
+        assert info["project"] == "cashpilot"
+        assert info["worker_image"] == "drumsergio/cashpilot-worker:1.35"
+        assert info["ui_image"] == "drumsergio/cashpilot:1.35"
+        assert info["updater_running"] is False
+
+    def test_docker_run_install_is_not_compose_managed(self):
+        me = _fake_container(labels={})
+        with patch.object(orchestrator, "_get_client", return_value=_fake_docker(me=me)):
+            info = orchestrator.self_update_info()
+        assert info["compose_managed"] is False
+
+    def test_running_updater_is_reported(self):
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        updater = _fake_container(status="running")
+        with patch.object(orchestrator, "_get_client", return_value=_fake_docker(me=me, updater=updater)):
+            info = orchestrator.self_update_info()
+        assert info["updater_running"] is True
+
+
+class TestSpawnSelfUpdate:
+    def test_spawns_the_pinned_helper_with_only_derived_values(self):
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        client = _fake_docker(me=me)
+        client.containers.run.return_value = _fake_container()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            result = orchestrator.spawn_self_update()
+
+        assert result["working_dir"] == "/srv/cashpilot"
+        kwargs = client.containers.run.call_args.kwargs
+        args = client.containers.run.call_args.args
+        # Image pinned — never :latest, never caller-supplied.
+        assert args[0] == orchestrator.UPDATER_IMAGE
+        assert ":" in orchestrator.UPDATER_IMAGE and not orchestrator.UPDATER_IMAGE.endswith(":latest")
+        # Fixed command: the documented update, nothing else.
+        assert kwargs["command"] == ["sh", "-c", "docker compose pull && docker compose up -d"]
+        # Exactly two binds: the socket and the compose project dir.
+        assert set(kwargs["volumes"]) == {"/var/run/docker.sock", "/srv/cashpilot"}
+        assert kwargs["working_dir"] == "/srv/cashpilot"
+        # Compose label separates files with commas; COMPOSE_FILE wants colons.
+        assert kwargs["environment"] == {
+            "COMPOSE_FILE": "/srv/cashpilot/docker-compose.yml:/srv/cashpilot/override.yml"
+        }
+        assert kwargs["name"] == orchestrator.UPDATER_NAME
+        assert kwargs["detach"] is True
+        assert kwargs["remove"] is True
+
+    def test_refuses_without_compose_labels(self):
+        me = _fake_container(labels={})
+        client = _fake_docker(me=me)
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(orchestrator.SelfUpdateUnavailable) as ei,
+        ):
+            orchestrator.spawn_self_update()
+        assert "not managed by Docker Compose" in str(ei.value)
+        client.containers.run.assert_not_called()
+
+    def test_refuses_when_it_cannot_see_itself(self):
+        client = _fake_docker(me=None)
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(orchestrator.SelfUpdateUnavailable),
+        ):
+            orchestrator.spawn_self_update()
+        client.containers.run.assert_not_called()
+
+    def test_refuses_while_an_update_is_running(self):
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        updater = _fake_container(status="running")
+        client = _fake_docker(me=me, updater=updater)
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(orchestrator.SelfUpdateUnavailable) as ei,
+        ):
+            orchestrator.spawn_self_update()
+        assert "already running" in str(ei.value)
+        client.containers.run.assert_not_called()
+
+    def test_clears_a_leftover_stopped_helper_then_spawns(self):
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        leftover = _fake_container(status="exited")
+        client = _fake_docker(me=me, updater=leftover)
+        client.containers.run.return_value = _fake_container()
+        with patch.object(orchestrator, "_get_client", return_value=client):
+            orchestrator.spawn_self_update()
+        leftover.remove.assert_called_once_with(force=True)
+        client.containers.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Worker endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerUpdateEndpoints:
+    def test_update_info_requires_auth(self):
+        resp = _worker_client().get("/api/update/info", headers={"Authorization": "Bearer nope"})
+        assert resp.status_code == 401
+
+    def test_update_info_returns_orchestrator_facts(self):
+        facts = {"compose_managed": True, "working_dir": "/srv/x", "updater_running": False}
+        with patch.object(orchestrator, "self_update_info", return_value=facts):
+            resp = _worker_client().get("/api/update/info", headers=_worker_auth())
+        assert resp.status_code == 200
+        assert resp.json()["compose_managed"] is True
+
+    def test_update_info_maps_daemon_outage_to_503(self):
+        with patch.object(orchestrator, "self_update_info", side_effect=RuntimeError("Docker socket not available")):
+            resp = _worker_client().get("/api/update/info", headers=_worker_auth())
+        assert resp.status_code == 503
+
+    def test_update_self_requires_auth(self):
+        resp = _worker_client().post("/api/update/self", headers={"Authorization": "Bearer nope"})
+        assert resp.status_code == 401
+
+    def test_update_self_starts_the_helper(self):
+        with patch.object(
+            orchestrator, "spawn_self_update", return_value={"updater_id": "abc123def456", "working_dir": "/srv/x"}
+        ):
+            resp = _worker_client().post("/api/update/self", headers=_worker_auth())
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "updating"
+        assert body["updater_id"] == "abc123def456"
+
+    def test_update_self_unavailable_is_409_with_instructions(self):
+        with patch.object(
+            orchestrator,
+            "spawn_self_update",
+            side_effect=orchestrator.SelfUpdateUnavailable("Update manually: docker compose pull"),
+        ):
+            resp = _worker_client().post("/api/update/self", headers=_worker_auth())
+        assert resp.status_code == 409
+        assert "Update manually" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# UI routes
+# ---------------------------------------------------------------------------
+
+
+class TestUiUpdateRoutes:
+    def test_update_info_merges_worker_facts_with_release_state(self):
+        worker_facts = {"compose_managed": True, "working_dir": "/srv/x", "updater_running": False}
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_to_worker", new_callable=AsyncMock, return_value=dict(worker_facts)),
+            patch("app.main.update_check.state", return_value={"known": True, "latest": "v1.35.2", "behind": False}),
+            patch("app.main.version.current", return_value="1.35.0"),
+        ):
+            resp = _ui_client().get("/api/update-info")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["compose_managed"] is True
+        assert body["current"] == "1.35.0"
+        assert body["latest"] == "v1.35.2"
+        # Same series, strictly newer patch: the button has something to install.
+        assert body["patch_available"] is True
+
+    def test_patch_available_false_across_series(self):
+        # A newer SERIES is not something `compose pull` can install on a
+        # series-pinned install — that is `behind`, handled as guidance.
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_to_worker", new_callable=AsyncMock, return_value={"compose_managed": True}),
+            patch("app.main.update_check.state", return_value={"known": True, "latest": "v1.36.0", "behind": True}),
+            patch("app.main.version.current", return_value="1.35.1"),
+        ):
+            resp = _ui_client().get("/api/update-info")
+        body = resp.json()
+        assert body["patch_available"] is False
+        assert body["behind"] is True
+
+    def test_patch_available_false_when_latest_unknown(self):
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main._proxy_to_worker", new_callable=AsyncMock, return_value={"compose_managed": True}),
+            patch("app.main.update_check.state", return_value={"known": False, "latest": None, "behind": False}),
+            patch("app.main.version.current", return_value="1.35.1"),
+        ):
+            resp = _ui_client().get("/api/update-info")
+        body = resp.json()
+        assert body["patch_available"] is False
+        assert body["known"] is False
+
+    def test_update_posts_to_the_worker_with_a_long_timeout(self):
+        captured: dict = {}
+
+        async def fake_proxy(worker_id, method, path, **kwargs):
+            captured.update({"worker_id": worker_id, "method": method, "path": path, **kwargs})
+            return {"status": "updating", "updater_id": "abc"}
+
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=3),
+            patch("app.main._proxy_to_worker", side_effect=fake_proxy),
+        ):
+            resp = _ui_client().post("/api/update?worker_id=3")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updating"
+        assert captured["method"] == "POST"
+        assert captured["path"] == "/api/update/self"
+        # The helper-image pull can be slow; the default 30s proxy timeout is
+        # exactly the kind of silent cap that turns a working update into a 503.
+        assert captured["timeout"] == 120
+
+    def test_worker_refusal_passes_through(self):
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch(
+                "app.main._proxy_to_worker",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=409, detail="This install is not managed by Docker Compose"),
+            ),
+        ):
+            resp = _ui_client().post("/api/update")
+        assert resp.status_code == 409
+        assert "not managed by Docker Compose" in resp.json()["detail"]
+
+    def test_update_requires_owner(self):
+        with patch("app.main.auth.get_current_user", return_value={"uid": 2, "u": "w", "r": "writer"}):
+            resp = _ui_client().post("/api/update")
+        assert resp.status_code in (401, 403)

--- a/tests/test_update_feature.py
+++ b/tests/test_update_feature.py
@@ -103,6 +103,7 @@ _COMPOSE_LABELS = {
     "com.docker.compose.project.working_dir": "/srv/cashpilot",
     "com.docker.compose.project.config_files": "/srv/cashpilot/docker-compose.yml,/srv/cashpilot/override.yml",
     "com.docker.compose.project": "cashpilot",
+    "com.docker.compose.service": "cashpilot-worker",
 }
 
 
@@ -168,13 +169,20 @@ class TestSpawnSelfUpdate:
             result = orchestrator.spawn_self_update()
 
         assert result["working_dir"] == "/srv/cashpilot"
+        assert result["services"] == ["cashpilot-worker"]
         kwargs = client.containers.run.call_args.kwargs
         args = client.containers.run.call_args.args
         # Image pinned — never :latest, never caller-supplied.
         assert args[0] == orchestrator.UPDATER_IMAGE
         assert ":" in orchestrator.UPDATER_IMAGE and not orchestrator.UPDATER_IMAGE.endswith(":latest")
-        # Fixed command: the documented update, nothing else.
-        assert kwargs["command"] == ["sh", "-c", "docker compose pull && docker compose up -d"]
+        # Fixed script template: guards first, then the documented update SCOPED
+        # to the label-derived service names — never a whole-project `up -d`.
+        assert kwargs["command"][:2] == ["sh", "-c"]
+        script = kwargs["command"][2]
+        assert "docker compose config" in script
+        assert "is not set" in script
+        assert "docker compose pull cashpilot-worker" in script
+        assert "docker compose up -d --no-deps cashpilot-worker" in script
         # Exactly two binds: the socket and the compose project dir.
         assert set(kwargs["volumes"]) == {"/var/run/docker.sock", "/srv/cashpilot"}
         assert kwargs["working_dir"] == "/srv/cashpilot"
@@ -228,6 +236,45 @@ class TestSpawnSelfUpdate:
         leftover.remove.assert_called_once_with(force=True)
         client.containers.run.assert_called_once()
 
+    def test_refuses_when_the_service_name_cannot_be_derived(self):
+        # Compose project labels but NO service label: the scoped update cannot
+        # be constructed, and an unscoped whole-project `up -d` is forbidden.
+        labels = {k: v for k, v in _COMPOSE_LABELS.items() if k != "com.docker.compose.service"}
+        client = _fake_docker(me=_fake_container(labels=labels))
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(orchestrator.SelfUpdateUnavailable) as ei,
+        ):
+            orchestrator.spawn_self_update()
+        assert "scoped" in str(ei.value)
+        client.containers.run.assert_not_called()
+
+    def test_racing_updates_map_the_name_conflict_to_already_running(self):
+        from docker.errors import APIError
+
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        client = _fake_docker(me=me)
+        conflict = APIError("conflict", response=MagicMock(status_code=409))
+        client.containers.run.side_effect = conflict
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(orchestrator.SelfUpdateUnavailable) as ei,
+        ):
+            orchestrator.spawn_self_update()
+        assert "already running" in str(ei.value)
+
+    def test_other_daemon_errors_surface_as_outage_not_500(self):
+        from docker.errors import APIError
+
+        me = _fake_container(labels=_COMPOSE_LABELS)
+        client = _fake_docker(me=me)
+        client.containers.run.side_effect = APIError("boom", response=MagicMock(status_code=500))
+        with (
+            patch.object(orchestrator, "_get_client", return_value=client),
+            pytest.raises(RuntimeError, match="refused to start"),
+        ):
+            orchestrator.spawn_self_update()
+
 
 # ---------------------------------------------------------------------------
 # Worker endpoints
@@ -265,7 +312,7 @@ class TestWorkerUpdateEndpoints:
         assert body["status"] == "updating"
         assert body["updater_id"] == "abc123def456"
 
-    def test_update_self_unavailable_is_409_with_instructions(self):
+    def test_update_self_unavailable_is_409_with_structured_instructions(self):
         with patch.object(
             orchestrator,
             "spawn_self_update",
@@ -273,7 +320,12 @@ class TestWorkerUpdateEndpoints:
         ):
             resp = _worker_client().post("/api/update/self", headers=_worker_auth())
         assert resp.status_code == 409
-        assert "Update manually" in resp.json()["detail"]
+        detail = resp.json()["detail"]
+        # Structured on purpose: the UI's worker-detail sanitizer forwards only
+        # allowlisted shapes, and a bare string would be replaced with a
+        # generic message — losing the instructions this refusal exists for.
+        assert detail["error"] == "self_update_unavailable"
+        assert "Update manually" in detail["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -367,3 +419,81 @@ class TestUiUpdateRoutes:
         with patch("app.main.auth.get_current_user", return_value={"uid": 2, "u": "w", "r": "writer"}):
             resp = _ui_client().post("/api/update")
         assert resp.status_code in (401, 403)
+
+    def test_the_refusal_survives_the_real_worker_detail_sanitizer(self):
+        """Regression for the finding my own earlier test mocked past.
+
+        The earlier passthrough test patched _proxy_to_worker, so the real
+        _safe_worker_detail never ran — and it replaces every non-allowlisted
+        detail with "Worker request failed", which would have eaten the manual
+        instructions. This goes through the REAL proxy with only httpx mocked.
+        """
+        import json as _json
+
+        refusal = {
+            "detail": {
+                "error": "self_update_unavailable",
+                "message": "Update manually: docker compose pull && docker compose up -d",
+            }
+        }
+        resp409 = MagicMock()
+        resp409.status_code = 409
+        resp409.json.return_value = refusal
+        resp409.text = _json.dumps(refusal)
+        resp409.headers = {"content-type": "application/json"}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post.return_value = resp409
+
+        worker = {"id": 1, "name": "w1", "status": "online", "url": "http://192.168.1.10:8081"}
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
+            patch("app.main.httpx.AsyncClient", return_value=mock_client),
+            patch("app.main.FLEET_API_KEY", "test-key"),
+        ):
+            resp = _ui_client().post("/api/update?worker_id=1")
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert detail["error"] == "self_update_unavailable"
+        assert "Update manually" in detail["message"]
+
+    def test_arbitrary_worker_error_bodies_stay_generic(self):
+        # Negative control for the sanitizer: a non-allowlisted shape must NOT
+        # pass through — that protection is the reason the refusal is structured.
+        import json as _json
+
+        leak = {"detail": "secret-laden arbitrary worker error"}
+        resp500 = MagicMock()
+        resp500.status_code = 500
+        resp500.json.return_value = leak
+        resp500.text = _json.dumps(leak)
+        resp500.headers = {"content-type": "application/json"}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post.return_value = resp500
+
+        worker = {"id": 1, "name": "w1", "status": "online", "url": "http://192.168.1.10:8081"}
+        with (
+            _auth_owner(),
+            patch("app.main._resolve_worker_id", new_callable=AsyncMock, return_value=1),
+            patch("app.main.database.get_worker", new_callable=AsyncMock, return_value=worker),
+            patch("app.main.httpx.AsyncClient", return_value=mock_client),
+            patch("app.main.FLEET_API_KEY", "test-key"),
+        ):
+            resp = _ui_client().post("/api/update?worker_id=1")
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Worker request failed"
+
+
+class TestVersionPrefixStrictness:
+    def test_multiple_leading_v_is_not_a_release(self):
+        # lstrip("v") would accept vv1.36.0; removeprefix must not.
+        assert version.release_tuple("vv1.36.0") is None
+        assert version.series("vv1.36.0") is None
+        assert not version.is_newer("vv9.9.9", "1.35.0")


### PR DESCRIPTION
kissofkill asked for a button to update CashPilot from the dashboard settings (#342). The compose file this project documents already names the update path — `docker compose pull && docker compose up -d` against the pinned MAJOR.MINOR series — so that is exactly what the button runs, from a one-shot helper container, because the worker cannot recreate itself from inside the process being recreated.

**How it works.** The UI asks the local worker; the worker inspects its **own** container for the compose-project labels (working dir, config files), then starts a transient, pinned `docker:27.5.1-cli` helper (ships compose v2.33.0, verified) that runs the documented two commands in that project and removes itself. The dashboard and worker get recreated on the new images; the settings card warns the user the page will briefly go away.

**The security shape.** `POST /api/update/self` is deliberately **parameterless**: the project location comes from the worker's own labels, the helper image is a pinned constant, the command is fixed — the caller controls nothing that reaches Docker, and a regression test pins that property (it fails if any caller-controlled value ever reaches the helper). The caller must hold the per-worker key, and whoever holds that already commands this worker's socket through the deploy API. A fixed helper name doubles as the only-one-update-at-a-time lock.

**Honest in every state.** Installs not managed by Compose (plain `docker run`) are refused with the manual commands (409) rather than guessed at. Installs pinning an **exact** tag — GitOps fleets — get a no-op pull by construction. The card's button label tells the truth per state: "Update to vX.Y.Z" when a same-series patch exists, "Pull newest patches" plus a tags-need-editing note when a newer **series** exists (`behind` from the existing daily release check is series-based on purpose; the new `patch_available` answers the button's different question), "Re-pull images" when current, and an honest unknown when the release feed is off or unreachable.

27 new tests, all mutation-verified (unpinning the helper image and dropping the long proxy timeout each turn the suite red).

Closes #342



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an About & Updates section in Settings with current and latest release details.
  * Added protected actions to check for available updates and start self-updates.
  * Added Docker Compose support for installing the latest patch in the configured release series.
  * Added clear status messages for unavailable updates, errors, and in-progress updates.

* **Bug Fixes**
  * Improved release version validation and comparison for update availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->